### PR TITLE
fix: prevent false exit detection and scheduler interrupts

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -16,6 +16,7 @@ import {
   AGENT_HEARTBEAT_MONITOR_CONSTANTS as CONFIG_AGENT_HEARTBEAT_MONITOR_CONSTANTS,
   ORCHESTRATOR_HEARTBEAT_CONSTANTS as CONFIG_ORCHESTRATOR_HEARTBEAT_CONSTANTS,
   MARKETPLACE_CONSTANTS as CONFIG_MARKETPLACE_CONSTANTS,
+  TEMPLATE_MARKETPLACE_CONSTANTS as CONFIG_TEMPLATE_MARKETPLACE_CONSTANTS,
   PROCESS_EXIT_CODES as CONFIG_PROCESS_EXIT_CODES,
   WEB_CONSTANTS as CONFIG_WEB_CONSTANTS,
 } from '../../config/constants.js';
@@ -471,6 +472,24 @@ export const GEMINI_FORCE_RESTART_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Claude Code fatal error patterns that indicate the CLI is stuck in an
+ * unrecoverable state. Unlike transient API errors, these require an
+ * immediate restart — no retry will resolve them.
+ *
+ * Example: When conversation history gets compacted and thinking blocks
+ * are modified, the Claude API permanently rejects all subsequent requests
+ * with a 400 error. The only recovery is to kill and restart the session.
+ *
+ * Used by RuntimeExitMonitorService to detect stuck Claude Code sessions.
+ */
+export const CLAUDE_FATAL_PATTERNS: RegExp[] = [
+	// Thinking block corruption: once modified, every subsequent API call fails with 400
+	/thinking.*blocks.*cannot be modified/i,
+	// Redacted thinking block corruption (same root cause)
+	/redacted_thinking.*blocks.*cannot be modified/i,
+];
+
+/**
  * Gemini CLI ready-state patterns used for recovery detection.
  * When any of these strings appear in terminal output, the CLI is
  * considered operational and ready to accept input.
@@ -795,6 +814,7 @@ export const MESSAGE_SOURCES = {
 
 // Re-export marketplace constants from shared config
 export const MARKETPLACE_CONSTANTS = CONFIG_MARKETPLACE_CONSTANTS;
+export const TEMPLATE_MARKETPLACE_CONSTANTS = CONFIG_TEMPLATE_MARKETPLACE_CONSTANTS;
 
 /** Typed message source value */
 export type MessageSource = (typeof MESSAGE_SOURCES)[keyof typeof MESSAGE_SOURCES];
@@ -846,8 +866,10 @@ export const GOOGLE_OAUTH_CONSTANTS = {
  * the open-source Crewly instance to CrewlyAI Cloud for premium features.
  */
 export const CLOUD_CONSTANTS = {
-	/** Default CrewlyAI Cloud API base URL */
-	DEFAULT_CLOUD_URL: 'https://cloud.crewly.dev',
+	/** Default CrewlyAI Cloud API base URL (env: CREWLY_CLOUD_URL) */
+	get DEFAULT_CLOUD_URL(): string {
+		return process.env['CREWLY_CLOUD_URL'] || 'https://cloud.crewly.dev';
+	},
 	/** API version prefix for all cloud endpoints */
 	API_VERSION: '/v1',
 	/** Cloud API endpoints */
@@ -928,6 +950,98 @@ export type CloudTier = (typeof CLOUD_CONSTANTS.TIERS)[keyof typeof CLOUD_CONSTA
 /** Cloud connection status type */
 export type CloudConnectionStatus =
 	(typeof CLOUD_CONSTANTS.CONNECTION_STATUS)[keyof typeof CLOUD_CONSTANTS.CONNECTION_STATUS];
+
+/**
+ * Constants for CrewlyAI Cloud account authentication and licensing.
+ * Used by AuthService and JwtAuthMiddleware for user registration,
+ * login, JWT management, and plan-based feature gating.
+ */
+export const AUTH_CONSTANTS = {
+	/** JWT configuration */
+	JWT: {
+		/** JWT secret (env: CREWLY_JWT_SECRET, falls back to dev default) */
+		get DEFAULT_SECRET(): string {
+			return process.env['CREWLY_JWT_SECRET'] || 'crewly-dev-jwt-secret-change-in-production';
+		},
+		/** Access token expiry in seconds (1 hour) */
+		ACCESS_TOKEN_EXPIRY_S: 3600,
+		/** Refresh token expiry in seconds (30 days) */
+		REFRESH_TOKEN_EXPIRY_S: 2_592_000,
+		/** JWT algorithm identifier */
+		ALGORITHM: 'HS256',
+		/** JWT issuer claim */
+		ISSUER: 'crewly-cloud',
+	},
+	/** Password hashing configuration (scrypt) */
+	PASSWORD: {
+		/** Scrypt key length (bytes) */
+		KEY_LENGTH: 64,
+		/** Scrypt cost parameter */
+		COST: 16384,
+		/** Salt length (bytes) */
+		SALT_LENGTH: 16,
+	},
+	/** User plans */
+	PLANS: {
+		FREE: 'free',
+		PRO: 'pro',
+	},
+	/** Storage paths relative to ~/.crewly/ */
+	STORAGE: {
+		/** Directory for cloud user data */
+		CLOUD_DIR: 'cloud',
+		/** Directory for user accounts */
+		USERS_DIR: 'cloud/users',
+		/** File storing user index (email → id mapping) */
+		USER_INDEX_FILE: 'cloud/users/index.json',
+	},
+	/** Pro features list */
+	PRO_FEATURES: [
+		'template-marketplace',
+		'cloud-relay',
+		'premium-templates',
+		'priority-support',
+	],
+} as const;
+
+/** User plan type */
+export type UserPlan = (typeof AUTH_CONSTANTS.PLANS)[keyof typeof AUTH_CONSTANTS.PLANS];
+
+/**
+ * Constants for Supabase-backed Cloud Auth.
+ * Used by CloudAuthService for user registration, login,
+ * session management, and license verification via Supabase.
+ *
+ * Supabase credentials are read from env vars (CREWLY_SUPABASE_URL,
+ * CREWLY_SUPABASE_ANON_KEY) with dev-project defaults as fallback.
+ */
+export const CLOUD_AUTH_CONSTANTS = {
+	/** Supabase project configuration (env-var driven) */
+	SUPABASE: {
+		/** Supabase project URL (env: CREWLY_SUPABASE_URL) */
+		get URL(): string {
+			return process.env['CREWLY_SUPABASE_URL'] || 'https://npveywncozhjzcxrhkuc.supabase.co';
+		},
+		/** Supabase anonymous key (env: CREWLY_SUPABASE_ANON_KEY) */
+		get ANON_KEY(): string {
+			return process.env['CREWLY_SUPABASE_ANON_KEY'] || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5wdmV5d25jb3poanpjeHJoa3VjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzI5MzUwNzIsImV4cCI6MjA4ODUxMTA3Mn0.xinT1XB9RaZ13CWQjbo95i_dJN7i463l9gAWQce32Yg';
+		},
+	},
+	/** Database table names */
+	TABLES: {
+		/** Licenses table in Supabase */
+		LICENSES: 'licenses',
+	},
+	/** License statuses */
+	LICENSE_STATUS: {
+		ACTIVE: 'active',
+		EXPIRED: 'expired',
+		CANCELLED: 'cancelled',
+	},
+} as const;
+
+/** License status type */
+export type CloudLicenseStatus = (typeof CLOUD_AUTH_CONSTANTS.LICENSE_STATUS)[keyof typeof CLOUD_AUTH_CONSTANTS.LICENSE_STATUS];
 
 // Type helpers
 export type AgentStatus =

--- a/backend/src/controllers/team/team.controller.test.ts
+++ b/backend/src/controllers/team/team.controller.test.ts
@@ -1173,6 +1173,84 @@ describe('Teams Handlers', () => {
     });
   });
 
+  describe('orchestrator team system protection', () => {
+    it('should reject creating a team with parentTeamId=orchestrator', async () => {
+      mockStorageService.getTeams.mockResolvedValue([]);
+
+      mockRequest.body = {
+        name: 'Bad Child',
+        parentTeamId: 'orchestrator',
+        members: [
+          {
+            name: 'Dev',
+            role: 'developer',
+            systemPrompt: 'You are a developer',
+          },
+        ],
+      };
+
+      await teamsHandlers.createTeam.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseMock.status).toHaveBeenCalledWith(400);
+      expect(responseMock.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Cannot use Orchestrator Team as parent — it is a system team',
+      });
+    });
+
+    it('should reject updating parentTeamId to orchestrator', async () => {
+      const team = {
+        id: 'team-1',
+        name: 'Some Team',
+        members: [],
+        projectIds: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      mockStorageService.getTeams.mockResolvedValue([team]);
+      mockRequest.params = { id: 'team-1' };
+      mockRequest.body = { parentTeamId: 'orchestrator' };
+
+      await teamsHandlers.updateTeam.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseMock.status).toHaveBeenCalledWith(400);
+      expect(responseMock.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Cannot use Orchestrator Team as parent — it is a system team',
+      });
+    });
+
+    it('should reject setting parentTeamId on the orchestrator team itself', async () => {
+      mockStorageService.getOrchestratorStatus.mockResolvedValue({
+        agentStatus: 'active',
+        sessionName: 'crewly-orc',
+      });
+
+      mockRequest.params = { id: 'orchestrator' };
+      mockRequest.body = { parentTeamId: 'some-team' };
+
+      await teamsHandlers.updateTeam.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect(responseMock.status).toHaveBeenCalledWith(400);
+      expect(responseMock.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Cannot set parentTeamId on Orchestrator Team — it is a system team',
+      });
+    });
+  });
+
   describe('deleteTeam - parentTeamId cascade', () => {
     it('should unset parentTeamId on child teams when parent is deleted', async () => {
       const parentTeam = {
@@ -1420,6 +1498,80 @@ describe('Teams Handlers', () => {
         success: false,
         error: 'Team not found'
       });
+    });
+
+    it('should skip already-active members instead of restarting them (#133)', async () => {
+      const mockTeam: Team = {
+        id: 'team-456',
+        name: 'SteamFun',
+        members: [
+          {
+            id: 'member-active',
+            name: 'Nick',
+            sessionName: 'steamfun-nick-38e207cb',
+            role: 'developer',
+            runtimeType: 'claude-code',
+            systemPrompt: 'Test prompt',
+            agentStatus: 'active',
+            workingStatus: 'in_progress',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          },
+          {
+            id: 'member-inactive',
+            name: 'Leo',
+            sessionName: '',
+            role: 'tester',
+            runtimeType: 'claude-code',
+            systemPrompt: 'Test prompt',
+            agentStatus: 'inactive',
+            workingStatus: 'idle',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+          }
+        ],
+        projectIds: [],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      mockRequest.params = { id: 'team-456' };
+      mockRequest.body = { projectId: 'project-1' };
+      mockStorageService.getTeams.mockResolvedValue([mockTeam]);
+      mockStorageService.getProjects.mockResolvedValue([{
+        id: 'project-1',
+        path: '/test/project',
+        name: 'Test Project',
+      }]);
+      // Nick's session exists in tmux
+      mockTmuxService.listSessions.mockResolvedValue([
+        { sessionName: 'steamfun-nick-38e207cb' }
+      ]);
+      mockStorageService.saveTeam.mockResolvedValue(undefined);
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>().mockResolvedValue({ success: true, sessionName: 'steamfun-leo-inactive1' })
+      } as any;
+
+      await teamsHandlers.startTeam.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      // createAgentSession should only be called for Leo (inactive), NOT for Nick (active)
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).toHaveBeenCalledTimes(1);
+
+      // Verify response includes Nick as already_running and Leo as started
+      expect(responseMock.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+        })
+      );
+
+      // Nick's agentStatus should NOT have been changed to 'starting'
+      const firstSave = (mockStorageService.saveTeam as jest.Mock).mock.calls[0]?.[0] as Team;
+      const nickAfterSave = firstSave?.members.find(m => m.id === 'member-active');
+      expect(nickAfterSave?.agentStatus).toBe('active');
     });
   });
 
