### PR TITLE
chore: sync package.json version to 1.3.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.2.6",
+  "version": "1.3.41",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "main": "dist/cli/cli/src/index.js",


### PR DESCRIPTION
## Summary
- Bump package.json version from 1.2.6 to 1.3.41
- Aligns with crewly-web deployed version (1.3.40) + 1 for latest F6/F7/Stripe commits

## Context
Version was stuck at 1.2.6 while npm published 1.3.31 and crewly-web is at 1.3.40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)