### PR TITLE
fix: heartbeat fires during active skill execution

### DIFF
--- a/backend/src/services/messaging/queue-processor.service.test.ts
+++ b/backend/src/services/messaging/queue-processor.service.test.ts
@@ -11,11 +11,13 @@ import { ResponseRouterService } from './response-router.service.js';
 
 // Mock PtyActivityTrackerService
 const mockRecordActivity = jest.fn();
+const mockRecordApiActivity = jest.fn();
 let mockIdleTimeMs = 0;
 jest.mock('../agent/pty-activity-tracker.service.js', () => ({
   PtyActivityTrackerService: {
     getInstance: () => ({
       recordActivity: mockRecordActivity,
+      recordApiActivity: mockRecordApiActivity,
       getIdleTimeMs: jest.fn().mockImplementation(() => mockIdleTimeMs),
     }),
   },
@@ -766,11 +768,11 @@ describe('QueueProcessorService', () => {
 
       // Keepalive interval is HEARTBEAT_REQUEST_THRESHOLD_MS / 2 = 150000ms
       // Advance past one keepalive tick
-      mockRecordActivity.mockClear();
+      mockRecordApiActivity.mockClear();
       jest.advanceTimersByTime(150_000);
 
-      expect(mockRecordActivity).toHaveBeenCalledWith('crewly-orc');
-      const callCountDuringProcessing = mockRecordActivity.mock.calls.length;
+      expect(mockRecordApiActivity).toHaveBeenCalledWith('crewly-orc');
+      const callCountDuringProcessing = mockRecordApiActivity.mock.calls.length;
       expect(callCountDuringProcessing).toBeGreaterThanOrEqual(1);
 
       // Simulate response to complete processing
@@ -786,9 +788,9 @@ describe('QueueProcessorService', () => {
       await flushPromises();
 
       // Clear mock and advance another keepalive period — should NOT fire again
-      mockRecordActivity.mockClear();
+      mockRecordApiActivity.mockClear();
       jest.advanceTimersByTime(150_000);
-      expect(mockRecordActivity).not.toHaveBeenCalled();
+      expect(mockRecordApiActivity).not.toHaveBeenCalled();
     });
 
     it('should clear keepalive interval even on processing error', async () => {
@@ -811,9 +813,9 @@ describe('QueueProcessorService', () => {
       await flushPromises();
 
       // Processing should be done (error path). Verify keepalive is cleared.
-      mockRecordActivity.mockClear();
+      mockRecordApiActivity.mockClear();
       jest.advanceTimersByTime(150_000);
-      expect(mockRecordActivity).not.toHaveBeenCalled();
+      expect(mockRecordApiActivity).not.toHaveBeenCalled();
     });
 
     it('should increment retryCount on each requeue', async () => {

--- a/backend/src/services/messaging/queue-processor.service.ts
+++ b/backend/src/services/messaging/queue-processor.service.ts
@@ -182,7 +182,7 @@ export class QueueProcessorService extends EventEmitter {
     // one activity ping before the monitor considers the orchestrator idle.
     const KEEPALIVE_INTERVAL_MS = ORCHESTRATOR_HEARTBEAT_CONSTANTS.HEARTBEAT_REQUEST_THRESHOLD_MS / 2;
     const keepaliveInterval = setInterval(() => {
-      PtyActivityTrackerService.getInstance().recordActivity(ORCHESTRATOR_SESSION_NAME);
+      PtyActivityTrackerService.getInstance().recordApiActivity(ORCHESTRATOR_SESSION_NAME);
     }, KEEPALIVE_INTERVAL_MS);
 
     try {


### PR DESCRIPTION
## Summary
- Queue processor keepalive was calling `recordActivity()` instead of `recordApiActivity()`, so the heartbeat monitor's `apiIdleTimeMs` kept growing even while the orchestrator was actively processing messages (running bash skills, writing files, etc.)
- After 5 minutes, the heartbeat fires "Please run your heartbeat skill now" despite the orchestrator being clearly active
- One-line fix: change keepalive to `recordApiActivity()` so the heartbeat monitor correctly suppresses during message processing

## Test plan
- [x] Queue processor tests pass (40/40)
- [x] TypeScript compiles cleanly
- [ ] Manual: send a message that triggers long skill execution (>5 min), verify no heartbeat fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)