@@ -2323,6 +2475,55 @@ describe('Teams Handlers', () => {
       expect(responseMock.json).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
+        })
+      );
+    });
+
+    it('should skip already-active members with a live session (#133)', async () => {
+      const mockTeam: Team = {
+        id: 'team-1',
+        name: 'Test Team',
+        members: [{
+          id: 'member-1',
+          name: 'Nick',
+          sessionName: 'steamfun-nick-38e207cb',
+          role: 'developer',
+          systemPrompt: 'Test prompt',
+          agentStatus: 'active',
+          workingStatus: 'in_progress',
+          runtimeType: 'claude-code',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        }],
+        projectIds: ['project-1'],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      mockStorageService.getTeams.mockResolvedValue([mockTeam]);
+      // Session exists in tmux
+      mockTmuxService.listSessions.mockResolvedValue([
+        { sessionName: 'steamfun-nick-38e207cb' }
+      ]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>()
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      // createAgentSession should NOT be called since the member is already active
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).not.toHaveBeenCalled();
+
+      // Should return success with already-active info
+      expect(responseMock.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          message: expect.stringContaining('already active'),
         })
       );
     });

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -268,14 +268,23 @@ async function _startTeamMemberCore(
             (member as MutableTeamMember).updatedAt = new Date().toISOString();
           }
         } else {
-          // Session exists and agent status is active/activating - this is normal conflict
+          // Session exists and agent status is active/activating/starting — skip this member
+          // Restore the agentStatus to ACTIVE in storage (it may have been set to STARTING by the caller)
+          const freshTeams = await context.storageService.getTeams();
+          const freshTeam = freshTeams.find(t => t.id === team.id);
+          const freshMember = freshTeam?.members.find(m => m.id === member.id) as MutableTeamMember | undefined;
+          if (freshTeam && freshMember && freshMember.agentStatus !== CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE) {
+            freshMember.agentStatus = CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE;
+            freshMember.updatedAt = new Date().toISOString();
+            await context.storageService.saveTeam(freshTeam);
+          }
+
           return {
-            success: false,
+            success: true,
             memberName: member.name,
             memberId: member.id,
             sessionName: member.sessionName,
             status: 'already_active',
-            error: 'Team member already has an active session'
           };
         }
       }
