### PR TITLE
fix: upgrade default model to gemini-3.1-flash

### DIFF
--- a/backend/src/services/agent/crewly-agent/model-manager.test.ts
+++ b/backend/src/services/agent/crewly-agent/model-manager.test.ts
@@ -61,9 +61,9 @@ describe('ModelManager', () => {
     });
 
     it('should create a Google model', async () => {
-      const model = await manager.getModel({ provider: 'google', modelId: 'gemini-2.5-flash' });
+      const model = await manager.getModel({ provider: 'google', modelId: 'gemini-3.1-flash' });
       expect(model).toBeDefined();
-      expect((model as any).modelId).toBe('gemini-2.5-flash');
+      expect((model as any).modelId).toBe('gemini-3.1-flash');
     });
 
     it('should use default config when none provided', async () => {
@@ -120,7 +120,7 @@ describe('ModelManager', () => {
       process.env.GOOGLE_GENERATIVE_AI_API_KEY = 'stale-free-key';
       // getModel calls ensureApiKeyInEnv internally; the mock resolves from process.env
       // But in production, settings.getApiKey returns the paid key which overwrites env
-      await manager.getModel({ provider: 'google', modelId: 'gemini-2.5-flash' });
+      await manager.getModel({ provider: 'google', modelId: 'gemini-3.1-flash' });
       // The key should now be whatever settings returned (in our mock: the env value itself,
       // but the important thing is ensureApiKeyInEnv does NOT skip when env already set)
       expect(process.env.GOOGLE_GENERATIVE_AI_API_KEY).toBeDefined();

--- a/backend/src/services/agent/crewly-agent/smoke-test.ts
+++ b/backend/src/services/agent/crewly-agent/smoke-test.ts
@@ -27,7 +27,7 @@ if (!API_KEY) {
 async function main(): Promise<void> {
   console.log('=== Crewly Agent Runtime Smoke Test ===\n');
   console.log('Provider: google');
-  console.log('Model: gemini-2.5-flash');
+  console.log('Model: gemini-3.1-flash');
   console.log('API Key: ...%s', API_KEY!.slice(-6));
   console.log();
 
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
     // Step 1: Initialize with Gemini
     console.log('[1/4] Initializing runtime...');
     await runtime.initializeInProcess('smoke-test-session', {
-      model: { provider: 'google', modelId: 'gemini-2.5-flash' },
+      model: { provider: 'google', modelId: 'gemini-3.1-flash' },
       maxSteps: 5,
       systemPrompt: `You are a test agent. When asked to check team status, you MUST call the get_team_status tool. After getting the result, summarize it briefly. Always use tools when available.`,
     });

--- a/backend/src/services/agent/crewly-agent/types.test.ts
+++ b/backend/src/services/agent/crewly-agent/types.test.ts
@@ -71,7 +71,7 @@ describe('Crewly Agent Types', () => {
     it('should return true for valid configs', () => {
       expect(isModelConfig({ provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' })).toBe(true);
       expect(isModelConfig({ provider: 'openai', modelId: 'gpt-4o', temperature: 0.5 })).toBe(true);
-      expect(isModelConfig({ provider: 'google', modelId: 'gemini-2.5-flash', maxTokens: 4096 })).toBe(true);
+      expect(isModelConfig({ provider: 'google', modelId: 'gemini-3.1-flash', maxTokens: 4096 })).toBe(true);
     });
 
     it('should return false for invalid configs', () => {

--- a/backend/src/services/agent/crewly-agent/types.ts
+++ b/backend/src/services/agent/crewly-agent/types.ts
@@ -30,7 +30,7 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
 export interface ModelConfig {
   /** Model provider (e.g., 'anthropic', 'openai', 'google') */
   provider: ModelProvider;
-  /** Model identifier (e.g., 'claude-sonnet-4-20250514', 'gpt-4o', 'gemini-2.5-flash') */
+  /** Model identifier (e.g., 'claude-sonnet-4-20250514', 'gpt-4o', 'gemini-3.1-flash') */
   modelId: string;
   /** Optional temperature override (0-1) */
   temperature?: number;
@@ -278,7 +278,7 @@ export const CREWLY_AGENT_DEFAULTS = {
   /** Default model configuration */
   DEFAULT_MODEL: {
     provider: 'google' as ModelProvider,
-    modelId: 'gemini-2.5-flash',
+    modelId: 'gemini-3.1-flash',
     temperature: 0.3,
     maxTokens: 8192,
   } satisfies ModelConfig,


### PR DESCRIPTION
## Summary

- Upgrade default Crewly Agent model from `gemini-2.5-flash` to `gemini-3.1-flash`
- Updated across types.ts (default config), smoke-test.ts, model-manager.test.ts, types.test.ts
- Marketplace gemini-video skill configs intentionally left at 2.5-flash (different use case)

## Code Review (3 rounds)
All rounds found no issues — this is a simple string constant replacement with no logic changes.

## Test plan
- [x] `npm run build` passes
- [x] model-manager.test.ts passes (10 tests)
- [x] types.test.ts passes (31 tests)
- [x] No remaining `gemini-2.5-flash` references in backend/src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)