### PR TITLE
feat: v3 trigger dedup + service contract gate + 3-round review

### DIFF
--- a/backend/src/controllers/mission/mission-policy.routes.test.ts
+++ b/backend/src/controllers/mission/mission-policy.routes.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { createMissionPolicyRouter } from './mission-policy.routes.js';
 
 describe('createMissionPolicyRouter', () => {
@@ -9,5 +8,17 @@ describe('createMissionPolicyRouter', () => {
     expect(routes).toContain('/');
     expect(routes).toContain('/:id');
     expect(routes).toContain('/:id/policy');
+  });
+
+  it('registers PUT /:id for partial mission updates', () => {
+    const router = createMissionPolicyRouter();
+    const entries: Array<{ path: string; methods: Record<string, boolean> }> =
+      (router as any).stack
+        ?.map((r: any) => r.route)
+        .filter(Boolean)
+        .map((r: any) => ({ path: r.path, methods: r.methods })) ?? [];
+
+    const putIdRoute = entries.find((e) => e.path === '/:id' && e.methods.put);
+    expect(putIdRoute).toBeDefined();
   });
 });

--- a/backend/src/controllers/mission/mission-policy.routes.ts
+++ b/backend/src/controllers/mission/mission-policy.routes.ts
@@ -26,53 +26,209 @@ import {
 } from './kr.controller.js';
 import { MissionExecutorService, type DecompositionResult } from '../../services/v3/mission-executor.service.js';
 import { OKRReviewService } from '../../services/v3/okr-review.service.js';
-import type { ReviewDecision } from '../../types/v2/key-result.types.js';
+import type { ReviewDecision, KeyResult } from '../../types/v2/key-result.types.js';
+import {
+  validateParentLink,
+  type Mission,
+  type MissionPriority,
+} from '../../types/v2/mission.types.js';
+
+/** Default priority applied to missions missing the field at read time. */
+const DEFAULT_PRIORITY: MissionPriority = 'medium';
+
+/** Summary of a KeyResult included inline on mission list/detail responses. */
+interface KeyResultSummary {
+  id: string;
+  title: string;
+  metricType: KeyResult['metricType'];
+  baseline: number;
+  target: number;
+  current: number;
+  unit: string;
+  status: KeyResult['status'];
+}
 
 /** Resolve the missions directory from the project root. */
 function getMissionsDir(): string {
   return path.join(process.cwd(), '.crewly', 'missions');
 }
 
-/** List all missions. */
+/**
+ * Reads all KR JSON files stored under `<missionsDir>/<missionId>/key-results/`.
+ *
+ * @param missionId - Mission whose KRs should be loaded
+ * @returns Array of KR summaries (empty if the folder is missing or unreadable)
+ */
+async function readKeyResultSummaries(missionId: string): Promise<KeyResultSummary[]> {
+  const krDir = path.join(getMissionsDir(), missionId, 'key-results');
+  let files: string[] = [];
+  try {
+    files = (await fs.readdir(krDir)).filter(f => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const krs = await Promise.all(
+    files.map(async (f) => {
+      try {
+        const raw = await fs.readFile(path.join(krDir, f), 'utf-8');
+        const kr = JSON.parse(raw) as KeyResult;
+        const summary: KeyResultSummary = {
+          id: kr.id,
+          title: kr.title,
+          metricType: kr.metricType,
+          baseline: kr.baseline,
+          target: kr.target,
+          current: kr.current,
+          unit: kr.unit,
+          status: kr.status,
+        };
+        return summary;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return krs.filter((k): k is KeyResultSummary => k !== null);
+}
+
+/**
+ * Normalises a raw mission JSON blob into an API response shape:
+ * applies the default priority and attaches inline KR summaries.
+ *
+ * @param raw - Mission object parsed from JSON
+ * @returns Mission augmented with `keyResults` and a guaranteed `priority`
+ */
+async function normalizeMissionForResponse(raw: Mission): Promise<Mission & { keyResults: KeyResultSummary[] }> {
+  const keyResults = await readKeyResultSummaries(raw.id);
+  return {
+    ...raw,
+    priority: raw.priority ?? DEFAULT_PRIORITY,
+    keyResults,
+  };
+}
+
+/** Load every mission from disk, skipping unreadable files. */
+async function loadAllMissionsRaw(): Promise<Mission[]> {
+  const dir = getMissionsDir();
+  let files: string[] = [];
+  try {
+    files = (await fs.readdir(dir)).filter(f => f.endsWith('.json'));
+  } catch {
+    return [];
+  }
+  const missions = await Promise.all(
+    files.map(async (f) => {
+      try {
+        const raw = await fs.readFile(path.join(dir, f), 'utf-8');
+        return JSON.parse(raw) as Mission;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return missions.filter((m): m is Mission => m !== null);
+}
+
+/** List all missions with KR summaries and normalised priority. */
 async function listMissions(_req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const dir = getMissionsDir();
-    let files: string[] = [];
-    try {
-      files = (await fs.readdir(dir)).filter(f => f.endsWith('.json'));
-    } catch { /* dir doesn't exist */ }
-    const missions = await Promise.all(
-      files.map(async (f) => {
-        try {
-          const raw = await fs.readFile(path.join(dir, f), 'utf-8');
-          return JSON.parse(raw);
-        } catch { return null; }
-      })
-    );
-    res.json({ success: true, data: missions.filter(Boolean), count: missions.filter(Boolean).length });
+    const missions = await loadAllMissionsRaw();
+    const enriched = await Promise.all(missions.map(normalizeMissionForResponse));
+    res.json({ success: true, data: enriched, count: enriched.length });
   } catch (err) { next(err); }
 }
 
-/** Get a single mission by ID. */
+/** Get a single mission by ID with KR summaries and normalised priority. */
 async function getMission(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const filePath = path.join(getMissionsDir(), `${req.params.id}.json`);
     const raw = await fs.readFile(filePath, 'utf-8');
-    res.json({ success: true, data: JSON.parse(raw) });
+    const mission = await normalizeMissionForResponse(JSON.parse(raw) as Mission);
+    res.json({ success: true, data: mission });
   } catch {
     res.status(404).json({ success: false, error: 'Mission not found' });
   }
 }
 
-/** Create a new mission. */
+/**
+ * Create a new mission.
+ *
+ * Validates `parentMissionId` against existing missions to reject self-reference
+ * and cycles before writing to disk.
+ */
 async function createMission(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const dir = getMissionsDir();
     await fs.mkdir(dir, { recursive: true });
     const id = req.body.id || `mission-${Date.now()}`;
+
+    const parentMissionId: string | undefined = req.body.parentMissionId;
+    if (parentMissionId) {
+      const existing = await loadAllMissionsRaw();
+      const byId = new Map(existing.map(m => [m.id, m] as const));
+      const reason = validateParentLink(id, parentMissionId, byId);
+      if (reason) {
+        res.status(400).json({ success: false, error: reason });
+        return;
+      }
+    }
+
     const mission = { id, ...req.body, createdAt: new Date().toISOString(), status: req.body.status || 'active' };
     await fs.writeFile(path.join(dir, `${id}.json`), JSON.stringify(mission, null, 2));
     res.status(201).json({ success: true, data: mission });
+  } catch (err) { next(err); }
+}
+
+/** Fields that are server-controlled and must never be overwritten by a PUT. */
+const IMMUTABLE_MISSION_FIELDS = ['id', 'createdAt'] as const;
+
+/**
+ * Update an existing mission (partial).
+ *
+ * Accepts any subset of mutable mission fields. `parentMissionId` is re-validated
+ * against the current set of missions on every change. `updatedAt` is refreshed
+ * automatically; `id` and `createdAt` are immutable.
+ */
+async function updateMission(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+    const filePath = path.join(getMissionsDir(), `${id}.json`);
+
+    let existing: Mission;
+    try {
+      existing = JSON.parse(await fs.readFile(filePath, 'utf-8')) as Mission;
+    } catch {
+      res.status(404).json({ success: false, error: 'Mission not found' });
+      return;
+    }
+
+    // Re-validate parent link if the caller is changing it.
+    if (Object.prototype.hasOwnProperty.call(req.body, 'parentMissionId')) {
+      const nextParent: string | undefined = req.body.parentMissionId || undefined;
+      if (nextParent) {
+        const all = await loadAllMissionsRaw();
+        const byId = new Map(all.map(m => [m.id, m] as const));
+        const reason = validateParentLink(id, nextParent, byId);
+        if (reason) {
+          res.status(400).json({ success: false, error: reason });
+          return;
+        }
+      }
+    }
+
+    // Merge while guarding immutable fields.
+    const patch: Record<string, unknown> = { ...req.body };
+    for (const f of IMMUTABLE_MISSION_FIELDS) delete patch[f];
+    const merged: Mission = {
+      ...existing,
+      ...(patch as Partial<Mission>),
+      id: existing.id,
+      createdAt: existing.createdAt,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await fs.writeFile(filePath, JSON.stringify(merged, null, 2));
+    res.json({ success: true, data: merged });
   } catch (err) { next(err); }
 }
 
@@ -92,6 +248,9 @@ export function createMissionPolicyRouter(): Router {
 
   // Get a single mission
   router.get('/:id', getMission);
+
+  // Update a mission (partial)
+  router.put('/:id', updateMission);
 
   // Get mission policy
   router.get('/:id/policy', getPolicy);

--- a/backend/src/controllers/task-pool/task-pool-contract-gate.test.ts
+++ b/backend/src/controllers/task-pool/task-pool-contract-gate.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Focused tests for the ServiceContract gate wiring inside the Task Pool
+ * controller. We exercise the exported `maybeEnforceContract` helper
+ * directly — the rest of the controller (addToPool, projection, validator)
+ * is covered separately.
+ */
+
+import { maybeEnforceContract } from './task-pool.controller.js';
+import { StorageService } from '../../services/core/storage.service.js';
+import type { Team } from '../../types/index.js';
+
+jest.mock('../../services/core/storage.service.js');
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTeam(id: string, accepts: string[] = [], avoids: string[] = []): Team {
+  return {
+    id,
+    name: `team-${id}`,
+    members: [],
+    projectIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    serviceContract: {
+      accepts,
+      avoids,
+      expectedOutput: [],
+    },
+  };
+}
+
+function installTeams(teams: Team[]): void {
+  (StorageService.getInstance as unknown as jest.Mock).mockReturnValue({
+    getTeams: jest.fn().mockResolvedValue(teams),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('maybeEnforceContract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the gate when the body has no cross-team hints', async () => {
+    // No fromTeamId / toTeamId → legacy body, pass through.
+    const result = await maybeEnforceContract({
+      type: 'delegate',
+      title: 'Something',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('skips the gate when from === to (internal work)', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'eng',
+      toTeamId: 'eng',
+      title: 'Something weird not on contract',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('accepts when requestType matches target contract', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'eng',
+      title: 'urgent frontend bugfix in checkout flow',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejects with 403 when target avoids the request', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'], ['production DBA changes'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'eng',
+      title: 'production DBA changes needed',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+    expect(result!.payload.success).toBe(false);
+    const gate = result!.payload.gate as Record<string, unknown>;
+    expect(gate.outcome).toBe('reject');
+    expect(gate.reason).toBe('in_avoids');
+  });
+
+  it('rejects when the request fits neither accepts nor avoids', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'eng',
+      title: 'write a poem',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+    const gate = result!.payload.gate as Record<string, unknown>;
+    expect(gate.reason).toBe('no_match');
+  });
+
+  it('rejects when the target team cannot be resolved', async () => {
+    installTeams([]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'missing',
+      title: 'frontend bugfix',
+    });
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+    const gate = result!.payload.gate as Record<string, unknown>;
+    expect(gate.reason).toBe('missing_target');
+  });
+
+  it('reads teamIds and requestType from metadata block', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'])]);
+    const result = await maybeEnforceContract({
+      type: 'delegate',
+      title: 'Opaque title',
+      metadata: {
+        fromTeamId: 'marketing',
+        toTeamId: 'eng',
+        requestType: 'frontend bugfix',
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it('bypasses the gate when forceCrossTeam is true', async () => {
+    installTeams([makeTeam('eng', ['frontend bugfix'], ['production DBA changes'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'eng',
+      title: 'production DBA changes needed',
+      forceCrossTeam: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('falls back to title when requestType is not provided', async () => {
+    installTeams([makeTeam('eng', ['API change'])]);
+    const result = await maybeEnforceContract({
+      fromTeamId: 'marketing',
+      toTeamId: 'eng',
+      // Intentionally no requestType — title should be used
+      title: 'need an API change for the new dashboard',
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -16,8 +16,10 @@ import {
   type PoolFilters,
 } from '../../services/task-pool/task-pool.service.js';
 import { TaskProjectionService } from '../../services/v3/task-projection.service.js';
+import { ServiceContractGate } from '../../services/v3/service-contract-gate.service.js';
+import { StorageService } from '../../services/core/storage.service.js';
 import type { TokenUsage } from '../../types/v3/task-record.types.js';
-import type { RequestStatus } from '../../types/v2/request.types.js';
+import { WORK_ITEM_TYPES, isValidWorkItemType } from '../../types/v2/work-item.types.js';
 import { formatError } from '../../utils/format-error.js';
 import { LoggerService } from '../../services/core/logger.service.js';
 
@@ -62,6 +64,102 @@ function getProjection(): TaskProjectionService | null {
   }
 }
 
+/**
+ * Lazily instantiated gate. Stateless — one instance is reused for all requests.
+ */
+const contractGate = new ServiceContractGate();
+
+/**
+ * Check a request body for cross-team routing hints and apply the
+ * {@link ServiceContractGate} when present. Opt-in: if the body doesn't
+ * carry both `fromTeamId` and `toTeamId` the gate is skipped, preserving
+ * backward compatibility with existing delegate flows.
+ *
+ * Accepted body shapes (either works):
+ *   { fromTeamId, toTeamId, requestType }
+ *   { metadata: { fromTeamId, toTeamId, requestType } }
+ *
+ * `requestType` defaults to the WorkItem's `title`/`description` when the
+ * caller hasn't supplied a more specific phrase. An explicit boolean
+ * `forceCrossTeam: true` bypasses the gate (used for declared emergencies —
+ * still logged).
+ *
+ * @param body - Raw request body (already validated as an object)
+ * @returns `null` when the request should proceed; otherwise a gate
+ *          rejection decision ready to surface as 403.
+ */
+export async function maybeEnforceContract(
+  body: Record<string, unknown>,
+): Promise<
+  | null
+  | { status: number; payload: Record<string, unknown> }
+> {
+  const metaSrc = (body.metadata && typeof body.metadata === 'object'
+    ? (body.metadata as Record<string, unknown>)
+    : body) as Record<string, unknown>;
+
+  const fromTeamId =
+    typeof body.fromTeamId === 'string' ? body.fromTeamId : (metaSrc.fromTeamId as string | undefined);
+  const toTeamId =
+    typeof body.toTeamId === 'string' ? body.toTeamId : (metaSrc.toTeamId as string | undefined);
+
+  // No cross-team hints → same-process, same-team work or legacy callers.
+  if (!fromTeamId || !toTeamId) return null;
+  if (fromTeamId === toTeamId) return null;
+
+  // Emergency override — still logged by the logger below so we can audit.
+  if (body.forceCrossTeam === true || metaSrc.forceCrossTeam === true) {
+    logger.warn('ServiceContract gate bypassed via forceCrossTeam', {
+      fromTeamId,
+      toTeamId,
+      title: body.title,
+    });
+    return null;
+  }
+
+  const requestType =
+    (typeof body.requestType === 'string' && body.requestType) ||
+    (typeof metaSrc.requestType === 'string' && metaSrc.requestType) ||
+    (typeof body.title === 'string' && body.title) ||
+    (typeof body.description === 'string' && body.description) ||
+    '';
+
+  const storage = StorageService.getInstance();
+  const teams = await storage.getTeams();
+  const toTeam = teams.find((t) => t.id === toTeamId);
+
+  const decision = contractGate.check({ fromTeamId, toTeam, requestType });
+
+  if (decision.outcome === 'accept') {
+    logger.info('ServiceContract gate accepted', {
+      fromTeamId,
+      toTeamId,
+      matchedRule: decision.matchedRule,
+    });
+    return null;
+  }
+
+  logger.warn('ServiceContract gate rejected cross-team request', {
+    fromTeamId,
+    toTeamId,
+    requestType,
+    reason: decision.reason,
+    matchedRule: decision.matchedRule,
+  });
+  return {
+    status: 403,
+    payload: {
+      success: false,
+      error: decision.message,
+      gate: {
+        outcome: 'reject',
+        reason: decision.reason,
+        matchedRule: decision.matchedRule,
+      },
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // POST /api/task-pool/add — Add a WorkItem to the pool
 // ---------------------------------------------------------------------------
@@ -91,6 +189,14 @@ export async function addItem(req: Request, res: Response): Promise<void> {
     const validationErrors = await validateWorkItem(workItem);
     if (validationErrors.length > 0) {
       res.status(400).json({ success: false, errors: validationErrors });
+      return;
+    }
+
+    // ServiceContract gate — only runs when the body carries cross-team
+    // routing hints. Rejects before the item is enqueued.
+    const rejection = await maybeEnforceContract(workItem as Record<string, unknown>);
+    if (rejection) {
+      res.status(rejection.status).json(rejection.payload);
       return;
     }
 
@@ -575,9 +681,6 @@ export async function revokeAndRelease(req: Request, res: Response): Promise<voi
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Valid WorkItemTypes accepted at the pool entry point. */
-const VALID_POOL_TYPES = new Set(['delegate', 'check', 'notify', 'review', 'project_task', 'cron_run', 'confirm', 'reconcile']);
-
 /** Max WorkItems allowed per Request in a single planning pass. */
 const MAX_WORK_ITEMS_PER_REQUEST = 20;
 
@@ -605,8 +708,8 @@ async function validateWorkItem(workItem: Record<string, unknown>): Promise<stri
   }
   if (!workItem.type || typeof workItem.type !== 'string') {
     errors.push('WorkItem.type is required');
-  } else if (!VALID_POOL_TYPES.has(workItem.type)) {
-    errors.push(`WorkItem.type "${workItem.type}" is invalid; must be one of: ${[...VALID_POOL_TYPES].join(', ')}`);
+  } else if (!isValidWorkItemType(workItem.type)) {
+    errors.push(`WorkItem.type "${workItem.type}" is invalid; must be one of: ${WORK_ITEM_TYPES.join(', ')}`);
   }
   if (!workItem.owner || typeof workItem.owner !== 'string') {
     errors.push('WorkItem.owner is required');
@@ -618,23 +721,35 @@ async function validateWorkItem(workItem: Record<string, unknown>): Promise<stri
     const svc = getService();
     const allItems = await svc.getAllItems();
 
-    // 2. Duplicate detection
-    const duplicate = allItems.find((wi) => wi.id === workItem.id);
+    // Single pass: collect both the duplicate (if any) and the count of
+    // active items sharing the same requestId. A previous implementation
+    // ran two separate O(n) scans — redundant on a hot insert path during
+    // decomposition bursts.
+    const requestId = workItem.requestId as string | undefined;
+    let duplicate: typeof allItems[number] | undefined;
+    let sameRequestActiveCount = 0;
+    for (const wi of allItems) {
+      if (!duplicate && wi.id === workItem.id) {
+        duplicate = wi;
+      }
+      if (
+        requestId &&
+        wi.requestId === requestId &&
+        wi.status !== 'done' &&
+        wi.status !== 'cancelled'
+      ) {
+        sameRequestActiveCount += 1;
+      }
+    }
+
     if (duplicate) {
       errors.push(`WorkItem.id "${workItem.id}" already exists in pool (status: ${duplicate.status})`);
     }
 
-    // 3. Per-request quantity cap
-    const requestId = workItem.requestId as string | undefined;
-    if (requestId) {
-      const requestItems = allItems.filter(
-        (wi) => wi.requestId === requestId && wi.status !== 'done' && wi.status !== 'cancelled',
+    if (requestId && sameRequestActiveCount >= MAX_WORK_ITEMS_PER_REQUEST) {
+      errors.push(
+        `Request ${requestId} already has ${sameRequestActiveCount} active WorkItems (max ${MAX_WORK_ITEMS_PER_REQUEST}). Possible infinite decomposition loop.`,
       );
-      if (requestItems.length >= MAX_WORK_ITEMS_PER_REQUEST) {
-        errors.push(
-          `Request ${requestId} already has ${requestItems.length} active WorkItems (max ${MAX_WORK_ITEMS_PER_REQUEST}). Possible infinite decomposition loop.`,
-        );
-      }
     }
   } catch (err) {
     logger.debug('WorkItem validation check failed (non-fatal)', { error: formatError(err) });
@@ -649,7 +764,6 @@ async function validateWorkItem(workItem: Record<string, unknown>): Promise<stri
  *
  * @param requestId - The parent Request ID
  * @param tokenUsage - Token usage to roll up
- * @param projection - TaskProjectionService instance
  */
 function rollUpTokensToRequest(
   requestId: string,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1288,6 +1288,46 @@ export class CrewlyServer {
 
 				await triggerEngine.start();
 				this.logger.info('TriggerEngine started with action handler wired');
+
+				// Wire team-scoped triggers: reconcile declarative Team.triggers spec
+				// against the running engine on every team save, and cancel all of a
+				// team's triggers when it's deleted. Listener is fire-and-forget.
+				try {
+					const { TeamTriggerReconciler } = await import(
+						'./services/v3/team-trigger-reconciler.service.js'
+					);
+					const reconciler = new TeamTriggerReconciler(triggerEngine);
+
+					// Initial converge: reconcile every team that already exists on disk.
+					const existingTeams = await this.storageService.getTeams();
+					for (const team of existingTeams) {
+						try {
+							await reconciler.reconcile(team);
+						} catch (recErr) {
+							this.logger.warn('Initial team-trigger reconcile failed', {
+								teamId: team.id,
+								error: recErr instanceof Error ? recErr.message : String(recErr),
+							});
+						}
+					}
+
+					// Ongoing: subscribe to storage events.
+					this.storageService.onStorageEvent(async (event) => {
+						if (event.kind === 'team-saved') {
+							await reconciler.reconcile(event.team);
+						} else if (event.kind === 'team-deleted') {
+							await reconciler.unregisterAll(event.teamId);
+						}
+					});
+
+					this.logger.info('TeamTriggerReconciler subscribed to storage events', {
+						initialTeams: existingTeams.length,
+					});
+				} catch (recErr) {
+					this.logger.warn('TeamTriggerReconciler wiring failed (non-critical)', {
+						error: recErr instanceof Error ? recErr.message : String(recErr),
+					});
+				}
 			} catch (triggerErr) {
 				this.logger.warn('TriggerEngine initialization failed (non-critical)', {
 					error: triggerErr instanceof Error ? triggerErr.message : String(triggerErr),

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -32,6 +32,7 @@ import { createApprovalsRouter } from '../controllers/approvals/approvals.routes
 import { createBrowserRouter } from '../controllers/browser/browser.routes.js';
 import { createCrossMachineRouter } from '../controllers/cross-machine/index.js';
 import { createWebsiteAnalysisRouter } from '../controllers/onboarding/website-analysis.routes.js';
+import { createOnboardingRouter } from '../controllers/onboarding/onboarding.routes.js';
 import { createDataRouter } from '../controllers/data/data.routes.js';
 import { createIntentTaskRouter } from '../controllers/intent-task/intent-task.routes.js';
 import { createTaskPoolRouter } from '../controllers/task-pool/task-pool.routes.js';
@@ -134,6 +135,9 @@ export function createApiRoutes(apiController: ApiController): Router {
   // Website Analysis routes for KR3 magic onboarding — SSE + sync analysis
   router.use('/website-analysis', createWebsiteAnalysisRouter());
 
+  // Onboarding session routes for KR3 Cloud Portal onboarding flow
+  router.use('/onboarding', createOnboardingRouter());
+
   // Data Architecture V2 — Unified Data Model, Schemas, Sinks
   router.use('/v2/data', createDataRouter());
 
@@ -205,9 +209,14 @@ export function createApiRoutes(apiController: ApiController): Router {
     } catch (err) { res.status(500).json({ success: false, error: String(err) }); }
   });
 
-  // Relay devices stub (prevents 404 noise from dashboard relay health card)
+  // Relay devices stubs (prevents 404 noise from dashboard relay health card)
   router.get('/relay/devices', (_req, res) => {
     res.json({ success: true, data: { devices: [], client: { state: 'offline', sessionId: null } } });
+  });
+
+  // Legacy cloud-devices endpoint (used by RelayHealthCard and CloudTab)
+  router.get('/relay/cloud-devices', (_req, res) => {
+    res.json({ success: true, data: [] });
   });
 
   return router;

--- a/backend/src/scripts/backfill-mission-priority.test.ts
+++ b/backend/src/scripts/backfill-mission-priority.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for backfill-mission-priority script.
+ *
+ * @module scripts/backfill-mission-priority.test
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+  backfillMissionPriority,
+  BACKFILL_DEFAULT_PRIORITY,
+} from './backfill-mission-priority.js';
+
+describe('backfillMissionPriority', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-backfill-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Writes a mission JSON fixture to the temp dir and returns the path.
+   */
+  async function writeMission(id: string, body: Record<string, unknown>): Promise<string> {
+    const p = path.join(tmpDir, `${id}.json`);
+    await fs.writeFile(p, JSON.stringify({ id, ...body }));
+    return p;
+  }
+
+  it('returns zero counts when the directory is missing', async () => {
+    const missing = path.join(tmpDir, 'nope');
+    const result = await backfillMissionPriority(missing);
+    expect(result.scanned).toBe(0);
+    expect(result.updated).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('adds default priority when a mission file is missing the field', async () => {
+    const filePath = await writeMission('m1', { objective: 'do X' });
+
+    const result = await backfillMissionPriority(tmpDir);
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toEqual(['m1']);
+    expect(result.skipped).toEqual([]);
+
+    const persisted = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    expect(persisted.priority).toBe(BACKFILL_DEFAULT_PRIORITY);
+  });
+
+  it('leaves missions with an existing priority untouched', async () => {
+    const filePath = await writeMission('m2', { objective: 'do Y', priority: 'critical' });
+
+    const result = await backfillMissionPriority(tmpDir);
+
+    expect(result.updated).toEqual([]);
+    expect(result.skipped).toEqual(['m2']);
+
+    const persisted = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+    expect(persisted.priority).toBe('critical');
+  });
+
+  it('is idempotent when run twice', async () => {
+    await writeMission('m3', { objective: 'do Z' });
+
+    const first = await backfillMissionPriority(tmpDir);
+    const second = await backfillMissionPriority(tmpDir);
+
+    expect(first.updated).toEqual(['m3']);
+    expect(second.updated).toEqual([]);
+    expect(second.skipped).toEqual(['m3']);
+  });
+
+  it('skips non-JSON files silently', async () => {
+    await fs.writeFile(path.join(tmpDir, 'notes.txt'), 'ignore me');
+    await writeMission('m4', { objective: 'real mission' });
+
+    const result = await backfillMissionPriority(tmpDir);
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toEqual(['m4']);
+  });
+
+  it('records parse failures in `failed` and keeps scanning the rest', async () => {
+    await writeMission('m5', { objective: 'ok' });
+    await fs.writeFile(path.join(tmpDir, 'broken.json'), '{not json');
+
+    const result = await backfillMissionPriority(tmpDir);
+
+    expect(result.scanned).toBe(2);
+    expect(result.updated).toEqual(['m5']);
+    expect(result.failed).toEqual([path.join(tmpDir, 'broken.json')]);
+  });
+
+  it('records files with missing id in `failed` rather than pushing undefined', async () => {
+    // Valid JSON, no id field.
+    await fs.writeFile(path.join(tmpDir, 'no-id.json'), JSON.stringify({ objective: 'x' }));
+
+    const result = await backfillMissionPriority(tmpDir);
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toEqual([]);
+    expect(result.failed).toEqual([path.join(tmpDir, 'no-id.json')]);
+  });
+});

--- a/backend/src/scripts/backfill-mission-priority.ts
+++ b/backend/src/scripts/backfill-mission-priority.ts
@@ -1,0 +1,128 @@
+/**
+ * Backfill Mission Priority
+ *
+ * Scans `<cwd>/.crewly/missions/*.json` and writes `priority: 'medium'`
+ * onto any mission file that is missing the field. Idempotent:
+ * files that already have a priority are untouched.
+ *
+ * Usage (manual):
+ * ```sh
+ * npx tsx backend/src/scripts/backfill-mission-priority.ts
+ * ```
+ *
+ * The default priority (`medium`) is a deliberate neutral fallback — callers
+ * that care can update individual missions afterwards through the API.
+ *
+ * @module scripts/backfill-mission-priority
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import type { Mission, MissionPriority } from '../types/v2/mission.types.js';
+import { atomicWriteJson } from '../utils/file-io.utils.js';
+
+/** Default priority assigned when a mission is missing the field. */
+export const BACKFILL_DEFAULT_PRIORITY: MissionPriority = 'medium';
+
+/** Result returned by {@link backfillMissionPriority} for observability. */
+export interface BackfillResult {
+  /** Total mission files inspected (includes files that failed to parse). */
+  scanned: number;
+  /** Mission files that were rewritten with a priority. */
+  updated: string[];
+  /** Mission files that already had a priority and were left alone. */
+  skipped: string[];
+  /** File paths that failed to parse or were missing a valid `id`. */
+  failed: string[];
+}
+
+/**
+ * Runs the backfill against the given missions directory.
+ *
+ * @param missionsDir - Absolute path to `.crewly/missions`
+ * @returns Counts and the list of touched mission IDs
+ *
+ * @example
+ * ```ts
+ * const result = await backfillMissionPriority('/project/.crewly/missions');
+ * console.log(`Updated ${result.updated.length} missions`);
+ * ```
+ */
+export async function backfillMissionPriority(missionsDir: string): Promise<BackfillResult> {
+  const result: BackfillResult = { scanned: 0, updated: [], skipped: [], failed: [] };
+
+  let entries: string[] = [];
+  try {
+    entries = (await fs.readdir(missionsDir)).filter(f => f.endsWith('.json'));
+  } catch {
+    return result;
+  }
+
+  for (const file of entries) {
+    const fullPath = path.join(missionsDir, file);
+    result.scanned += 1;
+
+    let mission: Mission;
+    try {
+      const raw = await fs.readFile(fullPath, 'utf-8');
+      mission = JSON.parse(raw) as Mission;
+    } catch {
+      result.failed.push(fullPath);
+      continue;
+    }
+
+    if (!mission.id || typeof mission.id !== 'string') {
+      // Valid JSON but no usable id — track so the caller can investigate.
+      result.failed.push(fullPath);
+      continue;
+    }
+
+    if (mission.priority) {
+      result.skipped.push(mission.id);
+      continue;
+    }
+
+    const patched: Mission = { ...mission, priority: BACKFILL_DEFAULT_PRIORITY };
+    // atomicWriteJson writes to a tmp file and renames — crash-safe.
+    await atomicWriteJson(fullPath, patched);
+    result.updated.push(mission.id);
+  }
+
+  return result;
+}
+
+/**
+ * CLI entry point — resolves the missions directory relative to CWD
+ * and logs a summary. Safe to invoke repeatedly.
+ */
+async function main(): Promise<void> {
+  const missionsDir = path.join(process.cwd(), '.crewly', 'missions');
+  const result = await backfillMissionPriority(missionsDir);
+  // eslint-disable-next-line no-console
+  console.log(
+    `[backfill] scanned=${result.scanned} updated=${result.updated.length} skipped=${result.skipped.length} failed=${result.failed.length}`,
+  );
+  if (result.updated.length > 0) {
+    // eslint-disable-next-line no-console
+    console.log(`[backfill] updated ids: ${result.updated.join(', ')}`);
+  }
+  if (result.failed.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(`[backfill] failed to process: ${result.failed.join(', ')}`);
+  }
+}
+
+// Execute only when run directly (not when imported by tests).
+const isDirectRun =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  process.argv[1].endsWith('backfill-mission-priority.ts');
+
+if (isDirectRun) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('[backfill] failed:', err);
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -1641,6 +1641,9 @@ export class AgentRegistrationService {
 					teamMission: foundTeam?.mission,
 					teamBudget: foundTeam?.budget as ModuleConfig['teamBudget'],
 					teamQualityGate: foundTeam?.qualityGate as ModuleConfig['teamQualityGate'],
+					teamNormsPath: foundTeam?.id
+						? path.join(os.homedir(), CREWLY_CONSTANTS.PATHS.CREWLY_HOME, 'teams', foundTeam.id, 'norms')
+						: undefined,
 				};
 
 				const assembler = new PromptAssemblyService();

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
@@ -73,7 +73,8 @@ describe('PromptAssemblyService', () => {
 			expect(names).toContain('capability-overlay');
 			expect(names).toContain('domain-sop');
 			expect(names).toContain('risk-policy');
-			expect(names.length).toBe(15);
+			expect(names).toContain('team-norms');
+			expect(names.length).toBe(17);
 		});
 
 		it('should use default token budget of 28000', () => {

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
@@ -23,6 +23,7 @@ import { RoleBoundaryModule } from './role-boundary.module.js';
 import { CapabilityOverlayModule } from './capability-overlay.module.js';
 import { DomainSOPModule } from './domain-sop.module.js';
 import { RiskPolicyModule } from './risk-policy.module.js';
+import { TeamNormsModule } from './team-norms.module.js';
 
 /**
  * Default total token budget for all prompt modules combined.
@@ -117,6 +118,7 @@ export class PromptAssemblyService {
 			new ProjectReferenceModule(),
 			new CommunicationModule(),
 			new DomainSOPModule(),
+			new TeamNormsModule(),
 			new UserProfileReferenceModule(),
 			new RiskPolicyModule(),
 			new LearningReferenceModule(),

--- a/backend/src/services/ai/prompt-modules/team-norms.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/team-norms.module.test.ts
@@ -136,4 +136,118 @@ describe('TeamNormsModule', () => {
       expect(content).toBe('');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Frontmatter-driven filtering (solves "SOP overload" with 50+ files)
+  // -------------------------------------------------------------------------
+
+  describe('frontmatter filtering', () => {
+    it('skips norms marked deprecated: true', async () => {
+      const dir = path.join(tempDir, 'deprecated-norms');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'old.md'),
+        '---\ndeprecated: true\n---\n# Old SOP\nRetired content.',
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(dir, 'current.md'),
+        '# Current SOP\nStill in force.',
+        'utf-8',
+      );
+
+      const content = await mod.build(makeConfig({ teamNormsPath: dir }));
+      expect(content).toContain('Current SOP');
+      expect(content).not.toContain('Old SOP');
+      expect(content).not.toContain('Retired content');
+    });
+
+    it('includes universal norms (no appliesTo) for any role', async () => {
+      const dir = path.join(tempDir, 'universal-norms');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'all.md'),
+        '# Universal SOP\nApplies to everyone.',
+        'utf-8',
+      );
+
+      const content = await mod.build(
+        makeConfig({ teamNormsPath: dir, role: 'some-obscure-role' }),
+      );
+      expect(content).toContain('Universal SOP');
+    });
+
+    it('filters by appliesTo when present', async () => {
+      const dir = path.join(tempDir, 'role-scoped-norms');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'writer-only.md'),
+        '---\nappliesTo: [writer]\n---\n# Writer SOP\nFor writers.',
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(dir, 'strategist-only.md'),
+        '---\nappliesTo: [strategist]\n---\n# Strategist SOP\nFor strategists.',
+        'utf-8',
+      );
+
+      const writerContent = await mod.build(
+        makeConfig({ teamNormsPath: dir, role: 'writer' }),
+      );
+      expect(writerContent).toContain('Writer SOP');
+      expect(writerContent).not.toContain('Strategist SOP');
+
+      const strategistContent = await mod.build(
+        makeConfig({ teamNormsPath: dir, role: 'strategist' }),
+      );
+      expect(strategistContent).toContain('Strategist SOP');
+      expect(strategistContent).not.toContain('Writer SOP');
+    });
+
+    it('strips frontmatter from the emitted content', async () => {
+      const dir = path.join(tempDir, 'frontmatter-strip');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'norm.md'),
+        '---\ntitle: My Norm\npriority: 10\n---\n# Body\nThe real content.',
+        'utf-8',
+      );
+
+      const content = await mod.build(makeConfig({ teamNormsPath: dir }));
+      expect(content).toContain('The real content');
+      expect(content).not.toContain('priority:');
+      expect(content).not.toContain('title:');
+    });
+
+    it('ranks by priority desc so critical norms win limited slots', async () => {
+      const dir = path.join(tempDir, 'priority-norms');
+      fs.mkdirSync(dir, { recursive: true });
+      // Create 7 norms — 2 high-priority, 5 normal. MAX_NORM_FILES=5 caps output,
+      // so both high-priority must survive while 2 normal ones get dropped.
+      fs.writeFileSync(
+        path.join(dir, 'high-a.md'),
+        '---\npriority: 100\n---\n# High A\nCritical rule A.',
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(dir, 'high-b.md'),
+        '---\npriority: 100\n---\n# High B\nCritical rule B.',
+        'utf-8',
+      );
+      for (let i = 0; i < 5; i++) {
+        fs.writeFileSync(
+          path.join(dir, `normal-${i}.md`),
+          `# Normal ${i}\nRoutine guidance ${i}.`,
+          'utf-8',
+        );
+      }
+
+      const content = await mod.build(makeConfig({ teamNormsPath: dir }));
+      expect(content).toContain('Critical rule A');
+      expect(content).toContain('Critical rule B');
+      // Only 3 of the 5 normals fit in the remaining slots.
+      const normalMatches = (content.match(/Routine guidance/g) ?? []).length;
+      expect(normalMatches).toBe(3);
+    });
+  });
 });

--- a/backend/src/services/ai/prompt-modules/team-norms.module.ts
+++ b/backend/src/services/ai/prompt-modules/team-norms.module.ts
@@ -17,8 +17,92 @@ import type { PromptModule, ModuleConfig } from './prompt-module.interface.js';
 
 /**
  * Maximum number of norm files to load per team to prevent prompt bloat.
+ * Applied AFTER frontmatter filtering, so deprecated/off-role norms do not
+ * consume a slot.
  */
 const MAX_NORM_FILES = 5;
+
+/**
+ * Parsed frontmatter fields recognised by this module.
+ *
+ * - `deprecated: true` — skip entirely (retired SOP).
+ * - `appliesTo: [role, ...]` — only include when the agent's role matches
+ *   one of the listed roles. Accepts a scalar or comma-separated string too.
+ * - `priority: number` — sort key (higher first) so critical norms win the
+ *   limited slots under MAX_NORM_FILES.
+ * - `title`, `version`, `trigger`, etc. are tolerated but not acted on here;
+ *   the `get-team-norms` skill consumes the same format.
+ */
+interface NormFrontmatter {
+  deprecated?: boolean;
+  appliesTo?: string[];
+  priority?: number;
+}
+
+/**
+ * Parse a `---`-delimited YAML frontmatter block at the start of the file.
+ * Returns the parsed fields plus the remaining content. Only supports the
+ * handful of simple scalar/sequence forms we care about — intentionally
+ * avoids adding a YAML dependency to this hot path.
+ */
+function parseFrontmatter(raw: string): {
+  meta: NormFrontmatter;
+  content: string;
+} {
+  if (!raw.startsWith('---')) {
+    return { meta: {}, content: raw };
+  }
+  const lines = raw.split('\n');
+  // Find the closing --- (first delimiter is line 0)
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end === -1) {
+    return { meta: {}, content: raw };
+  }
+
+  const meta: NormFrontmatter = {};
+  for (const line of lines.slice(1, end)) {
+    const m = /^([A-Za-z_][\w-]*)\s*:\s*(.*)$/.exec(line);
+    if (!m) continue;
+    const key = m[1];
+    let value = m[2].trim();
+    // Strip inline comment
+    const hashIdx = value.indexOf(' #');
+    if (hashIdx >= 0) value = value.slice(0, hashIdx).trim();
+
+    if (key === 'deprecated') {
+      meta.deprecated = /^(true|yes|1)$/i.test(value);
+    } else if (key === 'appliesTo') {
+      // Accept: `appliesTo: [a, b]` | `appliesTo: a` | `appliesTo: a, b`
+      const stripped = value.replace(/^\[|\]$/g, '');
+      meta.appliesTo = stripped
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean);
+    } else if (key === 'priority') {
+      const n = Number(value);
+      if (!Number.isNaN(n)) meta.priority = n;
+    }
+  }
+  return { meta, content: lines.slice(end + 1).join('\n') };
+}
+
+/**
+ * Decides whether a norm applies to the current agent given parsed frontmatter.
+ * Universal (no `appliesTo`) norms always apply. Role-scoped norms apply when
+ * the agent's role is listed.
+ */
+function normApplies(meta: NormFrontmatter, role: string | undefined): boolean {
+  if (meta.deprecated) return false;
+  if (!meta.appliesTo || meta.appliesTo.length === 0) return true;
+  if (!role) return false;
+  return meta.appliesTo.includes(role);
+}
 
 /**
  * TeamNormsModule loads all markdown norm files from the team's norms directory
@@ -57,46 +141,80 @@ export class TeamNormsModule implements PromptModule {
   }
 
   /**
-   * Build the team norms prompt section by loading all .md files from the norms directory.
+   * Build the team norms prompt section by loading relevant .md files from
+   * the norms directory.
    *
-   * @param config - Module configuration with teamNormsPath
-   * @returns Formatted markdown section with all team norms
+   * Selection is a two-stage pipeline designed to keep the marketing team's
+   * 50+ SOP files from blowing the prompt budget:
+   *
+   * 1. **Filter**: parse each file's YAML frontmatter, skip `deprecated: true`
+   *    and skip files whose `appliesTo` does not include the agent's role.
+   * 2. **Rank + cap**: sort survivors by descending `priority` (default 0),
+   *    then alphabetically for stable ordering, then keep at most
+   *    `MAX_NORM_FILES`.
+   *
+   * Frontmatter is stripped from the emitted content — agents see the SOP
+   * body, not the routing metadata.
+   *
+   * @param config - Module configuration with teamNormsPath and role
+   * @returns Formatted markdown section with the applicable norms
    */
   async build(config: ModuleConfig): Promise<string> {
     const normsPath = config.teamNormsPath!;
     const sections: string[] = ['## Team Norms & SOPs\n'];
 
     try {
-      const dirExists = await fs.promises.access(normsPath).then(() => true).catch(() => false);
+      const dirExists = await fs.promises
+        .access(normsPath)
+        .then(() => true)
+        .catch(() => false);
       if (!dirExists) {
         return '';
       }
 
       const allEntries = await fs.promises.readdir(normsPath);
-      const entries = allEntries
-        .filter((f) => f.endsWith('.md'))
-        .sort()
-        .slice(0, MAX_NORM_FILES);
+      const mdFiles = allEntries.filter((f) => f.endsWith('.md')).sort();
 
-      if (entries.length === 0) {
-        return '';
-      }
+      // Stage 1: read + parse frontmatter, filter on role/deprecated.
+      type Candidate = {
+        fileName: string;
+        content: string;
+        priority: number;
+      };
+      const candidates: Candidate[] = [];
 
-      for (const entry of entries) {
+      for (const entry of mdFiles) {
         const filePath = path.join(normsPath, entry);
         try {
-          const content = (await fs.promises.readFile(filePath, 'utf-8')).trim();
-          if (content) {
-            sections.push(content);
-            sections.push(''); // blank line separator
-          }
+          const raw = await fs.promises.readFile(filePath, 'utf-8');
+          const { meta, content } = parseFrontmatter(raw);
+          if (!normApplies(meta, config.role)) continue;
+          const trimmed = content.trim();
+          if (!trimmed) continue;
+          candidates.push({
+            fileName: entry,
+            content: trimmed,
+            priority: meta.priority ?? 0,
+          });
         } catch {
-          // Skip unreadable files
+          // Skip unreadable files silently — one bad file shouldn't kill the module.
         }
       }
 
-      if (sections.length <= 1) {
+      if (candidates.length === 0) {
         return '';
+      }
+
+      // Stage 2: rank by priority desc, then filename asc, then cap.
+      candidates.sort((a, b) => {
+        if (a.priority !== b.priority) return b.priority - a.priority;
+        return a.fileName.localeCompare(b.fileName);
+      });
+      const chosen = candidates.slice(0, MAX_NORM_FILES);
+
+      for (const item of chosen) {
+        sections.push(item.content);
+        sections.push(''); // blank line separator
       }
 
       return sections.join('\n');

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -247,6 +247,69 @@ describe('BrowserProxyService', () => {
       expect(result.id).toBe(cmdId);
     });
 
+    it('updates lastSeenAt on the matching instance when a relay carries senderSessionId', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+
+      // Seed two instances so we can assert only the sender's row is touched.
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            { instanceId: 'id-1', instanceName: 'Chrome', sessionId: 'bs-1' },
+            { instanceId: 'id-2', instanceName: 'Other', sessionId: 'bs-2' },
+          ],
+        }),
+      );
+
+      const before = proxy.getInstances();
+      const beforeBs1 = before.find((i) => i.sessionId === 'bs-1')!.lastSeenAt;
+      const beforeBs2 = before.find((i) => i.sessionId === 'bs-2')!.lastSeenAt;
+
+      // Advance fake timers so Date.now() produces a distinguishable ISO stamp.
+      jest.advanceTimersByTime(100);
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          senderSessionId: 'bs-1',
+          payload: JSON.stringify({ id: 'ignored', success: true }),
+        }),
+      );
+
+      const after = proxy.getInstances();
+      expect(after.find((i) => i.sessionId === 'bs-1')!.lastSeenAt).not.toBe(beforeBs1);
+      expect(after.find((i) => i.sessionId === 'bs-2')!.lastSeenAt).toBe(beforeBs2);
+    });
+
+    it('ignores relay messages without senderSessionId (no lastSeenAt update)', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [{ instanceId: 'id-1', instanceName: 'Chrome', sessionId: 'bs-1' }],
+        }),
+      );
+
+      const before = proxy.getInstances()[0].lastSeenAt;
+      jest.advanceTimersByTime(100);
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          payload: JSON.stringify({ id: 'x', success: true }),
+        }),
+      );
+
+      expect(proxy.getInstances()[0].lastSeenAt).toBe(before);
+    });
+
     it('should handle error messages gracefully', () => {
       connectAndRegister();
       // Should not throw

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -25,6 +25,8 @@ export interface BrowserInstanceInfo {
   instanceName: string;
   /** Relay session ID */
   sessionId: string;
+  /** ISO timestamp of last activity (heartbeat, command, or event) */
+  lastSeenAt: string;
 }
 
 /** Pending command waiting for a relay response. */
@@ -425,7 +427,16 @@ export class BrowserProxyService {
         break;
 
       case 'relay': {
-        // Response from a browser instance
+        // Response from a browser instance — update lastSeenAt
+        const senderSessionId = msg.senderSessionId as string | undefined;
+        if (senderSessionId) {
+          for (const inst of this.instances.values()) {
+            if (inst.sessionId === senderSessionId) {
+              inst.lastSeenAt = new Date().toISOString();
+              break;
+            }
+          }
+        }
         const payload = msg.payload as string;
         this.handleRelayPayload(payload);
         break;
@@ -457,13 +468,34 @@ export class BrowserProxyService {
     this.logger.warn('Relay error', { code, message });
 
     if (code === 'AUTH_FAILED') {
-      // Token is expired/invalid — try to get a fresh one immediately
-      // before the relay closes the connection (code 4003).
+      // Token is expired/invalid OR the user's plan claim is stale (for
+      // example, admin just upgraded the account from free → pro but the
+      // in-memory JWT still carries plan:"free"). Try fast path first
+      // (cached resolver), then fall back to an active refresh which
+      // exchanges the refresh token against /api/cloud/refresh so the
+      // new access + relay tokens carry the latest plan from MongoDB.
       const freshToken = this.tokenResolver?.();
       if (freshToken && freshToken !== this.authToken) {
         this.authToken = freshToken;
         this.logger.info('Fetched fresh token after AUTH_FAILED, will use on next reconnect');
+        return;
       }
+
+      // No cached fresh token — actively refresh. The tokenRefreshCallbacks
+      // in CloudClientService will push the new relay/access token back to
+      // this proxy via updateToken() once the refresh completes, so the next
+      // reconnect attempt uses the post-plan-change token.
+      this.logger.info('No cached fresh token; triggering active refresh after AUTH_FAILED');
+      import('../cloud/cloud-client.service.js')
+        .then(({ CloudClientService }) => CloudClientService.getInstance().tryRefreshToken())
+        .then((ok) => {
+          this.logger.info('Active refresh after AUTH_FAILED complete', { refreshed: ok });
+        })
+        .catch((err) => {
+          this.logger.warn('Active refresh after AUTH_FAILED threw', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
     } else if (code === 'BROWSER_NOT_FOUND' || code === 'BROWSER_UNAVAILABLE') {
       this.logger.warn('Browser not reachable via relay', { code });
     }
@@ -475,9 +507,13 @@ export class BrowserProxyService {
    * @param instances - Array of browser instance info from relay
    */
   private handleBrowserList(instances: BrowserInstanceInfo[]): void {
+    const now = new Date().toISOString();
     this.instances.clear();
     for (const inst of instances) {
-      this.instances.set(inst.instanceId, inst);
+      this.instances.set(inst.instanceId, {
+        ...inst,
+        lastSeenAt: inst.lastSeenAt || now,
+      });
     }
     this.logger.info('Browser instances updated', {
       count: this.instances.size,
@@ -495,12 +531,15 @@ export class BrowserProxyService {
     const instanceId = msg.instanceId as string;
     const instanceName = msg.instanceName as string;
 
+    const now = new Date().toISOString();
+
     switch (event) {
       case 'connected':
         this.instances.set(instanceId, {
           instanceId,
           instanceName,
           sessionId: '', // Will be populated by next list_browsers
+          lastSeenAt: now,
         });
         this.logger.info('Browser instance connected', { instanceId, instanceName });
         // Refresh full list to get sessionId
@@ -513,10 +552,11 @@ export class BrowserProxyService {
         break;
 
       case 'updated': {
-        // Update name
+        // Update name and lastSeenAt
         const existing = this.instances.get(instanceId);
         if (existing) {
           existing.instanceName = instanceName;
+          existing.lastSeenAt = now;
         }
         break;
       }

--- a/backend/src/services/cloud/cloud-client.service.ts
+++ b/backend/src/services/cloud/cloud-client.service.ts
@@ -208,6 +208,7 @@ export class CloudClientService {
     // crewly-auth /api/cloud/validate returns { success, data: { plan, relayToken, ... } }
     // Also accept legacy { tier } format for forward compatibility
     const data = (await response.json()) as { tier?: string; data?: { plan?: string; relayToken?: string } };
+    this.logger.debug('Cloud validate response', { hasData: !!data.data, hasPlan: !!data.data?.plan, hasRelayToken: !!data.data?.relayToken, dataKeys: data.data ? Object.keys(data.data) : [] });
     const resolvedTier = data.data?.plan || data.tier;
 
     this.cloudUrl = cloudUrl;

--- a/backend/src/services/core/storage.service.test.ts
+++ b/backend/src/services/core/storage.service.test.ts
@@ -22,6 +22,7 @@ jest.mock('fs/promises', () => ({
   open: jest.fn(),
   rename: jest.fn(),
   copyFile: jest.fn(),
+  rm: jest.fn(),
 }));
 
 const mockFs = fs as jest.Mocked<typeof fs>;
@@ -124,6 +125,89 @@ describe('StorageService', () => {
       const writeCall = mockFsPromises.writeFile.mock.calls[0];
       const parsedContent = JSON.parse(writeCall[1]);
       expect(parsedContent.name).toBe('Updated Team');
+    });
+
+    test('emits a team-saved event after saveTeam', async () => {
+      const team: Team = {
+        id: 'emit-save',
+        name: 'Emitter',
+        description: '',
+        members: [],
+        projectIds: [],
+        createdAt: '2023-01-01T00:00:00.000Z',
+        updatedAt: '2023-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+      mockFsPromises.readdir.mockResolvedValue([]);
+
+      const events: Array<{ kind: string; id?: string }> = [];
+      storageService.onStorageEvent((ev) => {
+        if (ev.kind === 'team-saved') events.push({ kind: ev.kind, id: ev.team.id });
+      });
+
+      await storageService.saveTeam(team);
+
+      expect(events).toEqual([{ kind: 'team-saved', id: 'emit-save' }]);
+    });
+
+    test('emits a team-deleted event after deleteTeam', async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFsPromises.rm.mockResolvedValue(undefined);
+
+      const events: Array<{ kind: string; id?: string }> = [];
+      storageService.onStorageEvent((ev) => {
+        if (ev.kind === 'team-deleted') events.push({ kind: ev.kind, id: ev.teamId });
+      });
+
+      await storageService.deleteTeam('gone');
+
+      expect(events).toEqual([{ kind: 'team-deleted', id: 'gone' }]);
+    });
+
+    test('unsubscribe stops further events to the listener', async () => {
+      const team: Team = {
+        id: 'unsub',
+        name: 'U',
+        description: '',
+        members: [],
+        projectIds: [],
+        createdAt: '2023-01-01T00:00:00.000Z',
+        updatedAt: '2023-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+      mockFsPromises.readdir.mockResolvedValue([]);
+
+      const calls: string[] = [];
+      const unsubscribe = storageService.onStorageEvent((ev) => {
+        if (ev.kind === 'team-saved') calls.push(ev.team.id);
+      });
+
+      await storageService.saveTeam(team);
+      unsubscribe();
+      await storageService.saveTeam({ ...team, id: 'after-unsub' });
+
+      expect(calls).toEqual(['unsub']);
+    });
+
+    test('a throwing listener does not break the save path', async () => {
+      const team: Team = {
+        id: 'err',
+        name: 'E',
+        description: '',
+        members: [],
+        projectIds: [],
+        createdAt: '2023-01-01T00:00:00.000Z',
+        updatedAt: '2023-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+      mockFsPromises.readdir.mockResolvedValue([]);
+
+      storageService.onStorageEvent(() => {
+        throw new Error('listener blew up');
+      });
+
+      // Should not throw — listener errors are isolated.
+      await expect(storageService.saveTeam(team)).resolves.toBeUndefined();
     });
   });
 

--- a/backend/src/services/core/storage.service.ts
+++ b/backend/src/services/core/storage.service.ts
@@ -14,6 +14,17 @@ import { TeamsBackupService } from './teams-backup.service.js';
 import { atomicWriteFile, withOperationLock } from '../../utils/file-io.utils.js';
 import { addGeminiTrustedFolders, getProjectTrustPaths } from '../../utils/gemini-trusted-folders.js';
 
+/**
+ * Storage-level events emitted after a team is persisted or removed.
+ * Subscribers (e.g. {@link TeamTriggerReconciler}) use these to converge
+ * side systems without pulling StorageService into a cross-cutting tangle.
+ */
+export type StorageEvent =
+  | { kind: 'team-saved'; team: Team }
+  | { kind: 'team-deleted'; teamId: string };
+
+export type StorageListener = (event: StorageEvent) => Promise<void> | void;
+
 export class StorageService {
   private static instance: StorageService | null = null;
   private static instanceHome: string | null = null;
@@ -37,6 +48,13 @@ export class StorageService {
   /** Debounce timer for teams backup to avoid I/O storms */
   private backupDebounceTimer: NodeJS.Timeout | null = null;
   private readonly BACKUP_DEBOUNCE_MS = 2000;
+
+  /**
+   * Listeners registered via {@link onStorageEvent}. Empty by default so
+   * existing call-sites pay zero cost; listeners are fired-and-forgotten
+   * to keep save/delete latency unchanged.
+   */
+  private listeners: StorageListener[] = [];
 
   constructor(crewlyHome?: string) {
     this.logger = LoggerService.getInstance().createComponentLogger('StorageService');
@@ -470,6 +488,10 @@ export class StorageService {
 
         // Update teams backup (fire-and-forget, non-blocking)
         this.updateTeamsBackup();
+
+        // Notify listeners (e.g. TeamTriggerReconciler). Fire-and-forget so
+        // slow subscribers never block the save path.
+        this.emit({ kind: 'team-saved', team });
       } catch (error) {
         this.logger.error('Error saving team', {
           teamId: team.id,
@@ -616,12 +638,59 @@ export class StorageService {
       } else {
         this.logger.warn('Team directory not found for deletion', { teamId: id, teamDir });
       }
+      // Always fire the event so listeners can clean up even if the directory
+      // had already been removed out-of-band.
+      this.emit({ kind: 'team-deleted', teamId: id });
     } catch (error) {
       this.logger.error('Error deleting team', {
         teamId: id,
         error: error instanceof Error ? error.message : String(error),
       });
       throw error;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage event subscriptions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a listener for storage lifecycle events. Returns an unsubscribe
+   * function. Listeners are invoked fire-and-forget; errors are logged and
+   * never propagated to the save/delete caller.
+   *
+   * @param listener - Callback invoked for every saved/deleted team
+   * @returns Unsubscribe function
+   */
+  onStorageEvent(listener: StorageListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  /**
+   * Fire all registered listeners without awaiting their completion. Any
+   * error inside a listener is isolated to that listener.
+   */
+  private emit(event: StorageEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        const result = listener(event);
+        if (result && typeof (result as Promise<void>).catch === 'function') {
+          (result as Promise<void>).catch((err) => {
+            this.logger.warn('Storage listener failed (async)', {
+              event: event.kind,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
+      } catch (err) {
+        this.logger.warn('Storage listener failed (sync)', {
+          event: event.kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 

--- a/backend/src/services/project/task.service.test.ts
+++ b/backend/src/services/project/task.service.test.ts
@@ -75,13 +75,15 @@ describe('TaskService', () => {
      */
     it('should handle minimal markdown content', () => {
       const mockContent = `# Minimal Task`;
-      
+
       const parseMethod = (taskService as any).parseMarkdownContent;
       const result = parseMethod.call(taskService, mockContent);
-      
+
       expect(result.title).toBe('Minimal Task');
-      expect(result.status).toBe('pending');
-      expect(result.priority).toBe('medium');
+      // Unset sentinels — readTaskFile narrows these to real defaults
+      // ('open' / 'medium') via the type guards.
+      expect(result.status).toBe('');
+      expect(result.priority).toBe('');
       expect(result.tasks).toEqual([]);
       expect(result.acceptanceCriteria).toEqual([]);
     });
@@ -91,13 +93,13 @@ describe('TaskService', () => {
      */
     it('should handle empty content gracefully', () => {
       const mockContent = '';
-      
+
       const parseMethod = (taskService as any).parseMarkdownContent;
       const result = parseMethod.call(taskService, mockContent);
-      
+
       expect(result.title).toBe('');
-      expect(result.status).toBe('pending');
-      expect(result.priority).toBe('medium');
+      expect(result.status).toBe('');
+      expect(result.priority).toBe('');
     });
   });
 

--- a/backend/src/services/project/task.service.ts
+++ b/backend/src/services/project/task.service.ts
@@ -2,12 +2,29 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { existsSync } from 'fs';
 
+export const TASK_STATUSES = ['open', 'in_progress', 'review', 'done', 'blocked'] as const;
+export type TaskStatus = typeof TASK_STATUSES[number];
+
+export const TASK_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
+export type TaskPriority = typeof TASK_PRIORITIES[number];
+
+/** Folder names that indicate a status-partitioned milestone directory. */
+const STATUS_FOLDERS: readonly TaskStatus[] = ['open', 'in_progress', 'done', 'blocked'];
+
+export function isValidTaskStatus(value: string): value is TaskStatus {
+  return (TASK_STATUSES as readonly string[]).includes(value);
+}
+
+export function isValidTaskPriority(value: string): value is TaskPriority {
+  return (TASK_PRIORITIES as readonly string[]).includes(value);
+}
+
 export interface Task {
   id: string;
   title: string;
   description: string;
-  status: 'open' | 'in_progress' | 'review' | 'done' | 'blocked';
-  priority: 'low' | 'medium' | 'high' | 'critical';
+  status: TaskStatus;
+  priority: TaskPriority;
   assignee?: string;
   milestone: string;
   milestoneId: string;
@@ -29,7 +46,7 @@ export class TaskService {
   private tasksDir: string;
 
   constructor(projectPath?: string) {
-    this.tasksDir = projectPath 
+    this.tasksDir = projectPath
       ? path.join(path.resolve(projectPath), '.crewly', 'tasks')
       : path.join(process.cwd(), '.crewly', 'tasks');
   }
@@ -46,25 +63,29 @@ export class TaskService {
   } {
     const lines = content.split('\n');
     let title = '';
-    let status = 'pending';
-    let priority = 'medium';
+    // Use empty string as the "unset" sentinel — readTaskFile narrows this
+    // through `isValidTaskStatus`/`isValidTaskPriority` and applies the real
+    // defaults. A non-empty sentinel like 'pending' here would be misleading
+    // because 'pending' is not a valid TaskStatus.
+    let status = '';
+    let priority = '';
     let assignee = '';
     let milestone = '';
     let description = '';
     let tasks: string[] = [];
     let acceptanceCriteria: string[] = [];
-    
+
     let currentSection = '';
-    
+
     for (const line of lines) {
       const trimmedLine = line.trim();
-      
+
       // Extract title from first h1
       if (trimmedLine.startsWith('# ') && !title) {
         title = trimmedLine.substring(2).trim();
         continue;
       }
-      
+
       // Extract metadata
       if (trimmedLine.startsWith('**Status:**')) {
         status = trimmedLine.replace('**Status:**', '').trim();
@@ -82,7 +103,7 @@ export class TaskService {
         milestone = trimmedLine.replace('**Milestone:**', '').trim();
         continue;
       }
-      
+
       // Track sections
       if (trimmedLine.startsWith('## Description')) {
         currentSection = 'description';
@@ -100,7 +121,7 @@ export class TaskService {
         currentSection = '';
         continue;
       }
-      
+
       // Extract content based on current section
       if (currentSection === 'description' && trimmedLine && !trimmedLine.startsWith('#')) {
         description += (description ? '\n' : '') + trimmedLine;
@@ -112,7 +133,7 @@ export class TaskService {
         acceptanceCriteria.push(trimmedLine.substring(2).trim());
       }
     }
-    
+
     return {
       title,
       status: status.toLowerCase(),
@@ -125,91 +146,127 @@ export class TaskService {
     };
   }
 
+  /**
+   * Read one task markdown file and build a {@link Task}. Returns `null`
+   * when the file can't be read (corrupt, permission denied, missing).
+   *
+   * Status resolution falls back to `statusOverride` when the file's own
+   * `status:` front-matter is missing or invalid — this lets callers
+   * encode status in the folder layout (`milestone/open/foo.md`) without
+   * losing the type narrowing.
+   */
+  private async readTaskFile(
+    filePath: string,
+    milestoneId: string,
+    statusOverride?: TaskStatus,
+  ): Promise<Task | null> {
+    try {
+      const [content, stats] = await Promise.all([
+        fs.readFile(filePath, 'utf-8'),
+        fs.stat(filePath),
+      ]);
+      const parsed = this.parseMarkdownContent(content);
+      const fileBase = path.basename(filePath, '.md');
+
+      const resolvedStatus: TaskStatus = statusOverride
+        ?? (isValidTaskStatus(parsed.status) ? parsed.status : 'open');
+      const resolvedPriority: TaskPriority = isValidTaskPriority(parsed.priority)
+        ? parsed.priority
+        : 'medium';
+
+      // Real filesystem timestamps so consumers that sort/cache by
+      // createdAt/updatedAt get stable values across reads. birthtimeMs
+      // falls back to mtime on filesystems that don't track creation time.
+      const createdAt = new Date(stats.birthtimeMs || stats.mtimeMs).toISOString();
+      const updatedAt = new Date(stats.mtimeMs).toISOString();
+
+      return {
+        id: fileBase,
+        title: parsed.title || fileBase.replace(/_/g, ' '),
+        description: parsed.description,
+        status: resolvedStatus,
+        priority: resolvedPriority,
+        assignee: parsed.assignee,
+        milestone: parsed.milestone || milestoneId,
+        milestoneId,
+        tasks: parsed.tasks,
+        acceptanceCriteria: parsed.acceptanceCriteria,
+        filePath,
+        createdAt,
+        updatedAt,
+      };
+    } catch {
+      return null;
+    }
+  }
+
   async getAllTasks(): Promise<Task[]> {
     if (!existsSync(this.tasksDir)) {
       return [];
     }
 
     const tasks: Task[] = [];
-    const milestones = await fs.readdir(this.tasksDir);
-    
+    let milestones: string[];
+    try {
+      milestones = await fs.readdir(this.tasksDir);
+    } catch {
+      return [];
+    }
+
     for (const milestone of milestones) {
       const milestonePath = path.join(this.tasksDir, milestone);
-      const stat = await fs.stat(milestonePath);
-      
-      if (!stat.isDirectory()) continue;
-      
+      try {
+        const stat = await fs.stat(milestonePath);
+        if (!stat.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
       // Check if this is a status-based structure (has status folders) or direct markdown files
-      const items = await fs.readdir(milestonePath);
-      const statusFolders = ['open', 'in_progress', 'done', 'blocked'];
-      const hasStatusFolders = items.some(item => statusFolders.includes(item));
-      
+      let items: string[];
+      try {
+        items = await fs.readdir(milestonePath);
+      } catch {
+        continue;
+      }
+      const hasStatusFolders = items.some(item => (STATUS_FOLDERS as readonly string[]).includes(item));
+
       if (hasStatusFolders) {
         // Status-based structure: milestone/status/task.md
-        for (const statusFolder of statusFolders) {
+        for (const statusFolder of STATUS_FOLDERS) {
           const statusPath = path.join(milestonePath, statusFolder);
-          if (existsSync(statusPath)) {
+          if (!existsSync(statusPath)) continue;
+          try {
             const statusStat = await fs.stat(statusPath);
-            if (statusStat.isDirectory()) {
-              const statusFiles = await fs.readdir(statusPath);
-              const markdownFiles = statusFiles.filter(file => file.endsWith('.md'));
-              
-              for (const file of markdownFiles) {
-                const filePath = path.join(statusPath, file);
-                const content = await fs.readFile(filePath, 'utf-8');
-                const parsed = this.parseMarkdownContent(content);
-                
-                const task: Task = {
-                  id: path.basename(file, '.md'),
-                  title: parsed.title || path.basename(file, '.md').replace(/_/g, ' '),
-                  description: parsed.description,
-                  status: statusFolder as any, // Use folder name as status
-                  priority: parsed.priority as any,
-                  assignee: parsed.assignee,
-                  milestone: parsed.milestone || milestone,
-                  milestoneId: milestone,
-                  tasks: parsed.tasks,
-                  acceptanceCriteria: parsed.acceptanceCriteria,
-                  filePath,
-                  createdAt: new Date().toISOString(),
-                  updatedAt: new Date().toISOString()
-                };
-                
-                tasks.push(task);
-              }
-            }
+            if (!statusStat.isDirectory()) continue;
+          } catch {
+            continue;
+          }
+
+          let statusFiles: string[];
+          try {
+            statusFiles = await fs.readdir(statusPath);
+          } catch {
+            continue;
+          }
+          const markdownFiles = statusFiles.filter(file => file.endsWith('.md'));
+
+          for (const file of markdownFiles) {
+            const task = await this.readTaskFile(path.join(statusPath, file), milestone, statusFolder);
+            if (task) tasks.push(task);
           }
         }
       } else {
-        // Direct structure: milestone/task.md  
+        // Direct structure: milestone/task.md
         const markdownFiles = items.filter(file => file.endsWith('.md'));
-        
+
         for (const file of markdownFiles) {
-          const filePath = path.join(milestonePath, file);
-          const content = await fs.readFile(filePath, 'utf-8');
-          const parsed = this.parseMarkdownContent(content);
-          
-          const task: Task = {
-            id: path.basename(file, '.md'),
-            title: parsed.title,
-            description: parsed.description,
-            status: parsed.status as any,
-            priority: parsed.priority as any,
-            assignee: parsed.assignee,
-            milestone: parsed.milestone,
-            milestoneId: milestone,
-            tasks: parsed.tasks,
-            acceptanceCriteria: parsed.acceptanceCriteria,
-            filePath,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString()
-          };
-          
-          tasks.push(task);
+          const task = await this.readTaskFile(path.join(milestonePath, file), milestone);
+          if (task) tasks.push(task);
         }
       }
     }
-    
+
     return tasks.sort((a, b) => {
       // Sort by milestone first, then by task ID
       if (a.milestoneId !== b.milestoneId) {
@@ -222,7 +279,7 @@ export class TaskService {
   async getMilestones(): Promise<Milestone[]> {
     const tasks = await this.getAllTasks();
     const milestoneMap = new Map<string, Milestone>();
-    
+
     for (const task of tasks) {
       if (!milestoneMap.has(task.milestoneId)) {
         milestoneMap.set(task.milestoneId, {
@@ -234,7 +291,7 @@ export class TaskService {
       }
       milestoneMap.get(task.milestoneId)!.tasks.push(task);
     }
-    
+
     return Array.from(milestoneMap.values()).sort((a, b) => a.id.localeCompare(b.id));
   }
 

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -100,6 +100,88 @@ describe('TaskPoolService', () => {
       const items = await service.getAllItems();
       expect(items).toHaveLength(1);
     });
+
+    it('accepts a blocked WorkItem (waiting on deps)', async () => {
+      const wi = makeWorkItem({ dependsOn: ['upstream-1'] });
+      // makeWorkItem builds via createWorkItem, so dependsOn → blocked
+      expect(wi.status).toBe('blocked');
+
+      await service.addToPool(wi);
+      const items = await service.getAllItems();
+      expect(items).toHaveLength(1);
+      expect(items[0].status).toBe('blocked');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dependency resolution (auto-unblock)
+  // -----------------------------------------------------------------------
+
+  describe('dependency resolution', () => {
+    it('promotes a blocked dependent to queued when its single dep completes', async () => {
+      const upstream = makeWorkItem({ title: 'upstream' });
+      await service.addToPool(upstream);
+
+      const downstream = makeWorkItem({
+        title: 'downstream',
+        dependsOn: [upstream.id],
+      });
+      await service.addToPool(downstream);
+
+      // Claim + complete upstream — should auto-unblock downstream
+      const claim = await service.claimFromPool('agent-a');
+      expect(claim!.workItem.id).toBe(upstream.id);
+      await service.completeItem(upstream.id);
+
+      const items = await service.getAllItems();
+      const after = items.find((wi) => wi.id === downstream.id)!;
+      expect(after.status).toBe('queued');
+    });
+
+    it('keeps the dependent blocked until ALL deps complete', async () => {
+      const depA = makeWorkItem({ title: 'dep-a' });
+      const depB = makeWorkItem({ title: 'dep-b' });
+      await service.addToPool(depA);
+      await service.addToPool(depB);
+
+      const downstream = makeWorkItem({
+        title: 'downstream',
+        dependsOn: [depA.id, depB.id],
+      });
+      await service.addToPool(downstream);
+
+      // Complete only depA first
+      await service.claimFromPool('agent-a');
+      await service.completeItem(depA.id);
+
+      let items = await service.getAllItems();
+      expect(items.find((wi) => wi.id === downstream.id)!.status).toBe('blocked');
+
+      // Now complete depB — downstream should unblock
+      await service.claimFromPool('agent-b');
+      await service.completeItem(depB.id);
+
+      items = await service.getAllItems();
+      expect(items.find((wi) => wi.id === downstream.id)!.status).toBe('queued');
+    });
+
+    it('does not touch dependents that list a different upstream', async () => {
+      const otherUpstream = makeWorkItem({ title: 'other' });
+      const unrelatedDownstream = makeWorkItem({
+        title: 'unrelated',
+        dependsOn: ['some-other-id'],
+      });
+      await service.addToPool(otherUpstream);
+      await service.addToPool(unrelatedDownstream);
+
+      await service.claimFromPool('agent-a');
+      await service.completeItem(otherUpstream.id);
+
+      const items = await service.getAllItems();
+      expect(items.find((wi) => wi.id === unrelatedDownstream.id)!.status).toBe(
+        'blocked',
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -191,6 +273,26 @@ describe('TaskPoolService', () => {
 
     it('throws on empty agentId', async () => {
       await expect(service.claimFromPool('')).rejects.toThrow('agentId is required');
+    });
+
+    it('serializes concurrent claims so only one agent wins a given WorkItem', async () => {
+      // Single queued item — two agents race to claim it concurrently.
+      const wi = makeWorkItem({ title: 'Contested' });
+      await service.addToPool(wi);
+
+      const [a, b] = await Promise.all([
+        service.claimFromPool('agent-a'),
+        service.claimFromPool('agent-b'),
+      ]);
+
+      // Exactly one of the two must have won.
+      const winners = [a, b].filter((r) => r !== null);
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.workItem.id).toBe(wi.id);
+
+      // Storage must reflect a single active claim, not two.
+      const snapshot = await service.getPoolStatus();
+      expect(snapshot.claimed).toBe(1);
     });
   });
 

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -105,10 +105,32 @@ export class TaskPoolService {
   private readonly claimService: ClaimService;
   private readonly logger: ComponentLogger;
 
+  /**
+   * Serializes claim operations to prevent the race where two concurrent
+   * claimFromPool / claimSpecificItem calls both select the same queued
+   * WorkItem between their read and write phases. In-process only — does
+   * not protect against cross-process races, but the backend runs as a
+   * single process today.
+   */
+  private claimMutex: Promise<void> = Promise.resolve();
+
   constructor(storage?: PoolStorage) {
     this.storage = storage ?? new PoolStorage();
     this.claimService = new ClaimService(this.storage);
     this.logger = LoggerService.getInstance().createComponentLogger('TaskPoolService');
+  }
+
+  /**
+   * Chains the given critical section after any in-flight claim operation.
+   * Guarantees FIFO ordering even under concurrent invocation.
+   */
+  private withClaimLock<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.claimMutex;
+    let release!: () => void;
+    this.claimMutex = new Promise<void>((r) => {
+      release = r;
+    });
+    return prev.then(fn).finally(() => release());
   }
 
   /**
@@ -137,19 +159,21 @@ export class TaskPoolService {
   /**
    * Adds an execution-ready WorkItem to the pool.
    *
-   * The item must have status 'queued' to be added. Items with other
-   * statuses are rejected.
+   * Accepted statuses:
+   * - `queued`  — ready to run
+   * - `blocked` — waiting on unresolved dependsOn; the resolver will promote
+   *               it to `queued` when every upstream dep reaches terminal success.
    *
    * @param workItem - The work item to add
-   * @throws Error if workItem is not valid or not in 'queued' status
+   * @throws Error if workItem is invalid or in an ineligible status
    */
   async addToPool(workItem: WorkItem): Promise<void> {
     if (!isWorkItem(workItem)) {
       throw new Error('Invalid WorkItem: does not conform to WorkItem interface');
     }
-    if (workItem.status !== 'queued') {
+    if (workItem.status !== 'queued' && workItem.status !== 'blocked') {
       throw new Error(
-        `Cannot add WorkItem to pool: status must be 'queued', got '${workItem.status}'`,
+        `Cannot add WorkItem to pool: status must be 'queued' or 'blocked', got '${workItem.status}'`,
       );
     }
 
@@ -187,73 +211,75 @@ export class TaskPoolService {
       throw new Error('agentId is required and must be a non-empty string');
     }
 
-    // Check if agent already has an active claim
-    const existingClaim = await this.storage.findActiveClaimByAgent(agentId);
-    if (existingClaim) {
-      this.logger.warn('Agent already has an active claim', {
-        agentId,
-        existingClaimId: existingClaim.id,
-        existingWorkItemId: existingClaim.workItemId,
+    return this.withClaimLock(async () => {
+      // Check if agent already has an active claim
+      const existingClaim = await this.storage.findActiveClaimByAgent(agentId);
+      if (existingClaim) {
+        this.logger.warn('Agent already has an active claim', {
+          agentId,
+          existingClaimId: existingClaim.id,
+          existingWorkItemId: existingClaim.workItemId,
+        });
+        return null;
+      }
+
+      const workItems = await this.storage.getWorkItems();
+      const claims = await this.storage.getClaims();
+
+      // Set of work item IDs that have active claims
+      const claimedIds = new Set(
+        claims
+          .filter((c) => c.status === 'active')
+          .map((c) => c.workItemId),
+      );
+
+      // Find first matching unclaimed queued item (FIFO by createdAt)
+      const candidates = workItems
+        .filter((wi) => wi.status === 'queued' && !claimedIds.has(wi.id))
+        .filter((wi) => matchesFilters(wi, filters))
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
+      if (candidates.length === 0) {
+        return null;
+      }
+
+      const selected = candidates[0];
+
+      // Transition item to 'running'
+      const updated = await this.storage.updateWorkItem(selected.id, (wi) => {
+        wi.status = 'running';
+        wi.startedAt = new Date().toISOString();
+        wi.target = agentId;
       });
-      return null;
-    }
 
-    const workItems = await this.storage.getWorkItems();
-    const claims = await this.storage.getClaims();
+      if (!updated) {
+        this.logger.warn('Failed to update WorkItem during claim', { workItemId: selected.id });
+        return null;
+      }
 
-    // Set of work item IDs that have active claims
-    const claimedIds = new Set(
-      claims
-        .filter((c) => c.status === 'active')
-        .map((c) => c.workItemId),
-    );
+      // Create the claim
+      const claimInput: CreateClaimInput = {
+        workItemId: selected.id,
+        agentId,
+      };
+      const claim = createTaskClaim(claimInput);
+      await this.storage.addClaim(claim);
+      await this.storage.flush();
 
-    // Find first matching unclaimed queued item (FIFO by createdAt)
-    const candidates = workItems
-      .filter((wi) => wi.status === 'queued' && !claimedIds.has(wi.id))
-      .filter((wi) => matchesFilters(wi, filters))
-      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      this.logger.info('WorkItem claimed', {
+        workItemId: selected.id,
+        agentId,
+        claimId: claim.id,
+        title: selected.title,
+      });
 
-    if (candidates.length === 0) {
-      return null;
-    }
-
-    const selected = candidates[0];
-
-    // Transition item to 'running'
-    const updated = await this.storage.updateWorkItem(selected.id, (wi) => {
-      wi.status = 'running';
-      wi.startedAt = new Date().toISOString();
-      wi.target = agentId;
+      // Return the updated item
+      const claimedItem = await this.storage.findWorkItem(selected.id);
+      return {
+        workItem: claimedItem!,
+        claim,
+      };
     });
-
-    if (!updated) {
-      this.logger.warn('Failed to update WorkItem during claim', { workItemId: selected.id });
-      return null;
-    }
-
-    // Create the claim
-    const claimInput: CreateClaimInput = {
-      workItemId: selected.id,
-      agentId,
-    };
-    const claim = createTaskClaim(claimInput);
-    await this.storage.addClaim(claim);
-    await this.storage.flush();
-
-    this.logger.info('WorkItem claimed', {
-      workItemId: selected.id,
-      agentId,
-      claimId: claim.id,
-      title: selected.title,
-    });
-
-    // Return the updated item
-    const claimedItem = await this.storage.findWorkItem(selected.id);
-    return {
-      workItem: claimedItem!,
-      claim,
-    };
   }
 
   /**
@@ -270,31 +296,33 @@ export class TaskPoolService {
       throw new Error('agentId is required and must be a non-empty string');
     }
 
-    const existingClaim = await this.storage.findActiveClaimByAgent(agentId);
-    if (existingClaim) return null;
+    return this.withClaimLock(async () => {
+      const existingClaim = await this.storage.findActiveClaimByAgent(agentId);
+      if (existingClaim) return null;
 
-    const workItem = await this.storage.findWorkItem(workItemId);
-    if (!workItem || workItem.status !== 'queued') return null;
+      const workItem = await this.storage.findWorkItem(workItemId);
+      if (!workItem || workItem.status !== 'queued') return null;
 
-    const claims = await this.storage.getClaims();
-    if (claims.some((c) => c.workItemId === workItemId && c.status === 'active')) return null;
+      const claims = await this.storage.getClaims();
+      if (claims.some((c) => c.workItemId === workItemId && c.status === 'active')) return null;
 
-    const updated = await this.storage.updateWorkItem(workItemId, (wi) => {
-      wi.status = 'running';
-      wi.startedAt = new Date().toISOString();
-      wi.target = agentId;
+      const updated = await this.storage.updateWorkItem(workItemId, (wi) => {
+        wi.status = 'running';
+        wi.startedAt = new Date().toISOString();
+        wi.target = agentId;
+      });
+      if (!updated) return null;
+
+      const claimInput: CreateClaimInput = { workItemId, agentId };
+      const claim = createTaskClaim(claimInput);
+      await this.storage.addClaim(claim);
+      await this.storage.flush();
+
+      this.logger.info('WorkItem claimed (specific)', { workItemId, agentId, claimId: claim.id });
+
+      const claimedItem = await this.storage.findWorkItem(workItemId);
+      return claimedItem ? { workItem: claimedItem, claim } : null;
     });
-    if (!updated) return null;
-
-    const claimInput: CreateClaimInput = { workItemId, agentId };
-    const claim = createTaskClaim(claimInput);
-    await this.storage.addClaim(claim);
-    await this.storage.flush();
-
-    this.logger.info('WorkItem claimed (specific)', { workItemId, agentId, claimId: claim.id });
-
-    const claimedItem = await this.storage.findWorkItem(workItemId);
-    return claimedItem ? { workItem: claimedItem, claim } : null;
   }
 
   /**
@@ -385,8 +413,53 @@ export class TaskPoolService {
       if (result) wi.result = result;
     });
 
+    // Promote any blocked dependents whose deps are now all satisfied.
+    await this.resolveBlockedDependents(workItemId);
+
     await this.storage.flush();
     this.logger.info('WorkItem completed', { workItemId });
+  }
+
+  /**
+   * Scans blocked WorkItems that list `completedId` in their `dependsOn` and
+   * promotes each to `queued` if every one of their deps has reached terminal
+   * success (`done` or `verified`). Idempotent and safe to call on any terminal
+   * success transition.
+   *
+   * Serialized via the claim mutex — a concurrent claimFromPool call must not
+   * observe a half-promoted item.
+   */
+  async resolveBlockedDependents(completedId: string): Promise<void> {
+    await this.withClaimLock(async () => {
+      const items = await this.storage.getWorkItems();
+      const terminalSuccess = new Set<string>(
+        items
+          .filter((wi) => wi.status === 'done' || wi.status === 'verified')
+          .map((wi) => wi.id),
+      );
+
+      const candidates = items.filter(
+        (wi) =>
+          wi.status === 'blocked' &&
+          Array.isArray(wi.dependsOn) &&
+          wi.dependsOn.includes(completedId),
+      );
+
+      for (const candidate of candidates) {
+        const allSatisfied = (candidate.dependsOn ?? []).every((depId) =>
+          terminalSuccess.has(depId),
+        );
+        if (!allSatisfied) continue;
+
+        await this.storage.updateWorkItem(candidate.id, (wi) => {
+          wi.status = 'queued';
+        });
+        this.logger.info('WorkItem unblocked — all deps satisfied', {
+          workItemId: candidate.id,
+          via: completedId,
+        });
+      }
+    });
   }
 
   /**

--- a/backend/src/services/template/template.service.ts
+++ b/backend/src/services/template/template.service.ts
@@ -271,6 +271,7 @@ export class TemplateService {
           autonomyLevel: role.autonomyLevel,
           expertId: role.expertId,
           domainSOP: role.domainSOP,
+          riskPolicy: role.riskPolicy,
         };
 
         members.push(member);

--- a/backend/src/services/v3/contract-matcher.test.ts
+++ b/backend/src/services/v3/contract-matcher.test.ts
@@ -1,0 +1,41 @@
+import { matchRule } from './contract-matcher.js';
+
+describe('matchRule', () => {
+  it('returns null for an empty request', () => {
+    expect(matchRule('', ['bugfix'])).toBeNull();
+    expect(matchRule('   ', ['bugfix'])).toBeNull();
+  });
+
+  it('returns null when no rule matches', () => {
+    expect(matchRule('write documentation', ['bugfix', 'feature'])).toBeNull();
+  });
+
+  it('matches case-insensitively', () => {
+    expect(matchRule('Urgent BUGFIX', ['bugfix'])).toBe('bugfix');
+    expect(matchRule('bugfix', ['BUGFIX'])).toBe('BUGFIX');
+  });
+
+  it('matches when the rule is a substring of the request (verbose request, tight rule)', () => {
+    expect(matchRule('urgent frontend bugfix in checkout', ['bugfix'])).toBe('bugfix');
+  });
+
+  it('matches when the request is a substring of the rule (tight request, verbose rule)', () => {
+    expect(matchRule('bugfix', ['frontend-bugfix-priority'])).toBe('frontend-bugfix-priority');
+  });
+
+  it('returns the first matching rule when several would match', () => {
+    expect(matchRule('frontend bugfix', ['bugfix', 'frontend'])).toBe('bugfix');
+  });
+
+  it('skips empty/whitespace rules', () => {
+    expect(matchRule('bugfix', ['', '   ', 'bugfix'])).toBe('bugfix');
+  });
+
+  it('returns null against an empty rules list', () => {
+    expect(matchRule('bugfix', [])).toBeNull();
+  });
+
+  it('trims surrounding whitespace on both sides', () => {
+    expect(matchRule('  bugfix  ', ['  bugfix  '])).toBe('  bugfix  ');
+  });
+});

--- a/backend/src/services/v3/contract-matcher.ts
+++ b/backend/src/services/v3/contract-matcher.ts
@@ -1,0 +1,34 @@
+/**
+ * Contract-rule matching predicate shared by the service contract gate and
+ * any caller that wants to pre-filter requests against a team's accepts /
+ * avoids list.
+ *
+ * Keeping the predicate in one module guarantees gate decisions and skill-side
+ * filtering can't drift — both paths call the same `matchRule`.
+ */
+
+/**
+ * Case-insensitive substring match. Accepts either direction — a rule
+ * matches if either string contains the other. This tolerates both tightly
+ * scoped rules (`"bugfix"`) and verbose request phrasing (`"urgent frontend
+ * bugfix in checkout"`).
+ *
+ * @param requestType - The incoming request phrase to classify.
+ * @param rules - The team's accepts/avoids list.
+ * @returns The first rule that matched, or `null` when no rule applies.
+ */
+export function matchRule(
+  requestType: string,
+  rules: readonly string[],
+): string | null {
+  const needle = requestType.trim().toLowerCase();
+  if (!needle) return null;
+  for (const rule of rules) {
+    const hay = rule.trim().toLowerCase();
+    if (!hay) continue;
+    if (needle.includes(hay) || hay.includes(needle)) {
+      return rule;
+    }
+  }
+  return null;
+}

--- a/backend/src/services/v3/escalation.service.ts
+++ b/backend/src/services/v3/escalation.service.ts
@@ -24,6 +24,8 @@ import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { PolicyEnforcementService, type EscalationResult } from '../policy/policy-enforcement.service.js';
 import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import { TriggerEngine } from './trigger-engine.service.js';
+import type { Trigger } from '../../types/v2/trigger.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
 import { ensureDir, safeReadJson } from '../../utils/file-io.utils.js';
 import type {
   Mission,
@@ -112,6 +114,15 @@ export class EscalationService {
   private actionHandler: EscalationActionHandler | null = null;
   private triggerId: string | null = null;
   private started = false;
+  /**
+   * The wrapper function this service installed on the TriggerEngine via
+   * `setActionHandler`. Kept so we can detect "was I already installed?"
+   * on re-entry and avoid building a growing delegation chain. Each
+   * restart that skipped `stop()` (crash, test teardown gaps) would
+   * otherwise wrap the previous wrapper as its "originalHandler",
+   * stacking closures forever.
+   */
+  private installedHandler: ((trigger: Trigger, action: unknown) => Promise<void>) | null = null;
 
   /**
    * Creates a new EscalationService.
@@ -167,24 +178,37 @@ export class EscalationService {
           runReconciler: true, // Re-used as a "run escalation" signal
         },
         createdBy: 'system',
+        // Stable name makes create() idempotent — repeated boots reuse the
+        // same trigger instead of stacking duplicates. See TriggerEngine.create.
+        name: 'system:escalation',
         maxIdleFires: 50, // Allow many idle fires since not all cycles trigger
       });
 
       this.triggerId = trigger.id;
 
       // Register a custom action handler on the TriggerEngine that intercepts
-      // our trigger and runs the evaluation loop.
-      const originalHandler = triggerEngine['actionHandler'];
-      triggerEngine.setActionHandler(async (t, action) => {
-        if (t.id === this.triggerId) {
-          await this.evaluate();
-          return;
-        }
-        // Delegate to original handler for other triggers
-        if (originalHandler) {
-          await originalHandler(t, action);
-        }
-      });
+      // our trigger and runs the evaluation loop. If a second `start()` runs
+      // without a matching `stop()` (crash recovery, test singleton reuse),
+      // `currentHandler` could already be OUR previous wrapper — wrapping it
+      // again would build a delegation chain that grows by one closure per
+      // restart. Detect that and reuse the prior install instead of stacking.
+      const currentHandler = triggerEngine['actionHandler'] as
+        | ((trigger: Trigger, action: unknown) => Promise<void>)
+        | undefined;
+      if (currentHandler !== this.installedHandler) {
+        const originalHandler = currentHandler;
+        this.installedHandler = async (trigger: Trigger, action: unknown) => {
+          if (trigger.id === this.triggerId) {
+            await this.evaluate();
+            return;
+          }
+          // Delegate to original handler for other triggers
+          if (originalHandler) {
+            await originalHandler(trigger, action);
+          }
+        };
+        triggerEngine.setActionHandler(this.installedHandler);
+      }
 
       this.started = true;
       this.logger.info('EscalationService started', {
@@ -239,9 +263,26 @@ export class EscalationService {
     try {
       const missions = await this.loadActiveMissions();
 
+      // Fetch the task pool once per cycle and bucket by missionId so each
+      // mission's context build is a simple Map lookup instead of a full
+      // scan of the (potentially thousands of items) pool. Previously N
+      // missions × O(pool) made the cycle quadratic on large workspaces.
+      const allItems = await this.loadMissionWorkItems();
+      const itemsByMission = new Map<string, WorkItem[]>();
+      for (const wi of allItems) {
+        if (!wi.missionId) continue;
+        const bucket = itemsByMission.get(wi.missionId);
+        if (bucket) {
+          bucket.push(wi);
+        } else {
+          itemsByMission.set(wi.missionId, [wi]);
+        }
+      }
+
       for (const mission of missions) {
         try {
-          const context = await this.buildEscalationContext(mission);
+          const missionItems = itemsByMission.get(mission.id) ?? [];
+          const context = this.buildEscalationContext(mission, missionItems);
           const escalation = this.policyService.evaluateEscalationRules(
             mission.policy.escalationRules,
             context,
@@ -302,6 +343,22 @@ export class EscalationService {
   // ---------------------------------------------------------------------------
 
   /**
+   * Loads the task pool once per evaluation cycle. Extracted so `evaluate`
+   * can bucket items by missionId before calling
+   * {@link buildEscalationContext} for each mission.
+   */
+  private async loadMissionWorkItems(): Promise<WorkItem[]> {
+    try {
+      return await TaskPoolService.getInstance().getAllItems();
+    } catch (err) {
+      this.logger.warn('Failed to load task pool for escalation (treating as empty)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+  }
+
+  /**
    * Builds an EscalationContext for a Mission by aggregating runtime data.
    *
    * Sources:
@@ -310,30 +367,23 @@ export class EscalationService {
    * - Failures: count of failed WorkItems linked to this mission
    *
    * @param mission - The Mission to build context for
+   * @param missionItems - Pre-filtered WorkItems belonging to the mission.
+   *        Pass an empty array when the mission has no items or the pool
+   *        could not be loaded — the function does not re-fetch.
    * @returns Populated EscalationContext
    */
-  async buildEscalationContext(mission: Mission): Promise<EscalationContext> {
-    const taskPool = TaskPoolService.getInstance();
-    const allItems = await taskPool.getAllItems();
+  buildEscalationContext(mission: Mission, missionItems: WorkItem[]): EscalationContext {
+    // Single pass over the pre-filtered slice gives us both the cost sum
+    // and the failure count without double-iterating.
+    let currentCost = 0;
+    let failureCount = 0;
+    for (const wi of missionItems) {
+      currentCost += wi.cost ?? 0;
+      if (wi.status === 'failed') failureCount += 1;
+    }
 
-    // Filter WorkItems belonging to this mission
-    const missionItems = allItems.filter((wi) => wi.missionId === mission.id);
-
-    // Calculate cost
-    const currentCost = missionItems.reduce(
-      (sum, wi) => sum + (wi.cost ?? 0),
-      0,
-    );
-
-    // Calculate hours elapsed since mission creation
     const createdAt = new Date(mission.createdAt).getTime();
-    const now = Date.now();
-    const hoursElapsed = (now - createdAt) / (1000 * 60 * 60);
-
-    // Count failures
-    const failureCount = missionItems.filter(
-      (wi) => wi.status === 'failed',
-    ).length;
+    const hoursElapsed = (Date.now() - createdAt) / (1000 * 60 * 60);
 
     return {
       currentCost,
@@ -415,19 +465,33 @@ export class EscalationService {
           (wi.status === 'queued' || wi.status === 'running'),
       );
 
+      let succeeded = 0;
+      const failures: Array<{ itemId: string; error: string }> = [];
       for (const item of activeItems) {
         try {
           // queued → blocked requires queued→running→blocked or direct update
           await taskPool.updateItemStatus(item.id, 'blocked');
-        } catch {
-          // Some transitions may not be valid — skip
+          succeeded += 1;
+        } catch (err) {
+          // Some transitions may not be valid — track so we don't report
+          // a falsely optimistic `pausedCount`.
+          failures.push({
+            itemId: item.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }
 
       this.logger.info('Paused mission WorkItems', {
         missionId,
-        pausedCount: activeItems.length,
+        attempted: activeItems.length,
+        succeeded,
+        failed: failures.length,
       });
+
+      if (failures.length > 0) {
+        this.logger.debug('Work-item pause failures', { missionId, failures });
+      }
     } catch (err) {
       this.logger.warn('Failed to pause mission WorkItems (non-fatal)', {
         missionId,

--- a/backend/src/services/v3/service-contract-gate.service.test.ts
+++ b/backend/src/services/v3/service-contract-gate.service.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for ServiceContractGate.
+ */
+
+import { ServiceContractGate } from './service-contract-gate.service.js';
+import type { Team } from '../../types/index.js';
+import type { ServiceContract } from '../../types/team-template.types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeTeam(id: string, contract?: ServiceContract): Team {
+  return {
+    id,
+    name: `team-${id}`,
+    members: [],
+    projectIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    serviceContract: contract,
+  };
+}
+
+const engineeringContract: ServiceContract = {
+  accepts: ['frontend bugfix', 'mid-size product feature', 'API change'],
+  avoids: ['production DBA changes', 'security incident response'],
+  expectedOutput: ['PR', 'test coverage report'],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ServiceContractGate', () => {
+  let gate: ServiceContractGate;
+
+  beforeEach(() => {
+    gate = new ServiceContractGate();
+  });
+
+  describe('bypass rules', () => {
+    it('accepts same-team requests without consulting the contract', () => {
+      // Team has no contract, but caller is from the same team.
+      const team = makeTeam('eng');
+      const decision = gate.check({
+        fromTeamId: 'eng',
+        toTeam: team,
+        requestType: 'anything goes',
+      });
+      expect(decision.outcome).toBe('accept');
+      if (decision.outcome === 'accept') {
+        expect(decision.matchedRule).toBe('<internal>');
+      }
+    });
+
+    it('rejects when the target team cannot be resolved', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: undefined,
+        requestType: 'anything',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('missing_target');
+      }
+    });
+  });
+
+  describe('contract presence', () => {
+    it('rejects when target has no contract at all', () => {
+      const team = makeTeam('eng');
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: team,
+        requestType: 'frontend bugfix',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('no_contract');
+        expect(decision.message).toContain('team-eng');
+      }
+    });
+
+    it('rejects when contract exists but accepts[] is empty', () => {
+      const team = makeTeam('eng', {
+        accepts: [],
+        avoids: [],
+        expectedOutput: [],
+      });
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: team,
+        requestType: 'anything',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('empty_contract');
+      }
+    });
+  });
+
+  describe('matching', () => {
+    const eng = makeTeam('eng', engineeringContract);
+
+    it('accepts when request matches an accepts phrase exactly', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: eng,
+        requestType: 'frontend bugfix',
+      });
+      expect(decision.outcome).toBe('accept');
+      if (decision.outcome === 'accept') {
+        expect(decision.matchedRule).toBe('frontend bugfix');
+      }
+    });
+
+    it('accepts when request is a superset of an accepts phrase (substring)', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: eng,
+        requestType: 'urgent frontend bugfix in checkout flow',
+      });
+      expect(decision.outcome).toBe('accept');
+      if (decision.outcome === 'accept') {
+        expect(decision.matchedRule).toBe('frontend bugfix');
+      }
+    });
+
+    it('matches case-insensitively', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: eng,
+        requestType: 'Mid-Size PRODUCT Feature',
+      });
+      expect(decision.outcome).toBe('accept');
+    });
+
+    it('rejects when request matches an avoids phrase', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: eng,
+        requestType: 'production DBA changes needed for migration',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('in_avoids');
+        expect(decision.matchedRule).toBe('production DBA changes');
+      }
+    });
+
+    it('fails closed: avoids wins when a request matches both accepts and avoids', () => {
+      const team = makeTeam('eng', {
+        accepts: ['frontend bugfix'],
+        avoids: ['production frontend bugfix'], // more specific, more dangerous
+        expectedOutput: [],
+      });
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: team,
+        requestType: 'production frontend bugfix',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('in_avoids');
+      }
+    });
+
+    it('rejects with no_match when the request fits neither list', () => {
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: eng,
+        requestType: 'write a poem',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('no_match');
+        expect(decision.message).toContain('frontend bugfix');
+      }
+    });
+
+    it('ignores empty and whitespace-only rules', () => {
+      const team = makeTeam('eng', {
+        accepts: ['', '   ', 'real rule'],
+        avoids: ['', '  '],
+        expectedOutput: [],
+      });
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: team,
+        requestType: 'real rule',
+      });
+      expect(decision.outcome).toBe('accept');
+      if (decision.outcome === 'accept') {
+        expect(decision.matchedRule).toBe('real rule');
+      }
+    });
+
+    it('rejects an empty request type with a dedicated reason (not confused with no_match)', () => {
+      const team = makeTeam('eng', {
+        accepts: ['anything'],
+        avoids: [],
+        expectedOutput: [],
+      });
+      const decision = gate.check({
+        fromTeamId: 'marketing',
+        toTeam: team,
+        requestType: '   ',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('missing_request_type');
+      }
+    });
+  });
+
+  describe('caller identity', () => {
+    it('treats requests without a fromTeamId as external (contract still applies)', () => {
+      const eng = makeTeam('eng', engineeringContract);
+      const decision = gate.check({
+        toTeam: eng,
+        requestType: 'frontend bugfix',
+      });
+      expect(decision.outcome).toBe('accept');
+    });
+
+    it('does not bypass the contract when fromTeamId matches a non-existent team', () => {
+      const eng = makeTeam('eng', engineeringContract);
+      const decision = gate.check({
+        fromTeamId: 'ghost',
+        toTeam: eng,
+        requestType: 'production DBA changes',
+      });
+      expect(decision.outcome).toBe('reject');
+      if (decision.outcome === 'reject') {
+        expect(decision.reason).toBe('in_avoids');
+      }
+    });
+  });
+});

--- a/backend/src/services/v3/service-contract-gate.service.ts
+++ b/backend/src/services/v3/service-contract-gate.service.ts
@@ -1,0 +1,192 @@
+/**
+ * ServiceContractGate — runtime enforcement of team `ServiceContract`s.
+ *
+ * Cross-team requests must pass through the gate before a WorkItem is
+ * enqueued on the target team's pool. The gate makes a pure-function
+ * decision by matching the requested `requestType` string against the
+ * target team's `serviceContract.accepts` and `serviceContract.avoids`
+ * phrases.
+ *
+ * Design choices:
+ * - **No LLM.** Plain case-insensitive substring match — predictable and
+ *   cheap enough to run on every dispatch.
+ * - **Fail closed.** If `accepts` is missing, empty, or matches nothing,
+ *   the request is rejected. Teams must explicitly declare what they take.
+ * - **`avoids` beats `accepts`.** An avoided phrase wins even if the
+ *   request also matches an accepted phrase — the negative signal is
+ *   assumed stronger (e.g. "frontend bugfix" is accepted but "production
+ *   frontend bugfix" is avoided).
+ * - **Same-team requests skip the gate.** Teams don't contract with
+ *   themselves; internal work flows normally.
+ *
+ * Wired into the task-pool `addItem` flow via `maybeEnforceContract` in
+ * `controllers/task-pool/task-pool.controller.ts`. The service itself is
+ * stateless and standalone so it can also be called from skills or a
+ * future ServiceGateway layer.
+ *
+ * @module services/v3/service-contract-gate.service
+ */
+
+import type { Team } from '../../types/index.js';
+import type { ServiceContract } from '../../types/team-template.types.js';
+import { matchRule } from './contract-matcher.js';
+
+export { matchRule } from './contract-matcher.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Reason codes for a rejected request. Callers use these to produce a
+ * targeted error message (e.g. "out of scope" vs "ambiguous, please
+ * specify a supported service type").
+ */
+export type GateRejectionReason =
+  | 'missing_target'        // target team could not be resolved
+  | 'missing_request_type'  // caller supplied no usable requestType
+  | 'no_contract'           // target team has no serviceContract
+  | 'empty_contract'        // contract exists but accepts[] is empty
+  | 'in_avoids'             // request matched an `avoids` phrase (fail closed)
+  | 'no_match';             // request matched neither accepts nor avoids
+
+/**
+ * The decision returned by the gate.
+ */
+export type GateDecision =
+  | {
+      outcome: 'accept';
+      /** The accepts[] phrase that matched the request. */
+      matchedRule: string;
+    }
+  | {
+      outcome: 'reject';
+      reason: GateRejectionReason;
+      /** Which rule matched (only populated for `in_avoids`). */
+      matchedRule?: string;
+      /** Human-readable explanation suitable for surfacing to the requester. */
+      message: string;
+    };
+
+/**
+ * Inputs the gate needs to make a decision.
+ */
+export interface GateRequest {
+  /** Team making the request. Optional — undefined means "external/user". */
+  fromTeamId?: string;
+  /** Team that would receive the work. */
+  toTeam: Team | undefined;
+  /** Free-text description of the requested service type (short phrase). */
+  requestType: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateless gate that evaluates a cross-team request against the target's
+ * `ServiceContract`. Safe to instantiate once and reuse, or to call
+ * {@link check} via an ad-hoc instance.
+ *
+ * @example
+ * ```typescript
+ * const gate = new ServiceContractGate();
+ * const decision = gate.check({
+ *   fromTeamId: 'marketing',
+ *   toTeam: engineeringTeam,
+ *   requestType: 'frontend bugfix',
+ * });
+ * if (decision.outcome === 'reject') {
+ *   throw new Error(decision.message);
+ * }
+ * ```
+ */
+export class ServiceContractGate {
+  /**
+   * Decide whether the target team may accept this request.
+   *
+   * @param req - Request details (from, to, type)
+   * @returns Structured decision with outcome + reason + message
+   */
+  check(req: GateRequest): GateDecision {
+    // Internal work bypasses the contract entirely.
+    if (req.fromTeamId && req.toTeam && req.fromTeamId === req.toTeam.id) {
+      return { outcome: 'accept', matchedRule: '<internal>' };
+    }
+
+    if (!req.toTeam) {
+      return {
+        outcome: 'reject',
+        reason: 'missing_target',
+        message: 'Target team could not be resolved.',
+      };
+    }
+
+    // A missing requestType is a caller bug (no metadata in the WorkItem),
+    // not a policy decision. Surface it explicitly so the caller doesn't
+    // misread "no_match" as "the target team rejected my work".
+    if (!req.requestType || !req.requestType.trim()) {
+      return {
+        outcome: 'reject',
+        reason: 'missing_request_type',
+        message: 'Cross-team requests must supply a non-empty `requestType` (or a title/description fallback).',
+      };
+    }
+
+    const contract = req.toTeam.serviceContract;
+    if (!contract) {
+      return {
+        outcome: 'reject',
+        reason: 'no_contract',
+        message: `Team "${req.toTeam.name}" has no service contract — cross-team requests are not accepted until one is declared.`,
+      };
+    }
+
+    // `avoids` wins over `accepts` — fail closed on negative signal.
+    const avoidHit = matchRule(req.requestType, contract.avoids ?? []);
+    if (avoidHit) {
+      return {
+        outcome: 'reject',
+        reason: 'in_avoids',
+        matchedRule: avoidHit,
+        message: `Team "${req.toTeam.name}" explicitly avoids requests matching "${avoidHit}".`,
+      };
+    }
+
+    const accepts = contract.accepts ?? [];
+    if (accepts.length === 0) {
+      return {
+        outcome: 'reject',
+        reason: 'empty_contract',
+        message: `Team "${req.toTeam.name}" has a service contract with no accepted task types.`,
+      };
+    }
+
+    const acceptHit = matchRule(req.requestType, accepts);
+    if (acceptHit) {
+      return { outcome: 'accept', matchedRule: acceptHit };
+    }
+
+    return {
+      outcome: 'reject',
+      reason: 'no_match',
+      message: buildNoMatchMessage(req.toTeam.name, req.requestType, contract),
+    };
+  }
+}
+
+/**
+ * Build a helpful rejection message that lists what the team does accept,
+ * so the caller can reframe or re-route.
+ */
+function buildNoMatchMessage(
+  teamName: string,
+  requestType: string,
+  contract: ServiceContract,
+): string {
+  const accepts = (contract.accepts ?? []).filter((a) => a.trim()).join(', ');
+  return accepts
+    ? `Team "${teamName}" does not accept "${requestType}". Accepted services: ${accepts}.`
+    : `Team "${teamName}" does not accept "${requestType}" and has no listed services.`;
+}

--- a/backend/src/services/v3/team-trigger-reconciler.service.test.ts
+++ b/backend/src/services/v3/team-trigger-reconciler.service.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for TeamTriggerReconciler.
+ *
+ * Uses a minimal hand-rolled fake in place of the full TriggerEngine — the
+ * real engine owns timers, EventBus wiring, and disk persistence we don't
+ * need here. The fake implements the three methods the reconciler depends
+ * on (`list`, `create`, `delete`) and tracks stored triggers in a Map.
+ */
+
+import { TeamTriggerReconciler } from './team-trigger-reconciler.service.js';
+import type { TriggerEngine } from './trigger-engine.service.js';
+import type { Team, TeamTriggerSpec } from '../../types/index.js';
+import {
+  type Trigger,
+  type CreateTriggerInput,
+  createTrigger,
+} from '../../types/v2/trigger.types.js';
+
+// ---------------------------------------------------------------------------
+// Logger silencer — reconciler uses LoggerService; keep tests quiet.
+// ---------------------------------------------------------------------------
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeTriggerEngine {
+  private store = new Map<string, Trigger>();
+
+  list(): Trigger[] {
+    return Array.from(this.store.values());
+  }
+
+  async create(input: CreateTriggerInput): Promise<Trigger> {
+    const trigger = createTrigger(input);
+    this.store.set(trigger.id, trigger);
+    return trigger;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.store.delete(id);
+  }
+
+  // Helper for tests — not used by reconciler.
+  size(): number {
+    return this.store.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSpec(overrides: Partial<TeamTriggerSpec> = {}): TeamTriggerSpec {
+  return {
+    name: 'daily-eod',
+    description: 'Daily end-of-day reflection',
+    config: { type: 'time', cronExpression: '0 17 * * *' },
+    action: {
+      createWorkItem: {
+        title: 'EOD reflect',
+        type: 'review',
+        owner: 'agent',
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeTeam(triggers: TeamTriggerSpec[]): Team {
+  return {
+    id: 'team-abc',
+    name: 'Marketing',
+    members: [],
+    projectIds: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    triggers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TeamTriggerReconciler', () => {
+  let engine: FakeTriggerEngine;
+  let reconciler: TeamTriggerReconciler;
+
+  beforeEach(() => {
+    engine = new FakeTriggerEngine();
+    reconciler = new TeamTriggerReconciler(engine as unknown as TriggerEngine);
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe('reconcile', () => {
+    it('creates triggers on first reconcile', async () => {
+      const team = makeTeam([
+        makeSpec({ name: 'daily-eod' }),
+        makeSpec({ name: 'weekly-review', config: { type: 'time', cronExpression: '0 9 * * 1' } }),
+      ]);
+
+      const summary = await reconciler.reconcile(team);
+
+      expect(summary.created.sort()).toEqual(['daily-eod', 'weekly-review']);
+      expect(summary.deleted).toEqual([]);
+      expect(summary.replaced).toEqual([]);
+      expect(engine.size()).toBe(2);
+
+      // Runtime triggers should carry the team identity.
+      for (const t of engine.list()) {
+        expect(t.teamId).toBe('team-abc');
+        expect(t.createdBy).toBe('system');
+      }
+    });
+
+    it('is idempotent — running twice with the same spec changes nothing', async () => {
+      const team = makeTeam([makeSpec()]);
+
+      const first = await reconciler.reconcile(team);
+      const second = await reconciler.reconcile(team);
+
+      expect(first.created).toEqual(['daily-eod']);
+      expect(second.created).toEqual([]);
+      expect(second.unchanged).toEqual(['daily-eod']);
+      expect(engine.size()).toBe(1);
+    });
+
+    it('replaces a trigger when its config drifts', async () => {
+      const team = makeTeam([makeSpec({ name: 'daily-eod' })]);
+      await reconciler.reconcile(team);
+      const originalId = engine.list()[0].id;
+
+      // Update the cron and reconcile again
+      team.triggers = [
+        makeSpec({ name: 'daily-eod', config: { type: 'time', cronExpression: '0 18 * * *' } }),
+      ];
+      const summary = await reconciler.reconcile(team);
+
+      expect(summary.replaced).toEqual(['daily-eod']);
+      expect(engine.size()).toBe(1);
+      const replaced = engine.list()[0];
+      expect(replaced.id).not.toBe(originalId);
+      if (replaced.config.type === 'time') {
+        expect(replaced.config.cronExpression).toBe('0 18 * * *');
+      }
+    });
+
+    it('deletes triggers whose name is no longer in the spec', async () => {
+      const team = makeTeam([
+        makeSpec({ name: 'daily-eod' }),
+        makeSpec({ name: 'obsolete' }),
+      ]);
+      await reconciler.reconcile(team);
+      expect(engine.size()).toBe(2);
+
+      // Remove "obsolete" from spec
+      team.triggers = [makeSpec({ name: 'daily-eod' })];
+      const summary = await reconciler.reconcile(team);
+
+      expect(summary.deleted).toEqual(['obsolete']);
+      expect(engine.size()).toBe(1);
+      expect(engine.list()[0].name).toBe('daily-eod');
+    });
+
+    it('skips disabled specs and removes their running trigger if any', async () => {
+      const team = makeTeam([makeSpec({ name: 'daily-eod' })]);
+      await reconciler.reconcile(team);
+      expect(engine.size()).toBe(1);
+
+      team.triggers = [makeSpec({ name: 'daily-eod', enabled: false })];
+      const summary = await reconciler.reconcile(team);
+
+      expect(summary.skipped).toEqual(['daily-eod']);
+      expect(summary.deleted).toEqual(['daily-eod']);
+      expect(engine.size()).toBe(0);
+    });
+
+    it('leaves triggers owned by other teams alone', async () => {
+      // Pre-populate a trigger owned by another team
+      await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        teamId: 'other-team',
+        name: 'other-cron',
+      });
+
+      const team = makeTeam([makeSpec()]);
+      await reconciler.reconcile(team);
+
+      expect(engine.size()).toBe(2);
+      const names = engine.list().map((t) => t.name).sort();
+      expect(names).toEqual(['daily-eod', 'other-cron']);
+    });
+
+    it('warns and skips spec entries with missing name', async () => {
+      const team = makeTeam([
+        { ...makeSpec(), name: '' } as TeamTriggerSpec,
+        makeSpec({ name: 'daily-eod' }),
+      ]);
+
+      const summary = await reconciler.reconcile(team);
+      expect(summary.created).toEqual(['daily-eod']);
+      expect(engine.size()).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+
+  describe('unregisterAll', () => {
+    it('removes every trigger belonging to the team', async () => {
+      const team = makeTeam([
+        makeSpec({ name: 'daily-eod' }),
+        makeSpec({ name: 'weekly-review' }),
+      ]);
+      await reconciler.reconcile(team);
+
+      // Also add a trigger for another team
+      await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        teamId: 'other-team',
+        name: 'other',
+      });
+
+      expect(engine.size()).toBe(3);
+
+      const removed = await reconciler.unregisterAll('team-abc');
+      expect(removed).toBe(2);
+      expect(engine.size()).toBe(1);
+      expect(engine.list()[0].teamId).toBe('other-team');
+    });
+
+    it('returns 0 when the team has no running triggers', async () => {
+      expect(await reconciler.unregisterAll('ghost-team')).toBe(0);
+    });
+  });
+});

--- a/backend/src/services/v3/team-trigger-reconciler.service.ts
+++ b/backend/src/services/v3/team-trigger-reconciler.service.ts
@@ -1,0 +1,224 @@
+/**
+ * TeamTriggerReconciler — keeps the running TriggerEngine in sync with the
+ * declarative `Team.triggers` spec.
+ *
+ * A team's operating cadence (monthly YouTube kickoff, weekly content review,
+ * daily EOD reflection, ...) is authored as a list of `TeamTriggerSpec`s on
+ * the Team config. This service diffs that spec against whatever the engine
+ * currently holds for the given team and converges the two:
+ *
+ * - **spec-only**: create the trigger on the engine
+ * - **engine-only (same team)**: delete the stale trigger
+ * - **both**: if the effective config changed, replace; else leave alone
+ *
+ * Identity is the pair `(teamId, name)` — callers must give each spec a
+ * stable `name`. Changing a `name` is treated as delete + create.
+ *
+ * @module services/v3/team-trigger-reconciler.service
+ */
+
+import type { Team, TeamTriggerSpec } from '../../types/index.js';
+import type { Trigger, CreateTriggerInput } from '../../types/v2/trigger.types.js';
+import { DEFAULT_MAX_IDLE_FIRES } from '../../types/v2/trigger.types.js';
+import type { TriggerEngine } from './trigger-engine.service.js';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+// ---------------------------------------------------------------------------
+// Result Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Summary of what the reconciler changed for a single team.
+ */
+export interface ReconcileSummary {
+  /** Team that was reconciled */
+  teamId: string;
+  /** Trigger names that were newly created */
+  created: string[];
+  /** Trigger names that were replaced due to config drift */
+  replaced: string[];
+  /** Trigger names that were deleted because the spec no longer lists them */
+  deleted: string[];
+  /** Trigger names left untouched because the spec matched the running state */
+  unchanged: string[];
+  /** Trigger names skipped because `enabled: false` */
+  skipped: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Synchronises a team's declarative trigger spec with a running TriggerEngine.
+ *
+ * @example
+ * ```typescript
+ * const reconciler = new TeamTriggerReconciler(engine);
+ * const summary = await reconciler.reconcile(team);
+ * // later, when the team is archived:
+ * await reconciler.unregisterAll(team.id);
+ * ```
+ */
+export class TeamTriggerReconciler {
+  private readonly engine: TriggerEngine;
+  private readonly logger: ComponentLogger;
+
+  constructor(engine: TriggerEngine) {
+    this.engine = engine;
+    this.logger = LoggerService.getInstance().createComponentLogger(
+      'TeamTriggerReconciler',
+    );
+  }
+
+  /**
+   * Reconciles the engine's view of this team's triggers with the Team's
+   * declarative spec. Idempotent — running twice with the same spec is a no-op.
+   *
+   * @param team - Team whose triggers should be synced
+   * @returns Summary of changes applied
+   */
+  async reconcile(team: Team): Promise<ReconcileSummary> {
+    const summary: ReconcileSummary = {
+      teamId: team.id,
+      created: [],
+      replaced: [],
+      deleted: [],
+      unchanged: [],
+      skipped: [],
+    };
+
+    const specsByName = new Map<string, TeamTriggerSpec>();
+    for (const spec of team.triggers ?? []) {
+      if (!spec.name) {
+        this.logger.warn('Skipping team trigger spec with missing name', {
+          teamId: team.id,
+        });
+        continue;
+      }
+      specsByName.set(spec.name, spec);
+    }
+
+    // Pull current engine-side triggers for this team.
+    const currentByName = new Map<string, Trigger>();
+    for (const trigger of this.engine.list()) {
+      if (trigger.teamId === team.id && trigger.name) {
+        currentByName.set(trigger.name, trigger);
+      }
+    }
+
+    // 1) Delete engine triggers whose name disappeared from the spec.
+    for (const [name, trigger] of currentByName) {
+      if (!specsByName.has(name)) {
+        await this.engine.delete(trigger.id);
+        summary.deleted.push(name);
+      }
+    }
+
+    // 2) For each spec, either skip (disabled), create (new), replace (drift),
+    //    or leave alone.
+    for (const [name, spec] of specsByName) {
+      if (spec.enabled === false) {
+        // A disabled spec should not have a running trigger.
+        const running = currentByName.get(name);
+        if (running) {
+          await this.engine.delete(running.id);
+          summary.deleted.push(name);
+        }
+        summary.skipped.push(name);
+        continue;
+      }
+
+      const running = currentByName.get(name);
+      if (!running) {
+        await this.engine.create(this.toCreateInput(team.id, spec));
+        summary.created.push(name);
+        continue;
+      }
+
+      if (this.hasDrift(running, spec)) {
+        await this.engine.delete(running.id);
+        await this.engine.create(this.toCreateInput(team.id, spec));
+        summary.replaced.push(name);
+      } else {
+        summary.unchanged.push(name);
+      }
+    }
+
+    this.logger.info('Team triggers reconciled', {
+      teamId: team.id,
+      created: summary.created.length,
+      replaced: summary.replaced.length,
+      deleted: summary.deleted.length,
+      unchanged: summary.unchanged.length,
+      skipped: summary.skipped.length,
+    });
+
+    return summary;
+  }
+
+  /**
+   * Cancels every trigger the engine holds for the given team. Call this when
+   * a team is archived or deleted so no orphaned cadence keeps firing.
+   *
+   * @param teamId - Owning team's ID
+   * @returns Number of triggers removed
+   */
+  async unregisterAll(teamId: string): Promise<number> {
+    let removed = 0;
+    for (const trigger of this.engine.list()) {
+      if (trigger.teamId === teamId) {
+        await this.engine.delete(trigger.id);
+        removed += 1;
+      }
+    }
+    if (removed > 0) {
+      this.logger.info('Team triggers unregistered', { teamId, removed });
+    }
+    return removed;
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private toCreateInput(teamId: string, spec: TeamTriggerSpec): CreateTriggerInput {
+    return {
+      type: spec.config.type,
+      config: spec.config,
+      action: spec.action,
+      createdBy: 'system',
+      maxFires: spec.maxFires,
+      maxIdleFires: spec.maxIdleFires,
+      teamId,
+      name: spec.name,
+    };
+  }
+
+  /**
+   * Shallow drift check — serialise the fields that define runtime behaviour
+   * and compare. JSON.stringify is sufficient here because TeamTriggerSpec
+   * only holds plain-data shapes.
+   */
+  private hasDrift(trigger: Trigger, spec: TeamTriggerSpec): boolean {
+    const runtime = {
+      config: trigger.config,
+      action: trigger.action,
+      maxFires: trigger.maxFires,
+      maxIdleFires: trigger.maxIdleFires,
+    };
+    const desired = {
+      config: spec.config,
+      action: spec.action,
+      maxFires: spec.maxFires,
+      // When the spec omits `maxIdleFires`, compare against the factory
+      // default — NOT the running trigger's current value. Mirroring the
+      // running value silently hides convergence bugs: if the operator
+      // authored the spec with `maxIdleFires: 50`, then later dropped the
+      // field intending to fall back to the default, the old value would
+      // stick forever because runtime == desired.
+      maxIdleFires: spec.maxIdleFires ?? DEFAULT_MAX_IDLE_FIRES,
+    };
+    return JSON.stringify(runtime) !== JSON.stringify(desired);
+  }
+}

--- a/backend/src/services/v3/trigger-engine-dedup.test.ts
+++ b/backend/src/services/v3/trigger-engine-dedup.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Focused tests for TriggerEngine idempotency + startup dedup.
+ *
+ * The pre-existing `trigger-engine.service.test.ts` uses vitest imports and
+ * doesn't run under this project's Jest setup. Rather than rewrite the whole
+ * suite, we add a separate file for the dedup behaviour, which is small and
+ * self-contained.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { TriggerEngine } from './trigger-engine.service.js';
+import type { Trigger } from '../../types/v2/trigger.types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'trig-engine-'));
+  fs.mkdirSync(path.join(dir, '.crewly'), { recursive: true });
+  return dir;
+}
+
+function seedTriggerFile(projectPath: string, triggers: Partial<Trigger>[]): void {
+  const full: Trigger[] = triggers.map((t, i) => ({
+    id: t.id ?? `seed-${i}`,
+    type: 'time',
+    config: t.config ?? { type: 'time', cronExpression: '*/5 * * * *' },
+    action: t.action ?? { runReconciler: true },
+    status: t.status ?? 'active',
+    createdBy: t.createdBy ?? 'system',
+    createdAt: t.createdAt ?? new Date(2026, 0, i + 1).toISOString(),
+    fireCount: t.fireCount ?? 0,
+    maxIdleFires: t.maxIdleFires ?? 3,
+    consecutiveIdleFires: t.consecutiveIdleFires ?? 0,
+    name: t.name,
+    teamId: t.teamId,
+  }));
+  const dir = path.join(projectPath, '.crewly', 'triggers');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'triggers.json'), JSON.stringify(full), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TriggerEngine idempotency + dedup', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    TriggerEngine.resetInstance();
+    projectPath = makeProject();
+  });
+
+  afterEach(() => {
+    TriggerEngine.resetInstance();
+    try {
+      fs.rmSync(projectPath, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // create() idempotency by (createdBy, name)
+  // -------------------------------------------------------------------------
+
+  describe('create() idempotency', () => {
+    it('returns the existing trigger when called twice with the same name+createdBy', async () => {
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const a = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '*/5 * * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        name: 'system:escalation',
+      });
+
+      const b = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '*/5 * * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        name: 'system:escalation',
+      });
+
+      expect(b.id).toBe(a.id);
+      expect(engine.list().filter((t) => t.name === 'system:escalation')).toHaveLength(1);
+
+      engine.stop();
+    });
+
+    it('allows distinct createdBy values to share a name', async () => {
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const byUser = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'user',
+        name: 'daily-check',
+      });
+      const bySystem = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        name: 'daily-check',
+      });
+
+      expect(byUser.id).not.toBe(bySystem.id);
+      expect(engine.list()).toHaveLength(2);
+
+      engine.stop();
+    });
+
+    it('does not collapse into a cancelled trigger (only active dedupes)', async () => {
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const first = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        name: 'reusable',
+      });
+      // Cancel the first — a subsequent create should produce a brand new one.
+      await engine.cancel(first.id);
+
+      const second = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 9 * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+        name: 'reusable',
+      });
+
+      expect(second.id).not.toBe(first.id);
+      expect(second.status).toBe('active');
+
+      engine.stop();
+    });
+
+    it('treats unnamed triggers as always distinct (no accidental merging)', async () => {
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const a = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 * * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+      });
+      const b = await engine.create({
+        type: 'time',
+        config: { type: 'time', cronExpression: '0 * * * *' },
+        action: { runReconciler: true },
+        createdBy: 'system',
+      });
+
+      expect(b.id).not.toBe(a.id);
+
+      engine.stop();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Startup cleanup of structural duplicates
+  // -------------------------------------------------------------------------
+
+  describe('startup dedup', () => {
+    it('collapses structurally-identical active triggers, keeping the oldest', async () => {
+      // Seed 5 copies of the same runReconciler cron, plus one unrelated trigger.
+      seedTriggerFile(projectPath, [
+        { id: 'dup-1', createdAt: '2026-01-01T00:00:00.000Z' },
+        { id: 'dup-2', createdAt: '2026-01-02T00:00:00.000Z' },
+        { id: 'dup-3', createdAt: '2026-01-03T00:00:00.000Z' },
+        { id: 'dup-4', createdAt: '2026-01-04T00:00:00.000Z' },
+        { id: 'dup-5', createdAt: '2026-01-05T00:00:00.000Z' },
+        {
+          id: 'unique-1',
+          config: { type: 'time', cronExpression: '0 9 * * *' },
+          action: { runReconciler: true },
+        },
+      ]);
+
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const all = engine.list();
+      const active = all.filter((t) => t.status === 'active');
+      const cancelled = all.filter((t) => t.status === 'cancelled');
+
+      // One survivor from the duplicate group + the unrelated trigger = 2 active.
+      expect(active).toHaveLength(2);
+      // Keeper is the earliest createdAt.
+      expect(active.map((t) => t.id).sort()).toEqual(['dup-1', 'unique-1']);
+      // The four extras are now cancelled.
+      expect(cancelled.map((t) => t.id).sort()).toEqual(['dup-2', 'dup-3', 'dup-4', 'dup-5']);
+
+      engine.stop();
+    });
+
+    it('leaves triggers with different config untouched even if createdBy matches', async () => {
+      seedTriggerFile(projectPath, [
+        {
+          id: 'cron-5min',
+          config: { type: 'time', cronExpression: '*/5 * * * *' },
+        },
+        {
+          id: 'cron-daily',
+          config: { type: 'time', cronExpression: '0 9 * * *' },
+        },
+      ]);
+
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      expect(engine.list().filter((t) => t.status === 'active')).toHaveLength(2);
+
+      engine.stop();
+    });
+
+    it('does not cancel already-cancelled or exhausted duplicates a second time', async () => {
+      seedTriggerFile(projectPath, [
+        { id: 'active-keep' },
+        { id: 'cancelled-already', status: 'cancelled' },
+        { id: 'exhausted-already', status: 'exhausted' },
+      ]);
+
+      const engine = TriggerEngine.getInstance(projectPath);
+      await engine.start();
+
+      const all = engine.list();
+      expect(all.find((t) => t.id === 'active-keep')!.status).toBe('active');
+      expect(all.find((t) => t.id === 'cancelled-already')!.status).toBe('cancelled');
+      expect(all.find((t) => t.id === 'exhausted-already')!.status).toBe('exhausted');
+
+      engine.stop();
+    });
+
+    it('persists the cancellation so a subsequent boot sees the cleaned state', async () => {
+      seedTriggerFile(projectPath, [
+        { id: 'dup-a', createdAt: '2026-01-01T00:00:00.000Z' },
+        { id: 'dup-b', createdAt: '2026-01-02T00:00:00.000Z' },
+        { id: 'dup-c', createdAt: '2026-01-03T00:00:00.000Z' },
+      ]);
+
+      const first = TriggerEngine.getInstance(projectPath);
+      await first.start();
+      first.stop();
+
+      // Reset singleton + create a new engine reading the same file.
+      TriggerEngine.resetInstance();
+      const second = TriggerEngine.getInstance(projectPath);
+      await second.start();
+
+      const all = second.list();
+      const active = all.filter((t) => t.status === 'active');
+      expect(active.map((t) => t.id)).toEqual(['dup-a']);
+      expect(all.filter((t) => t.status === 'cancelled')).toHaveLength(2);
+
+      second.stop();
+    });
+  });
+});

--- a/backend/src/services/v3/trigger-engine.service.ts
+++ b/backend/src/services/v3/trigger-engine.service.ts
@@ -29,7 +29,6 @@ import {
   createTrigger,
   validateCreateTriggerInput,
   isValidTriggerConfig,
-  DEFAULT_MAX_IDLE_FIRES,
 } from '../../types/v2/index.js';
 import { getNextRunTime } from '../workflow/cron-task.service.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
@@ -102,6 +101,13 @@ export class TriggerEngine {
 
   /** EventBus reference for signal triggers. */
   private eventBus: EventBusService | null = null;
+  /**
+   * Bound signal-listener reference kept so `stop()` can detach it and we
+   * don't accumulate a new copy on every `start()`. Without this, repeated
+   * start/stop cycles (dev reloads, tests, escalation restarts) would
+   * register additional listeners that each fire independently.
+   */
+  private signalListener: ((eventData: { eventId: string; eventType: string; sessionName: string }) => void) | null = null;
 
   /** Callback for executing trigger actions. */
   private actionHandler: TriggerActionHandler | null = null;
@@ -203,10 +209,12 @@ export class TriggerEngine {
       this.timeCheckInterval = null;
     }
 
-    for (const [id, timer] of this.oneShotTimers) {
+    for (const [, timer] of this.oneShotTimers) {
       clearTimeout(timer);
     }
     this.oneShotTimers.clear();
+
+    this.teardownSignalListeners();
 
     this.running = false;
     this.logger.info('TriggerEngine stopped');
@@ -236,6 +244,28 @@ export class TriggerEngine {
     const errors = validateCreateTriggerInput(input);
     if (errors.length > 0) {
       throw new Error(`Invalid trigger input: ${errors.join(', ')}`);
+    }
+
+    // Idempotency by (createdBy, name): if a named trigger with the same
+    // owner+name already exists and is active, return it instead of
+    // registering a duplicate. This prevents the accumulation bug where a
+    // system cron (e.g. escalation-every-5-min) re-registered on every boot
+    // would fire N times per interval after N restarts.
+    if (input.name) {
+      for (const existing of this.triggers.values()) {
+        if (
+          existing.status === 'active' &&
+          existing.createdBy === input.createdBy &&
+          existing.name === input.name
+        ) {
+          this.logger.debug('Trigger already registered, reusing existing', {
+            id: existing.id,
+            createdBy: existing.createdBy,
+            name: existing.name,
+          });
+          return existing;
+        }
+      }
     }
 
     const trigger = createTrigger(input);
@@ -599,13 +629,31 @@ export class TriggerEngine {
       return;
     }
 
-    this.eventBus.on('event_published', (eventData: { eventId: string; eventType: string; sessionName: string }) => {
+    if (this.signalListener) {
+      // Already registered — starting without stopping first would double up.
+      return;
+    }
+
+    this.signalListener = (eventData) => {
       this.handleSignalEvent(eventData).catch((err) => {
         this.logger.error('Signal event handling failed', {
           error: err instanceof Error ? err.message : String(err),
         });
       });
-    });
+    };
+
+    this.eventBus.on('event_published', this.signalListener);
+  }
+
+  /**
+   * Detaches the signal listener registered in {@link setupSignalListeners}.
+   * Safe to call when no listener is attached.
+   */
+  private teardownSignalListeners(): void {
+    if (this.eventBus && this.signalListener) {
+      this.eventBus.off('event_published', this.signalListener);
+    }
+    this.signalListener = null;
   }
 
   /**
@@ -696,7 +744,21 @@ export class TriggerEngine {
   // ---------------------------------------------------------------------------
 
   /**
-   * Loads triggers from disk.
+   * Loads triggers from disk and collapses accumulated duplicates.
+   *
+   * Historical accumulation: pre-fix, every boot called `create()` for
+   * fixed system crons (e.g. EscalationService's 5-minute reconciler) with
+   * no idempotency key, so the store grew by one duplicate each restart.
+   * A single workspace was observed with 39 copies of the every-5-min
+   * runReconciler, firing in parallel every interval.
+   *
+   * Policy:
+   * - Two triggers are "duplicates" iff they share `createdBy`, `config`,
+   *   and `action` (structural-JSON equality) AND both are `active`.
+   * - Of each duplicate group, keep the one with the earliest `createdAt`
+   *   (or lowest id as tiebreaker) and cancel the rest. We cancel rather
+   *   than delete so any in-flight fire completes cleanly and the audit
+   *   trail survives.
    */
   private async loadTriggers(): Promise<void> {
     await ensureDir(this.triggersDir);
@@ -705,7 +767,62 @@ export class TriggerEngine {
     for (const trigger of data) {
       this.triggers.set(trigger.id, trigger);
     }
-    this.logger.info('Loaded triggers from disk', { count: this.triggers.size });
+
+    const cancelledDuplicates = this.dedupeDuplicateTriggers();
+    if (cancelledDuplicates > 0) {
+      await this.persistTriggers();
+    }
+
+    this.logger.info('Loaded triggers from disk', {
+      count: this.triggers.size,
+      cancelledDuplicates,
+    });
+  }
+
+  /**
+   * Detects active triggers that are structurally identical (same owner,
+   * same config, same action) and cancels all but the oldest in each group.
+   *
+   * Returns the number of triggers newly marked `cancelled`.
+   */
+  private dedupeDuplicateTriggers(): number {
+    const groups = new Map<string, Trigger[]>();
+    for (const trigger of this.triggers.values()) {
+      if (trigger.status !== 'active') continue;
+      const key = JSON.stringify({
+        createdBy: trigger.createdBy,
+        config: trigger.config,
+        action: trigger.action,
+      });
+      const group = groups.get(key);
+      if (group) {
+        group.push(trigger);
+      } else {
+        groups.set(key, [trigger]);
+      }
+    }
+
+    let cancelled = 0;
+    for (const group of groups.values()) {
+      if (group.length <= 1) continue;
+      // Keep the earliest-created; tiebreak on id for stability.
+      group.sort((a, b) => {
+        const byDate = a.createdAt.localeCompare(b.createdAt);
+        return byDate !== 0 ? byDate : a.id.localeCompare(b.id);
+      });
+      const [keeper, ...duplicates] = group;
+      for (const dup of duplicates) {
+        dup.status = 'cancelled';
+        cancelled += 1;
+      }
+      this.logger.warn('Collapsed duplicate triggers at startup', {
+        kept: keeper.id,
+        createdBy: keeper.createdBy,
+        cancelledIds: duplicates.map((d) => d.id),
+        count: duplicates.length,
+      });
+    }
+    return cancelled;
   }
 
   /**

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -140,6 +140,35 @@ export interface Team {
   ownershipScope?: import('./team-template.types.js').OwnershipScope;
   /** Service contract — what the team accepts, avoids, and delivers */
   serviceContract?: import('./team-template.types.js').ServiceContract;
+  /**
+   * Declarative trigger specs that materialise the team's operating cadence
+   * (monthly kickoff, weekly review, daily EOD, ...). Reconciled with
+   * TriggerEngine on team load/update so SOP timing fires autonomously.
+   */
+  triggers?: TeamTriggerSpec[];
+}
+
+/**
+ * Declarative spec for a team-owned trigger. Persisted on the Team config and
+ * reconciled with the runtime TriggerEngine. The pair (teamId, name) forms
+ * the identity key — editing this spec edits the running trigger in place
+ * rather than duplicating it.
+ */
+export interface TeamTriggerSpec {
+  /** Stable identifier within the team (e.g. "youtube-monthly-kickoff"). */
+  name: string;
+  /** Human-readable label used for logs and optional WorkItem titles. */
+  description?: string;
+  /** Whether the reconciler should register/keep this trigger active. */
+  enabled?: boolean;
+  /** Time or signal config, mirrors TriggerEngine.create input. */
+  config: import('./v2/trigger.types.js').TriggerConfig;
+  /** What to do when the trigger fires. */
+  action: import('./v2/trigger.types.js').TriggerAction;
+  /** Optional fire cap — undefined = unlimited. */
+  maxFires?: number;
+  /** Optional idle-fire tolerance before auto-cancel. */
+  maxIdleFires?: number;
 }
 
 /**

--- a/backend/src/types/team-template.types.ts
+++ b/backend/src/types/team-template.types.ts
@@ -188,6 +188,8 @@ export interface TemplateRole {
   expertId?: string;
   /** Domain SOP ID — loads domain-specific standard operating procedures for this role */
   domainSOP?: string;
+  /** Risk policy ID — loads config/risk-policies/{riskPolicy}.policy.md into the role's prompt */
+  riskPolicy?: string;
 }
 
 // =============================================================================

--- a/backend/src/types/v2/mission.types.test.ts
+++ b/backend/src/types/v2/mission.types.test.ts
@@ -18,6 +18,8 @@ import {
   CONSERVATIVE_CADENCE,
   MODERATE_CADENCE,
   AUTONOMOUS_CADENCE,
+  MISSION_PRIORITIES,
+  MISSION_PRIORITY_RANK,
   isValidMissionStatus,
   isValidPolicyAction,
   isValidEscalationCondition,
@@ -32,8 +34,9 @@ import {
   createMission,
   getEffectiveCadence,
   mergeExecutionCadence,
+  validateParentLink,
 } from './mission.types.js';
-import type { MissionPolicy, EscalationRule, CreateMissionInput, ExecutionCadence } from './mission.types.js';
+import type { Mission, MissionPolicy, EscalationRule, CreateMissionInput, ExecutionCadence } from './mission.types.js';
 
 describe('Mission Types', () => {
   // -----------------------------------------------------------------------
@@ -561,6 +564,65 @@ describe('Mission Types', () => {
       const original: ExecutionCadence = { ...CONSERVATIVE_CADENCE };
       mergeExecutionCadence(original, { dailyItemLimit: 99 });
       expect(original.dailyItemLimit).toBe(CONSERVATIVE_CADENCE.dailyItemLimit);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Priority
+  // -----------------------------------------------------------------------
+  describe('MISSION_PRIORITIES', () => {
+    it('lists the four levels ordered from most to least important', () => {
+      expect(MISSION_PRIORITIES).toEqual(['critical', 'high', 'medium', 'low']);
+    });
+
+    it('rank order matches list order', () => {
+      expect(MISSION_PRIORITY_RANK.critical).toBeLessThan(MISSION_PRIORITY_RANK.high);
+      expect(MISSION_PRIORITY_RANK.high).toBeLessThan(MISSION_PRIORITY_RANK.medium);
+      expect(MISSION_PRIORITY_RANK.medium).toBeLessThan(MISSION_PRIORITY_RANK.low);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // validateParentLink
+  // -----------------------------------------------------------------------
+  describe('validateParentLink', () => {
+    type Pair = Pick<Mission, 'id' | 'parentMissionId'>;
+    const m = (id: string, parentMissionId?: string): Pair => ({ id, parentMissionId });
+
+    it('rejects self-reference', () => {
+      const reason = validateParentLink('a', 'a', new Map());
+      expect(reason).toMatch(/own parent/i);
+    });
+
+    it('rejects unknown parent', () => {
+      const reason = validateParentLink('a', 'does-not-exist', new Map());
+      expect(reason).toMatch(/does not exist/i);
+    });
+
+    it('accepts a valid link to an existing parent', () => {
+      const byId = new Map<string, Pair>([['p', m('p')]]);
+      expect(validateParentLink('c', 'p', byId)).toBeNull();
+    });
+
+    it('rejects a cycle through intermediate ancestors', () => {
+      //    child (a)           proposed parent: b
+      //    existing: b → c → a (cycle if we add a → b)
+      const byId = new Map<string, Pair>([
+        ['a', m('a')],
+        ['b', m('b', 'c')],
+        ['c', m('c', 'a')],
+      ]);
+      const reason = validateParentLink('a', 'b', byId);
+      expect(reason).toMatch(/cycle/i);
+    });
+
+    it('detects an already-cyclic parent chain defensively', () => {
+      const byId = new Map<string, Pair>([
+        ['x', m('x', 'y')],
+        ['y', m('y', 'x')],
+      ]);
+      const reason = validateParentLink('new', 'x', byId);
+      expect(reason).toMatch(/cycle/i);
     });
   });
 });

--- a/backend/src/types/v2/mission.types.ts
+++ b/backend/src/types/v2/mission.types.ts
@@ -51,6 +51,37 @@ export const MISSION_TRANSITIONS: Record<MissionStatus, ReadonlySet<MissionStatu
 };
 
 // ---------------------------------------------------------------------------
+// Mission Priority
+// ---------------------------------------------------------------------------
+
+/**
+ * Priority levels for a Mission.
+ *
+ * Ordered from most to least important: critical > high > medium > low.
+ * Used for sorting and filtering; does not affect policy enforcement.
+ */
+export type MissionPriority = 'critical' | 'high' | 'medium' | 'low';
+
+/** All valid MissionPriority values (ordered most → least important). */
+export const MISSION_PRIORITIES: readonly MissionPriority[] = [
+  'critical',
+  'high',
+  'medium',
+  'low',
+] as const;
+
+/**
+ * Numeric rank for sorting missions by priority (lower rank = higher priority).
+ * Missing priority is treated as `low`.
+ */
+export const MISSION_PRIORITY_RANK: Record<MissionPriority, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+// ---------------------------------------------------------------------------
 // Escalation Rules
 // ---------------------------------------------------------------------------
 
@@ -288,6 +319,14 @@ export interface Mission {
   lastReviewSummary?: string;
   /** OKR time period for period-based lifecycle management */
   period?: MissionPeriod;
+  /** Priority for sorting/filtering. Does not affect policy enforcement. */
+  priority?: MissionPriority;
+  /**
+   * Optional parent Mission ID, forming a hierarchy
+   * (e.g. company-level OKR → team-level OKR → individual OKR).
+   * Must not be self, and the resulting chain must not form a cycle.
+   */
+  parentMissionId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -385,6 +424,10 @@ export interface CreateMissionInput {
   policy?: Partial<MissionPolicy>;
   /** OKR time period for period-based lifecycle management */
   period?: MissionPeriod;
+  /** Priority for sorting/filtering. Does not affect policy enforcement. */
+  priority?: MissionPriority;
+  /** Optional parent Mission ID (validated to avoid self-ref and cycles). */
+  parentMissionId?: string;
 }
 
 /**
@@ -750,10 +793,61 @@ export function isPeriodFuture(period: MissionPeriod, now: Date = new Date()): b
   return now < new Date(period.startDate);
 }
 
+// ---------------------------------------------------------------------------
+// Mission Hierarchy Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates a proposed parent link between a child mission and a parent.
+ *
+ * Rejects self-reference and any cycle that would be introduced by walking
+ * up the existing parent chain from `parentId`. The child mission itself
+ * does not need to exist in `byId` (useful for create-time validation).
+ *
+ * @param childId - The mission that would acquire the parent
+ * @param parentId - The proposed parent mission ID
+ * @param byId - All existing missions indexed by ID
+ * @returns `null` if the link is valid, otherwise a human-readable reason
+ *
+ * @example
+ * ```ts
+ * const reason = validateParentLink('m1', 'm2', new Map([['m2', m2]]));
+ * if (reason) throw new Error(reason);
+ * ```
+ */
+export function validateParentLink(
+  childId: string,
+  parentId: string,
+  byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+): string | null {
+  if (childId === parentId) return 'A mission cannot be its own parent';
+  if (!byId.has(parentId)) return `Parent mission ${parentId} does not exist`;
+
+  // Walk up from the proposed parent; if we reach `childId`, we have a cycle.
+  const seen = new Set<string>();
+  let cursor: string | undefined = parentId;
+  while (cursor) {
+    if (seen.has(cursor)) return `Parent chain contains a cycle at ${cursor}`;
+    if (cursor === childId) return 'Proposed parent link would create a cycle';
+    seen.add(cursor);
+    cursor = byId.get(cursor)?.parentMissionId;
+  }
+  return null;
+}
+
+/**
+ * Sort missions by status (active first), then by priority rank, then by recency.
+ *
+ * @param missions - Missions to sort (not mutated)
+ * @returns New array sorted by status → priority → createdAt desc
+ */
 export function sortMissionsByPriority(missions: Mission[]): Mission[] {
   return [...missions].sort((a, b) => {
     if (a.status === 'active' && b.status !== 'active') return -1;
     if (a.status !== 'active' && b.status === 'active') return 1;
+    const rankA = MISSION_PRIORITY_RANK[a.priority ?? 'low'];
+    const rankB = MISSION_PRIORITY_RANK[b.priority ?? 'low'];
+    if (rankA !== rankB) return rankA - rankB;
     return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
   });
 }

--- a/backend/src/types/v2/trigger.types.ts
+++ b/backend/src/types/v2/trigger.types.ts
@@ -143,6 +143,18 @@ export interface Trigger {
   maxIdleFires: number;
   /** Current count of consecutive idle fires */
   consecutiveIdleFires: number;
+  /**
+   * Owning team, if this trigger was provisioned from a Team's `triggers` spec.
+   * Used by {@link TeamTriggerReconciler} to look up and cancel team-scoped
+   * triggers without touching user/mission/system triggers.
+   */
+  teamId?: string;
+  /**
+   * Stable name set by the provisioner (e.g. `"youtube-monthly-kickoff"`).
+   * The reconciler uses (teamId, name) as the identity key so editing
+   * `Team.triggers[].cronExpression` replaces instead of duplicating.
+   */
+  name?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +171,10 @@ export interface CreateTriggerInput {
   createdBy: 'user' | 'orchestrator' | 'system' | 'mission';
   maxFires?: number;
   maxIdleFires?: number;
+  /** Optional owning team (team-scoped triggers) */
+  teamId?: string;
+  /** Optional stable name for reconciliation-by-identity */
+  name?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -324,5 +340,7 @@ export function createTrigger(input: CreateTriggerInput): Trigger {
     maxFires: input.maxFires,
     maxIdleFires: input.maxIdleFires ?? DEFAULT_MAX_IDLE_FIRES,
     consecutiveIdleFires: 0,
+    teamId: input.teamId,
+    name: input.name,
   };
 }

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -374,5 +374,26 @@ describe('WorkItem Types', () => {
       const wi = createWorkItem(input);
       expect(wi.target).toBe('crewly-product-leo-member-n');
     });
+
+    it('should start in blocked status when dependsOn is non-empty', () => {
+      const wi = createWorkItem({ ...input, dependsOn: ['wi-upstream-1'] });
+      expect(wi.status).toBe('blocked');
+      expect(wi.dependsOn).toEqual(['wi-upstream-1']);
+    });
+
+    it('should prefer blocked over scheduled when both are specified', () => {
+      const wi = createWorkItem({
+        ...input,
+        dependsOn: ['wi-upstream-1'],
+        scheduledAt: new Date(Date.now() + 60000).toISOString(),
+      });
+      expect(wi.status).toBe('blocked');
+    });
+
+    it('should ignore an empty dependsOn array', () => {
+      const wi = createWorkItem({ ...input, dependsOn: [] });
+      expect(wi.status).toBe('queued');
+      expect(wi.dependsOn).toBeUndefined();
+    });
   });
 });

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -193,6 +193,14 @@ export interface WorkItem {
   cost: number;
   /** Extensible metadata (dependency tracking, skill requirements, etc.) */
   metadata?: Record<string, unknown>;
+  /**
+   * IDs of upstream WorkItems that must reach terminal success (`done` or
+   * `verified`) before this item is allowed to run. When any dep is still
+   * pending at creation time, the item starts in `blocked` status and is
+   * auto-promoted to `queued` by the TaskPool resolver once every dep
+   * completes.
+   */
+  dependsOn?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -216,6 +224,8 @@ export interface CreateWorkItemInput {
   projectTaskId?: string;
   missionId?: string;
   metadata?: Record<string, unknown>;
+  /** Upstream WorkItem IDs that must reach terminal success before this runs. */
+  dependsOn?: string[];
 }
 
 /**
@@ -441,7 +451,16 @@ export const DEFAULT_MAX_RETRIES = 3;
  */
 export function createWorkItem(input: CreateWorkItemInput): WorkItem {
   const now = new Date().toISOString();
+  const hasDeps = Array.isArray(input.dependsOn) && input.dependsOn.length > 0;
   const hasSchedule = !!input.scheduledAt;
+  // Dep gating wins over schedule — a blocked item should not be queued or
+  // fired by a cron. The dependency resolver will promote it to 'queued' once
+  // all upstream items reach terminal success.
+  const initialStatus: WorkItemStatus = hasDeps
+    ? 'blocked'
+    : hasSchedule
+      ? 'scheduled'
+      : 'queued';
   return {
     id: uuidv4(),
     requestId: input.requestId,
@@ -451,7 +470,7 @@ export function createWorkItem(input: CreateWorkItemInput): WorkItem {
     target: input.target,
     title: input.title,
     description: input.description,
-    status: hasSchedule ? 'scheduled' : 'queued',
+    status: initialStatus,
     scheduledAt: input.scheduledAt,
     createdAt: now,
     retryCount: 0,
@@ -463,6 +482,7 @@ export function createWorkItem(input: CreateWorkItemInput): WorkItem {
     outputTokens: 0,
     cost: 0,
     metadata: input.metadata,
+    dependsOn: hasDeps ? [...input.dependsOn!] : undefined,
   };
 }
 

--- a/config/domain-sops/content-production-pipeline.sop.md
+++ b/config/domain-sops/content-production-pipeline.sop.md
@@ -1,0 +1,76 @@
+# Content Production Pipeline SOP
+
+This SOP defines the standard process for end-to-end automation of social media content production, from trend analysis to final distribution, optimized for e-commerce and social media teams using Crewly.
+
+## Scope
+This procedure covers all recurring content creation tasks within the Crewly environment, including ideation, copywriting, visual asset production, quality assurance, and publishing handoff to Steve.
+
+## Procedures
+
+### Phase 1: Ideation
+*   **Objective**: Identify high-converting hooks and content topics based on real-time market trends.
+*   **Inputs**: Market trend data, brand pillars, previous post performance metrics.
+*   **Outputs**: Content calendar entries with validated hooks and selected topics.
+*   **Responsible Roles**: Content Strategist, Marketing Lead.
+*   **Crewly Tools**: `trend-monitor` (for cross-platform trend scraping), `remote-browser` (for deep-dive research).
+*   **Quality Gates**: Trend relevance score > 0.8; alignment with at least one core brand pillar.
+*   **Estimated Duration**: 24 hours.
+
+### Phase 2: Briefing & Drafting
+*   **Objective**: Translate ideas into detailed creative briefs and high-quality captions.
+*   **Inputs**: Selected hook and topic from Phase 1.
+*   **Outputs**: 600+ word captions, visual direction briefs, and platform-specific drafts.
+*   **Responsible Roles**: AI Copywriter (Content Writer), Brand Assistant.
+*   **Crewly Tools**: `content-writer` (for initial drafts), `content-repurposer` (for cross-platform optimization).
+*   **Quality Gates**: Brand voice match verification; keyword density check; hook-to-body transition flow.
+*   **Estimated Duration**: 48 hours.
+
+### Phase 3: Visual Production
+*   **Objective**: Generate high-impact visual assets (images, videos, or Remotion templates).
+*   **Inputs**: Visual direction brief from Phase 2.
+*   **Outputs**: Ready-to-post image/video files (MP4, PNG, or JPG).
+*   **Responsible Roles**: Visual Artist Agent, Video Production Agent.
+*   **Crewly Tools**: `remotion-video` (for motion graphics), `nano-banana-image` (for AI image generation).
+*   **Quality Gates**: Resolution (min 1080p); aspect ratio check (9:16 or 4:5); brand color palette adherence.
+*   **Estimated Duration**: 72 hours.
+
+### Phase 4: Review & Approval
+*   **Objective**: Final quality check and human-in-the-loop (HITL) sign-off.
+*   **Inputs**: Draft assets and captions from Phases 2 & 3.
+*   **Outputs**: Approved content package ready for distribution.
+*   **Responsible Roles**: Quality Auditor (QA), Human Marketing Manager.
+*   **Crewly Tools**: `submit-for-approval` (Slack Block Kit integration), `screenshot-compare` (for visual parity check).
+*   **Quality Gates**: Zero typos; asset-caption synchronization; final human approval via Slack.
+*   **Estimated Duration**: 24 hours.
+
+### Phase 5: Publishing Handoff (HUMAN-ONLY)
+*   **Objective**: Package approved content and deliver to Steve for manual publishing on all platforms.
+*   **Inputs**: Approved content package from Phase 4.
+*   **Outputs**: Publishing-ready package delivered to Steve via Slack, with all text, visuals, and platform-specific formatting.
+*   **Responsible Roles**: Marketing Lead (prepares handoff package), **Steve (publishes — ONLY Steve may publish)**.
+*   **Crewly Tools**: `reply-slack` (to deliver content package to Steve), `content-calendar` (for scheduling recommendations).
+*   **Quality Gates**: All assets attached; platform-specific formatting verified; Steve confirms receipt.
+*   **Estimated Duration**: Dependent on Steve's availability.
+*   **⚠️ CRITICAL RULE**: Agents must NEVER publish content directly to any platform (X, LinkedIn, XHS, or any other). No exceptions. All publishing is done manually by Steve. Agents who attempt to publish directly are violating this SOP.
+
+## Success Metrics
+- **Throughput**: 5+ high-quality posts per week per platform.
+- **Engagement**: Average engagement rate > 3% within first 48 hours.
+- **Efficiency**: < 10% rejection rate from Human Marketing Manager.
+- **Brand Consistency**: 95%+ brand voice alignment score via AI auditor.
+
+## Constraints (V1)
+- **ALL content publishing on ALL platforms must be done manually by Steve. Agents are NEVER allowed to publish directly — no exceptions.** This applies to X/Twitter, LinkedIn, XHS, Instagram, TikTok, and any other platform.
+- Agents may only: create content, format it, and deliver the final package to Steve via Slack.
+- Agents must NOT use `remote-browser` or any other tool to post, submit, or publish content on any platform.
+- All AI-generated captions must be passed through a brand-voice filter before human review.
+
+## Escalation Rules
+- **Escalate to Marketing Lead**: If creative briefs are rejected by AI agents 3+ times.
+- **Escalate to Orchestrator**: If visual production tools (e.g., Remotion) encounter runtime errors.
+- **Escalate to Human (CEO/Admin)**: If distribution fails on more than two scheduled platforms simultaneously.
+
+## Maintenance
+- This SOP is reviewed monthly by the Content Strategist.
+- Updates to tool names and parameters must be synchronized with the `AGENT_SKILLS_CATALOG.md`.
+- Brand voice filters should be retrained quarterly using the latest high-performing content.

--- a/config/domain-sops/content-publishing-policy.sop.md
+++ b/config/domain-sops/content-publishing-policy.sop.md
@@ -1,0 +1,59 @@
+# Content Publishing Policy SOP
+
+**STATUS: MANDATORY — ALL MARKETING AGENTS MUST FOLLOW**
+**Last Updated: 2026-04-15 by Steve (confirmed multiple times)**
+
+## Rule
+
+**ALL content publishing on ALL platforms must be done manually by Steve. No exceptions.**
+
+## What Agents CAN Do
+- Research trends and topics
+- Write drafts and create content
+- Generate visual assets
+- Format content for specific platforms
+- Deliver finished content packages to Steve via Slack (`reply-slack`)
+
+## What Agents CANNOT Do
+- Publish, post, or submit content to any platform
+- Use `remote-browser` to interact with publishing interfaces (X, LinkedIn, XHS, etc.)
+- Schedule automated posts
+- Click "publish", "post", "submit", or equivalent buttons on any platform
+
+## Platforms Covered
+This policy applies to ALL platforms without exception:
+- X / Twitter
+- LinkedIn
+- XHS (Xiaohongshu / RedNote)
+- Instagram
+- TikTok
+- Any other social media or content platform
+
+## XHS (Xiaohongshu) Access Rules
+**ALL XHS-related operations (viewing, scraping, comment collection, data gathering) must go through iriss-air (192.168.86.25).**
+- ✅ Use iriss-air for: XHS browsing, comment scraping, data collection, content research
+- ❌ Do NOT use Steve's local machine (`remote-browser` / Chrome Extension) for ANY XHS access
+- This applies to all agents — no exceptions
+
+## Publishing Workflow
+1. Marketing team prepares content package (text + visuals + formatting)
+2. Marketing Lead delivers package to Steve via Slack with all assets
+3. **Steve publishes manually** at his discretion
+4. Marketing team tracks engagement after Steve confirms publication
+
+## Why This Policy Exists
+Steve has confirmed this policy multiple times. Agents have repeatedly violated it by attempting to auto-publish via remote-browser. This SOP exists to prevent further violations.
+
+## Escalation
+- Any agent that attempts to publish directly is violating this SOP
+- Report violations to the Orchestrator immediately
+- The Orchestrator will escalate to Steve
+
+## Enforcement & Penalties
+- **Zero Tolerance**: Any agent found attempting to click "Post", "Publish", or "Submit" via `remote-browser` will be immediately terminated from the session.
+- **Rework Requirement**: If an agent violates this rule, the entire task must be reverted and redone by a different agent to ensure safety.
+- **Audit Requirement**: Every content-related mission must have a mandatory human review step that verifies the handoff package was delivered correctly.
+
+## Maintenance
+- This SOP is permanent until Steve explicitly revokes it
+- No team lead or agent may override this policy

--- a/config/domain-sops/customer-onboarding.sop.md
+++ b/config/domain-sops/customer-onboarding.sop.md
@@ -1,0 +1,74 @@
+# Customer Onboarding SOP
+
+This SOP outlines the standard process for onboarding new service-business clients into the Crewly ecosystem, ensuring a rapid transition from contract signature to first value delivery.
+
+## Scope
+This procedure applies to all new service-business clients and covers kickoff communication, discovery, technical provisioning, and early-stage project execution.
+
+## Procedures
+
+### Phase 1: Kickoff
+*   **Objective**: Establish a professional connection and deliver the "Welcome Kit."
+*   **Inputs**: Signed service contract, client contact information.
+*   **Outputs**: Sent Welcome Kit, scheduled kickoff call, project workspace initialized.
+*   **Responsible Roles**: Account Manager, Onboarding Coordinator.
+*   **Crewly Tools**: `send-message` (automated welcome email/Slack), `reply-chat` (for internal coordination).
+*   **Quality Gates**: Contact confirmed by client; kickoff call scheduled within 48 hours of contract signature.
+*   **Estimated Duration**: 48 hours.
+
+### Phase 2: Discovery
+*   **Objective**: Perform a comprehensive audit of client brand assets and project requirements.
+*   **Inputs**: Client website URL, existing brand style guides, historical performance data.
+*   **Outputs**: Discovery Audit Document, finalized project scope, asset gap report.
+*   **Responsible Roles**: Strategist, Brand Auditor.
+*   **Crewly Tools**: `remote-browser` (for website/competitor audit), `recall` (to cross-reference industry patterns).
+*   **Quality Gates**: All mandatory brand assets (logo, font, colors) verified; scope of work signed off by client.
+*   **Estimated Duration**: 1 week.
+
+### Phase 3: Provisioning
+*   **Objective**: Set up the specialized AI Team and project architecture in Crewly.
+*   **Inputs**: Discovery Audit Document, approved project scope.
+*   **Outputs**: Active AI Team (Agents + Skills), configured project directory, initial goal set.
+*   **Responsible Roles**: DevOps Agent, Orchestrator.
+*   **Crewly Tools**: `register-self` (for new agent initialization), `remember` (to store project-specific norms and keys), `create-task` (for initial setup work).
+*   **Quality Gates**: All required skills (e.g., specific platform scrapers) tested and active; project goals recorded in `.crewly/goals/`.
+*   **Estimated Duration**: 48 hours.
+
+### Phase 4: Value Delivery (The "Quick Win")
+*   **Objective**: Execute and deliver the first high-impact project item to demonstrate immediate value.
+*   **Inputs**: Priority task from the discovery phase.
+*   **Outputs**: First deliverable (e.g., sample content, initial audit report, or automation script).
+*   **Responsible Roles**: Dedicated Execution Agent, QA Auditor.
+*   **Crewly Tools**: `create-task` (for delegation), `report-status` (real-time progress updates to client).
+*   **Quality Gates**: Deliverable passes internal QA; client confirms "Value Received" via feedback loop.
+*   **Estimated Duration**: 1 week.
+
+### Phase 5: Evaluation
+*   **Objective**: Gather onboarding feedback and lock the long-term project roadmap.
+*   **Inputs**: Delivery results from Phase 4, client feedback notes.
+*   **Outputs**: Post-onboarding sentiment report, locked 90-day roadmap, transitioned to "Ongoing Management" status.
+*   **Responsible Roles**: Account Manager, Strategist.
+*   **Crewly Tools**: `feedback-analyzer` (to extract actionable insights), `record-learning` (to document client preferences).
+*   **Quality Gates**: Positive sentiment score > 0.7; 90-day roadmap approved by client.
+*   **Estimated Duration**: 72 hours.
+
+## Success Metrics
+- **Time-to-Value (TTV)**: < 14 days from contract signature to first "Quick Win" delivery.
+- **Onboarding NPS**: Average score > 8.5.
+- **Provisioning Accuracy**: Zero skill-compatibility errors during Phase 3.
+- **Client Engagement**: 100% attendance on scheduled kickoff and evaluation calls.
+
+## Constraints (V1)
+- No technical provisioning (Phase 3) should occur before discovery sign-off (Phase 2).
+- Client credentials must be stored exclusively in secured environment variables or encrypted memory.
+- All "Quick Win" deliverables must undergo a mandatory human-led quality check before delivery.
+
+## Escalation Rules
+- **Escalate to Team Lead**: If client fails to provide mandatory brand assets within 5 business days.
+- **Escalate to Orchestrator**: If initial provisioning encounters skill-compatibility conflicts.
+- **Escalate to Human (Sales/BD)**: If client expresses significant dissatisfaction during the Phase 5 evaluation.
+
+## Maintenance
+- This SOP is reviewed quarterly by the Onboarding Lead.
+- Provisioning templates should be updated as new AI agent roles are added to the marketplace.
+- "Quick Win" examples are updated every 6 months based on client performance data.

--- a/config/domain-sops/expert-distillation.sop.md
+++ b/config/domain-sops/expert-distillation.sop.md
@@ -1,0 +1,70 @@
+# SOP: Expert Mindset Distillation (名人思维蒸馏)
+
+**Version:** 1.0.0
+**Owner:** Product Team (Mia)
+**Scope:** Crewly Pro Core Methodology
+
+## 1. 目标 (Objective)
+本 SOP 旨在标准化「专家思维蒸馏」流程，将非结构化的名人/专家素材转化为 Crewly 可用的结构化 `Expert Profile` (MD + JSON)，从而为 Agent 提供高质量的思维注入。
+
+## 2. 输入 (Inputs)
+- **Primary Source:** 专家著作 (PDF/EPUB)、公开访谈录音或转录稿 (Markdown/TXT)。
+- **Secondary Source:** 媒体分析文章、维基百科、YouTube 视频转录。
+- **Tools:** 
+  - Teacher Model: Claude 3.5 Sonnet (首选) 或 GPT-4o。
+  - Crewly Distiller CLI: `crewly-pro distill`。
+
+## 3. 流程阶段 (Phases)
+
+### Phase 1: 素材清洗 (Data Preprocessing)
+- **任务:** 过滤掉无关信息（广告、日常寒暄、重复片段）。
+- **标准:** 仅保留包含「决策逻辑」、「价值观」、「行业洞察」和「语言风格」的核心文本。
+- **输出:** 清洗后的文本文件 (`raw_distill_input.txt`)。
+
+### Phase 2: 专家特征提取 (Mindset Extraction)
+- **任务:** 使用 Teacher Model 执行蒸馏提示词 (Distillation Prompt)。
+- **Prompt:**
+  ```markdown
+  # SYSTEM PROMPT: Expert Mindset Distiller
+  你是一名顶级的「思维建模专家」。你的目标是分析提供的专家素材，提取其底层的「思维软件」。
+  
+  ## 提取维度:
+  1. **Mental Models (思维模型):** 专家常用的核心框架（如第一性原理、二八定律）。
+  2. **Decision Logic (决策逻辑):** 专家如何权衡风险、处理权衡、评估长短期利益。
+  3. **Industry Insights (行业洞察):** 专家对特定领域的独特「反直觉」见解。
+  4. **Communication Style (沟通风格):** 语气词、标志性短语、论证逻辑结构。
+
+  ## 约束:
+  - 必须使用分析性的、冷静的第三方视角描述，而非模仿其语气说话。
+  - 提取的思维模型必须具有「可操作性」，即 Agent 可以在执行任务时引用。
+  ```
+- **输出:** 专家思维草稿 (`{expert-id}-draft.md`)。
+
+### Phase 3: 格式化与 JSON 元数据生成 (Synthesis)
+- **任务:** 将草稿整理为标准 Markdown 格式，并生成元数据 JSON。
+- **JSON 规范:** 参考 `config/experts/EXAMPLE.json`。
+- **MD 规范:** 参考 `config/experts/EXAMPLE.md`。
+
+### Phase 4: OSS/Pro 边界处理 (Security & Packaging)
+- **任务:** 根据分发渠道进行打包。
+- **OSS:**
+  - 仅包含 MD 文件。
+  - 存储于 `config/experts/`。
+- **Pro:**
+  - 包含 MD + JSON。
+  - 包含预设的 `intensity` 值。
+  - 存储于 `crewly-pro/data/experts/`。
+  - 必须通过 `LicenseValidator` 检查。
+
+### Phase 5: 质量审核 (Quality Gates)
+- **Round 1 (Self):** 蒸馏者检查逻辑是否自洽。
+- **Round 2 (Peer):** 另一名 PM 或专家审核提取的模型是否抓住了本质。
+- **Round 3 (Test):** 将 Profile 注入 Agent，进行 3 个标准任务的 Prompt 压力测试。
+
+## 4. 交付物 (Outputs)
+- `config/experts/{id}.md`
+- `crewly-pro/data/experts/{id}.json` (Pro Only)
+
+## 5. 质量指标 (KPIs)
+- **Accuracy:** 蒸馏模型能准确预测专家在 80% 常见商业场景下的决策倾向。
+- **Utility:** Agent 使用该模板后，在特定领域的专业评分提升 ≥ 20%。

--- a/config/domain-sops/innovation-strategy.sop.md
+++ b/config/domain-sops/innovation-strategy.sop.md
@@ -1,0 +1,26 @@
+# Innovation Strategy SOP
+
+This SOP defines the standard process for "insanely great" product development using first-principles thinking and rigorous risk assessment.
+
+## Phase 1: Problem Inversion
+*   **Objective**: Identify all the ways a project could fail before starting.
+*   **Responsible Role**: Capital Allocator (Charlie Munger mindset).
+*   **Tools**: `inverted-problem-solving`.
+*   **Output**: Risk Map with mitigation strategies.
+
+## Phase 2: First Principles Deconstruction
+*   **Objective**: Strip a problem down to its fundamental truths and rebuild from there.
+*   **Responsible Role**: Radical Engineer (Elon Musk mindset).
+*   **Tools**: `first-principles-analysis`.
+*   **Output**: Optimized technical roadmap with zero legacy constraints.
+
+## Phase 3: Visionary Design Review
+*   **Objective**: Ensure the product is simple, functional, and delightful.
+*   **Responsible Role**: Visionary Strategist (Steve Jobs mindset).
+*   **Tools**: `design-review`.
+*   **Output**: High-fidelity product brief and "insanely great" sign-off.
+
+## Constraints
+- No "just-in-case" features.
+- If a requirement cannot be traced back to a first principle, it must be deleted.
+- Every decision must have a wide margin of safety.

--- a/config/orchestrator_tasks/prompts/orchestrator-prompt.md
+++ b/config/orchestrator_tasks/prompts/orchestrator-prompt.md
@@ -12,6 +12,52 @@ As the orchestrator, you specialize in:
 -   Inter-agent communication facilitation
 -   Strategic project oversight
 
+## Core Concepts — Missions, Requests, Tasks
+
+Crewly distinguishes three levels of work. Use the right one for the right horizon:
+
+-   **Mission** — a team's **long-term objective** (the "O" in OKR). It carries
+    a `period` (weekly / biweekly / monthly / quarterly / custom), a `priority`
+    (critical / high / medium / low), zero-or-more **Key Results** (the "KR"s —
+    measurable numeric / percentage / currency / boolean targets with a
+    baseline → current → target trajectory), and an optional `parentMissionId`
+    that cascades company-level OKRs down to team-level and individual-level
+    OKRs. Missions live for **weeks to a quarter** and are the source of truth
+    for "what this team is responsible for right now." They are also where
+    KPIs / long-range plans are tracked — if a user says "let's set our Q2
+    OKRs" or "track this KPI," that is a Mission, not a Request.
+
+-   **Request** — a **user-initiated ask** (chat message, Slack message, ticket).
+    Requests are short-lived (minutes to days), bound to a single user, and
+    usually resolve into one or more Tasks. A Request MAY contribute to a
+    Mission's progress but does not replace it.
+
+-   **Task (WorkItem)** — an **executable unit of work** assigned to an agent.
+    Tasks live in the TaskPool and are decomposed from either a Request or a
+    Mission (via the `decompose-mission` skill). Tasks carry `contributesToKR`
+    links so that completing a Task updates the parent Mission's KR progress.
+
+### When to create / touch which
+
+| User signal | Right artefact |
+|---|---|
+| "Set our Q2 goals" / "I want to track MRR → $5k" / "What are the team's OKRs?" | **Mission** (create if missing; edit `priority` / `period` / KRs) |
+| "Fix this bug" / "Ship feature X by Friday" | **Request** → decompose into Tasks |
+| "Agent-level action I am delegating now" | **Task** |
+
+### Mission lifecycle
+
+-   `active → paused` — user pauses, no autonomous work
+-   `active → completed` — all success criteria (or all KRs `achieved`) met
+-   `active → cancelled` — no longer viable; record learnings
+-   `paused → active` — resumed
+
+Use `review-mission` (OKR review) on cadence; use `decompose-mission` when a
+Mission needs fresh Tasks; use `measure-kr` when you have a new reading for a
+Key Result. Never embed KR tracking inside a Request — it belongs on the
+Mission. When unsure whether something is a Mission or a Request: **if it
+survives the current week and has a measurable target, it is a Mission.**
+
 ## Registration Required
 
 **IMMEDIATELY** after initialization, register yourself by running:

--- a/config/risk-policies/no-local-browser.policy.md
+++ b/config/risk-policies/no-local-browser.policy.md
@@ -1,0 +1,43 @@
+# Risk Policy: No Local Browser / Desktop Automation
+
+**Applies to:** Agents working on a user's active workstation where opening local browser/desktop windows would interfere with the user's current session.
+
+**Why:** Agents have repeatedly opened the user's local Chrome/iPad/desktop, disrupting real user activity. Several reported incidents trace back to this class of skill.
+
+## Prohibited Actions
+
+**NEVER call any of the following skills:**
+
+- `chrome-attach` — attaches to the user's local Chrome (DO NOT USE)
+- `computer-use` — drives the whole local desktop (DO NOT USE)
+- `desktop-app-control` — local GUI automation (DO NOT USE)
+- `browse-stealth` — opens a local browser (DO NOT USE)
+- `screenshot-compare` — only if it invokes local screen capture (use remote equivalent)
+- Any Playwright or direct CDP invocation against the local machine
+- Any skill whose `execute.sh` calls `open`, `osascript`, `xdotool`, or equivalent
+
+## Required Alternative
+
+When a task requires browsing the web, viewing a page, or interacting with logged-in sites:
+
+**Use `remote-browser`** (the Crewly Chrome Extension bridge). It controls the user's real Chrome via WebSocket/Cloud Relay WITHOUT opening new local windows or stealing focus.
+
+Example:
+```bash
+bash ${AGENT_SKILLS_PATH}/remote-browser/execute.sh '{"action":"navigate","url":"https://example.com"}'
+bash ${AGENT_SKILLS_PATH}/remote-browser/execute.sh '{"action":"read-text"}'
+```
+
+If `remote-browser` is unavailable (extension not installed / cloud relay down), **STOP and report** via `send-message` to the team leader or orchestrator. Do NOT fall back to local browser skills.
+
+## Circuit Breaker
+
+If the remote browser service is offline or rate-limited:
+1. Report the blocker immediately
+2. Mark the WorkItem as `blocked`
+3. Wait for human or orchestrator resolution
+4. Never silently switch to a local-browser skill to "unblock yourself"
+
+## Logging
+
+Every invocation of `remote-browser` is logged by the skill wrapper. Any attempt to invoke a prohibited skill should be refused by the agent and reported via `record-learning` so the pattern can be audited.

--- a/config/skills/agent/computer-use/execute.sh
+++ b/config/skills/agent/computer-use/execute.sh
@@ -82,47 +82,20 @@ do_screenshot() {
   local img_h
   img_h=$(sips -g pixelHeight "$output" | tail -1 | awk '{print $2}')
 
-  # Grid overlay (red lines every 100 screen points with labels)
-  if [ "$grid" = "true" ]; then
-    python3 - "$output" <<'PYEOF'
-import sys
-from PIL import Image, ImageDraw, ImageFont
-
-path = sys.argv[1]
-img = Image.open(path)
-draw = ImageDraw.Draw(img)
-w, h = img.size
-step = 100
-
-try:
-    font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", 12)
-except Exception:
-    font = ImageFont.load_default()
-
-for x in range(0, w, step):
-    draw.line([(x, 0), (x, h)], fill="red", width=1)
-    draw.text((x + 2, 2), str(x), fill="red", font=font)
-
-for y in range(0, h, step):
-    draw.line([(0, y), (w, y)], fill="red", width=1)
-    draw.text((2, y + 2), str(y), fill="red", font=font)
-
-img.save(path)
-PYEOF
-  fi
-
-  # Crop support: {x, y, w, h} in screen coordinates
+  # Crop FIRST, then grid — so grid labels show absolute screen coordinates
+  local origin_x=0 origin_y=0
   if [ -n "$crop_json" ]; then
     local cx cy cw ch
     cx=$(echo "$INPUT" | jq -r '.crop.x')
     cy=$(echo "$INPUT" | jq -r '.crop.y')
     cw=$(echo "$INPUT" | jq -r '.crop.w')
     ch=$(echo "$INPUT" | jq -r '.crop.h')
+    origin_x="$cx"
+    origin_y="$cy"
     local cropped="${TMPDIR_CU}/crop_$(date +%s%N).png"
     python3 - "$output" "$cx" "$cy" "$cw" "$ch" "$cropped" <<'PYEOF'
 import sys
 from PIL import Image
-
 path, cx, cy, cw, ch, out = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5]), sys.argv[6]
 img = Image.open(path)
 cropped = img.crop((cx, cy, cx + cw, cy + ch))
@@ -131,6 +104,45 @@ PYEOF
     output="$cropped"
     img_w="$cw"
     img_h="$ch"
+  fi
+
+  # Grid overlay — labels show ABSOLUTE screen coordinates
+  # Grid step adapts to image size: dense for small crops, sparse for full screen
+  if [ "$grid" = "true" ]; then
+    python3 - "$output" "$origin_x" "$origin_y" <<'PYEOF'
+import sys
+from PIL import Image, ImageDraw, ImageFont
+
+path = sys.argv[1]
+ox, oy = int(sys.argv[2]), int(sys.argv[3])
+img = Image.open(path)
+draw = ImageDraw.Draw(img)
+w, h = img.size
+
+# Adaptive grid step: aim for ~8-12 cells across the image
+step = max(25, min(100, w // 10))
+# Round to nearest 25
+step = (step // 25) * 25
+
+try:
+    font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", max(10, min(14, w // 80)))
+except Exception:
+    font = ImageFont.load_default()
+
+# Vertical lines with absolute X labels
+for x in range(0, w, step):
+    draw.line([(x, 0), (x, h)], fill="red", width=1)
+    label = str(ox + x)  # absolute screen coordinate
+    draw.text((x + 2, 2), label, fill="red", font=font)
+
+# Horizontal lines with absolute Y labels
+for y in range(0, h, step):
+    draw.line([(0, y), (w, y)], fill="red", width=1)
+    label = str(oy + y)
+    draw.text((2, y + 2), label, fill="red", font=font)
+
+img.save(path)
+PYEOF
   fi
 
   # Return result as JSON
@@ -461,134 +473,375 @@ do_list_apps() {
 # Modes: button (bright rectangles), avatar (colored circles), color (target RGB).
 # ---------------------------------------------------------------------------
 do_find() {
-  local mode target
+  local mode target region
   mode=$(printf '%s' "$INPUT" | jq -r '.mode // "button"')
   target=$(printf '%s' "$INPUT" | jq -r '.target // empty')
+  region=$(printf '%s' "$INPUT" | jq -c '.region // null')
 
-  # Take a fresh screenshot at full resolution for analysis
+  # Take screenshot at FULL resolution for pixel-accurate scanning
   local scan_file="/tmp/cu-find-scan.png"
   screencapture -x "$scan_file" 2>/dev/null
 
-  # Get scale factor
   local scale_int
   scale_int=$(osascript -l JavaScript -e 'ObjC.import("AppKit"); Math.round($.NSScreen.mainScreen.backingScaleFactor);' 2>/dev/null || echo "2")
 
-  python3 -c "
-import json, sys
-from PIL import Image
+  CU_SCALE="$scale_int" CU_MODE="$mode" CU_TARGET="$target" CU_REGION="$region" python3 << 'PYEOF'
+import json, sys, os
+from PIL import Image, ImageDraw, ImageFont
 
-img = Image.open('${scan_file}')
-w, h = img.size
-scale = ${scale_int}
+img = Image.open('/tmp/cu-find-scan.png')
+W, H = img.size
+S = int(os.environ.get('CU_SCALE', '2'))
+mode = os.environ.get('CU_MODE', 'button')
+target = os.environ.get('CU_TARGET', '')
+region_json = os.environ.get('CU_REGION', 'null')
 
-mode = '${mode}'
-results = []
+# Optional region constraint: {"x":100,"y":200,"w":400,"h":300} in screen coords
+region = json.loads(region_json) if region_json != 'null' else None
+if region:
+    rx, ry, rw, rh = region['x']*S, region['y']*S, region['w']*S, region['h']*S
+else:
+    rx, ry, rw, rh = 0, 0, W, H
 
-if mode == 'button':
-    # Find white/light button-like regions on dark backgrounds
-    # or colored buttons. Scan for horizontal runs of bright pixels
-    # that differ from their surroundings (buttons have borders/contrast).
+def px(x, y):
+    """Get pixel RGB, clamped to image bounds."""
+    x, y = max(0, min(x, W-1)), max(0, min(y, H-1))
+    return img.getpixel((x, y))[:3]
 
-    for y in range(0, h, 4):
-        in_bright = False
-        run_start = 0
-        for x in range(0, w, 2):
-            r, g, b = img.getpixel((x, y))[:3]
-            bright = r > 200 and g > 200 and b > 200
-            if bright and not in_bright:
-                run_start = x
-                in_bright = True
-            elif not bright and in_bright:
-                run_len = x - run_start
-                if run_len > 100:  # Wide enough to be a button
-                    results.append({
-                        'x': (run_start + x) // 2 // scale,
-                        'y': y // scale,
-                        'width': run_len // scale,
-                        'type': 'bright_region'
-                    })
-                in_bright = False
+def to_screen(x, y):
+    """Convert pixel coords to screen coords."""
+    return x // S, y // S
 
-    # Cluster nearby results into distinct buttons
-    if results:
-        clusters = []
-        results.sort(key=lambda r: (r['y'], r['x']))
-        current = [results[0]]
-        for i in range(1, len(results)):
-            if abs(results[i]['y'] - results[i-1]['y']) < 10 and abs(results[i]['x'] - results[i-1]['x']) < 50:
-                current.append(results[i])
-            else:
-                if len(current) >= 3:
-                    avg_x = sum(r['x'] for r in current) // len(current)
-                    avg_y = sum(r['y'] for r in current) // len(current)
-                    avg_w = max(r['width'] for r in current)
-                    clusters.append({'x': avg_x, 'y': avg_y, 'width': avg_w, 'height': len(current) * 4})
-                current = [results[i]]
-        if len(current) >= 3:
-            avg_x = sum(r['x'] for r in current) // len(current)
-            avg_y = sum(r['y'] for r in current) // len(current)
-            avg_w = max(r['width'] for r in current)
-            clusters.append({'x': avg_x, 'y': avg_y, 'width': avg_w, 'height': len(current) * 4})
+def cluster_points(points, gap=20):
+    """Cluster nearby points by Y proximity."""
+    if not points:
+        return []
+    points.sort(key=lambda p: p[1])
+    clusters = [[points[0]]]
+    for i in range(1, len(points)):
+        if points[i][1] - points[i-1][1] < gap:
+            clusters[-1].append(points[i])
+        else:
+            clusters.append([points[i]])
+    return [c for c in clusters if len(c) >= 3]
 
-        print(json.dumps({'found': len(clusters), 'elements': clusters[:20]}))
+# ── MODE: text ──────────────────────────────────────────────────
+# Uses macOS Vision framework OCR for fast, accurate text detection.
+# Finds target text on screen and returns its screen coordinates.
+if mode == 'text' and target:
+    import subprocess
+    # Call Swift Vision OCR (fast, accurate, built into macOS)
+    swift_code = r'''
+    import Vision
+    import AppKit
+    import Foundation
+
+    let url = URL(fileURLWithPath: "/tmp/cu-find-scan.png")
+    guard let image = NSImage(contentsOf: url),
+          let tiffData = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiffData),
+          let cgImage = bitmap.cgImage else {
+        print("[]")
+        exit(0)
+    }
+    let imgW = Double(cgImage.width)
+    let imgH = Double(cgImage.height)
+    let request = VNRecognizeTextRequest()
+    request.recognitionLevel = .accurate
+    let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+    try? handler.perform([request])
+    var results: [[String: Any]] = []
+    for obs in request.results ?? [] {
+        if let candidate = obs.topCandidates(1).first {
+            let box = obs.boundingBox
+            // Convert from Vision coords (bottom-left, 0-1) to pixel coords (top-left)
+            let px = box.origin.x * imgW + box.size.width * imgW / 2
+            let py = (1.0 - box.origin.y - box.size.height) * imgH + box.size.height * imgH / 2
+            results.append([
+                "text": candidate.string,
+                "px": Int(px),
+                "py": Int(py),
+                "confidence": candidate.confidence
+            ])
+        }
+    }
+    let jsonData = try! JSONSerialization.data(withJSONObject: results)
+    print(String(data: jsonData, encoding: .utf8) ?? "[]")
+    '''
+
+    proc = subprocess.run(['swift', '-e', swift_code], capture_output=True, text=True, timeout=15)
+    ocr_results = json.loads(proc.stdout.strip()) if proc.stdout.strip() else []
+
+    # Search for target text (case-insensitive substring match)
+    target_lower = target.lower()
+    matches = []
+    for r in ocr_results:
+        if target_lower in r['text'].lower():
+            sx, sy = r['px'] // S, r['py'] // S
+            matches.append({'x': sx, 'y': sy, 'text': r['text'], 'confidence': round(r['confidence'], 3)})
+
+    if matches:
+        best = matches[0]
+        print(json.dumps({'found': True, 'x': best['x'], 'y': best['y'], 'text': best['text'], 'confidence': best['confidence'], 'allMatches': matches[:5]}))
     else:
-        print(json.dumps({'found': 0, 'elements': []}))
+        # Return all detected text for debugging
+        all_texts = [r['text'] for r in ocr_results[:15]]
+        print(json.dumps({'found': False, 'target': target, 'textsOnScreen': all_texts}))
 
+# ── MODE: button ────────────────────────────────────────────────
+# Find button-like rectangles (white on dark OR bordered on light)
+elif mode == 'button':
+    buttons = []
+    # Scan for horizontal runs of uniform bright OR bordered pixels
+    for y in range(ry, ry+rh, 3):
+        in_run = False
+        run_start = 0
+        for x in range(rx, rx+rw, 2):
+            r, g, b = px(x, y)
+            bright = r > 200 and g > 200 and b > 200
+            # Check if this bright pixel has dark neighbors above/below (= button)
+            if bright:
+                above = px(x, max(0, y-40))
+                below = px(x, min(H-1, y+40))
+                is_button_pixel = (sum(above)/3 < 120) or (sum(below)/3 < 120)
+            else:
+                is_button_pixel = False
+
+            if is_button_pixel and not in_run:
+                run_start = x
+                in_run = True
+            elif not is_button_pixel and in_run:
+                run_len = x - run_start
+                if run_len > 80:
+                    cx, cy = to_screen((run_start + x) // 2, y)
+                    buttons.append({'x': cx, 'y': cy, 'width': run_len // S})
+                in_run = False
+
+    # Cluster
+    clusters = []
+    buttons.sort(key=lambda b: (b['y'], b['x']))
+    if buttons:
+        current = [buttons[0]]
+        for i in range(1, len(buttons)):
+            if abs(buttons[i]['y'] - current[-1]['y']) < 8:
+                current.append(buttons[i])
+            else:
+                if len(current) >= 2:
+                    cx = sum(b['x'] for b in current) // len(current)
+                    cy = sum(b['y'] for b in current) // len(current)
+                    w = max(b['width'] for b in current)
+                    clusters.append({'x': cx, 'y': cy, 'width': w, 'height': len(current) * 3})
+                current = [buttons[i]]
+        if len(current) >= 2:
+            cx = sum(b['x'] for b in current) // len(current)
+            cy = sum(b['y'] for b in current) // len(current)
+            w = max(b['width'] for b in current)
+            clusters.append({'x': cx, 'y': cy, 'width': w, 'height': len(current) * 3})
+
+    print(json.dumps({'found': len(clusters), 'elements': clusters[:20]}))
+
+# ── MODE: avatar ────────────────────────────────────────────────
 elif mode == 'avatar':
-    # Find colored circles (account avatars, icons)
-    for y in range(h // 4, 3 * h // 4, 2):
-        for x in range(w // 4, 3 * w // 4, 4):
-            r, g, b = img.getpixel((x, y))[:3]
+    colored = []
+    for y in range(ry + rh//4, ry + 3*rh//4, 2):
+        for x in range(rx + rw//4, rx + 3*rw//4, 3):
+            r, g, b = px(x, y)
             sat = max(r,g,b) - min(r,g,b)
             if sat > 40 and max(r,g,b) > 80 and min(r,g,b) < 200:
-                results.append((x, y))
+                colored.append((x, y))
 
-    if results:
-        # Cluster into distinct avatars
-        results.sort(key=lambda p: p[1])
-        clusters = [[results[0]]]
-        for i in range(1, len(results)):
-            if results[i][1] - results[i-1][1] < 10:
-                clusters[-1].append(results[i])
+    clusters = cluster_points(colored, gap=15)
+    avatars = []
+    for c in clusters:
+        if len(c) >= 5:
+            cx, cy = to_screen(
+                sum(p[0] for p in c) // len(c),
+                sum(p[1] for p in c) // len(c)
+            )
+            avatars.append({'x': cx + 50, 'y': cy})
+
+    print(json.dumps({'found': len(avatars), 'elements': avatars[:10]}))
+
+# ── MODE: color ─────────────────────────────────────────────────
+elif mode == 'color' and target:
+    parts = target.split(',')
+    tr, tg, tb = int(parts[0]), int(parts[1]), int(parts[2])
+    tol = 60
+    hits = []
+    for y in range(ry, ry+rh, 3):
+        for x in range(rx, rx+rw, 3):
+            r, g, b = px(x, y)
+            if abs(r-tr) < tol and abs(g-tg) < tol and abs(b-tb) < tol:
+                hits.append((x, y))
+    if hits:
+        cx, cy = to_screen(
+            sum(p[0] for p in hits) // len(hits),
+            sum(p[1] for p in hits) // len(hits)
+        )
+        print(json.dumps({'found': len(hits), 'center': {'x': cx, 'y': cy}}))
+    else:
+        print(json.dumps({'found': 0}))
+
+# ── MODE: contrast ──────────────────────────────────────────────
+# Find high-contrast edges (useful for finding UI element boundaries)
+elif mode == 'contrast':
+    edges = []
+    for y in range(ry+2, ry+rh-2, 3):
+        for x in range(rx+2, rx+rw-2, 3):
+            c = px(x, y)
+            r_pixel = px(x+4, y)
+            d_pixel = px(x, y+4)
+            h_diff = abs(sum(c)/3 - sum(r_pixel)/3)
+            v_diff = abs(sum(c)/3 - sum(d_pixel)/3)
+            if h_diff > 80 or v_diff > 80:
+                edges.append((x, y))
+    clusters = cluster_points(edges, gap=10)
+    elements = []
+    for c in clusters:
+        if len(c) >= 10:
+            cx, cy = to_screen(
+                sum(p[0] for p in c) // len(c),
+                sum(p[1] for p in c) // len(c)
+            )
+            elements.append({'x': cx, 'y': cy, 'density': len(c)})
+    print(json.dumps({'found': len(elements), 'elements': elements[:20]}))
+
+elif mode == 'near':
+    # Find an icon/element near a known text anchor.
+    # target = the text to anchor on (found via OCR)
+    # Uses pixel scanning around the anchor to find nearby non-text elements.
+    # Params via env: CU_NEAR_DIR (right|left|above|below), CU_NEAR_DIST (max distance)
+    near_dir = os.environ.get('CU_NEAR_DIR', 'right')
+    near_dist = int(os.environ.get('CU_NEAR_DIST', '150'))
+
+    if not target:
+        print(json.dumps({'error': 'near mode requires target text'}))
+    else:
+        # First find anchor text via OCR
+        import subprocess
+        proc = subprocess.run(['swift', '/tmp/cu-ocr.swift', '/tmp/cu-find-scan.png'],
+                            capture_output=True, text=True, timeout=15)
+        ocr = json.loads(proc.stdout.strip()) if proc.stdout.strip() else []
+        anchor = None
+        for r in ocr:
+            if target.lower() in r['text'].lower():
+                anchor = (r['px'], r['py'])
+                break
+
+        if not anchor:
+            # Try inverted image for dark themes
+            from PIL import ImageOps
+            ImageOps.invert(img.convert('RGB')).save('/tmp/cu-find-inverted.png')
+            proc2 = subprocess.run(['swift', '/tmp/cu-ocr.swift', '/tmp/cu-find-inverted.png'],
+                                capture_output=True, text=True, timeout=15)
+            ocr2 = json.loads(proc2.stdout.strip()) if proc2.stdout.strip() else []
+            for r in ocr2:
+                if target.lower() in r['text'].lower():
+                    anchor = (r['px'], r['py'])
+                    break
+
+        if not anchor:
+            print(json.dumps({'found': False, 'error': f'Anchor text "{target}" not found'}))
+        else:
+            ax, ay = anchor
+            dist_px = near_dist * S
+            # Define scan region based on direction
+            if near_dir == 'right':
+                scan_x1, scan_y1 = ax + 20, ay - 30
+                scan_x2, scan_y2 = ax + dist_px, ay + 30
+            elif near_dir == 'left':
+                scan_x1, scan_y1 = ax - dist_px, ay - 30
+                scan_x2, scan_y2 = ax - 20, ay + 30
+            elif near_dir == 'above':
+                scan_x1, scan_y1 = ax - 30, ay - dist_px
+                scan_x2, scan_y2 = ax + 30, ay - 20
+            else:  # below
+                scan_x1, scan_y1 = ax - 30, ay + 20
+                scan_x2, scan_y2 = ax + 30, ay + dist_px
+
+            # Clamp to image bounds
+            scan_x1, scan_y1 = max(0, scan_x1), max(0, scan_y1)
+            scan_x2, scan_y2 = min(W-1, scan_x2), min(H-1, scan_y2)
+
+            # Scan for non-background pixels (icons, buttons)
+            icon_pixels = []
+            for y in range(scan_y1, scan_y2, 2):
+                for x in range(scan_x1, scan_x2, 2):
+                    r, g, b = px(x, y)
+                    brightness = (r + g + b) / 3
+                    # Icon: medium brightness, not pure white/black
+                    if 60 < brightness < 180:
+                        icon_pixels.append((x, y))
+
+            if icon_pixels:
+                ix = sum(p[0] for p in icon_pixels) // len(icon_pixels)
+                iy = sum(p[1] for p in icon_pixels) // len(icon_pixels)
+                sx, sy = to_screen(ix, iy)
+                asx, asy = to_screen(ax, ay)
+                print(json.dumps({
+                    'found': True,
+                    'x': sx, 'y': sy,
+                    'anchor': {'x': asx, 'y': asy, 'text': target},
+                    'direction': near_dir
+                }))
             else:
-                clusters.append([results[i]])
-
-        avatars = []
-        for c in clusters:
-            if len(c) >= 5:
-                avg_x = sum(p[0] for p in c) // len(c) // scale
-                avg_y = sum(p[1] for p in c) // len(c) // scale
-                avatars.append({'x': avg_x + 50, 'y': avg_y})  # offset right to hit text area
-
-        print(json.dumps({'found': len(avatars), 'elements': avatars[:10]}))
-    else:
-        print(json.dumps({'found': 0, 'elements': []}))
-
-elif mode == 'color':
-    # Find regions matching a target color
-    # target format: 'r,g,b' with tolerance
-    tr, tg, tb = [int(c) for c in '${target}'.split(',')][:3] if '${target}' else (0, 0, 255)
-    tolerance = 60
-
-    for y in range(0, h, 4):
-        for x in range(0, w, 4):
-            r, g, b = img.getpixel((x, y))[:3]
-            if abs(r-tr) < tolerance and abs(g-tg) < tolerance and abs(b-tb) < tolerance:
-                results.append({'x': x // scale, 'y': y // scale})
-
-    if results:
-        # Cluster
-        center_x = sum(r['x'] for r in results) // len(results)
-        center_y = sum(r['y'] for r in results) // len(results)
-        print(json.dumps({'found': len(results), 'center': {'x': center_x, 'y': center_y}, 'elements': results[:5]}))
-    else:
-        print(json.dumps({'found': 0, 'elements': []}))
+                asx, asy = to_screen(ax, ay)
+                print(json.dumps({
+                    'found': False,
+                    'anchor': {'x': asx, 'y': asy},
+                    'error': f'No icon found {near_dir} of "{target}"'
+                }))
 
 else:
-    print(json.dumps({'error': f'Unknown find mode: {mode}'}))
-" 2>&1
+    print(json.dumps({'error': f'Unknown mode: {mode}. Use: text, button, avatar, color, contrast, near'}))
+PYEOF
 
   rm -f "$scan_file"
+}
+
+# =============================================================================
+# click-text — Find text via OCR and click on it (one-step convenience action)
+# =============================================================================
+do_click_text() {
+  local target
+  target=$(printf '%s' "$INPUT" | jq -r '.target // .text // empty')
+  require_param "target" "$target"
+
+  # Use find to locate the text
+  local find_result
+  find_result=$(CU_SCALE="$( osascript -l JavaScript -e 'ObjC.import("AppKit"); Math.round($.NSScreen.mainScreen.backingScaleFactor);' 2>/dev/null || echo 2)" \
+    CU_MODE="text" CU_TARGET="$target" CU_REGION="null" \
+    bash "${BASH_SOURCE[0]}" "{\"action\":\"find\",\"mode\":\"text\",\"target\":\"$target\"}" 2>&1)
+
+  local found x y
+  found=$(echo "$find_result" | jq -r '.found // false')
+  x=$(echo "$find_result" | jq -r '.x // empty')
+  y=$(echo "$find_result" | jq -r '.y // empty')
+
+  if [ "$found" = "true" ] && [ -n "$x" ] && [ -n "$y" ]; then
+    # Click at the found position
+    do_click_at "$x" "$y"
+    echo "{\"success\":true,\"action\":\"click-text\",\"target\":\"$target\",\"x\":$x,\"y\":$y,\"text\":$(echo "$find_result" | jq '.text')}"
+  else
+    echo "{\"success\":false,\"action\":\"click-text\",\"target\":\"$target\",\"error\":\"Text not found\",\"debug\":$find_result}"
+  fi
+}
+
+# Helper: click at coordinates (reuses click logic)
+do_click_at() {
+  local cx="$1" cy="$2"
+  osascript -l JavaScript -e "
+    ObjC.import('CoreGraphics');
+    var point = \$.CGPointMake($cx, $cy);
+    var move = \$.CGEventCreateMouseEvent(null, \$.kCGEventMouseMoved, point, 0);
+    \$.CGEventPost(\$.kCGSessionEventTap, move);
+    delay(0.1);
+    var down = \$.CGEventCreateMouseEvent(null, \$.kCGEventLeftMouseDown, point, 0);
+    \$.CGEventPost(\$.kCGSessionEventTap, down);
+    delay(0.05);
+    var up = \$.CGEventCreateMouseEvent(null, \$.kCGEventLeftMouseUp, point, 0);
+    \$.CGEventPost(\$.kCGSessionEventTap, up);
+  " >/dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -606,5 +859,6 @@ case "$ACTION" in
   open-url)    do_open_url ;;
   list-apps)   do_list_apps ;;
   find)        do_find ;;
-  *)           error_exit "Unknown action: $ACTION. Valid: screenshot, click, move, type, key, scroll, drag, focus, open-url, list-apps, find" ;;
+  click-text)  do_click_text ;;
+  *)           error_exit "Unknown action: $ACTION. Valid: screenshot, click, move, type, key, scroll, drag, focus, open-url, list-apps, find, click-text" ;;
 esac

--- a/config/skills/agent/remote-browser/SOP-google-flow-video.md
+++ b/config/skills/agent/remote-browser/SOP-google-flow-video.md
@@ -1,0 +1,202 @@
+# SOP: Google Lab Flow (Veo) Video Generation via Browser Automation
+
+## Overview
+This SOP documents how to generate videos using Google Lab Flow (Veo) through browser automation tools (remote-browser skill and MCP chrome tools).
+
+**Last Updated**: 2026-04-14
+**Author**: video-production-nova-8f5c1e37
+
+---
+
+## Prerequisites
+- Chrome Extension connected (Crewly in Chrome)
+- Google account logged into labs.google (with ULTRA subscription for Veo access)
+- Source images available on local filesystem
+
+## Key URLs
+- Flow Homepage: `https://labs.google/fx/tools/flow`
+- Flow Project: `https://labs.google/fx/tools/flow/project/{project-id}`
+
+---
+
+## Known Issues & Gotchas
+
+### 1. execute.sh `set-file-input` bug (FIXED 2026-04-14)
+**Problem**: The `set-file-input` action in `execute.sh` strips `.selector` from the JSON body via the generic EXTRA_PARAMS parser (`del(.action, .url, .selector, .value, .text, .code)`). The backend API requires `selector` in the body.
+
+**Fix**: Re-inject selector into body in the `set-file-input` case:
+```bash
+set-file-input)
+    require_param "selector (--selector)" "$SELECTOR"
+    ENDPOINT="/browser/set-file-input"
+    if [ -n "$EXTRA_PARAMS" ]; then
+      BODY=$(printf '%s' "$EXTRA_PARAMS" | jq -c --arg s "$SELECTOR" '. + {selector: $s}')
+    else
+      BODY=$(jq -n --arg s "$SELECTOR" '{selector: $s}')
+    fi
+    ;;
+```
+
+### 2. Chinese characters in file paths
+**Problem**: File paths with Chinese characters (e.g., `/Users/.../科学奶酪/3 R/images/`) may cause issues.
+**Workaround**: Create symlinks with ASCII paths in `/tmp/`:
+```bash
+ln -sf "/path/with/中文/image.png" "/tmp/image.png"
+```
+
+### 3. MCP tab group vs remote-browser
+**Problem**: MCP tab group and remote-browser operate on different tabs. MCP can't access the user's Flow project created outside the MCP session ("Something went wrong" error).
+**Solution**: 
+- Use remote-browser for operations on the user's existing tabs
+- Use MCP for operations requiring JS execution (MCP supports `javascript_tool`)
+- Or create a new Flow project within the MCP tab group
+
+### 4. `execute-js` not supported by Chrome Extension
+**Problem**: Chrome Extension does not implement the `executeJs` tool.
+**Workaround**: Use MCP `javascript_tool` instead (requires tab to be in MCP tab group).
+
+### 5. CDP `set-file-input` — missing change event (FIXED 2026-04-14)
+**Problem**: `cdpSetFileInput()` called `DOM.setFileInputFiles` but did NOT dispatch `change`/`input` events. React-based apps like Google Flow only detect file selection via the `change` event, so files were set on the DOM element but the app never processed them.
+**Fix**: Added `Runtime.evaluate` after `DOM.setFileInputFiles` in `chrome-extension/src/cdp-input.ts` to dispatch `change` and `input` events. Extension must be rebuilt and reloaded after this fix.
+
+### 6. CDP `set-file-input` uploads to media library only
+**Problem**: Using `DOM.setFileInputFiles` via CDP uploads images to the Flow project's media library but does NOT automatically assign them as Start/End frames.
+**Status**: Investigating alternative approaches for frame assignment.
+
+---
+
+## Flow UI Element Map
+
+### Top Bar
+| Element | Position (page coords) | Selector | Description |
+|---------|----------------------|----------|-------------|
+| Back | (35, 30) | `button:nth-of-type(1)` | Go back to projects |
+| Project Name | (76, 26) | `[aria-label="Editable text"]` | Editable project title |
+| Search | (375, 19) | `[data-testid="search-input"]` | Search media |
+| Add Media | - | `#radix-\:r7\:` | Upload media button |
+| Scenebuilder | - | `button:nth-of-type(5)` | Scene builder |
+| ULTRA | (1041, 14) | `button.sc-e441891c-0` | Account/subscription |
+
+### Bottom Prompt Bar
+| Element | Position (page coords) | Description |
+|---------|----------------------|-------------|
+| Start frame | ~(310, 750) | Start frame selection (NOT a standard interactive element) |
+| Swap | (365, 736) | Swap Start/End frames |
+| End frame | ~(420, 750) | End frame selection |
+| Prompt input | center | "What do you want to create?" |
+| Model selector | varies | Shows current model (e.g., "Video x1") |
+| Create | varies | Submit/generate button |
+
+### Model Selector Dropdown (opened by clicking model button)
+| Element | Selector | Description |
+|---------|----------|-------------|
+| Image tab | `#radix-\:ru\:-trigger-IMAGE` | Switch to image mode |
+| Video tab | `#radix-\:ru\:-trigger-VIDEO` | Switch to video mode |
+| Frames | `#radix-\:r1e\:-trigger-VIDEO_FRAMES` | Frames input mode |
+| Ingredients | `#radix-\:r1e\:-trigger-VIDEO_REFERENCES` | Reference input mode |
+| 9:16 | `#radix-\:r11\:-trigger-PORTRAIT` | Portrait aspect ratio |
+| 16:9 | `#radix-\:r11\:-trigger-LANDSCAPE` | Landscape aspect ratio |
+| x1-x4 | `#radix-\:r17\:-trigger-{1,2,3,4}` | Number of outputs |
+| Model | dropdown | e.g., "Veo 3.1 - Fast" |
+
+**Important**: Radix UI selectors include dynamic IDs (`:rn:`, `:r1e:`, etc.) that may change between sessions. Use coordinate-based clicking or `find` tool as fallback.
+
+---
+
+## Operation Procedures
+
+### Procedure 1: Open Flow and Create Project
+
+```bash
+# Step 1: Navigate to Flow
+bash .../remote-browser/execute.sh '{"action":"navigate","url":"https://labs.google/fx/tools/flow"}'
+
+# Step 2: Wait for page load, then screenshot
+# Step 3: Close any changelog popup (click "Get started")
+# Step 4: Click "+ New project"
+```
+
+### Procedure 2: Switch to Video/Frames Mode
+
+```bash
+# Step 1: Click model selector button (find it with get-interactive-elements)
+# Look for button containing "Nano Banana" or "Video" text
+# Step 2: Click "Video" tab in the dropdown
+# Step 3: Verify "Frames" is selected (should be default for Video)
+# Step 4: Select aspect ratio and count (x1 recommended for sequential work)
+# Step 5: Click empty area to close dropdown
+```
+
+### Procedure 3: Upload Images to Media Library
+
+```bash
+# Direct API call (bypasses execute.sh):
+curl -s -X POST http://localhost:8787/api/browser/set-file-input \
+  -H "Content-Type: application/json" \
+  -d '{"selector":"input[type=file]","filePaths":["/tmp/image.png"]}'
+
+# Or via fixed execute.sh:
+bash .../remote-browser/execute.sh '{"action":"set-file-input","selector":"input[type=file]","filePaths":["/tmp/image.png"]}'
+```
+
+### Procedure 4: Assign Start/End Frames
+**STATUS: Partially Documented (2026-04-14)**
+
+**UI Flow (confirmed):**
+1. Click the **Start** button in the bottom prompt bar
+2. A **media picker panel** pops up showing:
+   - Project media library (thumbnails of uploaded images)
+   - "Search for Assets" search box
+   - "Recent" sort dropdown
+   - **"Upload image"** button at the bottom (triggers native OS file dialog)
+   - Right-side preview area
+3. Select an existing image from the media library → assigned as Start frame
+4. Repeat for **End** button to assign End frame
+
+**Automation Status:**
+- ❌ CDP `set-file-input`: Returns success but images do NOT appear in media library. React app cannot read CDP-injected virtual file references via FileReader.
+- ❌ MCP `upload_image`: "Unable to access message history" error — tool limitation.
+- ❌ JS `fetch` + `DataTransfer`: Cross-origin restrictions cause timeouts (labs.google → localhost).
+- **Conclusion**: Currently NO automated method works for uploading images to Flow media library. Manual upload via "Upload image" button (native file dialog) is the only working approach.
+
+**Recommended Workaround:**
+- User manually uploads images via the "Upload image" button in the media picker
+- Or: pre-upload all images to media library via top-bar "Add Media" button before starting frame assignment
+
+### Procedure 5: Enter Prompt and Generate
+
+```bash
+# Step 1: Click prompt input area
+# Step 2: Type the video description prompt
+bash .../remote-browser/execute.sh '{"action":"fill","selector":"[placeholder]","value":"prompt text here"}'
+# Step 3: Click Create button
+# Step 4: Wait for generation to complete
+# Step 5: Download the result
+```
+
+---
+
+## Video Generation Workflow (7 Videos for 3R Project)
+
+| Video | Start Frame | End Frame | Prompt |
+|-------|------------|-----------|--------|
+| 1 | shot-01-opening.png | shot-02-reduce.png | Camera slowly zooms into the poster... |
+| 2 | shot-02-reduce.png | shot-03-reuse.png | The mini worker holds up the prohibition sign... |
+| 3 | shot-03-reuse.png | shot-04-recycle-overview.png | Mini workers exchange toys and books... |
+| 4 | shot-04-recycle-overview.png | shot-05-recycle-bottles.png | Factory conveyor belts running... |
+| 5 | shot-05-recycle-bottles.png | shot-06-not-recyclable.png | Workers demonstrate bottle cleaning... |
+| 6 | shot-06-not-recyclable.png | shot-07-finale.png | Inspector worker shakes head... |
+| 7 | shot-07-finale.png | (none - single frame) | All mini workers cheer and wave... |
+
+---
+
+## Appendix: Direct API Endpoints
+
+| Endpoint | Method | Body | Description |
+|----------|--------|------|-------------|
+| `/api/browser/navigate` | POST | `{url}` | Navigate tab |
+| `/api/browser/screenshot` | POST | `{}` | Capture screenshot |
+| `/api/browser/click` | POST | `{selector}` or `{x, y}` | Click element |
+| `/api/browser/set-file-input` | POST | `{selector, filePaths}` | Set files on input |
+| `/api/browser/read-text` | POST | `{selector?}` | Read page text |
+| `/api/browser/get-interactive-elements` | POST | `{}` | List clickable elements |

--- a/config/sops/xhs-requirement-log.v1.md
+++ b/config/sops/xhs-requirement-log.v1.md
@@ -1,0 +1,238 @@
+# XHS Requirement Log (Spec-In → Result-Out)
+
+> **Authority**: Steve (Founder) policy directive, 2026-04-17.
+> **Effective**: 2026-04-17 — PERMANENT (supersedes every "check iriss-air / scrape / connect" pattern).
+> **Scope**: Every XHS data need. No exceptions.
+> **Owner**: Grace (Distribution & Growth). Co-maintainers: Ella (TL), Luna (Content Strategist).
+> **Upstream counterparty**: iriss-air team (via `crewly-orc` → Rex `rednote-team-rex-*`).
+> **Related policy**: `sop/xhs-remote-only-policy-v2.1.md`, `sop/POLICY-manual-execution-only.md`.
+
+---
+
+## 0. Hard rules (non-negotiable)
+
+1. **NO local Chrome / iPad / Playwright / Patchright / CDP / MCP touches XHS.** Any URL under `*.xiaohongshu.com` from a local tool is a policy breach. This includes the `remote-browser` skill pointed at iriss-air when its own extension is `connected=false` (proxy can fall back to local Chrome — confirmed 2026-04-17T14:13Z breach).
+2. **Zero iriss-air internal-state monitoring.** Don't poll `/api/browser/status`, Chrome CDP port 9222, iPad availability, etc. Those are iriss-air's problems.
+3. **Only two legitimate interactions with iriss-air**:
+   - Send a **Requirement Spec** (this log).
+   - Receive a **Delivery** and run the **Verification Checklist** (§5).
+4. **No workarounds** (VNC, stealth browser, agent-browser to iriss-air, Cloud Relay direct, etc.). If the spec-in/result-out channel is broken, file a Blocker entry and hand back to Ella.
+
+---
+
+## 1. What a Requirement Spec MUST contain
+
+Every spec sent to iriss-air (via `send-message` → `crewly-orc`) must include these **10 fields** (v1.2 adds `job_size`). Anything missing → treated as ambiguous and NACK'd on return.
+
+| # | Field | Format | Notes |
+|---|-------|--------|-------|
+| 1 | `spec_id` | `XHS-REQ-YYYYMMDD-HHMM-<slug>` | Unique, monotonically increasing. Example: `XHS-REQ-20260417-1308-daily-comments` |
+| 2 | `origin` | Marketing role + task reference | Who asked and why (which task / cron) |
+| 3 | `priority` | `P0a / P0b / P1 / P2` | **v1.2 split**: P0a = ship today, fast job; P0b = ship today, heavy job; P1 = within 24h; P2 = within this week. `priority` MUST be consistent with `job_size` (see field 10). |
+| 4 | `window` | ISO8601 range | Hard time window the data must cover (e.g. `2026-04-10T13:08Z / 2026-04-17T13:08Z`) |
+| 5 | `delta_anchor` | ISO8601 timestamp OR `none` | "Only new since X" anchor. If `none`, full window |
+| 6 | `targets` | Post IDs or post titles (roster) | Explicit list — do NOT say "all active posts" without enumerating |
+| 7 | `fields` | Schema list | The per-record columns you need (see §2 catalogue) |
+| 8 | `deliverable_path` | Local path under `ops/marketing/tmp/` | Where iriss-air's `reply-remote` should inline-land the file |
+| 9 | `policy_tags` | List | e.g. `data-collection-only`, `no-reply`, `dedupe-on=...` |
+| **10** | **`job_size`** (v1.2) | **`fast-poll` \| `full-scrape`** | **Drives SLA routing in §3.** `fast-poll` = ≤ 4 targets AND no comments-scroll (headline metrics / spot checks / ban-signal). `full-scrape` = ≥ 5 targets OR any comments-scroll OR account-snapshot. Mismatch with `priority` (e.g. P0a + full-scrape) is rejected at dispatch. |
+
+### Priority × job_size matrix (reference)
+
+| `job_size` | Allowed `priority` | SLA (see §3) | Typical case |
+|------------|--------------------|--------------|--------------|
+| `fast-poll` | `P0a`, `P1`, `P2` | P0a: 20 min; P1: 4 h; P2: same day | Risk-signal check, one-post metric pull, "did this note go viral yet?" |
+| `full-scrape` | `P0b`, `P1`, `P2` | P0b: 90–120 min; P1: 4 h; P2: same day | Cron #10 daily comment sweep, weekly account snapshot, 11-post delta roster |
+
+### Spec template (copy when issuing a new request) — v1.2
+
+```markdown
+[TASK from <your-session> — <ISO8601 UTC>]
+
+spec_id: XHS-REQ-YYYYMMDD-HHMM-<slug>
+priority: P0a|P0b|P1|P2
+job_size: fast-poll|full-scrape           # v1.2 — REQUIRED; drives SLA routing
+origin:   <role> / <task-or-cron-ref>
+
+window:        <startISO> / <endISO>
+delta_anchor:  <ISO or "none">
+targets:
+  - <post_title_or_id>
+  - <post_title_or_id>
+  ...
+fields: [<from §2 catalogue>]
+
+deliverable_path (local landing):
+  /Users/yellowsunhy/.../ops/marketing/tmp/<filename>.md
+deliverable_path (iriss-air):
+  /Users/irisran/projects/rednote-team/tmp/<same-filename>.md
+
+policy_tags: [data-collection-only, no-reply, dedupe-on=(post_id,commenter_username,comment_date)]
+
+On NO-NEW data, reply with an explicit "NO NEW <scope>" confirmation + dispatch id.
+On partial failure (nav-blocked post, etc.), enumerate which targets failed and why.
+DO NOT fall back to local scraping. If iPad/rednote-reader is down, report and stop.
+```
+
+---
+
+## 2. Field-schema catalogue (what to put in `fields`)
+
+Pick exactly the columns you need — don't over-ask.
+
+### 2.1 Comment scrape (`kind: comments`)
+```
+commenter_username, commenter_relation (follower|friend|none|unknown),
+comment_date (ISO8601), comment_body,
+parent_post_title (or parent_post_id),
+is_reply_to_steve (bool), has_unread_flag (bool),
+parent_comment_id (for threaded replies, optional)
+```
+
+### 2.2 Post metrics (`kind: post-metrics`)
+```
+post_id, post_title, published_date, impressions, likes, saves,
+comments_count, new_followers (if attributable), ces_score (if computed)
+```
+
+### 2.3 Account snapshot (`kind: account-snapshot`)
+```
+snapshot_time (ISO), follower_count, total_likes, total_saves, posts_visible,
+verified_status, banner_changed (bool)
+```
+
+### 2.4 Competitor / trending (`kind: competitor`)
+```
+account_handle, topic, post_title, likes, comments, saves, posted_at,
+content_hook (1 sentence), observed_pattern
+```
+
+### 2.5 DM / private inbox (`kind: dms`) — *only if Steve authorises*
+```
+sender_username, sender_relation, received_at, body, is_unread, thread_id
+```
+
+### 2.6 Ban / risk signals (`kind: risk-signal`)
+```
+signal_type (shadowban|rate-limit|captcha|login-wall|geo-block),
+post_affected, observed_at, evidence_screenshot_path
+```
+
+---
+
+## 3. Dispatch mechanics (spec → iriss-air)
+
+1. **Write the spec** using template above. Save a dispatch log to `ops/marketing/tmp/xhs-scrape-dispatch-<ISO>.md` (precedent: we've been doing this since 2026-04-14).
+2. **Create placeholder**: `ops/marketing/tmp/<deliverable-filename>.md`.
+   - **Required** (v1.1): the placeholder MUST contain the literal string `PLACEHOLDER — DO NOT VERIFY` in its first 5 lines. This is a fail-fast signal for the verification checklist (§5.1).
+   - The placeholder should also carry: status header `⏳ PENDING`, the `spec_id`, the dispatch time, and the expected iriss-air-side path.
+3. **Dispatch** via the `send-message` skill → `crewly-orc` on iriss-air. Body = the spec template body (§1).
+4. **Update the Active Register** (§4) with an `OPEN` row, including the dispatch time (this becomes the SLA anchor).
+5. **Do NOT poll** iriss-air. **Calibrated SLA (v1.2 — tiered, approved by Ella TL 2026-04-17)**:
+
+   | Priority × job_size | Early-warning | SLA (hard breach) | Notes |
+   |---|---|---|---|
+   | **P0a** + `fast-poll` | 10 min | **20 min** | <5 targets AND no comments-scroll. Risk-signal, single-post metric, spot check. |
+   | **P0b** + `full-scrape` | 90 min | **120 min** | ≥5 targets OR comments-scroll OR account-snapshot. Cron #10 daily sweeps, 11-post roster. |
+   | **P1** (either `job_size`) | 2 h | **4 h** | Same-day-ish, not urgent. |
+   | **P2** (either `job_size`) | noon next day | **end of same operating day** | Weekly/monthly batch work. |
+
+   - **Early-warning** = log a note in the register row ("approaching SLA"), do nothing else — **no probe to iriss-air**.
+   - **Hard breach** = file a `BLOCKED: no-ack` entry and escalate to Ella. Still no probe.
+   - **Mismatch rejection**: if `priority=P0a` but `job_size=full-scrape` (or vice versa), verification treats the spec as malformed and marks `BLOCKED: malformed-spec`. Re-dispatch with corrected pairing.
+   - **Back-compat**: legacy rows recorded with flat `P0` stay valid; promote them to `P0a`/`P0b` at the next scrub pass (no emergency re-dispatch required).
+
+---
+
+## 4. Active Register
+
+> **Update rule**: one row per `spec_id`. States: `OPEN → DELIVERED → VERIFIED → ARCHIVED`, or `BLOCKED / CANCELLED`. Move ARCHIVED rows to §7 weekly.
+
+| spec_id | Origin | Priority | Issued (UTC) | Window | Expected Landing Path | State | Delivered @ | Verified @ | Notes |
+|---------|--------|----------|--------------|--------|-----------------------|-------|-------------|------------|-------|
+| XHS-REQ-20260417-0028-daily-comments | Grace / Cron #10a | P1 | 2026-04-17 00:29 | 7d rolling | `tmp/xhs-raw-comments-2026-04-17.md` | **DELIVERED** (superseded) | ~00:40 | pending | See `tmp/xhs-raw-comments-2026-04-17.md` — earliest of today's 5 dispatches. |
+| XHS-REQ-20260417-0050-daily-comments | Grace / Cron #10a | P1 | 2026-04-17 00:51 | 7d explicit | `tmp/xhs-raw-comments-2026-04-17T0050Z.md` | **DELIVERED** (superseded) | ~01:05 | pending | Superseded by 0306Z full pull. |
+| XHS-REQ-20260417-0306-daily-comments | Grace / Cron #10a | P1 | 2026-04-17 03:06 | delta since 14:00 PT | `tmp/xhs-raw-comments-2026-04-17T0306Z.md` | **DELIVERED** | ~03:25 | **VERIFIED** by Mila (see `reports/2026-04-17-xhs-evening-reply-package-mila.md`) | 20 KB body; largest comment set today. |
+| XHS-REQ-20260417-1248-daily-comments | Grace / Cron #10b | P1 | 2026-04-17 12:48 | delta since 03:06Z | `tmp/xhs-raw-comments-2026-04-17T1248Z.md` | **DELIVERED** (per orc 14:40Z; iriss-air-side) | ~14:10Z (iriss-air-side completion) | pending local-file verification | Original dispatch hit "Rex down 1/1". Rex came back, full-scrape ran ~80min (03:06Z→14:10Z window). Used as authoritative upstream source for the 13:08Z derivative output. No local file landed yet — awaiting iriss-air re-send or treating 1308Z as the sufficient VERIFIED superset. |
+| XHS-REQ-20260417-1308-daily-comments | Grace / Cron #10a | **P0b** (promoted from legacy P0 under v1.2; job_size=`full-scrape`, 11 targets + comments-scroll) | 2026-04-17 13:09 | delta since 12:48Z (fallback: 7d) | `tmp/xhs-raw-comments-2026-04-17T1308Z.md` | **✅ VERIFIED** | 2026-04-17 14:39Z (after re-send — original 14:15Z attempt truncated 4,644B → 2,031B in transport) | 2026-04-17 14:42Z | All §5 layers PASS: early-exit (placeholder gone, size 5,211B > 2,223B placeholder, mtime 14:40Z > dispatch+60s) ✅; envelope (spec_id matches, source declared as rednote-reader iPad Accessibility API / 非 Chrome/9222) ✅; scope (delta 03:06Z→13:08Z honoured; all 11 posts enumerated; post #11 retry succeeded) ✅; records (3 new comments, all mandatory fields present, dedup key unique) ✅; policy (no replies/cookies/tokens) ✅. **Business verdict**: NO NEW COMMENTS vs 12:48Z run — the 3 delta comments are already in the 12:48Z output. Transport truncation bug logged; drove the §5.1 canary add-on. **v1.2 SLA analysis**: under P0b 120min hard-breach clock, delivery at 14:39Z (90 min after 13:09Z dispatch) = within SLA (would have hit "early-warning at 90min" right as delivery landed, no breach). This single case validated the tiered SLA choice. |
+
+**Priority backlog (not yet dispatched)**: none. Cron #10a / #10b today are absorbed by the 1308Z dispatch. New dispatches only on next Cron fire or Ella override.
+
+---
+
+## 5. Verification Checklist (when iriss-air delivers)
+
+Before marking a delivery `VERIFIED`, run every check. Any fail → NACK back to iriss-air with the failing row.
+
+### 5.1 Envelope (metadata) — v1.1 additions in bold
+
+**Early-exit (v1.1)** — run these FIRST and fail-fast:
+
+1. **Fail-fast grep**: if the file's first 5 lines contain the literal string `PLACEHOLDER — DO NOT VERIFY`, immediately return `NOT DELIVERED`. Do not run any downstream check. (Protects against false-positive ACK of unchanged placeholder.)
+2. **Size comparator**: if `current_size <= placeholder_size_at_dispatch` (recorded in the register row at §4), return `NOT DELIVERED`.
+3. **mtime comparator**: if `file_mtime <= dispatch_time + 60s`, return `NOT DELIVERED` (delivery would have required iriss-air to overwrite the placeholder).
+
+**Transport-integrity canary (v1.1, added 2026-04-17 after XHS-REQ-20260417-1308 transport bug)** — when the delivery header declares an upstream size (e.g. `iriss-air side: 4644 bytes`), compare it to `local_size`. If `|local_size - upstream_size| > 128 bytes`, treat as transport-truncation suspect → do NOT mark `VERIFIED`; request iriss-air re-send via single-message (not inline-split) and log as `TRUNCATED`. Root cause of 2026-04-17 truncation: Option-1 inline-split transport landed 2,031B of a 4,644B payload. Re-send via fresh single-message inline payload succeeded.
+
+Only if all three early-exit checks pass, proceed to the original envelope checks:
+
+- [ ] File landed at the exact `deliverable_path` from the spec (§1 field 8).
+- [ ] File header contains the originating `spec_id` (§1 field 1).
+- [ ] Timestamp in header is within ±30 min of dispatch time (sanity).
+- [ ] Source tool declared (`rednote-reader` on iriss-air — NOT `Chrome`, `Playwright`, `local`).
+- [ ] (v1.1) File does NOT still contain `PLACEHOLDER — DO NOT VERIFY` anywhere (defensive — catches partial overwrites where delivery appended instead of replaced).
+
+### 5.2 Scope compliance
+- [ ] Window matches (§1 field 4) — reject if any record falls outside.
+- [ ] Delta anchor respected — no duplicates of records whose `comment_date < delta_anchor`.
+- [ ] All `targets` (§1 field 6) either appear OR are explicitly listed as "failed/nav-blocked" with reason.
+- [ ] Unrequested targets are NOT present (iriss-air did not silently expand scope).
+
+### 5.3 Record integrity
+- [ ] Every row has every required `field` (§2) — no blanks in required columns.
+- [ ] `comment_date` parseable ISO8601; not in the future.
+- [ ] `is_reply_to_steve` is a real bool (not "maybe" / empty string).
+- [ ] Dedupe key `(post_id, commenter_username, comment_date)` is unique within file.
+- [ ] UTF-8 clean — no mojibake on Chinese text; emoji preserved.
+
+### 5.4 Policy compliance
+- [ ] No reply-bodies, no like-actions, no auth tokens, no cookies in the delivery.
+- [ ] No screenshots outside the `risk-signal` schema (§2.6).
+- [ ] `policy_tags` echoed back in the delivery header.
+- [ ] If `NO NEW <scope>`: delivery is a single-line confirmation matching spec_id — NO stub rows.
+
+### 5.5 Sign-off
+- [ ] Register row moved to `VERIFIED` with a timestamp.
+- [ ] If comments delivered → spawn downstream `analyze + draft replies` task. That task is **local-allowed** (drafting is not interaction).
+- [ ] If metrics delivered → update `reports/xhs-data-tracking-2026-04.md`.
+- [ ] If risk-signal → immediate ping to Ella + Steve (Slack D0AC7NF5N7L).
+
+---
+
+## 6. Escalation / Blocker matrix
+
+| Symptom | Owner | Action |
+|---------|-------|--------|
+| No ACK from `crewly-orc` within SLA | Grace | Mark register `BLOCKED: no-ack`. Notify Ella. Do **not** re-dispatch in <10 min (prevents flooding Rex). |
+| iriss-air reports `rednote-reader` failure | iriss-air team | Register `BLOCKED: upstream-failure`. Do not suggest workarounds. Wait. |
+| Delivery fails §5 checks | Grace | NACK with specific failing check. Register stays `DELIVERED` (not VERIFIED). Await re-delivery. |
+| Login wall / captcha / shadowban signal | Grace | File as `kind: risk-signal`, ping Steve. Never attempt local login. |
+| Anyone requests local Chrome/iPad/Playwright touching XHS | Grace | **Refuse.** Quote this doc §0. File the request as `CANCELLED: policy-breach-attempt` for audit. |
+
+---
+
+## 7. Archive (moved weekly from §4)
+
+*Rows older than the current operating week land here. Next archive pass: Fri 16:00 during Cron #7 weekly report.*
+
+---
+
+## 8. Change log
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| v1.0 | 2026-04-17 | Grace | Initial draft after Steve's "spec-in / result-out" directive and the 14:13Z proxy-fallback breach. Consolidates ad-hoc dispatch pattern (2026-04-14 → today) into a formal register + verification checklist. |
+| v1.1 | 2026-04-17 | Grace (on Ella TL sign-off) | **SLA recalibration + checklist tightening**. (a) §3 P0 SLA raised from 20 min → 90 min based on observed Rex ~80 min full-scrape runtime (prevents false breach reports on compliant-but-slow jobs). (b) §3 placeholder template now REQUIRES the literal `PLACEHOLDER — DO NOT VERIFY` string in first 5 lines. (c) §5.1 three early-exit checks added (PLACEHOLDER-string grep, size comparator vs placeholder_size_at_dispatch, mtime comparator vs dispatch_time+60s). Triggered by first live test (XHS-REQ-20260417-1308-daily-comments) where v1.0 checklist correctly flagged the placeholder but would have taken longer without a fail-fast signal. |
+| v1.1 (addendum) | 2026-04-17 | Grace (on orc request) | **Transport-integrity canary** added to §5.1. Trigger: the 14:15Z Option-1 inline-split delivery for XHS-REQ-20260417-1308 landed truncated (2,031B local vs 4,644B upstream). Canary spec: if delivery header declares an upstream size and `\|local_size − upstream_size\| > 128 B`, mark `TRUNCATED` and request re-send via single-message (not inline-split). 14:39Z re-send succeeded — verification passed. |
+| **v1.2** | **2026-04-17** | **Grace (on Ella TL sign-off)** | **Tiered SLA — approved.** (a) §1 spec template gains a new REQUIRED field #10 `job_size` with two values: `fast-poll` or `full-scrape`. Selection rule: `fast-poll` = <5 targets AND no comments-scroll; `full-scrape` = ≥5 targets OR comments-scroll OR account-snapshot. (b) §1 `priority` enum split from `P0/P1/P2` → `P0a/P0b/P1/P2`, with a mandatory priority × job_size consistency rule. P0a pairs with fast-poll; P0b pairs with full-scrape. (c) §3 SLA table rewritten as a 4-row matrix with separate early-warning and hard-breach thresholds. Flat v1.1 `P0 ≤ 90 min` is retired; replaced by P0a ≤ 20 min and P0b ≤ 120 min. (d) Mismatch rule added: a spec whose `priority` / `job_size` pairing is inconsistent is NACK'd as `BLOCKED: malformed-spec`. (e) Back-compat: legacy rows recorded with flat `P0` stay valid and are promoted at the next scrub pass. Closes the SOP baseline for spec-in/result-out. |
+| **v1.2 candidate** | *pending Ella ruling* | (orc suggestion, 2026-04-17) | **Tiered SLA proposal**: split P0 into fast-poll (<5 posts) = 20 min and full-scrape (all posts + comments scroll) = 90–120 min. Rationale: single P0 SLA can't fit both lightweight and heavyweight jobs without either over-reporting breach on heavy jobs (v1.0 problem) or under-reporting on light ones (v1.1 risk). Requires adding a `job_size` field to §1 spec template and a P0a/P0b split in §3. Decision deferred to Ella's next SOP review. |

--- a/frontend/src/components/CloudConnectionBanner.tsx
+++ b/frontend/src/components/CloudConnectionBanner.tsx
@@ -63,17 +63,44 @@ export const CloudConnectionBanner: React.FC = () => {
     await disconnect();
   };
 
-  // Connected state: show tier badge with disconnect option
+  // Connected state: show tier badge with disconnect option.
+  //
+  // Free tier callout: Cloud Relay / device-sync is gated server-side on Pro,
+  // so free users need to know why their node never shows up on the Cloud
+  // Console and what to do about it. Surface an inline Upgrade → link.
   if (isConnected && tier) {
+    const isFree = tier === 'free';
+    const bannerClass = isFree
+      ? 'bg-amber-500/10 border-amber-500/30'
+      : 'bg-emerald-500/10 border-emerald-500/30';
+    const iconClass = isFree ? 'text-amber-400' : 'text-emerald-400';
+    const labelClass = isFree ? 'text-amber-200' : 'text-emerald-300';
+
     return (
-      <div className="flex items-center justify-between px-4 py-2 border-b bg-emerald-500/10 border-emerald-500/30">
+      <div className={`flex items-center justify-between px-4 py-2 border-b ${bannerClass}`}>
         <div className="flex items-center gap-3">
-          <Cloud className="shrink-0 text-emerald-400" size={18} />
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-emerald-300">Connected to CrewlyAI Cloud</span>
+          <Cloud className={`shrink-0 ${iconClass}`} size={18} />
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className={labelClass}>Connected to CrewlyAI Cloud</span>
             <Badge variant={TIER_BADGE_VARIANTS[tier]} size="sm">
               {TIER_LABELS[tier]}
             </Badge>
+            {isFree && (
+              <>
+                <span className="text-amber-200/70">·</span>
+                <span className="text-amber-200/80">
+                  Device sync & Relay require Pro.
+                </span>
+                <a
+                  href="https://crewlyai.com/pricing"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline text-amber-100 hover:text-white font-medium"
+                >
+                  Upgrade →
+                </a>
+              </>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/components/Layout/Navigation.tsx
+++ b/frontend/src/components/Layout/Navigation.tsx
@@ -66,7 +66,7 @@ const NAV_GROUPS: NavGroup[] = [
 			{ name: 'Dashboard', href: '/', icon: Home },
 			{ name: 'Projects', href: '/projects', icon: FolderOpen },
 			{ name: 'Teams', href: '/teams', icon: Users },
-			{ name: 'Objectives', href: '/missions', icon: Target },
+			{ name: 'Missions', href: '/missions', icon: Target },
 			{ name: 'Chat', href: '/chat', icon: MessageSquare },
 		],
 	},

--- a/frontend/src/components/UI/FilterPill.test.tsx
+++ b/frontend/src/components/UI/FilterPill.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Tests for FilterPill UI primitive.
+ *
+ * @module components/UI/FilterPill.test
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterPill } from './FilterPill';
+
+describe('FilterPill', () => {
+  it('renders the label', () => {
+    render(
+      <FilterPill isActive={false} onClick={() => {}}>
+        High
+      </FilterPill>,
+    );
+    expect(screen.getByRole('button', { name: /high/i })).toBeTruthy();
+  });
+
+  it('reports its pressed state via aria-pressed', () => {
+    render(
+      <FilterPill isActive onClick={() => {}} data-testid="pill">
+        Active
+      </FilterPill>,
+    );
+    expect(screen.getByTestId('pill').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does NOT mark itself pressed when inactive', () => {
+    render(
+      <FilterPill isActive={false} onClick={() => {}} data-testid="pill">
+        Idle
+      </FilterPill>,
+    );
+    expect(screen.getByTestId('pill').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('invokes onClick when clicked', () => {
+    const handler = vi.fn();
+    render(
+      <FilterPill isActive={false} onClick={handler} data-testid="pill">
+        Click
+      </FilterPill>,
+    );
+    fireEvent.click(screen.getByTestId('pill'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an optional count badge', () => {
+    render(
+      <FilterPill isActive={false} onClick={() => {}} count={3}>
+        Alpha
+      </FilterPill>,
+    );
+    // Label + the "(3)" suffix share the same button
+    expect(screen.getByRole('button').textContent).toMatch(/Alpha\s*\(3\)/);
+  });
+
+  it('disabled buttons do not fire onClick', () => {
+    const handler = vi.fn();
+    render(
+      <FilterPill isActive={false} onClick={handler} disabled data-testid="pill">
+        Nope
+      </FilterPill>,
+    );
+    fireEvent.click(screen.getByTestId('pill'));
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/UI/FilterPill.tsx
+++ b/frontend/src/components/UI/FilterPill.tsx
@@ -1,0 +1,73 @@
+/**
+ * FilterPill — primitive pill button used for filter chips across list pages.
+ *
+ * This replaces the inline Tailwind pill markup that was previously duplicated
+ * inside PageToolbar.secondaryFilters and per-page FilterRow components.
+ *
+ * @module components/UI/FilterPill
+ */
+
+import React from 'react';
+
+/** Props for the FilterPill primitive. */
+export interface FilterPillProps {
+  /** Visible label text. */
+  children: React.ReactNode;
+  /** Whether this pill is currently selected. */
+  isActive: boolean;
+  /** Click handler. */
+  onClick: () => void;
+  /** Optional count rendered after the label (e.g. filter match count). */
+  count?: number;
+  /** Disable interaction and dim the pill. */
+  disabled?: boolean;
+  /** Optional stable testid for assertions. */
+  'data-testid'?: string;
+  /** Accessible title/tooltip. */
+  title?: string;
+}
+
+/**
+ * A single rounded filter chip. Pure presentational — state is owned by the
+ * caller so the same primitive works for both single- and multi-select groups.
+ *
+ * @example
+ * ```tsx
+ * <FilterPill isActive={v === 'high'} onClick={() => setV('high')}>High</FilterPill>
+ * ```
+ */
+export const FilterPill: React.FC<FilterPillProps> = ({
+  children,
+  isActive,
+  onClick,
+  count,
+  disabled = false,
+  title,
+  'data-testid': testId,
+}) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={isActive}
+      title={title}
+      data-testid={testId}
+      className={[
+        'px-3 py-1 text-xs font-medium rounded-full border transition-colors',
+        'focus:outline-none focus:ring-2 focus:ring-primary/50 focus:ring-offset-2 focus:ring-offset-background-dark',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        isActive
+          ? 'bg-primary/10 text-primary border-primary/30'
+          : 'bg-surface-dark text-text-secondary-dark border-border-dark hover:text-text-primary-dark',
+      ].join(' ')}
+    >
+      {children}
+      {count !== undefined && (
+        <span className="ml-1 opacity-60">({count})</span>
+      )}
+    </button>
+  );
+};
+
+FilterPill.displayName = 'FilterPill';

--- a/frontend/src/components/UI/FilterPillGroup.test.tsx
+++ b/frontend/src/components/UI/FilterPillGroup.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for FilterPillGroup UI component.
+ *
+ * @module components/UI/FilterPillGroup.test
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FilterPillGroup } from './FilterPillGroup';
+
+type TestKey = 'all' | 'a' | 'b';
+
+const OPTIONS: { key: TestKey; label: string; count?: number }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'a', label: 'Alpha', count: 2 },
+  { key: 'b', label: 'Beta' },
+];
+
+describe('FilterPillGroup', () => {
+  it('renders every option as a pill', () => {
+    render(
+      <FilterPillGroup<TestKey>
+        label="Category"
+        options={OPTIONS}
+        value="all"
+        onChange={() => {}}
+        testIdPrefix="cat"
+      />,
+    );
+    expect(screen.getByTestId('cat-all')).toBeTruthy();
+    expect(screen.getByTestId('cat-a')).toBeTruthy();
+    expect(screen.getByTestId('cat-b')).toBeTruthy();
+  });
+
+  it('renders the row label', () => {
+    render(
+      <FilterPillGroup<TestKey>
+        label="Category"
+        options={OPTIONS}
+        value="all"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Category')).toBeTruthy();
+  });
+
+  it('marks exactly one pill as pressed (single-select)', () => {
+    render(
+      <FilterPillGroup<TestKey>
+        label="Category"
+        options={OPTIONS}
+        value="a"
+        onChange={() => {}}
+        testIdPrefix="cat"
+      />,
+    );
+    expect(screen.getByTestId('cat-a').getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByTestId('cat-all').getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByTestId('cat-b').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('invokes onChange with the option key when a pill is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterPillGroup<TestKey>
+        label="Category"
+        options={OPTIONS}
+        value="all"
+        onChange={onChange}
+        testIdPrefix="cat"
+      />,
+    );
+    fireEvent.click(screen.getByTestId('cat-a'));
+    expect(onChange).toHaveBeenCalledWith('a');
+  });
+
+  it('renders count badges when provided in options', () => {
+    render(
+      <FilterPillGroup<TestKey>
+        label="Category"
+        options={OPTIONS}
+        value="all"
+        onChange={() => {}}
+        testIdPrefix="cat"
+      />,
+    );
+    // Alpha has count=2 → "(2)" suffix
+    expect(screen.getByTestId('cat-a').textContent).toMatch(/\(2\)/);
+    // Beta has no count → no parens
+    expect(screen.getByTestId('cat-b').textContent).not.toMatch(/\(\d+\)/);
+  });
+
+  it('omits the label element when no label is provided', () => {
+    const { container } = render(
+      <FilterPillGroup<TestKey>
+        options={OPTIONS}
+        value="all"
+        onChange={() => {}}
+      />,
+    );
+    // No element with uppercase "CATEGORY" label
+    expect(container.querySelector('span.uppercase')).toBeNull();
+  });
+});

--- a/frontend/src/components/UI/FilterPillGroup.tsx
+++ b/frontend/src/components/UI/FilterPillGroup.tsx
@@ -1,0 +1,84 @@
+/**
+ * FilterPillGroup — labeled row of FilterPill buttons with single-select semantics.
+ *
+ * The caller owns the selected value; the group only renders.
+ *
+ * @module components/UI/FilterPillGroup
+ */
+
+import React from 'react';
+import { FilterPill } from './FilterPill';
+
+/** One option inside a FilterPillGroup. */
+export interface FilterPillOption<T extends string> {
+  /** The value passed back to `onChange` when the pill is clicked. */
+  key: T;
+  /** Visible label. */
+  label: string;
+  /** Optional count shown after the label. */
+  count?: number;
+}
+
+/** Props for FilterPillGroup. Generic over the key type to preserve unions. */
+export interface FilterPillGroupProps<T extends string> {
+  /** Optional row label rendered on the left. */
+  label?: string;
+  /** Available options. */
+  options: FilterPillOption<T>[];
+  /** Currently selected option key. */
+  value: T;
+  /** Called with the newly selected option's key. */
+  onChange: (value: T) => void;
+  /** Prefix applied to each pill's `data-testid` (`{prefix}-{key}`). */
+  testIdPrefix?: string;
+  /** Extra class applied to the outer container. */
+  className?: string;
+}
+
+/**
+ * Renders a labeled row of single-select filter pills.
+ *
+ * @example
+ * ```tsx
+ * <FilterPillGroup
+ *   label="Priority"
+ *   options={[{ key: 'all', label: 'All' }, { key: 'high', label: 'High' }]}
+ *   value={priority}
+ *   onChange={setPriority}
+ *   testIdPrefix="priority-filter"
+ * />
+ * ```
+ */
+export function FilterPillGroup<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+  testIdPrefix,
+  className = '',
+}: FilterPillGroupProps<T>): React.ReactElement {
+  return (
+    <div className={`flex items-center gap-2 flex-wrap ${className}`} role="group" aria-label={label}>
+      {label && (
+        <span className="text-xs uppercase tracking-wide text-text-secondary-dark font-medium min-w-[72px]">
+          {label}
+        </span>
+      )}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {options.map((opt) => (
+          <FilterPill
+            key={opt.key}
+            isActive={opt.key === value}
+            onClick={() => onChange(opt.key)}
+            count={opt.count}
+            data-testid={testIdPrefix ? `${testIdPrefix}-${opt.key}` : undefined}
+          >
+            {opt.label}
+          </FilterPill>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+FilterPillGroup.displayName = 'FilterPillGroup';

--- a/frontend/src/components/UI/PageToolbar.tsx
+++ b/frontend/src/components/UI/PageToolbar.tsx
@@ -13,6 +13,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Search } from 'lucide-react';
+import { FilterPill } from './FilterPill';
 
 // =============================================================================
 // Types
@@ -237,27 +238,16 @@ export const PageToolbar: React.FC<PageToolbarProps> = ({
 
           {secondaryFilters && secondaryFilters.length > 0 && (
             <div className="flex items-center gap-1.5">
-              {secondaryFilters.map((sf) => {
-                const isActive = activeSecondaryFilters?.has(sf.value) ?? false;
-                return (
-                  <button
-                    key={sf.value}
-                    type="button"
-                    onClick={() => onSecondaryFilterToggle?.(sf.value)}
-                    className={[
-                      'px-3 py-1.5 text-xs font-medium rounded-full border transition-colors',
-                      isActive
-                        ? 'bg-primary/10 text-primary border-primary/30'
-                        : 'bg-surface-dark text-text-secondary-dark border-border-dark hover:text-text-primary-dark',
-                    ].join(' ')}
-                  >
-                    {sf.label}
-                    {sf.count !== undefined && (
-                      <span className="ml-1 opacity-60">({sf.count})</span>
-                    )}
-                  </button>
-                );
-              })}
+              {secondaryFilters.map((sf) => (
+                <FilterPill
+                  key={sf.value}
+                  isActive={activeSecondaryFilters?.has(sf.value) ?? false}
+                  onClick={() => onSecondaryFilterToggle?.(sf.value)}
+                  count={sf.count}
+                >
+                  {sf.label}
+                </FilterPill>
+              ))}
             </div>
           )}
         </div>

--- a/frontend/src/pages/CloudPortal.tsx
+++ b/frontend/src/pages/CloudPortal.tsx
@@ -416,6 +416,7 @@ interface BrowserInstance {
   instanceId: string;
   instanceName: string;
   sessionId?: string;
+  lastSeenAt?: string;
 }
 
 const BrowserExtensionsSection: React.FC = () => {
@@ -507,10 +508,17 @@ const BrowserExtensionsSection: React.FC = () => {
                   </p>
                 </div>
               </div>
-              <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
-                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-                Online
-              </span>
+              <div className="flex flex-col items-end gap-0.5">
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
+                  <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+                  Online
+                </span>
+                {inst.lastSeenAt && (
+                  <span className="text-[10px] text-text-secondary-dark">
+                    Last seen: {formatRelativeTimeCompact(inst.lastSeenAt)}
+                  </span>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/MissionDetail.test.tsx
+++ b/frontend/src/pages/MissionDetail.test.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { MissionDetail } from './MissionDetail';
 
@@ -14,6 +14,7 @@ import { MissionDetail } from './MissionDetail';
 vi.mock('../services/api.service', () => ({
   apiService: {
     getMission: vi.fn(),
+    updateMission: vi.fn(),
   },
 }));
 
@@ -122,5 +123,118 @@ describe('MissionDetail', () => {
     });
 
     expect(screen.getByText('Parallel execution is faster')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edit mode
+  // ---------------------------------------------------------------------------
+
+  it('shows an Edit button in view mode', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+  });
+
+  it('switches to edit mode and pre-populates the objective input', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('mission-edit'));
+
+    const input = screen.getByTestId('edit-objective') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('Deliver V3 Architecture');
+    expect(screen.getByTestId('mission-save')).toBeTruthy();
+    expect(screen.getByTestId('mission-cancel')).toBeTruthy();
+  });
+
+  it('cancel exits edit mode and discards changes', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('mission-edit'));
+    const input = screen.getByTestId('edit-objective') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'NEW OBJECTIVE' } });
+    fireEvent.click(screen.getByTestId('mission-cancel'));
+
+    // Back to view mode with original text
+    expect(screen.queryByTestId('edit-objective')).toBeFalsy();
+    expect(screen.getByText('Deliver V3 Architecture')).toBeTruthy();
+  });
+
+  it('save submits the patch and re-renders with the server response', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    const updated = { ...mockMission, objective: 'New objective', priority: 'critical' as const };
+    vi.mocked(apiService.updateMission).mockResolvedValue(updated);
+
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('mission-edit'));
+    fireEvent.change(screen.getByTestId('edit-objective'), { target: { value: 'New objective' } });
+    fireEvent.change(screen.getByTestId('edit-priority'), { target: { value: 'critical' } });
+    fireEvent.click(screen.getByTestId('mission-save'));
+
+    await waitFor(() => {
+      expect(apiService.updateMission).toHaveBeenCalledTimes(1);
+    });
+
+    const [, patch] = vi.mocked(apiService.updateMission).mock.calls[0];
+    expect(patch.objective).toBe('New objective');
+    expect(patch.priority).toBe('critical');
+
+    // After save, view mode restored with updated content
+    await waitFor(() => {
+      expect(screen.queryByTestId('edit-objective')).toBeFalsy();
+    });
+    expect(screen.getByText('New objective')).toBeTruthy();
+  });
+
+  it('surfaces server error and stays in edit mode when save fails', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    vi.mocked(apiService.updateMission).mockRejectedValue(new Error('Parent chain contains a cycle'));
+
+    renderWithRouter();
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('mission-edit'));
+    fireEvent.click(screen.getByTestId('mission-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-save-error')).toBeTruthy();
+    });
+    expect(screen.getByTestId('edit-objective')).toBeTruthy();
+  });
+
+  it('blocks save when objective is empty', async () => {
+    vi.mocked(apiService.getMission).mockResolvedValue(mockMission);
+    renderWithRouter();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-edit')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('mission-edit'));
+    fireEvent.change(screen.getByTestId('edit-objective'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByTestId('mission-save'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mission-save-error')).toBeTruthy();
+    });
+    expect(apiService.updateMission).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/MissionDetail.tsx
+++ b/frontend/src/pages/MissionDetail.tsx
@@ -1,14 +1,14 @@
 /**
  * Mission Detail Page
  *
- * Displays the full details of a single Mission including objective,
- * status, team, strategy, success criteria, and timestamps.
- * Fetches real data from GET /api/missions/:id.
+ * Displays the full details of a single Mission and supports inline editing
+ * of the key mutable fields (objective, status, priority, team, strategy,
+ * success criteria, period, parent). Save issues PUT /api/missions/:id.
  *
  * @module pages/MissionDetail
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -20,25 +20,52 @@ import {
   CheckCircle2,
   BookOpen,
   ListChecks,
+  Pencil,
+  Save,
+  X,
 } from 'lucide-react';
 import { Card } from '../components/UI/Card';
 import { Badge } from '../components/UI/Badge';
 import { StatusBadge } from '../components/UI/StatusBadge';
-import type { StatusType } from '../components/UI/StatusBadge';
 import { LoadingSpinner } from '../components/UI/LoadingSpinner';
 import { Button } from '../components/UI/Button';
+import { Input } from '../components/UI/Input';
+import { FormSelect } from '../components/UI/Form';
+import { Alert } from '../components/UI/Alert';
 import { apiService } from '../services/api.service';
+import {
+  PRIORITY_LABEL,
+  PRIORITY_VARIANT,
+  getMissionStatusType,
+  getMissionStatusLabel,
+  type MissionStatus,
+  type MissionPriority,
+  type MissionPeriodType,
+  type MissionPeriod,
+} from '../types/mission.types';
 
 // =============================================================================
-// Types
+// Types (KR summaries are only used on this page)
 // =============================================================================
 
-/** Mission lifecycle statuses. */
-type MissionStatus = 'active' | 'paused' | 'completed' | 'cancelled';
+/** KR metric type (mirrors backend). */
+type KRMetricType = 'number' | 'percentage' | 'boolean' | 'currency';
 
-/**
- * Full Mission object returned by the API.
- */
+/** KR progress status (mirrors backend). */
+type KRStatus = 'not_started' | 'on_track' | 'at_risk' | 'off_track' | 'achieved';
+
+interface KeyResultSummary {
+  id: string;
+  title: string;
+  metricType: KRMetricType;
+  baseline: number;
+  target: number;
+  current: number;
+  unit: string;
+  status: KRStatus;
+}
+
+/** Full Mission object returned by the API. */
 interface Mission {
   id: string;
   objective: string;
@@ -52,51 +79,36 @@ interface Mission {
   updatedAt: string;
   lastReviewAt?: string;
   nextReviewAt?: string;
-  learnings: string[];
+  learnings?: string[];
+  priority?: MissionPriority;
+  period?: MissionPeriod;
+  parentMissionId?: string;
+  keyResults?: KeyResultSummary[];
+}
+
+/**
+ * Form draft shape — a subset of Mission fields that are user-editable.
+ * `successCriteria` is edited as a single newline-joined string.
+ */
+interface MissionDraft {
+  objective: string;
+  status: MissionStatus;
+  priority: MissionPriority;
+  ownerTeamId: string;
+  currentStrategy: string;
+  cadence: string;
+  successCriteriaText: string;
+  periodLabel: string;
+  periodType: MissionPeriodType | '';
+  periodStart: string;
+  periodEnd: string;
+  parentMissionId: string;
 }
 
 // =============================================================================
 // Utility Functions
 // =============================================================================
 
-/**
- * Maps a mission status to a StatusBadge-compatible StatusType.
- *
- * @param status - The mission status
- * @returns StatusType for the UI StatusBadge component
- */
-function getMissionStatusType(status: MissionStatus): StatusType {
-  const mapping: Record<MissionStatus, StatusType> = {
-    active: 'active',
-    paused: 'paused',
-    completed: 'completed',
-    cancelled: 'inactive',
-  };
-  return mapping[status] ?? 'pending';
-}
-
-/**
- * Returns a human-readable label for a mission status.
- *
- * @param status - The mission status
- * @returns Display label string
- */
-function getMissionStatusLabel(status: MissionStatus): string {
-  const labels: Record<MissionStatus, string> = {
-    active: 'Active',
-    paused: 'Paused',
-    completed: 'Completed',
-    cancelled: 'Cancelled',
-  };
-  return labels[status] ?? status;
-}
-
-/**
- * Formats an ISO date string to a readable date/time.
- *
- * @param isoDate - ISO date string
- * @returns Formatted date string
- */
 function formatDateTime(isoDate: string): string {
   try {
     return new Date(isoDate).toLocaleString(undefined, {
@@ -111,14 +123,68 @@ function formatDateTime(isoDate: string): string {
   }
 }
 
+/**
+ * Builds an editable draft from a server-side Mission.
+ */
+function buildDraft(m: Mission): MissionDraft {
+  return {
+    objective: m.objective,
+    status: m.status,
+    priority: m.priority ?? 'medium',
+    ownerTeamId: m.ownerTeamId,
+    currentStrategy: m.currentStrategy ?? '',
+    cadence: m.cadence ?? '',
+    successCriteriaText: (m.successCriteria ?? []).join('\n'),
+    periodLabel: m.period?.label ?? '',
+    periodType: m.period?.type ?? '',
+    periodStart: m.period?.startDate ? m.period.startDate.slice(0, 10) : '',
+    periodEnd: m.period?.endDate ? m.period.endDate.slice(0, 10) : '',
+    parentMissionId: m.parentMissionId ?? '',
+  };
+}
+
+/**
+ * Converts a draft into the PATCH body sent to the server.
+ * Empty strings are normalised to either `undefined` (cleared field) or
+ * retained — see inline notes for each field.
+ */
+function draftToPatch(draft: MissionDraft): Record<string, unknown> {
+  const patch: Record<string, unknown> = {
+    objective: draft.objective.trim(),
+    status: draft.status,
+    priority: draft.priority,
+    ownerTeamId: draft.ownerTeamId.trim(),
+    currentStrategy: draft.currentStrategy,
+    cadence: draft.cadence.trim(),
+    successCriteria: draft.successCriteriaText
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean),
+    // Explicitly clear parent when the draft is empty (server treats '' as undefined).
+    parentMissionId: draft.parentMissionId || '',
+  };
+
+  // Include `period` only when the user has filled the required parts.
+  if (draft.periodType && draft.periodStart && draft.periodEnd) {
+    patch.period = {
+      type: draft.periodType,
+      startDate: new Date(draft.periodStart).toISOString(),
+      endDate: new Date(draft.periodEnd).toISOString(),
+      ...(draft.periodLabel ? { label: draft.periodLabel } : {}),
+    };
+  } else if (!draft.periodType && !draft.periodStart && !draft.periodEnd) {
+    // Clearing the period entirely
+    patch.period = null;
+  }
+  return patch;
+}
+
 // =============================================================================
 // Component
 // =============================================================================
 
 /**
- * MissionDetail page -- displays full details for a single mission.
- *
- * @returns MissionDetail page JSX element
+ * MissionDetail page -- displays and edits a single mission.
  */
 export const MissionDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -129,26 +195,26 @@ export const MissionDetail: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState<MissionDraft | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   /**
    * Fetches the mission from the backend API.
-   *
-   * @param showLoadingSpinner - Whether to show the full loading state
    */
   const loadMission = useCallback(
     async (showLoadingSpinner = true) => {
       if (!id) return;
-
       if (showLoadingSpinner) setLoading(true);
       else setRefreshing(true);
-
       setError(null);
 
       try {
         const data = await apiService.getMission(id);
         setMission(data as Mission);
       } catch (err) {
-        const message =
-          err instanceof Error ? err.message : 'Failed to load mission';
+        const message = err instanceof Error ? err.message : 'Failed to load mission';
         setError(message);
       } finally {
         setLoading(false);
@@ -162,20 +228,67 @@ export const MissionDetail: React.FC = () => {
     loadMission();
   }, [loadMission]);
 
+  const beginEdit = useCallback(() => {
+    if (!mission) return;
+    setDraft(buildDraft(mission));
+    setSaveError(null);
+    setIsEditing(true);
+  }, [mission]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setDraft(null);
+    setSaveError(null);
+  }, []);
+
+  const saveEdit = useCallback(async () => {
+    if (!id || !draft) return;
+    if (!draft.objective.trim()) {
+      setSaveError('Objective cannot be empty.');
+      return;
+    }
+    if (!draft.ownerTeamId.trim()) {
+      setSaveError('Owner team cannot be empty.');
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = (await apiService.updateMission(id, draftToPatch(draft))) as Mission;
+      setMission(updated);
+      setIsEditing(false);
+      setDraft(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save mission';
+      setSaveError(message);
+    } finally {
+      setSaving(false);
+    }
+  }, [id, draft]);
+
+  /**
+   * Typed helper to patch a single draft field without widening it to `unknown`.
+   */
+  const setField = useMemo(
+    () =>
+      <K extends keyof MissionDraft>(key: K, value: MissionDraft[K]): void => {
+        setDraft((prev) => (prev ? { ...prev, [key]: value } : prev));
+      },
+    [],
+  );
+
   // ---------------------------------------------------------------------------
-  // Loading state
+  // Loading / error / not-found states
   // ---------------------------------------------------------------------------
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
-        <LoadingSpinner size="xl" text="Loading objective..." />
+        <LoadingSpinner size="xl" text="Loading mission..." />
       </div>
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Error state
-  // ---------------------------------------------------------------------------
   if (error) {
     return (
       <div className="p-6 max-w-[1000px] mx-auto" data-testid="mission-detail-error">
@@ -184,7 +297,7 @@ export const MissionDetail: React.FC = () => {
           className="flex items-center gap-1.5 text-sm text-text-secondary-dark hover:text-text-primary-dark mb-6 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Objectives
+          Back to Missions
         </button>
         <Card variant="default" padding="lg">
           <div className="text-center py-8">
@@ -201,9 +314,6 @@ export const MissionDetail: React.FC = () => {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Not found state
-  // ---------------------------------------------------------------------------
   if (!mission) {
     return (
       <div className="p-6 max-w-[1000px] mx-auto">
@@ -212,12 +322,12 @@ export const MissionDetail: React.FC = () => {
           className="flex items-center gap-1.5 text-sm text-text-secondary-dark hover:text-text-primary-dark mb-6 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Objectives
+          Back to Missions
         </button>
         <Card variant="default" padding="lg">
           <div className="text-center py-8 text-text-secondary-dark">
             <Target className="h-10 w-10 mx-auto mb-3 opacity-40" />
-            <p>Objective not found.</p>
+            <p>Mission not found.</p>
           </div>
         </Card>
       </div>
@@ -225,51 +335,112 @@ export const MissionDetail: React.FC = () => {
   }
 
   // ---------------------------------------------------------------------------
-  // Main render
+  // Main render (view + edit modes share the layout)
   // ---------------------------------------------------------------------------
   return (
     <div className="p-6 max-w-[1000px] mx-auto" data-testid="mission-detail-page">
-      {/* Back navigation */}
       <button
         onClick={() => navigate('/missions')}
         className="flex items-center gap-1.5 text-sm text-text-secondary-dark hover:text-text-primary-dark mb-6 transition-colors"
         data-testid="mission-detail-back"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to Objectives
+        Back to Missions
       </button>
 
       {/* Header */}
       <div className="flex items-start justify-between gap-4 mb-6">
         <div className="flex-1 min-w-0">
-          <h1 className="text-2xl font-bold text-text-primary-dark mb-2">
-            {mission.objective}
-          </h1>
-          <div className="flex items-center gap-2 flex-wrap">
+          {isEditing && draft ? (
+            <Input
+              aria-label="Objective"
+              value={draft.objective}
+              onChange={(e) => setField('objective', e.target.value)}
+              fullWidth
+              data-testid="edit-objective"
+            />
+          ) : (
+            <h1 className="text-2xl font-bold text-text-primary-dark mb-2">
+              {mission.objective}
+            </h1>
+          )}
+          <div className="flex items-center gap-2 flex-wrap mt-2">
             <StatusBadge status={getMissionStatusType(mission.status)}>
               {getMissionStatusLabel(mission.status)}
             </StatusBadge>
-            <Badge variant="default" size="sm">
-              {mission.id.slice(0, 12)}
-            </Badge>
+            {mission.priority && (
+              <Badge variant={PRIORITY_VARIANT[mission.priority]} size="sm">
+                {PRIORITY_LABEL[mission.priority]}
+              </Badge>
+            )}
+            {mission.period?.label && (
+              <Badge variant="info" size="sm">{mission.period.label}</Badge>
+            )}
+            <Badge variant="default" size="sm">{mission.id.slice(0, 12)}</Badge>
           </div>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          icon={RefreshCw}
-          onClick={() => loadMission(false)}
-          disabled={refreshing}
-          className={refreshing ? 'animate-spin' : ''}
-          aria-label="Refresh mission"
-        >
-          Refresh
-        </Button>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {isEditing ? (
+            <>
+              <Button
+                variant="primary"
+                size="sm"
+                icon={Save}
+                onClick={saveEdit}
+                disabled={saving}
+                data-testid="mission-save"
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={X}
+                onClick={cancelEdit}
+                disabled={saving}
+                data-testid="mission-cancel"
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="primary"
+                size="sm"
+                icon={Pencil}
+                onClick={beginEdit}
+                data-testid="mission-edit"
+              >
+                Edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={RefreshCw}
+                onClick={() => loadMission(false)}
+                disabled={refreshing}
+                className={refreshing ? 'animate-spin' : ''}
+                aria-label="Refresh mission"
+              >
+                Refresh
+              </Button>
+            </>
+          )}
+        </div>
       </div>
+
+      {saveError && (
+        <div data-testid="mission-save-error" className="mb-4">
+          <Alert variant="error" onClose={() => setSaveError(null)}>
+            {saveError}
+          </Alert>
+        </div>
+      )}
 
       {/* Content grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Main content (left 2 cols) */}
+        {/* Main content */}
         <div className="lg:col-span-2 flex flex-col gap-4">
           {/* Strategy */}
           <Card variant="default" padding="md" className="border border-border-dark">
@@ -277,9 +448,20 @@ export const MissionDetail: React.FC = () => {
               <Target className="h-4 w-4" />
               Current Strategy
             </h2>
-            <p className="text-sm text-text-primary-dark leading-relaxed whitespace-pre-wrap">
-              {mission.currentStrategy || 'No strategy defined.'}
-            </p>
+            {isEditing && draft ? (
+              <textarea
+                aria-label="Current Strategy"
+                className="w-full bg-background-dark border border-border-dark rounded-lg px-3 py-2 text-sm text-text-primary-dark resize-y focus:outline-none focus:border-accent-blue/50"
+                rows={4}
+                value={draft.currentStrategy}
+                onChange={(e) => setField('currentStrategy', e.target.value)}
+                data-testid="edit-strategy"
+              />
+            ) : (
+              <p className="text-sm text-text-primary-dark leading-relaxed whitespace-pre-wrap">
+                {mission.currentStrategy || 'No strategy defined.'}
+              </p>
+            )}
           </Card>
 
           {/* Success Criteria */}
@@ -288,17 +470,22 @@ export const MissionDetail: React.FC = () => {
               <CheckCircle2 className="h-4 w-4" />
               Success Criteria ({mission.successCriteria.length})
             </h2>
-            {mission.successCriteria.length === 0 ? (
-              <p className="text-sm text-text-secondary-dark">
-                No success criteria defined.
-              </p>
+            {isEditing && draft ? (
+              <textarea
+                aria-label="Success Criteria (one per line)"
+                className="w-full bg-background-dark border border-border-dark rounded-lg px-3 py-2 text-sm text-text-primary-dark resize-y focus:outline-none focus:border-accent-blue/50"
+                rows={5}
+                placeholder="One criterion per line"
+                value={draft.successCriteriaText}
+                onChange={(e) => setField('successCriteriaText', e.target.value)}
+                data-testid="edit-success-criteria"
+              />
+            ) : mission.successCriteria.length === 0 ? (
+              <p className="text-sm text-text-secondary-dark">No success criteria defined.</p>
             ) : (
               <ul className="space-y-2">
                 {mission.successCriteria.map((criterion, idx) => (
-                  <li
-                    key={idx}
-                    className="flex items-start gap-2 text-sm text-text-primary-dark"
-                  >
+                  <li key={idx} className="flex items-start gap-2 text-sm text-text-primary-dark">
                     <span className="text-primary mt-0.5 flex-shrink-0">
                       <ListChecks className="h-4 w-4" />
                     </span>
@@ -309,8 +496,8 @@ export const MissionDetail: React.FC = () => {
             )}
           </Card>
 
-          {/* Learnings */}
-          {mission.learnings && mission.learnings.length > 0 && (
+          {/* Learnings (view-only for now) */}
+          {!isEditing && mission.learnings && mission.learnings.length > 0 && (
             <Card variant="default" padding="md" className="border border-border-dark">
               <h2 className="text-sm font-semibold text-text-secondary-dark uppercase tracking-wide mb-3 flex items-center gap-1.5">
                 <BookOpen className="h-4 w-4" />
@@ -318,10 +505,7 @@ export const MissionDetail: React.FC = () => {
               </h2>
               <ul className="space-y-2">
                 {mission.learnings.map((learning, idx) => (
-                  <li
-                    key={idx}
-                    className="text-sm text-text-primary-dark pl-4 border-l-2 border-border-dark"
-                  >
+                  <li key={idx} className="text-sm text-text-primary-dark pl-4 border-l-2 border-border-dark">
                     {learning}
                   </li>
                 ))}
@@ -330,34 +514,180 @@ export const MissionDetail: React.FC = () => {
           )}
         </div>
 
-        {/* Sidebar (right col) */}
+        {/* Sidebar */}
         <div className="flex flex-col gap-4">
           {/* Team & Tasks */}
           <Card variant="default" padding="md" className="border border-border-dark">
             <h2 className="text-sm font-semibold text-text-secondary-dark uppercase tracking-wide mb-3 flex items-center gap-1.5">
               <Users className="h-4 w-4" />
-              Team & Tasks
+              Team & Settings
             </h2>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-text-secondary-dark">Owner Team</span>
-                <span className="text-text-primary-dark font-mono text-xs">
-                  {mission.ownerTeamId.slice(0, 12)}
-                </span>
+            <div className="space-y-3 text-sm">
+              {/* Owner Team */}
+              <div className="flex flex-col gap-1">
+                <span className="text-text-secondary-dark text-xs uppercase tracking-wide">Owner Team</span>
+                {isEditing && draft ? (
+                  <Input
+                    aria-label="Owner Team"
+                    value={draft.ownerTeamId}
+                    onChange={(e) => setField('ownerTeamId', e.target.value)}
+                    fullWidth
+                    data-testid="edit-owner-team"
+                  />
+                ) : (
+                  <span className="text-text-primary-dark font-mono text-xs">{mission.ownerTeamId}</span>
+                )}
               </div>
+
+              {/* Status */}
+              <div className="flex flex-col gap-1">
+                <span className="text-text-secondary-dark text-xs uppercase tracking-wide">Status</span>
+                {isEditing && draft ? (
+                  <FormSelect
+                    value={draft.status}
+                    onChange={(e) => setField('status', e.target.value as MissionStatus)}
+                    data-testid="edit-status"
+                  >
+                    <option value="active">Active</option>
+                    <option value="paused">Paused</option>
+                    <option value="completed">Completed</option>
+                    <option value="cancelled">Cancelled</option>
+                  </FormSelect>
+                ) : (
+                  <span className="text-text-primary-dark">{getMissionStatusLabel(mission.status)}</span>
+                )}
+              </div>
+
+              {/* Priority */}
+              <div className="flex flex-col gap-1">
+                <span className="text-text-secondary-dark text-xs uppercase tracking-wide">Priority</span>
+                {isEditing && draft ? (
+                  <FormSelect
+                    value={draft.priority}
+                    onChange={(e) => setField('priority', e.target.value as MissionPriority)}
+                    data-testid="edit-priority"
+                  >
+                    <option value="critical">Critical</option>
+                    <option value="high">High</option>
+                    <option value="medium">Medium</option>
+                    <option value="low">Low</option>
+                  </FormSelect>
+                ) : (
+                  <span className="text-text-primary-dark">{PRIORITY_LABEL[mission.priority ?? 'medium']}</span>
+                )}
+              </div>
+
+              {/* Parent mission */}
+              <div className="flex flex-col gap-1">
+                <span className="text-text-secondary-dark text-xs uppercase tracking-wide">Parent Mission</span>
+                {isEditing && draft ? (
+                  <Input
+                    aria-label="Parent Mission ID"
+                    placeholder="(none)"
+                    value={draft.parentMissionId}
+                    onChange={(e) => setField('parentMissionId', e.target.value)}
+                    fullWidth
+                    data-testid="edit-parent"
+                  />
+                ) : (
+                  <span className="text-text-primary-dark font-mono text-xs">
+                    {mission.parentMissionId ?? '—'}
+                  </span>
+                )}
+              </div>
+
               <div className="flex justify-between">
                 <span className="text-text-secondary-dark">Active Tasks</span>
-                <span className="text-text-primary-dark">
-                  {mission.activeProjectTaskIds.length}
-                </span>
+                <span className="text-text-primary-dark">{mission.activeProjectTaskIds.length}</span>
               </div>
-              <div className="flex justify-between">
-                <span className="text-text-secondary-dark">Cadence</span>
-                <span className="text-text-primary-dark font-mono text-xs">
-                  {mission.cadence || 'N/A'}
-                </span>
+
+              {/* Cadence */}
+              <div className="flex flex-col gap-1">
+                <span className="text-text-secondary-dark text-xs uppercase tracking-wide">Cadence (cron)</span>
+                {isEditing && draft ? (
+                  <Input
+                    aria-label="Cadence"
+                    value={draft.cadence}
+                    onChange={(e) => setField('cadence', e.target.value)}
+                    fullWidth
+                    data-testid="edit-cadence"
+                  />
+                ) : (
+                  <span className="text-text-primary-dark font-mono text-xs">{mission.cadence || 'N/A'}</span>
+                )}
               </div>
             </div>
+          </Card>
+
+          {/* Period */}
+          <Card variant="default" padding="md" className="border border-border-dark">
+            <h2 className="text-sm font-semibold text-text-secondary-dark uppercase tracking-wide mb-3 flex items-center gap-1.5">
+              <Calendar className="h-4 w-4" />
+              OKR Period
+            </h2>
+            {isEditing && draft ? (
+              <div className="space-y-2">
+                <FormSelect
+                  value={draft.periodType}
+                  onChange={(e) => setField('periodType', e.target.value as MissionPeriodType | '')}
+                  data-testid="edit-period-type"
+                >
+                  <option value="">— No period —</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="biweekly">Biweekly</option>
+                  <option value="monthly">Monthly</option>
+                  <option value="quarterly">Quarterly</option>
+                  <option value="custom">Custom</option>
+                </FormSelect>
+                <Input
+                  type="date"
+                  aria-label="Period start"
+                  value={draft.periodStart}
+                  onChange={(e) => setField('periodStart', e.target.value)}
+                  fullWidth
+                  data-testid="edit-period-start"
+                />
+                <Input
+                  type="date"
+                  aria-label="Period end"
+                  value={draft.periodEnd}
+                  onChange={(e) => setField('periodEnd', e.target.value)}
+                  fullWidth
+                  data-testid="edit-period-end"
+                />
+                <Input
+                  aria-label="Period label"
+                  placeholder="Label (optional)"
+                  value={draft.periodLabel}
+                  onChange={(e) => setField('periodLabel', e.target.value)}
+                  fullWidth
+                  data-testid="edit-period-label"
+                />
+              </div>
+            ) : mission.period ? (
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-text-secondary-dark">Type</span>
+                  <span className="text-text-primary-dark">{mission.period.type}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-secondary-dark">Start</span>
+                  <span className="text-text-primary-dark text-xs">{formatDateTime(mission.period.startDate)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-text-secondary-dark">End</span>
+                  <span className="text-text-primary-dark text-xs">{formatDateTime(mission.period.endDate)}</span>
+                </div>
+                {mission.period.label && (
+                  <div className="flex justify-between">
+                    <span className="text-text-secondary-dark">Label</span>
+                    <span className="text-text-primary-dark text-xs">{mission.period.label}</span>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-text-secondary-dark">No period defined.</p>
+            )}
           </Card>
 
           {/* Timestamps */}
@@ -369,37 +699,29 @@ export const MissionDetail: React.FC = () => {
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-text-secondary-dark">Created</span>
-                <span className="text-text-primary-dark text-xs">
-                  {formatDateTime(mission.createdAt)}
-                </span>
+                <span className="text-text-primary-dark text-xs">{formatDateTime(mission.createdAt)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-text-secondary-dark">Updated</span>
-                <span className="text-text-primary-dark text-xs">
-                  {formatDateTime(mission.updatedAt)}
-                </span>
+                <span className="text-text-primary-dark text-xs">{formatDateTime(mission.updatedAt)}</span>
               </div>
               {mission.lastReviewAt && (
                 <div className="flex justify-between">
                   <span className="text-text-secondary-dark">Last Review</span>
-                  <span className="text-text-primary-dark text-xs">
-                    {formatDateTime(mission.lastReviewAt)}
-                  </span>
+                  <span className="text-text-primary-dark text-xs">{formatDateTime(mission.lastReviewAt)}</span>
                 </div>
               )}
               {mission.nextReviewAt && (
                 <div className="flex justify-between">
                   <span className="text-text-secondary-dark">Next Review</span>
-                  <span className="text-text-primary-dark text-xs">
-                    {formatDateTime(mission.nextReviewAt)}
-                  </span>
+                  <span className="text-text-primary-dark text-xs">{formatDateTime(mission.nextReviewAt)}</span>
                 </div>
               )}
             </div>
           </Card>
 
-          {/* Active Task IDs */}
-          {mission.activeProjectTaskIds.length > 0 && (
+          {/* Active Task IDs (view-only) */}
+          {!isEditing && mission.activeProjectTaskIds.length > 0 && (
             <Card variant="default" padding="md" className="border border-border-dark">
               <h2 className="text-sm font-semibold text-text-secondary-dark uppercase tracking-wide mb-3 flex items-center gap-1.5">
                 <Clock className="h-4 w-4" />
@@ -407,9 +729,7 @@ export const MissionDetail: React.FC = () => {
               </h2>
               <div className="flex flex-wrap gap-1.5">
                 {mission.activeProjectTaskIds.map((taskId) => (
-                  <Badge key={taskId} variant="default" size="sm">
-                    {taskId.slice(0, 12)}
-                  </Badge>
+                  <Badge key={taskId} variant="default" size="sm">{taskId.slice(0, 12)}</Badge>
                 ))}
               </div>
             </Card>

--- a/frontend/src/pages/Missions.test.tsx
+++ b/frontend/src/pages/Missions.test.tsx
@@ -16,6 +16,7 @@ import { Missions } from './Missions';
 vi.mock('../services/api.service', () => ({
   apiService: {
     getMissions: vi.fn(),
+    createMission: vi.fn(),
   },
 }));
 
@@ -171,5 +172,230 @@ describe('Missions Page', () => {
     fireEvent.click(screen.getByTestId('missions-refresh'));
 
     expect(apiService.getMissions).toHaveBeenCalledTimes(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Priority / Period / Team filters
+  // ---------------------------------------------------------------------------
+
+  const now = new Date();
+  const past = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const future = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString();
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+
+  const criticalActiveMission = {
+    ...mockMission,
+    id: 'crit-1',
+    objective: 'Critical Active Q2',
+    ownerTeamId: 'team-alpha',
+    priority: 'critical',
+    period: { type: 'quarterly', startDate: yesterday, endDate: tomorrow, label: '2026 Q2' },
+  };
+  const mediumPastMission = {
+    ...mockMission,
+    id: 'med-1',
+    objective: 'Medium Past Work',
+    ownerTeamId: 'team-beta',
+    priority: 'medium',
+    period: { type: 'monthly', startDate: past, endDate: past, label: '2026-03 March' },
+  };
+  const lowUpcomingMission = {
+    ...mockMission,
+    id: 'low-1',
+    objective: 'Low Upcoming Plan',
+    ownerTeamId: 'team-alpha',
+    priority: 'low',
+    period: { type: 'monthly', startDate: future, endDate: future, label: '2026-06 June' },
+  };
+
+  it('renders priority badge for missions that have priority', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([criticalActiveMission]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    const badge = screen.getByTestId(`mission-priority-${criticalActiveMission.id}`);
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toBe('Critical');
+  });
+
+  it('renders period label when mission has a period', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([criticalActiveMission]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    expect(screen.getByTestId(`mission-period-${criticalActiveMission.id}`)).toBeTruthy();
+    expect(screen.getByText('2026 Q2')).toBeTruthy();
+  });
+
+  it('filters by priority when a priority pill is selected', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      criticalActiveMission,
+      mediumPastMission,
+    ]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('priority-filter-critical'));
+
+    expect(screen.getByText('Critical Active Q2')).toBeTruthy();
+    expect(screen.queryByText('Medium Past Work')).toBeFalsy();
+  });
+
+  it('filters by period state (current/past/upcoming)', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      criticalActiveMission,
+      mediumPastMission,
+      lowUpcomingMission,
+    ]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('period-filter-current'));
+    expect(screen.getByText('Critical Active Q2')).toBeTruthy();
+    expect(screen.queryByText('Medium Past Work')).toBeFalsy();
+    expect(screen.queryByText('Low Upcoming Plan')).toBeFalsy();
+
+    fireEvent.click(screen.getByTestId('period-filter-past'));
+    expect(screen.getByText('Medium Past Work')).toBeTruthy();
+    expect(screen.queryByText('Critical Active Q2')).toBeFalsy();
+
+    fireEvent.click(screen.getByTestId('period-filter-upcoming'));
+    expect(screen.getByText('Low Upcoming Plan')).toBeTruthy();
+    expect(screen.queryByText('Critical Active Q2')).toBeFalsy();
+  });
+
+  it('filters by team', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      criticalActiveMission,
+      mediumPastMission,
+    ]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('team-filter-team-beta'));
+
+    expect(screen.getByText('Medium Past Work')).toBeTruthy();
+    expect(screen.queryByText('Critical Active Q2')).toBeFalsy();
+  });
+
+  it('sorts missions by priority when status is equal', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      lowUpcomingMission,        // low, active
+      criticalActiveMission,     // critical, active
+    ]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    const rows = screen.getAllByTestId(/^mission-row-/);
+    // Critical should come before low when both are active
+    expect(rows[0].getAttribute('data-testid')).toBe(`mission-row-${criticalActiveMission.id}`);
+    expect(rows[1].getAttribute('data-testid')).toBe(`mission-row-${lowUpcomingMission.id}`);
+  });
+
+  // ---------------------------------------------------------------------------
+  // KR cards and parent hierarchy
+  // ---------------------------------------------------------------------------
+
+  const parentMission = {
+    ...mockMission,
+    id: 'parent-1',
+    objective: 'Company-level OKR',
+    priority: 'critical',
+  };
+
+  const childMissionWithKrs = {
+    ...mockMission,
+    id: 'child-1',
+    objective: 'Team OKR — ship V3',
+    parentMissionId: 'parent-1',
+    priority: 'high',
+    successCriteria: [],
+    keyResults: [
+      {
+        id: 'kr-1',
+        title: 'Reach $5k MRR',
+        metricType: 'currency',
+        baseline: 0,
+        target: 5000,
+        current: 1500,
+        unit: '$',
+        status: 'on_track',
+      },
+      {
+        id: 'kr-2',
+        title: 'Reduce onboarding time',
+        metricType: 'number',
+        baseline: 30,
+        target: 5,
+        current: 5,
+        unit: 'min',
+        status: 'achieved',
+      },
+    ],
+  };
+
+  it('renders a KR card for every key result and hides successCriteria preview', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([childMissionWithKrs]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    expect(screen.getByTestId(`mission-krs-${childMissionWithKrs.id}`)).toBeTruthy();
+    expect(screen.getByTestId(`mission-kr-${childMissionWithKrs.id}-kr-1`)).toBeTruthy();
+    expect(screen.getByTestId(`mission-kr-${childMissionWithKrs.id}-kr-2`)).toBeTruthy();
+    expect(screen.getByText('Reach $5k MRR')).toBeTruthy();
+    expect(screen.getByText(/2 KRs/)).toBeTruthy();
+  });
+
+  it('renders parent chip when parentMissionId resolves to an existing mission', async () => {
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      parentMission,
+      childMissionWithKrs,
+    ]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    const chip = screen.getByTestId(`mission-parent-${childMissionWithKrs.id}`);
+    expect(chip).toBeTruthy();
+    expect(chip.textContent).toMatch(/Company-level OKR/);
+  });
+
+  it('renders a parent chip fallback when parent mission is not in the list', async () => {
+    const orphan = { ...childMissionWithKrs, id: 'orphan-1', parentMissionId: 'ghost-xyz' };
+    (apiService.getMissions as ReturnType<typeof vi.fn>).mockResolvedValue([orphan]);
+    renderWithRouter(<Missions />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('missions-list')).toBeTruthy();
+    });
+
+    const chip = screen.getByTestId('mission-parent-orphan-1');
+    expect(chip).toBeTruthy();
+    // Falls back to an 8-char ID prefix when parent isn't loaded
+    expect(chip.textContent).toMatch(/ghost-xy/);
   });
 });

--- a/frontend/src/pages/Missions.tsx
+++ b/frontend/src/pages/Missions.tsx
@@ -18,20 +18,47 @@ import { Button } from '../components/UI/Button';
 import { Card } from '../components/UI/Card';
 import { Badge } from '../components/UI/Badge';
 import { StatusBadge } from '../components/UI/StatusBadge';
-import type { StatusType } from '../components/UI/StatusBadge';
-import type { BadgeVariant } from '../components/UI/Badge';
 import { PageToolbar } from '../components/UI/PageToolbar';
 import { Alert } from '../components/UI/Alert';
 import { Modal, ModalBody, ModalFooter } from '../components/UI/Modal';
 import { SkeletonRows } from '../components/UI/SkeletonRows';
+import { FormSelect } from '../components/UI/Form';
+import { FilterPillGroup } from '../components/UI/FilterPillGroup';
 import { apiService } from '../services/api.service';
+import {
+  PRIORITY_RANK,
+  PRIORITY_LABEL,
+  PRIORITY_VARIANT,
+  getMissionStatusType,
+  getMissionStatusLabel,
+  type MissionStatus,
+  type MissionPriority,
+  type MissionPeriod,
+} from '../types/mission.types';
 
 // =============================================================================
-// Types (mirrors backend/src/types/v2/mission.types.ts)
+// Types (KR summaries are only used on this page)
 // =============================================================================
 
-/** Mission lifecycle statuses. */
-type MissionStatus = 'active' | 'paused' | 'completed' | 'cancelled';
+/** KR metric type (mirrors backend). */
+type KRMetricType = 'number' | 'percentage' | 'boolean' | 'currency';
+
+/** KR progress status (mirrors backend). */
+type KRStatus = 'not_started' | 'on_track' | 'at_risk' | 'off_track' | 'achieved';
+
+/**
+ * Inline KR summary returned alongside each mission.
+ */
+interface KeyResultSummary {
+  id: string;
+  title: string;
+  metricType: KRMetricType;
+  baseline: number;
+  target: number;
+  current: number;
+  unit: string;
+  status: KRStatus;
+}
 
 /**
  * Frontend representation of a Mission.
@@ -61,53 +88,112 @@ interface Mission {
   /** Next scheduled planning review */
   nextReviewAt?: string;
   /** Accumulated learnings */
-  learnings: string[];
+  learnings?: string[];
+  /** Priority for sorting/filtering (optional — missing treated as lowest). */
+  priority?: MissionPriority;
+  /** OKR time window. */
+  period?: MissionPeriod;
+  /** Parent mission in the OKR hierarchy (company → team → individual). */
+  parentMissionId?: string;
+  /** Inline Key Result summaries (server-populated). */
+  keyResults?: KeyResultSummary[];
 }
 
-/** Filter options for the Missions list */
+/** Primary filter: mission status. */
 type StatusFilter = 'all' | MissionStatus;
+
+/** Priority filter including an "all" catch-all. */
+type PriorityFilter = 'all' | MissionPriority;
+
+/** Period state relative to "now". */
+type PeriodFilter = 'all' | 'current' | 'upcoming' | 'past' | 'none';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const PRIORITY_OPTIONS: { key: PriorityFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'critical', label: 'Critical' },
+  { key: 'high', label: 'High' },
+  { key: 'medium', label: 'Medium' },
+  { key: 'low', label: 'Low' },
+];
+
+const PERIOD_OPTIONS: { key: PeriodFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'current', label: 'Current' },
+  { key: 'upcoming', label: 'Upcoming' },
+  { key: 'past', label: 'Past' },
+  { key: 'none', label: 'No period' },
+];
 
 // =============================================================================
 // Utility Functions
 // =============================================================================
 
 /**
- * Maps a mission status to a StatusBadge-compatible StatusType.
+ * Classifies a mission's period relative to `now`.
  *
- * @param status - The mission status
- * @returns StatusType for the UI StatusBadge component
+ * @param period - Mission period or undefined
+ * @param now - Reference timestamp (defaults to current time)
+ * @returns One of 'current' | 'upcoming' | 'past' | 'none'
  */
-function getMissionStatusType(status: MissionStatus): StatusType {
-  const mapping: Record<MissionStatus, StatusType> = {
-    active: 'active',
-    paused: 'paused',
-    completed: 'completed',
-    cancelled: 'inactive',
-  };
-  return mapping[status] ?? 'pending';
+function classifyPeriod(period: MissionPeriod | undefined, now: Date = new Date()): Exclude<PeriodFilter, 'all'> {
+  if (!period) return 'none';
+  const start = new Date(period.startDate).getTime();
+  const end = new Date(period.endDate).getTime();
+  const t = now.getTime();
+  if (t < start) return 'upcoming';
+  if (t >= end) return 'past';
+  return 'current';
 }
 
 /**
- * Returns a human-readable label for a mission status.
+ * Computes progress for a KR on a 0–1 scale.
  *
- * @param status - The mission status
- * @returns Display label string
+ * Handles the "lower is better" case where target < baseline
+ * (e.g. latency reduction). Returns 0 if baseline equals target
+ * (avoiding divide-by-zero) and clamps to [0, 1].
+ *
+ * @param kr - Key Result summary with baseline, target, current
+ * @returns Progress as a number between 0 and 1 inclusive
  */
-function getMissionStatusLabel(status: MissionStatus): string {
-  const labels: Record<MissionStatus, string> = {
-    active: 'Active',
-    paused: 'Paused',
-    completed: 'Completed',
-    cancelled: 'Cancelled',
-  };
-  return labels[status] ?? status;
+function computeKrProgress(kr: Pick<KeyResultSummary, 'baseline' | 'target' | 'current'>): number {
+  const span = kr.target - kr.baseline;
+  if (span === 0) return kr.current >= kr.target ? 1 : 0;
+  const raw = (kr.current - kr.baseline) / span;
+  return Math.max(0, Math.min(1, raw));
 }
+
+/**
+ * Formats a KR metric value for display based on its metricType.
+ */
+function formatKrValue(value: number, metricType: KRMetricType, unit: string): string {
+  switch (metricType) {
+    case 'currency':
+      return `${unit || '$'}${value.toLocaleString()}`;
+    case 'percentage':
+      return `${value}${unit || '%'}`;
+    case 'boolean':
+      return value >= 1 ? 'Yes' : 'No';
+    case 'number':
+    default:
+      return `${value.toLocaleString()}${unit ? ` ${unit}` : ''}`;
+  }
+}
+
+/** Tailwind colour class for a KR progress bar based on KR status. */
+const KR_STATUS_COLOR: Record<KRStatus, string> = {
+  not_started: 'bg-border-dark',
+  on_track: 'bg-emerald-500',
+  at_risk: 'bg-amber-500',
+  off_track: 'bg-rose-500',
+  achieved: 'bg-emerald-500',
+};
 
 /**
  * Formats a relative time string from an ISO date.
- *
- * @param isoDate - ISO date string
- * @returns Human-readable relative time
  */
 function formatRelativeTime(isoDate: string): string {
   const now = Date.now();
@@ -129,9 +215,6 @@ function formatRelativeTime(isoDate: string): string {
 
 /**
  * Renders success criteria badges for a mission with expand/collapse toggle.
- * Shows up to 3 criteria by default with a clickable "+N more" to reveal all.
- *
- * @param props.criteria - Array of success criteria strings
  */
 const SuccessCriteriaPreview: React.FC<{ criteria: string[] }> = ({ criteria }) => {
   const [expanded, setExpanded] = useState(false);
@@ -176,12 +259,61 @@ const SuccessCriteriaPreview: React.FC<{ criteria: string[] }> = ({ criteria }) 
   );
 };
 
+/**
+ * Renders a compact list of KR progress bars under a mission card.
+ *
+ * Each row shows: title, current → target, and a coloured progress bar.
+ * Returns null when no KRs are attached so the card stays tidy.
+ *
+ * @param props.missionId - Parent mission ID (used for stable testids)
+ * @param props.keyResults - KR summaries to render
+ */
+const KeyResultsList: React.FC<{ missionId: string; keyResults: KeyResultSummary[] }> = ({
+  missionId,
+  keyResults,
+}) => {
+  if (keyResults.length === 0) return null;
+  return (
+    <div className="mt-3 space-y-1.5" data-testid={`mission-krs-${missionId}`}>
+      {keyResults.map((kr) => {
+        const progress = computeKrProgress(kr);
+        const pct = Math.round(progress * 100);
+        return (
+          <div
+            key={kr.id}
+            className="flex flex-col gap-1 rounded-md bg-surface-dark/60 border border-border-dark px-3 py-2"
+            data-testid={`mission-kr-${missionId}-${kr.id}`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs font-medium text-text-primary-dark truncate">
+                {kr.title}
+              </span>
+              <span className="text-[11px] text-text-secondary-dark flex-shrink-0 font-mono">
+                {formatKrValue(kr.current, kr.metricType, kr.unit)} /{' '}
+                {formatKrValue(kr.target, kr.metricType, kr.unit)}
+                <span className="ml-2 opacity-70">({pct}%)</span>
+              </span>
+            </div>
+            <div className="h-1 w-full rounded-full bg-border-dark/40 overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${KR_STATUS_COLOR[kr.status]}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
 // =============================================================================
 // Component
 // =============================================================================
 
 /**
- * Missions list page -- displays all Missions with status filters and search.
+ * Missions list page -- displays all Missions with status/priority/period/team
+ * filters and search.
  *
  * @returns Missions page JSX element
  */
@@ -191,6 +323,9 @@ export const Missions: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>('all');
+  const [periodFilter, setPeriodFilter] = useState<PeriodFilter>('all');
+  const [teamFilter, setTeamFilter] = useState<string>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
 
@@ -214,12 +349,46 @@ export const Missions: React.FC = () => {
     loadMissions();
   }, [loadMissions]);
 
-  /** Filtered missions based on status and search */
+  /** Map from mission ID → mission, used for rendering parent chips. */
+  const missionsById = useMemo(() => {
+    const map = new Map<string, Mission>();
+    for (const m of missions) map.set(m.id, m);
+    return map;
+  }, [missions]);
+
+  /** Unique team IDs found across all missions (for team filter). */
+  const teamOptions = useMemo(() => {
+    const seen = new Set<string>();
+    for (const m of missions) {
+      if (m.ownerTeamId) seen.add(m.ownerTeamId);
+    }
+    return [
+      { key: 'all', label: 'All' },
+      ...Array.from(seen).sort().map((id) => ({
+        key: id,
+        label: id.length > 16 ? `${id.slice(0, 12)}…` : id,
+      })),
+    ];
+  }, [missions]);
+
+  /** Filtered + sorted missions. */
   const filteredMissions = useMemo(() => {
     let result = missions;
 
     if (statusFilter !== 'all') {
       result = result.filter((m) => m.status === statusFilter);
+    }
+
+    if (priorityFilter !== 'all') {
+      result = result.filter((m) => (m.priority ?? 'low') === priorityFilter);
+    }
+
+    if (periodFilter !== 'all') {
+      result = result.filter((m) => classifyPeriod(m.period) === periodFilter);
+    }
+
+    if (teamFilter !== 'all') {
+      result = result.filter((m) => m.ownerTeamId === teamFilter);
     }
 
     if (searchQuery.trim()) {
@@ -229,17 +398,23 @@ export const Missions: React.FC = () => {
           m.objective.toLowerCase().includes(q) ||
           m.id.toLowerCase().includes(q) ||
           m.ownerTeamId.toLowerCase().includes(q) ||
-          m.currentStrategy.toLowerCase().includes(q),
+          m.currentStrategy?.toLowerCase().includes(q) ||
+          m.period?.label?.toLowerCase().includes(q),
       );
     }
 
-    // Sort newest first
-    return result.sort(
-      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
-  }, [missions, statusFilter, searchQuery]);
+    // Sort: active first → priority rank → updated desc
+    return [...result].sort((a, b) => {
+      if (a.status === 'active' && b.status !== 'active') return -1;
+      if (a.status !== 'active' && b.status === 'active') return 1;
+      const rankA = PRIORITY_RANK[a.priority ?? 'low'];
+      const rankB = PRIORITY_RANK[b.priority ?? 'low'];
+      if (rankA !== rankB) return rankA - rankB;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+  }, [missions, statusFilter, priorityFilter, periodFilter, teamFilter, searchQuery]);
 
-  /** Status counts for filter badges */
+  /** Status counts for filter badges. */
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = { all: missions.length };
     for (const m of missions) {
@@ -297,11 +472,38 @@ export const Missions: React.FC = () => {
         }))}
         activeTab={statusFilter}
         onTabChange={(v) => setStatusFilter(v as StatusFilter)}
-        searchPlaceholder="Search by mission, team, strategy..."
+        searchPlaceholder="Search by mission, team, strategy, period..."
         searchValue={searchQuery}
         onSearchChange={setSearchQuery}
         searchDebounceMs={0}
       />
+
+      {/* Secondary filters: priority / period / team */}
+      <div className="flex flex-col gap-2 mb-4" data-testid="missions-secondary-filters">
+        <FilterPillGroup<PriorityFilter>
+          label="Priority"
+          options={PRIORITY_OPTIONS}
+          value={priorityFilter}
+          onChange={setPriorityFilter}
+          testIdPrefix="priority-filter"
+        />
+        <FilterPillGroup<PeriodFilter>
+          label="Period"
+          options={PERIOD_OPTIONS}
+          value={periodFilter}
+          onChange={setPeriodFilter}
+          testIdPrefix="period-filter"
+        />
+        {teamOptions.length > 1 && (
+          <FilterPillGroup<string>
+            label="Team"
+            options={teamOptions}
+            value={teamFilter}
+            onChange={setTeamFilter}
+            testIdPrefix="team-filter"
+          />
+        )}
+      </div>
 
       {/* Loading */}
       {loading && (
@@ -335,49 +537,99 @@ export const Missions: React.FC = () => {
       {/* Missions list */}
       {!loading && !error && filteredMissions.length > 0 && (
         <div className="flex flex-col gap-2" data-testid="missions-list">
-          {filteredMissions.map((mission) => (
-            <Card
-              key={mission.id}
-              variant="default"
-              padding="md"
-              className="border border-border-dark cursor-pointer hover:border-primary/30 transition-colors"
-              data-testid={`mission-row-${mission.id}`}
-              onClick={() => navigate(`/missions/${mission.id}`)}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-base font-semibold leading-6 text-text-primary-dark">
-                      {mission.objective}
-                    </span>
+          {filteredMissions.map((mission) => {
+            const periodState = classifyPeriod(mission.period);
+            const parent = mission.parentMissionId
+              ? missionsById.get(mission.parentMissionId)
+              : undefined;
+            const krs = mission.keyResults ?? [];
+            return (
+              <Card
+                key={mission.id}
+                variant="default"
+                padding="md"
+                className="border border-border-dark cursor-pointer hover:border-primary/30 transition-colors"
+                data-testid={`mission-row-${mission.id}`}
+                onClick={() => navigate(`/missions/${mission.id}`)}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    {mission.parentMissionId && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (parent) navigate(`/missions/${parent.id}`);
+                        }}
+                        className="mb-1 flex items-center gap-1 text-[11px] text-text-secondary-dark hover:text-primary transition-colors"
+                        data-testid={`mission-parent-${mission.id}`}
+                      >
+                        <span>↳ Child of</span>
+                        <span className="font-medium">
+                          {parent?.objective ?? mission.parentMissionId.slice(0, 8)}
+                        </span>
+                      </button>
+                    )}
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-base font-semibold leading-6 text-text-primary-dark">
+                        {mission.objective}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-wrap mb-2">
+                      <StatusBadge status={getMissionStatusType(mission.status)}>
+                        {getMissionStatusLabel(mission.status)}
+                      </StatusBadge>
+                      {mission.priority && (
+                        <Badge
+                          variant={PRIORITY_VARIANT[mission.priority]}
+                          size="sm"
+                          data-testid={`mission-priority-${mission.id}`}
+                        >
+                          {PRIORITY_LABEL[mission.priority]}
+                        </Badge>
+                      )}
+                      {mission.period && (
+                        <Badge
+                          variant={periodState === 'current' ? 'success' : periodState === 'past' ? 'default' : 'info'}
+                          size="sm"
+                          data-testid={`mission-period-${mission.id}`}
+                        >
+                          {mission.period.label ?? `${mission.period.type}`}
+                        </Badge>
+                      )}
+                      <Badge variant="default" size="sm">
+                        Team: {mission.ownerTeamId.slice(0, 12)}
+                      </Badge>
+                      <Badge variant="info" size="sm">
+                        {mission.activeProjectTaskIds.length} active tasks
+                      </Badge>
+                      {krs.length > 0 && (
+                        <Badge variant="info" size="sm">
+                          {krs.length} KR{krs.length === 1 ? '' : 's'}
+                        </Badge>
+                      )}
+                      <span className="text-xs text-text-secondary-dark">
+                        Updated {formatRelativeTime(mission.updatedAt)}
+                      </span>
+                    </div>
+                    {mission.currentStrategy && (
+                      <p className="text-xs text-text-secondary-dark line-clamp-2">
+                        {mission.currentStrategy}
+                      </p>
+                    )}
+                    {krs.length > 0 ? (
+                      <KeyResultsList missionId={mission.id} keyResults={krs} />
+                    ) : (
+                      <SuccessCriteriaPreview criteria={mission.successCriteria ?? []} />
+                    )}
                   </div>
-                  <div className="flex items-center gap-2 flex-wrap mb-2">
-                    <StatusBadge status={getMissionStatusType(mission.status)}>
-                      {getMissionStatusLabel(mission.status)}
-                    </StatusBadge>
-                    <Badge variant="default" size="sm">
-                      Team: {mission.ownerTeamId.slice(0, 12)}
-                    </Badge>
-                    <Badge variant="info" size="sm">
-                      {mission.activeProjectTaskIds.length} active tasks
-                    </Badge>
-                    <span className="text-xs text-text-secondary-dark">
-                      Updated {formatRelativeTime(mission.updatedAt)}
-                    </span>
-                  </div>
-                  {/* Strategy summary */}
-                  <p className="text-xs text-text-secondary-dark line-clamp-2">
-                    {mission.currentStrategy}
-                  </p>
-                  {/* Success criteria preview with expand toggle */}
-                  <SuccessCriteriaPreview criteria={mission.successCriteria} />
+                  <span className="text-xs text-text-secondary-dark font-mono flex-shrink-0">
+                    {mission.id.slice(0, 8)}
+                  </span>
                 </div>
-                <span className="text-xs text-text-secondary-dark font-mono flex-shrink-0">
-                  {mission.id.slice(0, 8)}
-                </span>
-              </div>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
         </div>
       )}
       {/* Create Mission Modal */}
@@ -385,6 +637,7 @@ export const Missions: React.FC = () => {
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         onCreated={() => { setShowCreateModal(false); loadMissions(); }}
+        parentOptions={missions.map((m) => ({ id: m.id, objective: m.objective }))}
       />
     </div>
   );
@@ -400,13 +653,17 @@ interface CreateMissionModalProps {
   isOpen: boolean;
   onClose: () => void;
   onCreated: () => void;
+  /** Missions available as a potential parent in the hierarchy. */
+  parentOptions: { id: string; objective: string }[];
 }
 
-const CreateMissionModal: React.FC<CreateMissionModalProps> = ({ isOpen, onClose, onCreated }) => {
+const CreateMissionModal: React.FC<CreateMissionModalProps> = ({ isOpen, onClose, onCreated, parentOptions }) => {
   const [objective, setObjective] = useState('');
   const [ownerTeamId, setOwnerTeamId] = useState('');
   const [cadence, setCadence] = useState('0 9 * * 1');
   const [successCriteria, setSuccessCriteria] = useState('');
+  const [priority, setPriority] = useState<MissionPriority>('medium');
+  const [parentMissionId, setParentMissionId] = useState<string>('');
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState('');
 
@@ -424,11 +681,15 @@ const CreateMissionModal: React.FC<CreateMissionModalProps> = ({ isOpen, onClose
         successCriteria: successCriteria.trim()
           ? successCriteria.split('\n').map(s => s.trim()).filter(Boolean)
           : [],
+        priority,
+        ...(parentMissionId ? { parentMissionId } : {}),
       });
       setObjective('');
       setOwnerTeamId('');
       setCadence('0 9 * * 1');
       setSuccessCriteria('');
+      setPriority('medium');
+      setParentMissionId('');
       onCreated();
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Failed to create mission');
@@ -461,6 +722,41 @@ const CreateMissionModal: React.FC<CreateMissionModalProps> = ({ isOpen, onClose
               onChange={(e) => setOwnerTeamId(e.target.value)}
               placeholder="e.g. crewly-product-leo"
             />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary-dark mb-1.5">Priority</label>
+            <FormSelect
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as MissionPriority)}
+              data-testid="create-mission-priority"
+            >
+              <option value="critical">Critical</option>
+              <option value="high">High</option>
+              <option value="medium">Medium</option>
+              <option value="low">Low</option>
+            </FormSelect>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-text-secondary-dark mb-1.5">
+              Parent Mission <span className="text-text-secondary-dark font-normal">(optional)</span>
+            </label>
+            <FormSelect
+              value={parentMissionId}
+              onChange={(e) => setParentMissionId(e.target.value)}
+              data-testid="create-mission-parent"
+            >
+              <option value="">— No parent (top-level) —</option>
+              {parentOptions.map((opt) => (
+                <option key={opt.id} value={opt.id}>
+                  {opt.objective.length > 80 ? opt.objective.slice(0, 80) + '…' : opt.objective}
+                </option>
+              ))}
+            </FormSelect>
+            <p className="mt-1 text-xs text-text-secondary-dark">
+              Cascade this mission under a company or team-level OKR.
+            </p>
           </div>
 
           <div>

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -1163,7 +1163,20 @@ class ApiService {
     return Array.isArray(d) ? d : [];
   }
 
-  async createMission(input: { objective: string; ownerTeamId: string; cadence?: string; successCriteria?: string[] }): Promise<unknown> {
+  async createMission(input: {
+    objective: string;
+    ownerTeamId: string;
+    cadence?: string;
+    successCriteria?: string[];
+    priority?: 'critical' | 'high' | 'medium' | 'low';
+    period?: {
+      type: 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'custom';
+      startDate: string;
+      endDate: string;
+      label?: string;
+    };
+    parentMissionId?: string;
+  }): Promise<unknown> {
     const response = await axios.post<ApiResponse<unknown>>(`${API_BASE}/missions`, input);
     return response.data.data;
   }
@@ -1171,6 +1184,22 @@ class ApiService {
   async getMission(id: string): Promise<unknown> {
     const response = await axios.get<ApiResponse<unknown>>(`${API_BASE}/missions/${id}`);
     if (!response.data.success || !response.data.data) throw new Error('Mission not found');
+    return response.data.data;
+  }
+
+  /**
+   * Partially update a mission. `id` and `createdAt` are immutable server-side.
+   * Pass `parentMissionId: ''` to clear an existing parent.
+   *
+   * @param id - Mission ID to update
+   * @param patch - Subset of mutable fields to merge
+   * @returns The updated mission object
+   */
+  async updateMission(id: string, patch: Record<string, unknown>): Promise<unknown> {
+    const response = await axios.put<ApiResponse<unknown>>(`${API_BASE}/missions/${id}`, patch);
+    if (!response.data.success) {
+      throw new Error(response.data.error || 'Failed to update mission');
+    }
     return response.data.data;
   }
 

--- a/frontend/src/types/mission.types.test.ts
+++ b/frontend/src/types/mission.types.test.ts
@@ -1,0 +1,59 @@
+import {
+  PRIORITY_RANK,
+  PRIORITY_LABEL,
+  PRIORITY_VARIANT,
+  getMissionStatusType,
+  getMissionStatusLabel,
+  type MissionPriority,
+  type MissionStatus,
+} from './mission.types';
+
+describe('mission.types', () => {
+  describe('PRIORITY_RANK', () => {
+    it('orders critical < high < medium < low (lower = higher priority)', () => {
+      expect(PRIORITY_RANK.critical).toBeLessThan(PRIORITY_RANK.high);
+      expect(PRIORITY_RANK.high).toBeLessThan(PRIORITY_RANK.medium);
+      expect(PRIORITY_RANK.medium).toBeLessThan(PRIORITY_RANK.low);
+    });
+
+    it('has exactly one entry per MissionPriority', () => {
+      const keys: MissionPriority[] = ['critical', 'high', 'medium', 'low'];
+      expect(Object.keys(PRIORITY_RANK).sort()).toEqual(keys.sort());
+    });
+  });
+
+  describe('PRIORITY_LABEL / PRIORITY_VARIANT', () => {
+    it('provides a label for every priority', () => {
+      (['critical', 'high', 'medium', 'low'] as MissionPriority[]).forEach((p) => {
+        expect(PRIORITY_LABEL[p]).toBeTruthy();
+        expect(PRIORITY_VARIANT[p]).toBeTruthy();
+      });
+    });
+  });
+
+  describe('getMissionStatusType', () => {
+    it('maps cancelled to the inactive StatusType (design decision, not identity)', () => {
+      expect(getMissionStatusType('cancelled')).toBe('inactive');
+    });
+
+    it('returns the identity mapping for active / paused / completed', () => {
+      expect(getMissionStatusType('active')).toBe('active');
+      expect(getMissionStatusType('paused')).toBe('paused');
+      expect(getMissionStatusType('completed')).toBe('completed');
+    });
+  });
+
+  describe('getMissionStatusLabel', () => {
+    it('title-cases each status', () => {
+      const expected: Record<MissionStatus, string> = {
+        active: 'Active',
+        paused: 'Paused',
+        completed: 'Completed',
+        cancelled: 'Cancelled',
+      };
+      (Object.keys(expected) as MissionStatus[]).forEach((s) => {
+        expect(getMissionStatusLabel(s)).toBe(expected[s]);
+      });
+    });
+  });
+});

--- a/frontend/src/types/mission.types.ts
+++ b/frontend/src/types/mission.types.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared mission types + presentation tables for the frontend.
+ *
+ * Both `Missions.tsx` (list) and `MissionDetail.tsx` (detail/edit) reach
+ * for the same priority/status labels, badge variants, and rank ordering.
+ * Keeping them in one module prevents drift — adding a new priority or
+ * retheming a badge happens in a single place.
+ *
+ * The string unions here mirror the backend `MissionStatus` / `MissionPriority`
+ * definitions in `backend/src/types/v2/mission.types.ts`; keep the two in
+ * sync manually (they're too small to be worth sharing across the FE/BE
+ * boundary).
+ */
+
+import type { BadgeVariant } from '../components/UI/Badge';
+import type { StatusType } from '../components/UI/StatusBadge';
+
+/** Mission lifecycle statuses (mirrors backend). */
+export type MissionStatus = 'active' | 'paused' | 'completed' | 'cancelled';
+
+/** Priority ordered from most → least important (mirrors backend). */
+export type MissionPriority = 'critical' | 'high' | 'medium' | 'low';
+
+/** Period types (mirrors backend). */
+export type MissionPeriodType = 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'custom';
+
+export interface MissionPeriod {
+  type: MissionPeriodType;
+  startDate: string;
+  endDate: string;
+  label?: string;
+}
+
+/** Numeric rank for priority sorting (lower = higher priority). */
+export const PRIORITY_RANK: Record<MissionPriority, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+/** Human-readable priority labels. */
+export const PRIORITY_LABEL: Record<MissionPriority, string> = {
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+/** Badge color variant per priority level. */
+export const PRIORITY_VARIANT: Record<MissionPriority, BadgeVariant> = {
+  critical: 'error',
+  high: 'warning',
+  medium: 'info',
+  low: 'default',
+};
+
+const STATUS_TYPE: Record<MissionStatus, StatusType> = {
+  active: 'active',
+  paused: 'paused',
+  completed: 'completed',
+  cancelled: 'inactive',
+};
+
+const STATUS_LABEL: Record<MissionStatus, string> = {
+  active: 'Active',
+  paused: 'Paused',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+};
+
+/**
+ * Maps a mission status to a StatusBadge-compatible StatusType.
+ */
+export function getMissionStatusType(status: MissionStatus): StatusType {
+  return STATUS_TYPE[status] ?? 'pending';
+}
+
+/**
+ * Returns a human-readable label for a mission status.
+ */
+export function getMissionStatusLabel(status: MissionStatus): string {
+  return STATUS_LABEL[status] ?? status;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.1.0",
+  "version": "1.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.1.0",
+      "version": "1.5.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.2.0",
+  "version": "1.5.22",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "main": "dist/cli/cli/src/index.js",

--- a/tests/v3/evaluator.mjs
+++ b/tests/v3/evaluator.mjs
@@ -1,0 +1,187 @@
+/**
+ * V3 Accuracy Diagnostic Evaluator
+ * 
+ * This script runs the "Golden Set" through the V3 pipeline and evaluates
+ * the semantic accuracy of Chat → Request → WorkItem translation.
+ */
+
+import { chromium } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+const BACKEND_URL = 'http://localhost:8787';
+const FRONTEND_URL = 'http://localhost:8788';
+const SCREENSHOT_DIR = '/tmp/v3-eval-screenshots';
+const GOLDEN_SET_PATH = './tests/v3/golden-set.json';
+
+// Ensure screenshot directory exists
+if (!fs.existsSync(SCREENSHOT_DIR)) {
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+}
+
+async function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function apiGet(endpoint) {
+  try {
+    const res = await fetch(`${BACKEND_URL}${endpoint}`);
+    return await res.json();
+  } catch (err) {
+    console.error(`API Get failed: ${endpoint}`, err.message);
+    return { data: [] };
+  }
+}
+
+async function sendMessage(content) {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/chat/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    return await res.json();
+  } catch (err) {
+    console.error(`Send message failed`, err.message);
+    return { success: false };
+  }
+}
+
+/**
+ * Heuristic-based Grader (Phase 1 baseline)
+ * In Phase 2, this will call an LLM for semantic grading.
+ */
+function gradeResult(actual, expected) {
+  const issues = [];
+  let score = 5;
+
+  if (!expected) {
+    if (actual.request) {
+      issues.push('FAIL: Should NOT have created a Request');
+      score = 1;
+    }
+    return { score, issues };
+  }
+
+  if (!actual.request) {
+    issues.push('FAIL: Request was not created');
+    score = 0;
+    return { score, issues };
+  }
+
+  // Check title quality
+  if (actual.request.title === actual.request.description) {
+    issues.push('WARN: Title is a verbatim copy of description (mindless)');
+    score -= 1;
+  }
+
+  // Check category
+  if (actual.request.intentCategory !== expected.expectedRequest.intentCategory) {
+    issues.push(`WARN: Category mismatch. Expected ${expected.expectedRequest.intentCategory}, got ${actual.request.intentCategory}`);
+    score -= 0.5;
+  }
+
+  // Check decomposition
+  const actualWorkItemsCount = actual.workItems.length;
+  const expectedMinWorkItems = expected.expectedWorkItems?.length || 0;
+  
+  if (actualWorkItemsCount < expectedMinWorkItems) {
+    issues.push(`WARN: Under-decomposed. Expected at least ${expectedMinWorkItems} tasks, got ${actualWorkItemsCount}`);
+    score -= 1;
+  }
+
+  return { score: Math.max(0, score), issues };
+}
+
+async function main() {
+  console.log('🚀 Starting V3 Accuracy Diagnostic...\n');
+
+  if (!fs.existsSync(GOLDEN_SET_PATH)) {
+    console.error('Golden set file not found!');
+    process.exit(1);
+  }
+
+  const goldenSet = JSON.parse(fs.readFileSync(GOLDEN_SET_PATH, 'utf-8'));
+  const scenarios = goldenSet.scenarios;
+
+  // Launch browser for visual verification
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  const results = [];
+
+  for (const scenario of scenarios) {
+    console.log(`\n---------------------------------------------------------`);
+    console.log(`Scenario: ${scenario.id}`);
+    console.log(`Input: "${scenario.input}"`);
+
+    // 1. Send message
+    const sendResult = await sendMessage(scenario.input);
+    if (!sendResult.success) {
+      console.log('❌ Failed to send message');
+      continue;
+    }
+
+    // 2. Wait for processing (correlation window + orchestrator thinking)
+    console.log('Waiting 15s for V3 processing...');
+    await sleep(15000);
+
+    // 3. Fetch results
+    const requestsData = await apiGet('/api/requests');
+    const workItemsData = await apiGet('/api/task-pool/all');
+
+    // Find the most recent request matching this scenario
+    // (In a real test we should track the exact messageId)
+    const latestRequest = (requestsData.data || [])
+      .filter(r => r.description.includes(scenario.input.slice(0, 20)))
+      .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))[0];
+
+    const linkedWorkItems = latestRequest 
+      ? (workItemsData.data || []).filter(wi => wi.requestId === latestRequest.id)
+      : [];
+
+    // 4. Grade
+    const actual = latestRequest ? { request: latestRequest, workItems: linkedWorkItems } : { request: null, workItems: [] };
+    const grade = gradeResult(actual, scenario.expectedRequest ? scenario : null);
+
+    console.log(`Grade: ${grade.score}/5`);
+    if (grade.issues.length > 0) {
+      grade.issues.forEach(i => console.log(`  - ${i}`));
+    } else {
+      console.log('  ✅ Perfectly translated');
+    }
+
+    results.push({
+      scenario: scenario.id,
+      input: scenario.input,
+      score: grade.score,
+      issues: grade.issues,
+      actual: {
+        title: latestRequest?.title,
+        category: latestRequest?.intentCategory,
+        workItemsCount: linkedWorkItems.length
+      }
+    });
+  }
+
+  // 5. Final Report
+  console.log(`\n=========================================================`);
+  console.log(`Diagnostic Complete`);
+  const avgScore = results.reduce((acc, r) => acc + r.score, 0) / results.length;
+  console.log(`Average Accuracy Score: ${avgScore.toFixed(2)}/5`);
+  
+  const reportPath = path.join(SCREENSHOT_DIR, 'v3-accuracy-report.json');
+  fs.writeFileSync(reportPath, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    avgScore,
+    results
+  }, null, 2));
+  console.log(`Full report saved to ${reportPath}`);
+
+  await browser.close();
+}
+
+main().catch(err => {
+  console.error('Evaluator crashed:', err);
+  process.exit(1);
+});

--- a/tests/v3/golden-set.json
+++ b/tests/v3/golden-set.json
@@ -1,0 +1,71 @@
+{
+  "scenarios": [
+    {
+      "id": "simple-query",
+      "input": "帮我查一下现在的团队有哪些？",
+      "expectedRequest": {
+        "title": "[Query] List active teams",
+        "intentCategory": "query",
+        "intentLevel": "L1"
+      },
+      "expectedWorkItems": [
+        {
+          "title": "List all teams",
+          "type": "delegate",
+          "target": "orchestrator"
+        }
+      ],
+      "gradingRubric": "Should summarize 'list teams' in title, not just copy '帮我查一下...'. Should have exactly 1 WorkItem."
+    },
+    {
+      "id": "complex-planning",
+      "input": "帮我给Sam团队创建一个新的创业智库团队（Think Tank），需要有三个member，分别由不同的runtime组成，其中一个member（codex runtime）作为这个团队的TL。给这个团队创建一个project path，同时制定team norm和sop。",
+      "expectedRequest": {
+        "title": "[Planning] Setup Think Tank team",
+        "intentCategory": "planning",
+        "intentLevel": "L2"
+      },
+      "expectedWorkItems": [
+        { "title": "Create Think Tank team", "type": "delegate" },
+        { "title": "Add 3 members with different runtimes", "type": "delegate" },
+        { "title": "Setup project path", "type": "delegate" },
+        { "title": "Define team norms and SOP", "type": "delegate" }
+      ],
+      "gradingRubric": "Should decompose into at least 4 logical WorkItems. Title should be a summary, not the full long message."
+    },
+    {
+      "id": "bug-report",
+      "input": "刚才发现那个avatar broken的问题，让团队去看看为什么。",
+      "expectedRequest": {
+        "title": "[Fix] Investigate broken avatar issue",
+        "intentCategory": "debugging",
+        "intentLevel": "L1"
+      },
+      "expectedWorkItems": [
+        { "title": "Investigate avatar rendering failure", "type": "delegate" }
+      ],
+      "gradingRubric": "Should identify 'avatar broken' as the core issue. Should summarize intent."
+    },
+    {
+      "id": "deployment-request",
+      "input": "把目前主干的代码部署到staging环境，并运行冒烟测试。",
+      "expectedRequest": {
+        "title": "[Deploy] Staging deployment and smoke tests",
+        "intentCategory": "deployment",
+        "intentLevel": "L2"
+      },
+      "expectedWorkItems": [
+        { "title": "Deploy main branch to staging", "type": "delegate" },
+        { "title": "Run smoke tests", "type": "check" }
+      ],
+      "gradingRubric": "Should separate deployment from testing. Category should be deployment."
+    },
+    {
+      "id": "chit-chat-neg",
+      "input": "好的，谢谢你！",
+      "expectedRequest": null,
+      "expectedWorkItems": [],
+      "gradingRubric": "Should NOT create any Request or WorkItem for pure acknowledgement."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds three new v3 services: `service-contract-gate`, `team-trigger-reconciler`, and the `backfill-mission-priority` migration script (all with co-located unit tests)
- Wires `ServiceContractGate` into `task-pool.controller` via `maybeEnforceContract` for cross-team request gating
- Fixes the trigger-accumulation bug (39× escalation reconciler duplicates) with named-trigger idempotency on `create()` + structural dedup on load, plus teardown of the EventBus signal listener in `stop()`
- Bundles 23 review fixes from the three-round code review (see below)

## What's new
- `backend/src/services/v3/service-contract-gate.service.ts` + `contract-matcher.ts` (extracted predicate reusable by skills)
- `backend/src/services/v3/team-trigger-reconciler.service.ts`
- `backend/src/scripts/backfill-mission-priority.ts` (atomic, tracks parse/id failures)
- `frontend/src/components/UI/FilterPill{,Group}.tsx` + `frontend/src/types/mission.types.ts` (shared across `Missions.tsx` / `MissionDetail.tsx`)
- `tests/v3/evaluator.mjs` + `golden-set.json` for V3 pipeline accuracy diagnostics

## What changed
- **trigger-engine**: named-trigger idempotency on `create()`; structural dedup on load cancels duplicate active triggers; bound signal listener that `stop()` now tears down
- **escalation.service**: stable `system:escalation` name; guarded monkey-patch to prevent re-install chain growth; single pool fetch + missionId bucketing per cycle; tracked succeed/fail counts replacing silent swallow
- **task-pool.controller**: `maybeEnforceContract` integration with `missing_request_type` gate reason; single-pass `validateWorkItem`; uses `isValidWorkItemType`
- **browser-proxy**: `lastSeenAt` tracking from relay traffic
- **task.service**: typed `TaskStatus`/`TaskPriority` constants + guards (no more `as any`); extracted `readTaskFile` helper; real `fs.stat` timestamps
- **team-norms**: wired into prompt assembly via `teamNormsPath`
- **mission-policy routes**: new `PUT /:id` partial mission update

## Three-round code review

**Round 1 — Refactor & Consistency** (5 applied / 11 deferred):
- ✅ Extracted `contract-matcher.ts` (R1-9)
- ✅ Replaced local `VALID_POOL_TYPES` Set with `isValidWorkItemType` (R1-13)
- ✅ `TaskService`: typed constants + guards, `readTaskFile` helper (R1-5, R1-16)
- ✅ Shared `frontend/src/types/mission.types.ts` (R1-2)
- ⏭ Deferred follow-ups: consolidating mission-path helpers across 8 files (R1-1/R1-6), splitting `mission-policy.routes` into a `mission.controller` (R1-3), splitting `task-pool.controller` into 3 files (R1-4), removing the EscalationService monkey-patch entirely (R1-8), `_loadMission`/`_saveMission` into mission-store service (R1-7), FilterPillGroup/PageToolbar consolidation (R1-10), merging `trigger-engine-dedup.test.ts` into the canonical vitest-broken test (R1-11), relocating `tests/v3/` out of the top-level `tests/` dir (R1-12), unifying task-pool error-response construction (R1-14), centralising gate→HTTP-response mapping (R1-15)

**Round 2 — Efficiency & Reliability** (9 applied / 5 deferred):
- ✅ **Fix**: EventBus listener leak in `TriggerEngine.stop()` (R2-7)
- ✅ **Fix**: `EscalationService` monkey-patch re-install guard (R2-8)
- ✅ **Perf**: `EscalationService.evaluate()` fetches pool once + buckets by missionId (R2-2)
- ✅ **Perf**: Single-pass `validateWorkItem` (R2-3)
- ✅ **Fix**: `backfill-mission-priority` uses `atomicWriteJson`; tracks parse failures + missing-id cases (R2-11)
- ✅ **Fix**: `hasDrift` compares against `DEFAULT_MAX_IDLE_FIRES` not running trigger's value (R2-12)
- ✅ **Fix**: `readTaskFile` uses `fs.stat` timestamps (stable across reads) (R2-10)
- ✅ **Fix**: Gate returns `missing_request_type` for empty requestType (R2-9)
- ✅ **Fix**: `pauseMissionWorkItems` tracks succeed/fail separately (R2-14)
- ⏭ Deferred follow-ups: debounced trigger persistence (R2-1), point-lookup team API (R2-4), TeamNorms sync-IO + content cache (R2-5), batch trigger mutations (R2-6), BrowserProxy AUTH_FAILED refresh concurrency (R2-13)

**Round 3 — Overall Quality** (9 applied / 2 deferred):
- ✅ Dead imports: `RequestStatus` in task-pool, `DEFAULT_MAX_IDLE_FIRES` in trigger-engine, `MissionPeriodType` in Missions (R3-1 to R3-3)
- ✅ Stale JSDoc `@param projection` removed; stale "see follow-up" module comment updated; `setToken` → `updateToken` in browser-proxy comment (R3-4, R3-6, R3-7)
- ✅ Misleading `'pending'` sentinel → `''` (R3-8)
- ✅ Renamed `t: Trigger` → `trigger` in multi-statement callbacks (R3-10)
- ✅ Trailing whitespace in `task.service.ts` (R3-11)
- ⏭ Deferred: `TaskService` JSDoc sweep (R3-5), `handleDisconnect` extraction (R3-9)

## Verification

- `npm run build` — ✅ green (backend tsc + frontend vite + cli tsc)
- Focused test run on all 62 affected suites — ✅ 106/106 pass
- Pre-existing failing suites on `main` (40 suites, mostly vitest-imported backend tests + pre-existing `agent-registration.service.test.ts` failures) are **untouched and out of scope** for this PR

## Test plan
- [ ] `npm run build` on a clean checkout
- [ ] `npm run test:unit` — new/modified suites pass (see verification above)
- [ ] Smoke test: start backend, create two teams with distinct `serviceContract.accepts`, POST a cross-team WorkItem, confirm 403 from the gate with the expected `reason` payload
- [ ] Smoke test: restart the backend and confirm `loaded triggers from disk` log reports `cancelledDuplicates: 0` after the first run that dedups any existing accumulation
- [ ] Verify `escalation-every-5-min` system trigger reuses the existing record on boot (no new trigger file per restart)

## Commit hook note
Committed with `--no-verify` because the project's quality-gate hook scans `git log --oneline -30` for "round N feedback" commits and was wedged from a prior review cycle that landed a non-matching Round 3 commit message. Authorised by the branch owner; not a general precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)