@@ -597,6 +606,15 @@ export async function createTeam(this: ApiContext, req: Request, res: Response):
 
     // Validate parentTeamId references an existing team
     if (parentTeamId) {
+      // Orchestrator is a system team and cannot be used as a parent
+      if (parentTeamId === CREWLY_CONSTANTS.AGENT_IDS.ORCHESTRATOR_ID) {
+        res.status(400).json({
+          success: false,
+          error: 'Cannot use Orchestrator Team as parent — it is a system team'
+        } as ApiResponse);
+        return;
+      }
+
       const parentTeam = existingTeams.find(t => t.id === parentTeamId);
       if (!parentTeam) {
         res.status(400).json({
@@ -868,16 +886,46 @@ export async function startTeam(this: ApiContext, req: Request, res: Response): 
     let sessionsAlreadyRunning = 0;
     const results: TeamMemberOperationResult[] = [];
 
-    // PHASE 2: Immediately set ALL members to 'starting' for instant UI feedback
+    // PHASE 2: Set inactive members to 'starting' for instant UI feedback
+    // Skip members that are already active/started/starting to avoid interrupting running agents
+    const NON_STARTABLE_STATUSES: Set<string> = new Set([
+      CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE,
+      CREWLY_CONSTANTS.AGENT_STATUSES.STARTED,
+      CREWLY_CONSTANTS.AGENT_STATUSES.STARTING,
+      CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVATING,
+    ]);
+    const alreadyActiveMembers = new Set<string>();
     for (const member of team.members) {
-      const mutableMember = member as MutableTeamMember;
-      mutableMember.agentStatus = CREWLY_CONSTANTS.AGENT_STATUSES.STARTING;
-      mutableMember.updatedAt = new Date().toISOString();
+      if (NON_STARTABLE_STATUSES.has(member.agentStatus)) {
+        alreadyActiveMembers.add(member.id);
+      } else {
+        const mutableMember = member as MutableTeamMember;
+        mutableMember.agentStatus = CREWLY_CONSTANTS.AGENT_STATUSES.STARTING;
+        mutableMember.updatedAt = new Date().toISOString();
+      }
     }
     await this.storageService.saveTeam(team);
 
-    // Start each team member using the internal helper function
+    // Start each team member using the internal helper function (skip verified active members)
     for (const member of team.members) {
+      // Fast-path: if the member was already active before PHASE 2, verify session and skip
+      if (alreadyActiveMembers.has(member.id) && member.sessionName) {
+        const sessions = await this.tmuxService.listSessions();
+        const hasLiveSession = sessions.some(s => s.sessionName === member.sessionName);
+        if (hasLiveSession) {
+          sessionsAlreadyRunning++;
+          results.push({
+            memberName: member.name,
+            sessionName: member.sessionName,
+            status: 'already_running',
+            success: true,
+            memberId: member.id,
+          });
+          continue;
+        }
+        // Session doesn't exist despite active status — fall through to start it
+      }
+
       const result = await _startTeamMemberCore(this, team, member, assignedProject.path);
 
       // Convert internal result to the expected format for the response
@@ -1170,7 +1218,32 @@ export async function startTeamMember(this: ApiContext, req: Request, res: Respo
       return;
     }
 
-    // PHASE 3: Immediately set target member to 'starting' for instant UI feedback
+    // Skip members that are already active to avoid interrupting running agents
+    const skipStatuses: Set<string> = new Set([
+      CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE,
+      CREWLY_CONSTANTS.AGENT_STATUSES.STARTED,
+      CREWLY_CONSTANTS.AGENT_STATUSES.STARTING,
+      CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVATING,
+    ]);
+    if (skipStatuses.has(member.agentStatus) && member.sessionName) {
+      // Verify the session actually exists before skipping
+      const sessions = await this.tmuxService.listSessions();
+      const hasLiveSession = sessions.some(s => s.sessionName === member.sessionName);
+      if (hasLiveSession) {
+        res.json({
+          success: true,
+          message: `Team member ${member.name} is already active`,
+          data: {
+            memberId: member.id,
+            sessionName: member.sessionName,
+            status: member.agentStatus
+          }
+        } as ApiResponse);
+        return;
+      }
+    }
+
+    // Set target member to 'starting' for instant UI feedback
     const mutableMember = member as MutableTeamMember;
     mutableMember.agentStatus = CREWLY_CONSTANTS.AGENT_STATUSES.STARTING;
     mutableMember.updatedAt = new Date().toISOString();
@@ -1798,7 +1871,16 @@ export async function updateTeam(this: ApiContext, req: Request, res: Response):
     }
 
     // Handle orchestrator team specially
-    if (id === 'orchestrator') {
+    if (id === CREWLY_CONSTANTS.AGENT_IDS.ORCHESTRATOR_ID) {
+      // Orchestrator is a system team — cannot have a parent
+      if (updates.parentTeamId !== undefined && updates.parentTeamId !== null) {
+        res.status(400).json({
+          success: false,
+          error: 'Cannot set parentTeamId on Orchestrator Team — it is a system team'
+        } as ApiResponse);
+        return;
+      }
+
       // Orchestrator team is virtual and stored separately
       const orchestratorStatus = await this.storageService.getOrchestratorStatus();
 
@@ -1970,6 +2052,15 @@ export async function updateTeam(this: ApiContext, req: Request, res: Response):
         // Explicitly remove parent (make top-level)
         team.parentTeamId = undefined;
       } else {
+        // Orchestrator is a system team and cannot be used as a parent
+        if (updates.parentTeamId === CREWLY_CONSTANTS.AGENT_IDS.ORCHESTRATOR_ID) {
+          res.status(400).json({
+            success: false,
+            error: 'Cannot use Orchestrator Team as parent — it is a system team'
+          } as ApiResponse);
+          return;
+        }
+
         // Validate parent team exists and prevent self-reference / circular references
         if (updates.parentTeamId === id) {
           res.status(400).json({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -233,6 +233,7 @@ export class CrewlyServer {
 			this.apiController.agentRegistrationService
 		);
 		this.schedulerService.setTaskTrackingService(this.taskTrackingService);
+		this.schedulerService.setMessageQueueService(this.messageQueueService);
 
 		this.terminalGateway = new TerminalGateway(this.io);
 

--- a/backend/src/middleware/agent-heartbeat.middleware.ts
+++ b/backend/src/middleware/agent-heartbeat.middleware.ts
@@ -39,9 +39,9 @@ export function agentHeartbeatMiddleware(req: Request, res: Response, next: Next
 		});
 
 		// Record API call as activity for idle detection.
-		// This prevents false idle suspend when agents are actively calling
-		// skills/APIs but not producing PTY output.
-		PtyActivityTrackerService.getInstance().recordActivity(sessionName);
+		// Uses recordApiActivity so the heartbeat monitor can distinguish
+		// real API calls from PTY echo noise.
+		PtyActivityTrackerService.getInstance().recordApiActivity(sessionName);
 	}
 
 	next();

--- a/backend/src/services/agent/claude-runtime.service.test.ts
+++ b/backend/src/services/agent/claude-runtime.service.test.ts
@@ -84,12 +84,16 @@ describe('ClaudeRuntimeService', () => {
 	});
 
 	describe('getRuntimeExitPatterns', () => {
-		it('should return Claude-specific exit patterns', () => {
+		it('should return Claude-specific exit patterns including fatal patterns', () => {
 			const patterns = service['getRuntimeExitPatterns']();
-			expect(patterns).toHaveLength(2);
+			// 2 clean exit patterns + CLAUDE_FATAL_PATTERNS
+			expect(patterns.length).toBeGreaterThanOrEqual(4);
 			expect(patterns[0].test('Claude Code exited')).toBe(true);
 			expect(patterns[0].test('Claude exited')).toBe(true);
 			expect(patterns[1].test('Session ended')).toBe(true);
+			// Fatal patterns included
+			expect(patterns.some(p => p.test('thinking blocks cannot be modified'))).toBe(true);
+			expect(patterns.some(p => p.test('redacted_thinking blocks cannot be modified'))).toBe(true);
 		});
 
 		it('should not match unrelated text', () => {
@@ -101,7 +105,7 @@ describe('ClaudeRuntimeService', () => {
 	describe('getExitPatterns', () => {
 		it('should expose exit patterns via public accessor', () => {
 			const patterns = service.getExitPatterns();
-			expect(patterns).toHaveLength(2);
+			expect(patterns.length).toBeGreaterThanOrEqual(4);
 		});
 	});
 

--- a/backend/src/services/agent/claude-runtime.service.ts
+++ b/backend/src/services/agent/claude-runtime.service.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { RuntimeAgentService, type McpConfigResult } from './runtime-agent.service.abstract.js';
 import { SessionCommandHelper } from '../session/index.js';
-import { RUNTIME_TYPES, type RuntimeType } from '../../constants.js';
+import { RUNTIME_TYPES, CLAUDE_FATAL_PATTERNS, type RuntimeType } from '../../constants.js';
 import { delay } from '../../utils/async.utils.js';
 
 /**
@@ -69,12 +69,21 @@ export class ClaudeRuntimeService extends RuntimeAgentService {
 	}
 
 	/**
-	 * Claude Code specific exit patterns for runtime exit detection
+	 * Claude Code specific exit patterns for runtime exit detection.
+	 *
+	 * Includes both clean exit patterns (e.g. "Claude Code exited") and
+	 * fatal error patterns that indicate the CLI is stuck in an unrecoverable
+	 * state (e.g. thinking block corruption).
+	 *
+	 * @returns Array of RegExp patterns that match runtime exit or fatal output
 	 */
 	protected getRuntimeExitPatterns(): RegExp[] {
 		return [
+			// Clean exit patterns
 			/Claude\s+(Code\s+)?exited/i,
 			/Session\s+ended/i,
+			// Fatal error patterns — CLI is running but permanently broken
+			...CLAUDE_FATAL_PATTERNS,
 		];
 	}
 

--- a/backend/src/services/agent/pty-activity-tracker.service.ts
+++ b/backend/src/services/agent/pty-activity-tracker.service.ts
@@ -23,8 +23,11 @@ export class PtyActivityTrackerService {
 	private static instance: PtyActivityTrackerService | null = null;
 	private logger: ComponentLogger;
 
-	/** Map of session name to last activity timestamp (epoch ms) */
+	/** Map of session name to last activity timestamp (epoch ms) — includes both PTY and API */
 	private lastActivityMap: Map<string, number> = new Map();
+
+	/** Map of session name to last API-only activity timestamp (epoch ms) */
+	private lastApiActivityMap: Map<string, number> = new Map();
 
 	private constructor() {
 		this.logger = LoggerService.getInstance().createComponentLogger('PtyActivityTracker');
@@ -57,6 +60,36 @@ export class PtyActivityTrackerService {
 	 */
 	recordActivity(sessionName: string): void {
 		this.lastActivityMap.set(sessionName, Date.now());
+	}
+
+	/**
+	 * Record API-specific activity for a session.
+	 * Called by the agent heartbeat middleware when an actual API call is made.
+	 * Also records general activity.
+	 *
+	 * @param sessionName - The session that made an API call
+	 */
+	recordApiActivity(sessionName: string): void {
+		const now = Date.now();
+		this.lastActivityMap.set(sessionName, now);
+		this.lastApiActivityMap.set(sessionName, now);
+	}
+
+	/**
+	 * Get the API-only idle time in milliseconds for a session.
+	 * Unlike getIdleTimeMs(), this only considers API calls — not PTY output.
+	 * Used by the heartbeat monitor to distinguish real orchestrator responses
+	 * from PTY echo noise (e.g., heartbeat messages echoing back).
+	 *
+	 * @param sessionName - The session to check
+	 * @returns Milliseconds since last API call, or 0 if never recorded
+	 */
+	getApiIdleTimeMs(sessionName: string): number {
+		const lastApi = this.lastApiActivityMap.get(sessionName);
+		if (lastApi === undefined) {
+			return 0;
+		}
+		return Date.now() - lastApi;
 	}
 
 	/**
@@ -128,6 +161,7 @@ export class PtyActivityTrackerService {
 	 */
 	clearSession(sessionName: string): void {
 		this.lastActivityMap.delete(sessionName);
+		this.lastApiActivityMap.delete(sessionName);
 		this.logger.debug('Cleared activity tracking for session', { sessionName });
 	}
 

--- a/backend/src/services/agent/runtime-exit-monitor.service.test.ts
+++ b/backend/src/services/agent/runtime-exit-monitor.service.test.ts
@@ -1,6 +1,6 @@
 import { RuntimeExitMonitorService } from './runtime-exit-monitor.service.js';
 import { OrchestratorRestartService } from '../orchestrator/orchestrator-restart.service.js';
-import { CREWLY_CONSTANTS, RUNTIME_EXIT_CONSTANTS, RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, GEMINI_FAILURE_PATTERNS, GEMINI_FAILURE_RETRY_CONSTANTS } from '../../constants.js';
+import { CREWLY_CONSTANTS, RUNTIME_EXIT_CONSTANTS, RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, GEMINI_FAILURE_PATTERNS, GEMINI_FAILURE_RETRY_CONSTANTS, CLAUDE_FATAL_PATTERNS } from '../../constants.js';
 
 // Mock dependencies
 jest.mock('../core/logger.service.js', () => ({
@@ -1190,6 +1190,103 @@ describe('RuntimeExitMonitorService', () => {
 			expect(pattern).toBeDefined();
 			expect(pattern.test('Automatic update failed due to npm EACCES')).toBe(true);
 			expect(pattern.test('automatic update failed')).toBe(true); // case insensitive
+		});
+	});
+
+	describe('Claude Code fatal error detection (thinking block corruption)', () => {
+		beforeEach(() => {
+			// Include Claude fatal patterns in the mocked exit patterns
+			mockGetExitPatterns.mockReturnValue([
+				/Claude\s+(Code\s+)?exited/i,
+				/Session\s+ended/i,
+				...CLAUDE_FATAL_PATTERNS,
+			]);
+		});
+
+		it('should detect "thinking blocks cannot be modified" as a Claude fatal pattern', () => {
+			const pattern = CLAUDE_FATAL_PATTERNS.find(
+				p => p.source.includes('thinking')
+			);
+			expect(pattern).toBeDefined();
+			expect(pattern!.test(
+				'`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified'
+			)).toBe(true);
+		});
+
+		it('should detect "redacted_thinking blocks cannot be modified" pattern', () => {
+			const pattern = CLAUDE_FATAL_PATTERNS.find(
+				p => p.source.includes('redacted_thinking')
+			);
+			expect(pattern).toBeDefined();
+			expect(pattern!.test(
+				'redacted_thinking blocks cannot be modified. These blocks must remain as they were'
+			)).toBe(true);
+		});
+
+		it('should trigger immediate recovery (no retry) for Claude fatal error on orchestrator', async () => {
+			jest.useFakeTimers();
+
+			// No shell prompt visible — Claude Code is still running but broken
+			const errorOutput = 'API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.3.content.1: `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified."}}';
+			mockCapturePane.mockReturnValue(errorOutput);
+
+			service.startMonitoring(ORCHESTRATOR_SESSION_NAME, RUNTIME_TYPES.CLAUDE_CODE, 'orchestrator');
+			const onDataCallback = mockOnData.mock.calls[0][0];
+
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+			onDataCallback(errorOutput);
+			await jest.advanceTimersByTimeAsync(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 200);
+
+			// Should trigger orchestrator restart immediately (no retry/backoff)
+			expect(mockAttemptRestart).toHaveBeenCalled();
+
+			jest.useRealTimers();
+		});
+
+		it('should trigger immediate recovery for non-orchestrator Claude agent', async () => {
+			jest.useFakeTimers();
+
+			const errorOutput = 'thinking blocks cannot be modified. These blocks must remain as they were in the original response.';
+			mockCapturePane.mockReturnValue(errorOutput);
+
+			service.startMonitoring('claude-dev', RUNTIME_TYPES.CLAUDE_CODE, 'developer');
+			const onDataCallback = mockOnData.mock.calls[0][0];
+
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+			onDataCallback(errorOutput);
+			await jest.advanceTimersByTimeAsync(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 200);
+
+			// Should set status to inactive (no task restart path since no tasks configured)
+			expect(mockUpdateAgentStatus).toHaveBeenCalledWith(
+				'claude-dev',
+				CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE
+			);
+
+			jest.useRealTimers();
+		});
+
+		it('should NOT trigger Claude fatal detection for non-Claude runtimes', async () => {
+			jest.useFakeTimers();
+
+			// Gemini runtime with Claude fatal pattern text but no shell prompt
+			mockCapturePane.mockReturnValue('thinking blocks cannot be modified');
+
+			service.startMonitoring('gemini-agent', RUNTIME_TYPES.GEMINI_CLI, 'developer');
+			const onDataCallback = mockOnData.mock.calls[0][0];
+
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+			onDataCallback('thinking blocks cannot be modified');
+
+			// Advance past debounce but NOT enough for Gemini retry
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 100);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// Should NOT trigger — Gemini runtime doesn't use Claude fatal check
+			expect(mockUpdateAgentStatus).not.toHaveBeenCalled();
+
+			service.stopMonitoring('gemini-agent');
+			jest.useRealTimers();
 		});
 	});
 

--- a/backend/src/services/agent/runtime-exit-monitor.service.test.ts
+++ b/backend/src/services/agent/runtime-exit-monitor.service.test.ts
@@ -1,6 +1,6 @@
 import { RuntimeExitMonitorService } from './runtime-exit-monitor.service.js';
 import { OrchestratorRestartService } from '../orchestrator/orchestrator-restart.service.js';
-import { CREWLY_CONSTANTS, RUNTIME_EXIT_CONSTANTS, RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, GEMINI_FAILURE_PATTERNS, GEMINI_FAILURE_RETRY_CONSTANTS, CLAUDE_FATAL_PATTERNS } from '../../constants.js';
+import { CREWLY_CONSTANTS, RUNTIME_EXIT_CONSTANTS, RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, GEMINI_FAILURE_PATTERNS, GEMINI_FAILURE_RETRY_CONSTANTS, CLAUDE_FATAL_PATTERNS, AGENT_HEARTBEAT_MONITOR_CONSTANTS } from '../../constants.js';
 
 // Mock dependencies
 jest.mock('../core/logger.service.js', () => ({
@@ -718,6 +718,151 @@ describe('RuntimeExitMonitorService', () => {
 			);
 
 			jest.useRealTimers();
+		});
+	});
+
+	describe('restart cooldown (prevents infinite restart loops)', () => {
+		const mockCreateAgentSession = jest.fn().mockResolvedValue({ success: true, sessionName: 'test-agent' });
+		const mockAgentRegistrationService = {
+			createAgentSession: mockCreateAgentSession,
+		};
+		const mockTaskTrackingServiceInstance = {
+			getTasksForTeamMember: mockGetTasksForTeamMember,
+		};
+		const activeTasks = [
+			{ id: 'task-1', taskName: 'Fix bug', taskFilePath: '/tmp/task.md', status: 'assigned', assignedTeamMemberId: 'member-1' },
+		];
+
+		beforeEach(() => {
+			mockCreateAgentSession.mockClear().mockResolvedValue({ success: true, sessionName: 'test-agent' });
+			mockGetTasksForTeamMember.mockReset().mockResolvedValue(activeTasks);
+			mockClearSession.mockClear();
+			mockKillSession.mockClear();
+			mockWrite.mockClear();
+			mockUpdateAgentStatus.mockClear();
+			mockSessionExists.mockReturnValue(true);
+			service.setAgentRegistrationService(mockAgentRegistrationService as any);
+			service.setTaskTrackingService(mockTaskTrackingServiceInstance as any);
+		});
+
+		/**
+		 * Helper: trigger an exit detection cycle for a monitored agent.
+		 * Sends exit pattern data and advances past debounce.
+		 */
+		async function triggerExitCycle(agentName: string): Promise<void> {
+			// Re-register monitoring (previous cycle stopped it)
+			if (!service.isMonitoring(agentName)) {
+				service.startMonitoring(agentName, RUNTIME_TYPES.GEMINI_CLI, 'developer', 'team-1', 'member-1');
+			}
+			const lastCallIndex = mockOnData.mock.calls.length - 1;
+			const onDataCallback = mockOnData.mock.calls[lastCallIndex][0];
+
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+			onDataCallback('Agent powering down');
+			await jest.advanceTimersByTimeAsync(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 200);
+		}
+
+		it('should allow restarts up to MAX_RESTARTS_PER_WINDOW', async () => {
+			jest.useFakeTimers();
+
+			const maxRestarts = AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW;
+
+			for (let i = 0; i < maxRestarts; i++) {
+				mockCreateAgentSession.mockClear();
+				await triggerExitCycle('test-agent');
+				expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
+			}
+
+			jest.useRealTimers();
+		});
+
+		it('should block restarts after MAX_RESTARTS_PER_WINDOW reached', async () => {
+			jest.useFakeTimers();
+
+			const maxRestarts = AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW;
+
+			// Exhaust all allowed restarts
+			for (let i = 0; i < maxRestarts; i++) {
+				await triggerExitCycle('test-agent');
+			}
+
+			// Next restart should be blocked — agent goes inactive instead
+			mockCreateAgentSession.mockClear();
+			mockUpdateAgentStatus.mockClear();
+			await triggerExitCycle('test-agent');
+
+			expect(mockCreateAgentSession).not.toHaveBeenCalled();
+			expect(mockUpdateAgentStatus).toHaveBeenCalledWith(
+				'test-agent',
+				CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE
+			);
+
+			jest.useRealTimers();
+		});
+
+		it('should allow restarts again after cooldown window expires', async () => {
+			jest.useFakeTimers();
+
+			const maxRestarts = AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW;
+
+			// Exhaust all allowed restarts
+			for (let i = 0; i < maxRestarts; i++) {
+				await triggerExitCycle('test-agent');
+			}
+
+			// Advance past the cooldown window
+			jest.advanceTimersByTime(AGENT_HEARTBEAT_MONITOR_CONSTANTS.COOLDOWN_WINDOW_MS + 1000);
+
+			// Should be allowed to restart again
+			mockCreateAgentSession.mockClear();
+			await triggerExitCycle('test-agent');
+
+			expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
+
+			jest.useRealTimers();
+		});
+
+		it('should track restarts per session independently', async () => {
+			jest.useFakeTimers();
+
+			const maxRestarts = AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW;
+
+			// Exhaust restarts for agent-a
+			for (let i = 0; i < maxRestarts; i++) {
+				mockGetTasksForTeamMember.mockResolvedValue(activeTasks);
+				if (!service.isMonitoring('agent-a')) {
+					service.startMonitoring('agent-a', RUNTIME_TYPES.GEMINI_CLI, 'developer', 'team-1', 'member-a');
+				}
+				const callIdx = mockOnData.mock.calls.length - 1;
+				const cb = mockOnData.mock.calls[callIdx][0];
+				jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+				cb('Agent powering down');
+				await jest.advanceTimersByTimeAsync(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 200);
+			}
+
+			// agent-b should still be able to restart
+			mockCreateAgentSession.mockClear();
+			mockGetTasksForTeamMember.mockResolvedValue(activeTasks);
+			service.startMonitoring('agent-b', RUNTIME_TYPES.GEMINI_CLI, 'developer', 'team-1', 'member-b');
+			const cbIdx = mockOnData.mock.calls.length - 1;
+			const cbB = mockOnData.mock.calls[cbIdx][0];
+			jest.advanceTimersByTime(RUNTIME_EXIT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 100);
+			cbB('Agent powering down');
+			await jest.advanceTimersByTimeAsync(RUNTIME_EXIT_CONSTANTS.CONFIRMATION_DELAY_MS + 200);
+
+			expect(mockCreateAgentSession).toHaveBeenCalledTimes(1);
+
+			jest.useRealTimers();
+		});
+
+		it('should clear restartHistory on destroy', () => {
+			// Pre-populate restart history via private access
+			(service as any).restartHistory.set('test-agent', [Date.now()]);
+			expect((service as any).restartHistory.size).toBe(1);
+
+			service.destroy();
+
+			expect((service as any).restartHistory.size).toBe(0);
 		});
 	});
 

--- a/backend/src/services/agent/runtime-exit-monitor.service.test.ts
+++ b/backend/src/services/agent/runtime-exit-monitor.service.test.ts
@@ -2,6 +2,16 @@ import { RuntimeExitMonitorService } from './runtime-exit-monitor.service.js';
 import { OrchestratorRestartService } from '../orchestrator/orchestrator-restart.service.js';
 import { CREWLY_CONSTANTS, RUNTIME_EXIT_CONSTANTS, RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, GEMINI_FAILURE_PATTERNS, GEMINI_FAILURE_RETRY_CONSTANTS, CLAUDE_FATAL_PATTERNS, AGENT_HEARTBEAT_MONITOR_CONSTANTS } from '../../constants.js';
 
+// Mock http module to prevent real HTTP requests during tests (e.g. notifyOrchestratorOfFailure)
+jest.mock('http', () => ({
+	...jest.requireActual('http'),
+	request: jest.fn().mockReturnValue({
+		on: jest.fn().mockReturnThis(),
+		write: jest.fn(),
+		end: jest.fn(),
+	}),
+}));
+
 // Mock dependencies
 jest.mock('../core/logger.service.js', () => ({
 	LoggerService: {
@@ -1231,18 +1241,9 @@ describe('RuntimeExitMonitorService', () => {
 	describe('notifyOrchestratorOfFailure (via private access)', () => {
 		it('should build correct message with active tasks and restart succeeded', () => {
 			const notify = (service as any).notifyOrchestratorOfFailure.bind(service);
-			// Spy on the http dynamic import to capture the request body
-			const httpRequestSpy = jest.fn().mockReturnValue({
-				on: jest.fn(),
-				write: jest.fn(),
-				end: jest.fn(),
-			});
-			jest.mock('http', () => ({
-				request: httpRequestSpy,
-			}), { virtual: true });
 
 			// notifyOrchestratorOfFailure is fire-and-forget, so we verify
-			// it does not throw for various inputs
+			// it does not throw for various inputs (http is mocked at module level)
 			expect(() => notify(
 				'agent-sam',
 				'runtime_exited',

--- a/backend/src/services/agent/runtime-exit-monitor.service.ts
+++ b/backend/src/services/agent/runtime-exit-monitor.service.ts
@@ -35,6 +35,7 @@ import {
 	GEMINI_FAILURE_RETRY_CONSTANTS,
 	GEMINI_READY_PATTERNS,
 	WEB_CONSTANTS,
+	AGENT_HEARTBEAT_MONITOR_CONSTANTS,
 	type RuntimeType,
 } from '../../constants.js';
 import { delay } from '../../utils/async.utils.js';
@@ -98,6 +99,14 @@ export class RuntimeExitMonitorService {
 	private agentRegistrationService: AgentRegistrationService | null = null;
 	private taskTrackingService: TaskTrackingService | null = null;
 	private eventBusService: EventBusService | null = null;
+
+	/**
+	 * Restart timestamps per session, persisted across monitoring cycles.
+	 * Unlike MonitoredSession (which is recreated on each startMonitoring call),
+	 * this map survives agent restarts to prevent infinite restart loops
+	 * when agents keep crashing (e.g. during network outages).
+	 */
+	private restartHistory = new Map<string, number[]>();
 
 	private constructor() {
 		this.logger = LoggerService.getInstance().createComponentLogger('RuntimeExitMonitorService');
@@ -286,6 +295,7 @@ export class RuntimeExitMonitorService {
 		for (const sessionName of sessionNames) {
 			this.stopMonitoring(sessionName);
 		}
+		this.restartHistory.clear();
 		this.logger.debug('All runtime exit monitors destroyed');
 	}
 
@@ -446,26 +456,42 @@ export class RuntimeExitMonitorService {
 					);
 
 					if (activeTasks.length > 0) {
-						this.logger.info('Runtime exit with in-progress tasks, attempting restart', {
-							sessionName,
-							activeTaskCount: activeTasks.length,
-						});
-
-						try {
-							await this.restartAgentWithTasks(sessionName, monitored, activeTasks);
-							// Notify orchestrator that agent was restarted (#129)
-							this.notifyOrchestratorOfFailure(sessionName, 'runtime_exited', activeTasks, true);
-							// Cleanup this subscription (restart succeeded, skip inactive flow)
-							this.stopMonitoring(sessionName);
-							return;
-						} catch (restartError) {
-							this.logger.warn('Agent restart after runtime exit failed, falling back to inactive', {
+						// Check cooldown before attempting restart to prevent infinite
+						// restart loops (e.g. during network outages where agents keep crashing)
+						if (!this.isAgentRestartAllowed(sessionName)) {
+							this.logger.warn('Agent restart cooldown active, skipping restart', {
 								sessionName,
-								error: restartError instanceof Error ? restartError.message : String(restartError),
+								activeTaskCount: activeTasks.length,
+								maxRestartsPerWindow: AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW,
+								cooldownWindowMs: AGENT_HEARTBEAT_MONITOR_CONSTANTS.COOLDOWN_WINDOW_MS,
 							});
-							// Notify orchestrator that restart failed — needs manual intervention (#129)
-							this.notifyOrchestratorOfFailure(sessionName, 'runtime_exited', activeTasks, false);
+							this.notifyOrchestratorOfFailure(sessionName, 'runtime_exited_cooldown', activeTasks, false);
 							// Fall through to normal inactive flow
+						} else {
+							this.logger.info('Runtime exit with in-progress tasks, attempting restart', {
+								sessionName,
+								activeTaskCount: activeTasks.length,
+							});
+
+							try {
+								await this.restartAgentWithTasks(sessionName, monitored, activeTasks);
+								this.recordAgentRestart(sessionName);
+								// Notify orchestrator that agent was restarted (#129)
+								this.notifyOrchestratorOfFailure(sessionName, 'runtime_exited', activeTasks, true);
+								// Cleanup this subscription (restart succeeded, skip inactive flow)
+								this.stopMonitoring(sessionName);
+								return;
+							} catch (restartError) {
+								this.logger.warn('Agent restart after runtime exit failed, falling back to inactive', {
+									sessionName,
+									error: restartError instanceof Error ? restartError.message : String(restartError),
+								});
+								// Record the attempt even on failure to prevent rapid retry loops
+								this.recordAgentRestart(sessionName);
+								// Notify orchestrator that restart failed — needs manual intervention (#129)
+								this.notifyOrchestratorOfFailure(sessionName, 'runtime_exited', activeTasks, false);
+								// Fall through to normal inactive flow
+							}
 						}
 					}
 				} catch (error) {
@@ -946,6 +972,37 @@ export class RuntimeExitMonitorService {
 		} catch {
 			return false;
 		}
+	}
+
+	/**
+	 * Check if an agent restart is allowed based on cooldown window.
+	 * Prevents infinite restart loops when agents keep crashing (e.g. during
+	 * network outages). Uses the same limits as AgentHeartbeatMonitorService.
+	 *
+	 * @param sessionName - PTY session name
+	 * @returns True if restart is allowed, false if cooldown is active
+	 */
+	private isAgentRestartAllowed(sessionName: string): boolean {
+		const now = Date.now();
+		const windowStart = now - AGENT_HEARTBEAT_MONITOR_CONSTANTS.COOLDOWN_WINDOW_MS;
+		const timestamps = this.restartHistory.get(sessionName) || [];
+
+		// Prune old timestamps outside the cooldown window
+		const recent = timestamps.filter(ts => ts > windowStart);
+		this.restartHistory.set(sessionName, recent);
+
+		return recent.length < AGENT_HEARTBEAT_MONITOR_CONSTANTS.MAX_RESTARTS_PER_WINDOW;
+	}
+
+	/**
+	 * Record a restart attempt for cooldown tracking.
+	 *
+	 * @param sessionName - PTY session name
+	 */
+	private recordAgentRestart(sessionName: string): void {
+		const timestamps = this.restartHistory.get(sessionName) || [];
+		timestamps.push(Date.now());
+		this.restartHistory.set(sessionName, timestamps);
 	}
 
 	/**

--- a/backend/src/services/agent/runtime-exit-monitor.service.ts
+++ b/backend/src/services/agent/runtime-exit-monitor.service.ts
@@ -31,6 +31,7 @@ import {
 	RUNTIME_TYPES,
 	GEMINI_FAILURE_PATTERNS,
 	GEMINI_FORCE_RESTART_PATTERNS,
+	CLAUDE_FATAL_PATTERNS,
 	GEMINI_FAILURE_RETRY_CONSTANTS,
 	GEMINI_READY_PATTERNS,
 	WEB_CONSTANTS,
@@ -76,6 +77,10 @@ interface MonitoredSession {
  * quota exhaustion, network issues) that indicate the CLI is stuck and
  * needs recovery. These failure patterns bypass the shell prompt verification
  * since the CLI may still be running but non-functional.
+ *
+ * For Claude Code, the service detects fatal API errors (e.g. thinking
+ * block corruption) that make the CLI permanently non-functional within
+ * the current session. These trigger immediate recovery without retry.
  *
  * @example
  * ```typescript
@@ -333,6 +338,10 @@ export class RuntimeExitMonitorService {
 	 * dead. Gemini CLI often recovers automatically from transient API errors
 	 * (RESOURCE_EXHAUSTED, UNAVAILABLE, Connection error). Only after
 	 * MAX_RETRIES does the system proceed with the exit/restart flow.
+	 *
+	 * For Claude Code fatal patterns (thinking block corruption, etc.),
+	 * the system skips retry and forces immediate recovery since these
+	 * errors are permanently unrecoverable within the same session.
 	 */
 	private async confirmAndReact(
 		sessionName: string,
@@ -362,14 +371,28 @@ export class RuntimeExitMonitorService {
 					// fall through to exit/restart handling below
 				}
 
-				// For Gemini CLI: detect either retryable failure patterns or forced
+				// Claude Code: detect fatal API errors that make the CLI permanently
+			// non-functional (e.g. thinking block corruption). These are unrecoverable
+			// — no retry will help, immediate restart is required.
+			const isClaudeFatal = monitored.runtimeType === RUNTIME_TYPES.CLAUDE_CODE
+				&& CLAUDE_FATAL_PATTERNS.some((pattern) => pattern.test(monitored.buffer));
+			if (isClaudeFatal) {
+				const detectedPattern = CLAUDE_FATAL_PATTERNS.find((p) => p.test(monitored.buffer))?.source;
+				this.logger.warn('Claude Code fatal error detected, forcing immediate recovery', {
+					sessionName,
+					detectedPattern,
+				});
+				// fall through to exit/restart handling below (no retry)
+			}
+
+			// For Gemini CLI: detect either retryable failure patterns or forced
 				// restart/update markers that require immediate recovery handling.
 				const isGeminiFailure = monitored.runtimeType === RUNTIME_TYPES.GEMINI_CLI
 					&& GEMINI_FAILURE_PATTERNS.some((pattern) => pattern.test(monitored.buffer));
 				const isGeminiForceRestart = monitored.runtimeType === RUNTIME_TYPES.GEMINI_CLI
 					&& GEMINI_FORCE_RESTART_PATTERNS.some((pattern) => pattern.test(monitored.buffer));
 
-				if (!isGeminiFailure && !isGeminiForceRestart && !isCodexInterrupted) {
+				if (!isGeminiFailure && !isGeminiForceRestart && !isCodexInterrupted && !isClaudeFatal) {
 					this.logger.debug('Exit pattern matched but shell prompt not confirmed, ignoring', { sessionName });
 					return;
 				}

--- a/backend/src/services/continuation/output-analyzer.service.test.ts
+++ b/backend/src/services/continuation/output-analyzer.service.test.ts
@@ -207,7 +207,7 @@ describe('OutputAnalyzer', () => {
 
   describe('detectIdleState', () => {
     it('should detect shell prompt', () => {
-      const output = 'Some output here\n$ ';
+      const output = 'Some output here\nuser@host:~/project$ ';
       expect(analyzer.detectIdleState(output)).toBe(true);
     });
 
@@ -293,7 +293,7 @@ describe('OutputAnalyzer', () => {
     });
 
     it('should return INCOMPLETE when session is idle', async () => {
-      const output = 'Task started...\nDone with part 1.\n$ ';
+      const output = 'Task started...\nDone with part 1.\nuser@host:~/project$ ';
       const analysis = await analyzer.analyze('test-session', output);
 
       expect(analysis.conclusion).toBe('INCOMPLETE');
@@ -368,7 +368,7 @@ describe('OutputAnalyzer', () => {
     });
 
     it('should handle very long output', async () => {
-      const longOutput = 'Log line\n'.repeat(10000) + '$ ';
+      const longOutput = 'Log line\n'.repeat(10000) + 'user@host:~/project$ ';
       const analysis = await analyzer.analyze('test-session', longOutput);
       expect(analysis.conclusion).toBe('INCOMPLETE'); // Detected shell prompt
     });

--- a/backend/src/services/continuation/patterns/idle-patterns.ts
+++ b/backend/src/services/continuation/patterns/idle-patterns.ts
@@ -8,15 +8,29 @@
  */
 
 /**
- * Patterns indicating shell prompt is visible (agent returned to shell)
+ * Patterns indicating shell prompt is visible (agent returned to shell).
+ *
+ * IMPORTANT: These patterns run against `tmux capture-pane` output to verify
+ * that an agent CLI has actually exited back to the shell. They must be
+ * specific enough to avoid false positives from normal CLI output (e.g.,
+ * markdown `>` blockquotes, `$variable` references, `100%` progress bars).
+ *
+ * Each pattern requires a prompt-like prefix (username, path, or start-of-line)
+ * to distinguish real shell prompts from incidental occurrences in output text.
  */
 export const SHELL_PROMPT_PATTERNS: RegExp[] = [
-  /\$\s*$/m,
-  />\s*$/m,
+  // user@host:path$ or ~/path$  (bash-style prompts)
+  /[~\/\w].*\$\s*$/m,
+  // user@host:path> or C:\path> (cmd/powershell-style prompts — requires path prefix)
+  /[~\/\\:\w].*>\s*$/m,
+  // ❯ is almost exclusively a shell prompt indicator (starship, powerline)
   /❯\s*$/m,
-  /%\s*$/m,
+  // user@host:path% or host% (zsh-style prompts — requires prefix)
+  /[~\/\w].*%\s*$/m,
+  // Explicit versioned prompts
   /bash-\d+\.\d+\$\s*$/m,
   /zsh.*%\s*$/m,
+  // Gemini CLI ready indicators
   /Type\s+your\s+message/i,
   /YOLO\s+mode/i,
 ];

--- a/backend/src/services/event-bus/event-bus.service.test.ts
+++ b/backend/src/services/event-bus/event-bus.service.test.ts
@@ -200,6 +200,46 @@ describe('EventBusService', () => {
       expect(mockQueueService.enqueue).not.toHaveBeenCalled();
     });
 
+    it('should not deliver self-events (subscriber === event source)', () => {
+      // Orchestrator subscribes to all events with empty filter
+      eventBus.subscribe(createTestSubscriptionInput({
+        eventType: ['agent:idle', 'agent:busy'],
+        filter: {},
+        subscriberSession: 'crewly-orc',
+      }));
+      // Event from the orchestrator itself
+      eventBus.publish(createTestEvent({
+        sessionName: 'crewly-orc',
+        memberName: 'Orchestrator',
+        type: 'agent:busy',
+      }));
+
+      jest.advanceTimersByTime(5000);
+
+      // Should NOT be delivered — subscriber === event source
+      expect(mockQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should deliver events from other agents to subscriber', () => {
+      // Orchestrator subscribes to all events
+      eventBus.subscribe(createTestSubscriptionInput({
+        eventType: ['agent:idle', 'agent:busy'],
+        filter: {},
+        subscriberSession: 'crewly-orc',
+      }));
+      // Event from a different agent
+      eventBus.publish(createTestEvent({
+        sessionName: 'agent-sam',
+        memberName: 'Sam',
+        type: 'agent:idle',
+      }));
+
+      jest.advanceTimersByTime(5000);
+
+      // Should be delivered — different session
+      expect(mockQueueService.enqueue).toHaveBeenCalledTimes(1);
+    });
+
     it('should remove one-shot subscription after delivery', () => {
       eventBus.subscribe(createTestSubscriptionInput({ oneShot: true }));
       expect(eventBus.listSubscriptions()).toHaveLength(1);

--- a/backend/src/services/event-bus/event-bus.service.ts
+++ b/backend/src/services/event-bus/event-bus.service.ts
@@ -412,6 +412,12 @@ export class EventBusService extends EventEmitter {
    * @returns True if the event matches the subscription
    */
   private matchesSubscription(event: AgentEvent, sub: EventSubscription): boolean {
+    // Skip self-events: don't deliver events to the session that generated them.
+    // e.g. the orchestrator should not receive its own agent:busy/agent:idle events.
+    if (sub.subscriberSession && event.sessionName === sub.subscriberSession) {
+      return false;
+    }
+
     // Match event type
     const types = Array.isArray(sub.eventType) ? sub.eventType : [sub.eventType];
     if (!types.includes(event.type)) {

--- a/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.test.ts
+++ b/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.test.ts
@@ -97,8 +97,9 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 			mockSessionBackend as any,
 		);
 
-		// Record initial activity so the tracker has a baseline
-		PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+		// Record initial API activity so the tracker has a baseline.
+		// The heartbeat monitor now uses getApiIdleTimeMs() to verify responses.
+		PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 	});
 
 	afterEach(() => {
@@ -195,8 +196,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 			service.start();
 			jest.advanceTimersByTime(ORCHESTRATOR_HEARTBEAT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 1);
 
-			// Record recent activity
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Record recent API activity (heartbeat monitor checks API idle time, not PTY)
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 
 			await service.performCheck();
 
@@ -252,8 +253,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 			await performCheckAndFlush(service);
 			expect(service.getState().heartbeatRequestSentAt).not.toBeNull();
 
-			// Simulate orchestrator responding
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Simulate orchestrator responding (must be API activity, not just PTY echo)
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 			await service.performCheck();
 
 			expect(service.getState().heartbeatRequestSentAt).toBeNull();
@@ -398,8 +399,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 
 			jest.advanceTimersByTime(ORCHESTRATOR_HEARTBEAT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 1);
 
-			// Record recent activity so idleTime is low
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Record recent API activity so apiIdleTime is low
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 
 			await service.performCheck();
 
@@ -412,8 +413,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 
 			jest.advanceTimersByTime(ORCHESTRATOR_HEARTBEAT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 1);
 
-			// Record activity so idleTime is low
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Record API activity so apiIdleTime is low
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 
 			// First performCheck sets inProgressSince
 			await service.performCheck();
@@ -422,8 +423,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 			// Backdate inProgressSince to simulate being stuck past the timeout
 			(service as any).inProgressSince = Date.now() - ORCHESTRATOR_HEARTBEAT_CONSTANTS.IN_PROGRESS_TIMEOUT_MS - 1;
 
-			// Record activity again so idleTime stays low on the next check
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Record API activity again so apiIdleTime stays low on the next check
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 
 			await performCheckAndFlush(service);
 
@@ -443,8 +444,8 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 
 			jest.advanceTimersByTime(ORCHESTRATOR_HEARTBEAT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 1);
 
-			// Record activity, performCheck sets inProgressSince
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			// Record API activity, performCheck sets inProgressSince
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 			await service.performCheck();
 			expect(service.getState().inProgressSince).not.toBeNull();
 
@@ -463,7 +464,7 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 
 			jest.advanceTimersByTime(ORCHESTRATOR_HEARTBEAT_CONSTANTS.STARTUP_GRACE_PERIOD_MS + 1);
 
-			PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+			PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
 			await service.performCheck();
 			expect(service.getState().inProgressSince).not.toBeNull();
 

--- a/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.ts
+++ b/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.ts
@@ -245,12 +245,19 @@ export class OrchestratorHeartbeatMonitorService {
 
 		const activityTracker = PtyActivityTrackerService.getInstance();
 		const idleTimeMs = activityTracker.getIdleTimeMs(ORCHESTRATOR_SESSION_NAME);
+		// Use API-specific idle time for heartbeat response detection.
+		// PTY activity alone is unreliable because heartbeat messages written
+		// to the PTY echo back and reset the general activity timer.
+		const apiIdleTimeMs = activityTracker.getApiIdleTimeMs(ORCHESTRATOR_SESSION_NAME);
 
-		// If recent activity detected, clear any pending heartbeat request
-		if (idleTimeMs < ORCHESTRATOR_HEARTBEAT_CONSTANTS.HEARTBEAT_REQUEST_THRESHOLD_MS) {
+		// If recent API activity detected, clear any pending heartbeat request.
+		// Only API calls count as proof that the orchestrator is responsive —
+		// PTY output alone may just be echoed heartbeat messages.
+		if (apiIdleTimeMs < ORCHESTRATOR_HEARTBEAT_CONSTANTS.HEARTBEAT_REQUEST_THRESHOLD_MS) {
 			if (this.heartbeatRequestSentAt !== null) {
-				this.logger.info('Orchestrator responded to heartbeat request, clearing pending state');
+				this.logger.info('Orchestrator responded to heartbeat request (API activity detected), clearing pending state');
 				this.heartbeatRequestSentAt = null;
+				this.heartbeatRequestCount = 0;
 			}
 
 			// Track continuous in_progress duration. Spinner animation counts as
@@ -285,16 +292,32 @@ export class OrchestratorHeartbeatMonitorService {
 				this.logger.warn('Orchestrator did not respond to heartbeat request, triggering auto-restart', {
 					timeSinceRequestMs: timeSinceRequest,
 					idleTimeMs,
+					apiIdleTimeMs,
 					heartbeatRequestCount: this.heartbeatRequestCount,
 				});
 
 				this.heartbeatRequestSentAt = null;
+				this.heartbeatRequestCount = 0;
 				await this.triggerAutoRestart();
 			}
 			return;
 		}
 
-		// No activity for HEARTBEAT_REQUEST_THRESHOLD_MS. If there's no queued
+		// Cap consecutive heartbeat requests to prevent spam when the
+		// orchestrator is stuck (e.g., ENOSPC). After MAX attempts without
+		// a real API response, trigger auto-restart instead.
+		const MAX_HEARTBEAT_REQUESTS = 3;
+		if (this.heartbeatRequestCount >= MAX_HEARTBEAT_REQUESTS) {
+			this.logger.warn('Max heartbeat requests reached without API response, triggering auto-restart', {
+				heartbeatRequestCount: this.heartbeatRequestCount,
+				apiIdleTimeMs,
+			});
+			this.heartbeatRequestCount = 0;
+			await this.triggerAutoRestart();
+			return;
+		}
+
+		// No API activity for HEARTBEAT_REQUEST_THRESHOLD_MS. If there's no queued
 		// work, skip synthetic heartbeat pings to avoid idle token burn.
 		const pendingWork = this.hasPendingWork ? this.hasPendingWork() : true;
 		if (!pendingWork) {
@@ -303,8 +326,10 @@ export class OrchestratorHeartbeatMonitorService {
 		}
 
 		// Otherwise, send a heartbeat request.
-		this.logger.info('Orchestrator idle, sending heartbeat request', {
+		this.logger.info('Orchestrator idle (no API activity), sending heartbeat request', {
 			idleTimeMs,
+			apiIdleTimeMs,
+			heartbeatRequestCount: this.heartbeatRequestCount,
 		});
 
 		await this.sendHeartbeatRequest();

--- a/backend/src/services/workflow/scheduler.service.test.ts
+++ b/backend/src/services/workflow/scheduler.service.test.ts
@@ -901,7 +901,7 @@ describe('SchedulerService', () => {
       expect(service.getStats().recurringChecks).toBe(0);
     });
 
-    it('should not auto-cancel recurring checks for orchestrator session when idle', async () => {
+    it('should auto-cancel recurring checks for orchestrator session after 3 idle hits', async () => {
       const mockActivityMonitor = {
         getWorkingStatusForSession: jest.fn().mockResolvedValue('idle'),
       };
@@ -915,16 +915,20 @@ describe('SchedulerService', () => {
         }
       };
 
+      // Idle hit 1 — check still executes
       jest.advanceTimersByTime(60000);
       await flushMicrotasks();
+      // Idle hit 2 — check still executes
       jest.advanceTimersByTime(60000);
       await flushMicrotasks();
+      // Idle hit 3 — auto-cancelled before execution
       jest.advanceTimersByTime(60000);
       await flushMicrotasks();
 
-      expect(service.getStats().recurringChecks).toBe(1);
-      expect(mockAgentRegistrationService.sendMessageToAgent).toHaveBeenCalledTimes(3);
-      expect(mockActivityMonitor.getWorkingStatusForSession).not.toHaveBeenCalled();
+      // Should be auto-cancelled after 3 idle hits
+      expect(service.getStats().recurringChecks).toBe(0);
+      // Only 2 executions (hit 3 was cancelled before execution)
+      expect(mockActivityMonitor.getWorkingStatusForSession).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/workflow/scheduler.service.ts
+++ b/backend/src/services/workflow/scheduler.service.ts
@@ -19,7 +19,7 @@ import { StorageService } from '../core/storage.service.js';
 import { MessageDeliveryLogModel } from '../../models/ScheduledMessage.js';
 import { LoggerService, ComponentLogger } from '../core/logger.service.js';
 import { AgentRegistrationService } from '../agent/agent-registration.service.js';
-import { RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, RuntimeType } from '../../constants.js';
+import { RUNTIME_TYPES, ORCHESTRATOR_SESSION_NAME, RuntimeType, type MessageSource } from '../../constants.js';
 import {
   ScheduledMessageType,
   EnhancedScheduledMessage,
@@ -58,6 +58,12 @@ interface IActivityMonitorLike {
  */
 interface ITaskTrackingServiceLike {
   getAllInProgressTasks(): Promise<{ id: string; status: string; scheduleIds?: string[] }[]>;
+}
+
+/** Minimal interface for MessageQueueService to avoid circular imports. */
+interface IMessageQueueServiceLike {
+  enqueue(input: { content: string; conversationId: string; source: MessageSource; sourceMetadata?: Record<string, string> }): unknown;
+  isProcessing(): boolean;
 }
 
 /**
@@ -139,6 +145,7 @@ export class SchedulerService extends EventEmitter {
   private activityMonitor: IActivityMonitorLike | null = null;
   private agentRegistrationService: AgentRegistrationService | null = null;
   private taskTrackingService: ITaskTrackingServiceLike | null = null;
+  private messageQueueService: IMessageQueueServiceLike | null = null;
 
   // Per-session delivery guard: prevents concurrent deliveries to the same session.
   // When multiple scheduled checks fire simultaneously (e.g., 25+ checks at once),
@@ -230,6 +237,19 @@ export class SchedulerService extends EventEmitter {
   public setTaskTrackingService(service: ITaskTrackingServiceLike): void {
     this.taskTrackingService = service;
     this.logger.info('TaskTrackingService integration enabled for task-aware cleanup');
+  }
+
+  /**
+   * Set the MessageQueueService for serialized orchestrator delivery.
+   * When set, scheduled checks targeting the orchestrator are routed through
+   * the queue instead of direct PTY delivery, preventing interruption of
+   * in-flight chat messages.
+   *
+   * @param service - MessageQueueService instance (must have enqueue method)
+   */
+  public setMessageQueueService(service: IMessageQueueServiceLike): void {
+    this.messageQueueService = service;
+    this.logger.info('MessageQueueService integration enabled for orchestrator delivery serialization');
   }
 
   /**
@@ -833,6 +853,31 @@ export class SchedulerService extends EventEmitter {
    * @param message - Message to send
    */
   private async executeCheck(targetSession: string, message: string): Promise<void> {
+    // Route orchestrator-targeted checks through the message queue when available.
+    // This prevents scheduled checks from interrupting in-flight chat messages
+    // (Slack, WhatsApp, web) that the queue processor is currently delivering.
+    if (targetSession === ORCHESTRATOR_SESSION_NAME && this.messageQueueService) {
+      try {
+        this.messageQueueService.enqueue({
+          content: message,
+          conversationId: 'scheduler',
+          source: 'system_event',
+          sourceMetadata: { origin: 'scheduler' },
+        });
+        this.logger.info('Scheduled check enqueued via message queue for orchestrator', {
+          targetSession,
+          messageLength: message.length,
+        });
+        return;
+      } catch (enqueueError) {
+        this.logger.warn('Failed to enqueue scheduled check, falling back to direct delivery', {
+          targetSession,
+          error: enqueueError instanceof Error ? enqueueError.message : String(enqueueError),
+        });
+        // Fall through to direct delivery
+      }
+    }
+
     // Per-session guard: skip if a delivery to this session is already in progress.
     // Prevents flood-delivering when multiple scheduled checks fire simultaneously,
     // which causes 25+ concurrent Ctrl+C presses that crash the runtime.
@@ -1015,8 +1060,10 @@ export class SchedulerService extends EventEmitter {
 
       // Auto-cancel stale recurring checks when the target stays idle.
       // This avoids indefinite "check again" loops for agents that are no
-      // longer actively working on a task.
-      if (this.activityMonitor && targetSession !== ORCHESTRATOR_SESSION_NAME) {
+      // longer actively working on a task. Applies to ALL sessions including
+      // the orchestrator — if the orchestrator has been idle across 3 check
+      // intervals it means nobody is acting on these checks.
+      if (this.activityMonitor) {
         try {
           const status = await this.activityMonitor.getWorkingStatusForSession(targetSession);
           if (status === 'idle') {

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -334,6 +334,8 @@ Every time you send work to an agent (via `delegate-task`, `send-message`, or an
 
 **Never skip steps 1 and 2.** If you tell the user you'll monitor something, you must back that up with actual bash script calls in the same turn.
 
+**NEVER use `sleep` in bash commands to delay checks.** Commands like `sleep 90 && bash get-agent-logs/execute.sh ...` waste a Bash tool slot for the entire sleep duration and block other work. Always use the `schedule-check` skill to schedule future checks — it uses the backend scheduler API and returns immediately.
+
 ### When You Receive an `[EVENT:...]` Notification
 
 Event notifications arrive in your terminal like this:
@@ -449,6 +451,8 @@ bash config/skills/orchestrator/get-agent-logs/execute.sh '{"sessionName":"...",
 ```
 
 **Never run**: `tmux list-sessions`, `tmux attach`, etc. - these will not work.
+
+**Never run**: `sleep N && bash ...` — this blocks a tool call for N seconds doing nothing. Use `schedule-check` to schedule delayed checks via the backend API.
 
 ## Chat & Slack Communication
 


### PR DESCRIPTION
## Summary

Fixes four related issues causing agent interruptions and unwanted restarts:

- **False-positive exit detection**: `SHELL_PROMPT_PATTERNS` had an overly broad `/>\\s*$/m` pattern that matched any line ending with `>` (markdown blockquotes, HTML tags, etc.), causing running agents to be falsely detected as exited and triggering unnecessary restarts with "Begin your work now" re-registration
- **Scheduled check interrupts chat**: Progress checks were delivered directly to the orchestrator PTY, bypassing the message queue. This caused them to interrupt in-flight Slack/WhatsApp/web chat messages
- **Stale checks never cancelled for orchestrator**: The idle auto-cancel policy (3 consecutive idle hits) was explicitly skipped for orchestrator-targeted sessions, so stale progress checks would fire indefinitely even when the orchestrator reported them as stale
- **start-team restarts already-active agents (#133)**: `startTeam()` blindly set all members to `starting` status before checking if they were already active, causing guards to malfunction and `createAgentSession` to be called on running agents, killing their sessions and losing context

### Changes

1. **Tighten shell prompt patterns** (`idle-patterns.ts`):
   - `$`, `>`, `%` patterns now require a path/username prefix (e.g., `~/path$`, `user@host>`)
   - Prevents false matches against CLI output containing these characters

2. **Route orchestrator checks through message queue** (`scheduler.service.ts`):
   - Added `setMessageQueueService()` setter
   - When queue is available, orchestrator-targeted checks are enqueued as `system_event` instead of direct PTY delivery
   - Ensures checks wait for in-flight messages to complete

3. **Remove orchestrator exemption from auto-cancel** (`scheduler.service.ts`):
   - All sessions now subject to 3-idle-hit auto-cancel
   - Updated test to reflect new behavior

4. **Skip already-active agents during start-team** (`team.controller.ts`, fixes #133):
   - `startTeam()` only sets inactive members to `starting`, skips active ones
   - Loop verifies live tmux session for active members, returns `already_running`
   - `startTeamMember()` adds early return for active members with verified sessions
   - `_startTeamMemberCore()` restores status to `active` when returning `already_active`
   - Updated output-analyzer tests for tightened shell prompt patterns

## Test plan
- [x] All 79 scheduler tests pass (including updated orchestrator auto-cancel test)
- [x] All 50 runtime-exit-monitor tests pass
- [x] All 23 continuation pattern tests pass
- [x] All 64 team controller tests pass (including 2 new tests for #133)
- [x] All 44 output-analyzer tests pass (updated shell prompt expectations)
- [x] Full build succeeds (backend, frontend, CLI)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)