### PR TITLE
refactor: rename Browser Bridge to Crewly in Chrome

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -81,7 +81,7 @@ export const AGENT_TIMEOUTS = {
 	STARTING_WATCHDOG: 300000, // 5 minutes
 } as const;
 
-// Browser Bridge constants for Chrome Extension WebSocket bridge
+// Crewly in Chrome constants for Chrome Extension WebSocket bridge
 export const BROWSER_BRIDGE_CONSTANTS = {
 	/** WebSocket server path for Chrome Extension connections */
 	WS_PATH: '/ws/browser',

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -1,7 +1,7 @@
 /**
  * Browser Controller
  *
- * REST API handlers for the Browser Bridge. Each handler translates an
+ * REST API handlers for Crewly in Chrome. Each handler translates an
  * HTTP request into a WebSocket command sent to the connected Chrome
  * Extension, waits for the response, and returns it as JSON.
  *
@@ -13,7 +13,7 @@ import { BrowserBridgeService } from '../../services/browser/browser-bridge.serv
 
 /**
  * GET /api/browser/status
- * Returns the current browser bridge connection status.
+ * Returns the current Crewly in Chrome connection status.
  *
  * @param _req - Express request (unused)
  * @param res - Express response

--- a/backend/src/controllers/browser/browser.routes.ts
+++ b/backend/src/controllers/browser/browser.routes.ts
@@ -1,7 +1,7 @@
 /**
  * Browser Routes
  *
- * Router configuration for Browser Bridge REST API endpoints.
+ * Router configuration for Crewly in Chrome REST API endpoints.
  * These endpoints are called by the remote-browser skill to control
  * the user's Chrome browser via the WebSocket bridge.
  *

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -211,9 +211,9 @@ export class CrewlyServer {
 			maxHttpBufferSize: 5 * 1024 * 1024, // 5MB
 			perMessageDeflate: false,
 			// CRITICAL: Prevent Engine.IO from destroying non-matching upgrade requests.
-			// BrowserBridgeService shares this httpServer and handles /ws/browser upgrades.
+			// Crewly in Chrome (BrowserBridgeService) shares this httpServer and handles /ws/browser upgrades.
 			// Without this, Engine.IO sets a 1-second timer to socket.end() any upgrade
-			// that doesn't match /socket.io/ — killing BrowserBridge connections before
+			// that doesn't match /socket.io/ — killing Crewly in Chrome connections before
 			// any data is exchanged (manifests as "Invalid frame header" errors).
 			destroyUpgrade: false,
 		});
@@ -782,14 +782,14 @@ export class CrewlyServer {
 				});
 			}
 
-			// Start Browser Bridge WebSocket server for Chrome Extension
+			// Start Crewly in Chrome WebSocket bridge
 			try {
 				const { BrowserBridgeService } = await import('./services/browser/browser-bridge.service.js');
 				const browserBridge = BrowserBridgeService.getInstance();
 				browserBridge.attach(this.httpServer);
-				this.logger.info('Browser Bridge WebSocket server started');
+				this.logger.info('Crewly in Chrome WebSocket bridge started');
 			} catch (error) {
-				this.logger.warn('Failed to start Browser Bridge (non-critical)', {
+				this.logger.warn('Failed to start Crewly in Chrome bridge (non-critical)', {
 					error: error instanceof Error ? error.message : String(error),
 				});
 			}
@@ -1793,7 +1793,7 @@ export class CrewlyServer {
 			// Stop orchestrator heartbeat monitor
 			OrchestratorHeartbeatMonitorService.getInstance().stop();
 
-			// Stop Browser Bridge WebSocket server
+			// Stop Crewly in Chrome WebSocket bridge
 			try {
 				const { BrowserBridgeService } = await import('./services/browser/browser-bridge.service.js');
 				BrowserBridgeService.getInstance().stop();

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -109,7 +109,7 @@ export function createApiRoutes(apiController: ApiController): Router {
   // Tool approval management routes for granular tool execution control
   router.use('/approvals', createApprovalsRouter());
 
-  // Browser Bridge routes for Chrome Extension remote browser control
+  // Crewly in Chrome routes for browser control
   router.use('/browser', createBrowserRouter());
 
   // Cross-machine communication routes for Slack-based inter-machine messaging

--- a/backend/src/services/agent/runtime-agent.service.abstract.ts
+++ b/backend/src/services/agent/runtime-agent.service.abstract.ts
@@ -501,7 +501,7 @@ export abstract class RuntimeAgentService {
 			const requiredServers: Record<string, { command: string; args: string[] }> = {};
 
 			// Skip Playwright injection when Crewly Pro addon is installed
-			// (Pro addon provides its own WS Browser Bridge for browser control)
+			// (Pro addon provides its own Crewly in Chrome bridge for browser control)
 			const proAddonInstalled = this.isProAddonInstalled();
 			if (proAddonInstalled) {
 				this.logger.info('Crewly Pro addon detected — skipping Playwright MCP injection', { projectPath });
@@ -629,7 +629,7 @@ export abstract class RuntimeAgentService {
 	/**
 	 * Check if the Crewly Pro addon is installed.
 	 *
-	 * Pro addon provides its own WS Browser Bridge, so Playwright MCP
+	 * Pro addon provides its own Crewly in Chrome bridge, so Playwright MCP
 	 * should not be injected when it is present.
 	 *
 	 * @returns True if crewly-pro addon manifest exists

--- a/backend/src/services/browser/browser-bridge.service.ts
+++ b/backend/src/services/browser/browser-bridge.service.ts
@@ -1,7 +1,7 @@
 /**
- * Browser Bridge Service
+ * Crewly in Chrome — Browser Bridge Service
  *
- * Provides a raw WebSocket server that the Crewly Chrome Extension connects to.
+ * Provides a raw WebSocket server that the Crewly in Chrome extension connects to.
  * Acts as a bridge between REST API calls (from remote-browser skill) and the
  * Chrome Extension. When a REST endpoint receives a command, it forwards it to
  * the connected Chrome Extension via WebSocket and waits for the response.
@@ -64,7 +64,7 @@ export interface BrowserCommandResponse {
 	error?: string;
 }
 
-/** Status information about the browser bridge */
+/** Status information about the Crewly in Chrome bridge */
 export interface BrowserBridgeStatus {
 	/** Whether at least one Chrome Extension is connected */
 	connected: boolean;
@@ -206,7 +206,7 @@ export class BrowserBridgeService {
 			this.logger.error('WebSocket server error', { error: err.message });
 		});
 
-		this.logger.info('Browser Bridge WebSocket server attached', {
+		this.logger.info('Crewly in Chrome WebSocket server attached', {
 			path: BROWSER_BRIDGE_CONSTANTS.WS_PATH,
 		});
 	}
@@ -340,7 +340,7 @@ export class BrowserBridgeService {
 		// Clear all pending commands
 		for (const [id, pending] of this.pendingCommands) {
 			clearTimeout(pending.timer);
-			pending.reject(new Error('Browser Bridge shutting down'));
+			pending.reject(new Error('Crewly in Chrome bridge shutting down'));
 			this.pendingCommands.delete(id);
 		}
 
@@ -360,6 +360,6 @@ export class BrowserBridgeService {
 			this.wss = null;
 		}
 
-		this.logger.info('Browser Bridge stopped');
+		this.logger.info('Crewly in Chrome bridge stopped');
 	}
 }

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,4 +1,4 @@
-# Crewly Remote Browser — Chrome Extension Demo
+# Crewly in Chrome — Chrome Extension Demo
 
 Allows Crewly Cloud agents to remotely operate a user's Chrome browser via WebSocket.
 

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,5 +1,5 @@
 /**
- * Crewly Remote Browser — Background Service Worker
+ * Crewly in Chrome — Background Service Worker
  *
  * Maintains a WebSocket connection to the Crewly Cloud relay server,
  * receives JSON commands, routes them to the appropriate Chrome API

--- a/chrome-extension/cdp-screenshot.js
+++ b/chrome-extension/cdp-screenshot.js
@@ -1,5 +1,5 @@
 /**
- * Crewly Remote Browser — CDP Screenshot Module
+ * Crewly in Chrome — CDP Screenshot Module
  *
  * Provides screenshot capture using Chrome DevTools Protocol (CDP)
  * via chrome.debugger API. Falls back to chrome.tabs.captureVisibleTab

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,5 +1,5 @@
 /**
- * Crewly Remote Browser — Content Script
+ * Crewly in Chrome — Content Script
  *
  * Injected into all pages. Provides DOM access helpers
  * that can be invoked from the background service worker

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Crewly Remote Browser",
+  "name": "Crewly in Chrome",
   "version": "0.1.0",
   "description": "Allows Crewly Cloud agents to remotely operate your Chrome browser via WebSocket.",
   "permissions": [

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -2,7 +2,7 @@
   "name": "crewly-remote-browser-test",
   "version": "0.1.0",
   "private": true,
-  "description": "Test server for Crewly Remote Browser Chrome Extension",
+  "description": "Test server for Crewly in Chrome Chrome Extension",
   "scripts": {
     "server": "node test-server.js"
   },

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -121,7 +121,7 @@
 
   <div id="errorText" class="error-text"></div>
 
-  <div class="footer">Crewly Remote Browser v0.1.0</div>
+  <div class="footer">Crewly in Chrome v0.1.0</div>
 
   <script src="popup.js"></script>
 </body>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,5 +1,5 @@
 /**
- * Crewly Remote Browser — Popup Script
+ * Crewly in Chrome — Popup Script
  *
  * Controls the popup UI: server URL input, connect/disconnect buttons,
  * and live connection status display.

--- a/chrome-extension/test-server.js
+++ b/chrome-extension/test-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Crewly Remote Browser — Test WebSocket Server
+ * Crewly in Chrome — Test WebSocket Server
  *
  * A simple CLI tool for testing the Chrome Extension.
  * Starts a WebSocket server, accepts one extension connection,
@@ -32,7 +32,7 @@ let extensionSocket = null;
 
 const wss = new WebSocketServer({ port: PORT });
 
-console.log(`\n  Crewly Remote Browser — Test Server`);
+console.log(`\n  Crewly in Chrome — Test Server`);
 console.log(`  WebSocket listening on ws://localhost:${PORT}`);
 console.log(`  Waiting for Chrome Extension to connect...\n`);
 


### PR DESCRIPTION
## Summary
- Rename all user-facing "Browser Bridge" / "Remote Browser" references to "Crewly in Chrome"
- Chrome Extension manifest name updated
- Backend log messages and comments updated
- Local skill SKILL.md and skill.json updated
- VNC Remote Browser Access (separate feature) NOT renamed

## Test plan
- [x] TypeScript compiles clean
- [x] No remaining "Browser Bridge" in user-facing strings
- [x] Class/variable names preserved for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)