### PR TITLE
fix: service restart loop ENOENT after global reinstall (#244)

### DIFF
--- a/cli/src/commands/service.test.ts
+++ b/cli/src/commands/service.test.ts
@@ -30,8 +30,13 @@ jest.mock('child_process', () => ({
 	exec: jest.fn(
 		(
 			cmd: string,
-			cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+			...rest: unknown[]
 		) => {
+			// exec(cmd, cb) or exec(cmd, opts, cb)
+			const cb = typeof rest[0] === 'function'
+				? rest[0] as (err: Error | null, result: { stdout: string; stderr: string }) => void
+				: rest[1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+
 			const result = mockExecAsync(cmd);
 			if (result instanceof Error) {
 				cb(result, { stdout: '', stderr: result.message });
@@ -49,6 +54,7 @@ jest.mock('child_process', () => ({
 			}
 		},
 	),
+	spawn: jest.fn(),
 }));
 
 jest.mock('../../../config/index.js', () => ({
@@ -237,6 +243,169 @@ describe('serviceCommand', () => {
 			expect(mockUnlinkSync).toHaveBeenCalledWith(
 				expect.stringContaining('crewly-service.sh'),
 			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// start subcommand
+	// -----------------------------------------------------------------------
+
+	describe('start (macOS)', () => {
+		it('opens .command file when not running', async () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return false;
+				if (p.includes('crewly-start.command')) return true;
+				return false;
+			});
+
+			mockExecAsync.mockReturnValue('');
+
+			await serviceCommand('start', {});
+
+			expect(mockExecAsync).toHaveBeenCalledWith(
+				expect.stringContaining('open'),
+			);
+
+			const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+			expect(output).toContain('started');
+		});
+
+		it('shows warning if already running', async () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return true;
+				return false;
+			});
+			mockReadFileSync.mockReturnValue('12345');
+
+			const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+
+			await serviceCommand('start', {});
+
+			const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+			expect(output).toContain('already running');
+
+			killSpy.mockRestore();
+		});
+
+		it('clears stale PID file before starting', async () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return true;
+				if (p.includes('crewly-start.command')) return true;
+				return false;
+			});
+			mockReadFileSync.mockReturnValue('99999');
+
+			// PID check fails → stale
+			const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+				throw new Error('ESRCH');
+			});
+			mockExecAsync.mockReturnValue('');
+
+			await serviceCommand('start', {});
+
+			expect(mockUnlinkSync).toHaveBeenCalledWith(
+				expect.stringContaining('crewly.pid'),
+			);
+
+			killSpy.mockRestore();
+		});
+
+		it('exits with error if not installed', async () => {
+			mockExistsSync.mockReturnValue(false);
+
+			await serviceCommand('start', {});
+
+			expect(exitSpy).toHaveBeenCalledWith(1);
+			const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+			expect(output).toContain('not installed');
+		});
+	});
+
+	describe('start (Linux)', () => {
+		beforeEach(() => {
+			Object.defineProperty(process, 'platform', { value: 'linux' });
+		});
+
+		it('calls systemctl start when installed', async () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return false;
+				if (p.includes('crewly.service')) return true;
+				return false;
+			});
+			mockExecAsync.mockReturnValue('');
+
+			await serviceCommand('start', {});
+
+			expect(mockExecAsync).toHaveBeenCalledWith(
+				expect.stringContaining('systemctl --user start'),
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// upgrade subcommand
+	// -----------------------------------------------------------------------
+
+	describe('upgrade (macOS)', () => {
+		it('stops, installs, regenerates, and starts', async () => {
+			// Stop phase: no running process
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return false;
+				if (p.includes('crewly-start.command')) return true;
+				if (p.includes('package.json')) return true;
+				return false;
+			});
+			mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'crewly' }));
+			mockExecAsync.mockReturnValue('');
+
+			await serviceCommand('upgrade', { version: '1.5.0' });
+
+			// Should run npm install
+			expect(mockExecAsync).toHaveBeenCalledWith(
+				'npm install -g crewly@1.5.0',
+			);
+
+			// Should regenerate .command file
+			expect(mockWriteFileSync).toHaveBeenCalledWith(
+				expect.stringContaining('crewly-start.command'),
+				expect.stringContaining('#!/bin/bash'),
+				expect.objectContaining({ mode: 0o755 }),
+			);
+
+			// Should open the .command file to start
+			expect(mockExecAsync).toHaveBeenCalledWith(
+				expect.stringContaining('open'),
+			);
+		});
+
+		it('defaults to latest when no version specified', async () => {
+			mockExistsSync.mockImplementation((p: string) => {
+				if (p.includes('crewly.pid')) return false;
+				if (p.includes('crewly-start.command')) return true;
+				if (p.includes('package.json')) return true;
+				return false;
+			});
+			mockReadFileSync.mockReturnValue(JSON.stringify({ name: 'crewly' }));
+			mockExecAsync.mockReturnValue('');
+
+			await serviceCommand('upgrade', {});
+
+			expect(mockExecAsync).toHaveBeenCalledWith(
+				'npm install -g crewly@latest',
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// help text
+	// -----------------------------------------------------------------------
+
+	describe('help text', () => {
+		it('shows start and upgrade in usage message', async () => {
+			await serviceCommand('bogus', {});
+			const output = logSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+			expect(output).toContain('start');
+			expect(output).toContain('upgrade');
 		});
 	});
 
@@ -549,6 +718,20 @@ describe('generateCommandFile', () => {
 		expect(content).toContain('pty.node');
 		expect(content).toContain('npm rebuild node-pty');
 		expect(content).toContain('Architecture mismatch');
+	});
+
+	it('#244: has cd INSIDE the while loop (not before it)', () => {
+		const content = generateCommandFile('/any/path');
+		const whilePos = content.indexOf('while true');
+		const cdPos = content.indexOf('cd "$CREWLY_DIR"');
+		// cd must appear AFTER 'while true', not before it
+		expect(whilePos).toBeGreaterThan(-1);
+		expect(cdPos).toBeGreaterThan(whilePos);
+	});
+
+	it('#244: cd has error handling', () => {
+		const content = generateCommandFile('/any/path');
+		expect(content).toContain('cd "$CREWLY_DIR" || {');
 	});
 });
 

--- a/cli/src/commands/service.ts
+++ b/cli/src/commands/service.ts
@@ -115,6 +115,8 @@ interface ServiceOptions {
 	app?: boolean;
 	lines?: string;
 	follow?: boolean;
+	/** Target version for upgrade (e.g. "1.4.48" or "latest") */
+	version?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -150,13 +152,19 @@ export async function serviceCommand(
 		case 'stop':
 			await stopService();
 			break;
+		case 'start':
+			await startService();
+			break;
+		case 'upgrade':
+			await upgradeService(options);
+			break;
 		case 'logs':
 			await serviceLogs(options);
 			break;
 		default:
 			console.log(chalk.red(`Unknown action: ${action}`));
 			console.log(
-				chalk.gray('Usage: crewly service <install|uninstall|status|restart|stop|logs>'),
+				chalk.gray('Usage: crewly service <install|uninstall|status|restart|stop|start|upgrade|logs>'),
 			);
 			process.exit(1);
 	}
@@ -562,6 +570,8 @@ export NODE_ENV="development"
 CREWLY_DIR="${projectRoot}"
 PIDFILE="$HOME/${CREWLY_CONSTANTS.PATHS.CREWLY_HOME}/crewly.pid"
 
+# cd on each systemd restart to handle directory inode changes after
+# npm install -g replaces the install directory. (#244)
 cd "$CREWLY_DIR" || { echo "Cannot cd to $CREWLY_DIR"; exit 1; }
 
 ${NATIVE_MODULE_CHECK}
@@ -651,12 +661,15 @@ if [ -f "$PIDFILE" ]; then
   fi
 fi
 
-cd "$CREWLY_DIR" || { echo "Cannot cd to $CREWLY_DIR"; exit 1; }
-
 echo "$(date): Starting Crewly backend (node $(node --version))..." | tee -a "$LOG_DIR/service.log"
 
 # Run in foreground so Terminal keeps the tab open; restart on crash
 while true; do
+  # cd inside the loop so the cwd is refreshed after npm install -g replaces
+  # the directory (new inode). Without this, the stale cwd causes ENOENT on
+  # every process.cwd() call in Node. (#244)
+  cd "$CREWLY_DIR" || { echo "Cannot cd to $CREWLY_DIR"; exit 1; }
+
   ${NATIVE_MODULE_CHECK}
 
   node dist/cli/cli/src/index.js start >> "$LOG_DIR/service.log" 2>&1 &
@@ -880,6 +893,143 @@ async function stopService(): Promise<void> {
 	}
 
 	console.log(chalk.green('Crewly service stopped.'));
+}
+
+// ===========================================================================
+// Start
+// ===========================================================================
+
+/**
+ * Starts the Crewly service if not already running.
+ *
+ * Checks the PID file for a running process, clears stale PID files,
+ * and launches the service using the platform-native method:
+ * - macOS: `open` the .command file (opens in Terminal.app)
+ * - Linux: `systemctl --user start`
+ *
+ * @throws Error if the service is not installed
+ */
+async function startService(): Promise<void> {
+	assertSupportedPlatform();
+
+	// Check if already running
+	const pid = getRunningPid();
+	if (pid) {
+		console.log(chalk.yellow(`Crewly service is already running (PID ${pid}).`));
+		return;
+	}
+
+	// Clear stale PID file
+	if (fs.existsSync(PID_FILE)) {
+		fs.unlinkSync(PID_FILE);
+	}
+
+	if (process.platform === 'darwin') {
+		if (!fs.existsSync(COMMAND_FILE_PATH)) {
+			console.log(chalk.red('Service is not installed. Run "crewly service install" first.'));
+			process.exit(1);
+		}
+
+		try {
+			await execAsync(`open "${COMMAND_FILE_PATH}"`);
+			console.log(chalk.green('Crewly service started (opened .command in Terminal.app).'));
+		} catch (error) {
+			console.log(chalk.red('Failed to open .command file.'));
+			console.log(chalk.gray(`  Try manually: open ${COMMAND_FILE_PATH}`));
+		}
+	} else {
+		// Linux
+		if (!fs.existsSync(SYSTEMD_UNIT_PATH)) {
+			console.log(chalk.red('Service is not installed. Run "crewly service install" first.'));
+			process.exit(1);
+		}
+
+		try {
+			await execAsync(`systemctl --user start ${SYSTEMD_UNIT_NAME}`);
+			console.log(chalk.green('Crewly service started via systemd.'));
+		} catch {
+			console.log(chalk.red('Failed to start service via systemctl.'));
+			console.log(chalk.gray(`  Try: systemctl --user start ${SYSTEMD_UNIT_NAME}`));
+		}
+	}
+}
+
+// ===========================================================================
+// Upgrade
+// ===========================================================================
+
+/**
+ * Upgrades the Crewly installation and regenerates service files.
+ *
+ * Steps:
+ * 1. Stop the running service
+ * 2. Run `npm install -g crewly@<version>` (defaults to "latest")
+ * 3. Regenerate the .command / systemd wrapper with the new project root
+ * 4. Restart the service
+ *
+ * @param options - Upgrade options (--version to specify target version)
+ */
+async function upgradeService(options: ServiceOptions): Promise<void> {
+	assertSupportedPlatform();
+
+	const targetVersion = options.version || 'latest';
+
+	console.log(chalk.blue(`Upgrading Crewly to ${targetVersion}...`));
+
+	// 1. Stop the service
+	console.log(chalk.gray('  Stopping service...'));
+	await stopService();
+
+	// 2. Run npm install -g
+	console.log(chalk.gray(`  Installing crewly@${targetVersion}...`));
+	try {
+		const { stdout, stderr } = await execAsync(
+			`npm install -g crewly@${targetVersion}`,
+			{ timeout: 120_000 },
+		);
+		if (stdout) console.log(chalk.gray(`  ${stdout.trim()}`));
+		if (stderr && !stderr.includes('npm warn')) {
+			console.log(chalk.yellow(`  ${stderr.trim()}`));
+		}
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		console.log(chalk.red(`  npm install failed: ${msg}`));
+		console.log(chalk.gray('  The service was stopped but not upgraded. Start it manually.'));
+		process.exit(1);
+	}
+
+	// 3. Regenerate service files with fresh project root
+	const newProjectRoot = findProjectRoot();
+	if (!newProjectRoot) {
+		console.log(chalk.yellow('  Could not detect new project root. Skipping service file regeneration.'));
+		console.log(chalk.gray('  Run "crewly service install --force" to regenerate manually.'));
+	} else {
+		console.log(chalk.gray('  Regenerating service files...'));
+		fs.mkdirSync(LOG_DIR, { recursive: true });
+
+		if (process.platform === 'darwin') {
+			const commandFileContent = generateCommandFile(newProjectRoot);
+			fs.writeFileSync(COMMAND_FILE_PATH, commandFileContent, { mode: 0o755 });
+			console.log(chalk.green(`  Updated ${COMMAND_FILE_PATH}`));
+		} else {
+			const wrapperContent = generateLinuxWrapper(newProjectRoot);
+			fs.writeFileSync(SYSTEMD_WRAPPER_PATH, wrapperContent, { mode: 0o755 });
+			console.log(chalk.green(`  Updated ${SYSTEMD_WRAPPER_PATH}`));
+
+			try {
+				await execAsync('systemctl --user daemon-reload');
+			} catch {
+				// Non-critical
+			}
+		}
+	}
+
+	// 4. Restart
+	console.log(chalk.gray('  Starting service...'));
+	await startService();
+
+	console.log('');
+	console.log(chalk.green(`Crewly upgraded to ${targetVersion} and restarted.`));
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Summary
Fixes #244: The .command service script's `cd` was outside the `while true` loop. After `npm install -g crewly` replaces the directory (new inode), the stale cwd causes ENOENT on every `process.cwd()` in Node.

## Changes

### Fix 1: `cd` inside the while loop
The `cd "$CREWLY_DIR"` was at line 654 (before `while true` at line 659). Moved it **inside** the loop so each restart iteration refreshes the cwd.

### Fix 2: `crewly service start`
- Checks PID file, clears stale PIDs
- macOS: `open` the .command file
- Linux: `systemctl --user start`
- Error if not installed

### Fix 3: `crewly service upgrade [--version X]`
- Stops service → `npm install -g crewly@<version>` → regenerates .command → restarts
- Defaults to `latest` if no version specified

## Test plan
- [x] 52 tests pass (10 new: cd-inside-loop, start macOS/Linux, upgrade, help text)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)