### PR TITLE
feat(tasks,ux,pty): skip-dir guard, Dashboard safety timeout, forceKill test

### DIFF
--- a/backend/src/services/project/task.service.test.ts
+++ b/backend/src/services/project/task.service.test.ts
@@ -162,6 +162,28 @@ describe('TaskService', () => {
     });
 
     /**
+     * Non-regular file shapes (FIFOs, device files, symlinks to
+     * directories) should also be skipped, not just plain directories.
+     */
+    it('readTaskFile returns null for non-regular, non-directory entries', async () => {
+      mockFs.readFile.mockResolvedValue('# Fake content' as unknown as Buffer);
+      mockFs.stat.mockResolvedValue({
+        isFile: () => false,
+        isDirectory: () => false,
+        birthtimeMs: Date.now(),
+        mtimeMs: Date.now(),
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+
+      const result = await (
+        taskService as unknown as {
+          readTaskFile: (p: string, m: string) => Promise<unknown>;
+        }
+      ).readTaskFile('/tasks/some.fifo.md', 'm1');
+
+      expect(result).toBeNull();
+    });
+
+    /**
      * Happy path: when the stat call says it IS a file, parsing proceeds.
      */
     it('readTaskFile returns a parsed Task when path is a regular file', async () => {

--- a/backend/src/services/project/task.service.test.ts
+++ b/backend/src/services/project/task.service.test.ts
@@ -134,9 +134,54 @@ describe('TaskService', () => {
      */
     it('should handle file writing operations', async () => {
       mockFs.writeFile.mockResolvedValue(undefined);
-      
+
       await mockFs.writeFile('test.md', 'content');
       expect(mockFs.writeFile).toHaveBeenCalledWith('test.md', 'content');
+    });
+
+    /**
+     * readTaskFile must skip directory entries that happen to end in `.md`.
+     * Without the isFile() guard, readdir-based callers would try to read a
+     * directory path as a file and the error would bubble up.
+     */
+    it('readTaskFile returns null when path points to a directory', async () => {
+      mockFs.readFile.mockResolvedValue('# Fake content' as unknown as Buffer);
+      mockFs.stat.mockResolvedValue({
+        isFile: () => false,
+        birthtimeMs: Date.now(),
+        mtimeMs: Date.now(),
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+
+      const result = await (
+        taskService as unknown as {
+          readTaskFile: (p: string, m: string) => Promise<unknown>;
+        }
+      ).readTaskFile('/tasks/archive.md', 'm1');
+
+      expect(result).toBeNull();
+    });
+
+    /**
+     * Happy path: when the stat call says it IS a file, parsing proceeds.
+     */
+    it('readTaskFile returns a parsed Task when path is a regular file', async () => {
+      mockFs.readFile.mockResolvedValue(
+        '# Hello\n\n**Status:** open\n' as unknown as Buffer,
+      );
+      mockFs.stat.mockResolvedValue({
+        isFile: () => true,
+        birthtimeMs: Date.now(),
+        mtimeMs: Date.now(),
+      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
+
+      const result = (await (
+        taskService as unknown as {
+          readTaskFile: (p: string, m: string) => Promise<Task | null>;
+        }
+      ).readTaskFile('/tasks/real-task.md', 'm1')) as Task | null;
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('real-task');
     });
   });
 

--- a/backend/src/services/project/task.service.ts
+++ b/backend/src/services/project/task.service.ts
@@ -165,9 +165,9 @@ export class TaskService {
         fs.readFile(filePath, 'utf-8'),
         fs.stat(filePath),
       ]);
-      // Skip directory entries that happen to end in `.md` — e.g. a stray
-      // `archive.md/` folder. readFile would have already errored on a
-      // directory, but belt-and-suspenders: bail cleanly if it didn't.
+      // Defensive: bail on anything that isn't a regular file (symlinks
+      // to directories, FIFOs, etc.). Reader loops upstream assume `.md`
+      // names map to files — this guard keeps that assumption honest.
       if (!stats.isFile()) return null;
       const parsed = this.parseMarkdownContent(content);
       const fileBase = path.basename(filePath, '.md');

--- a/backend/src/services/project/task.service.ts
+++ b/backend/src/services/project/task.service.ts
@@ -165,6 +165,10 @@ export class TaskService {
         fs.readFile(filePath, 'utf-8'),
         fs.stat(filePath),
       ]);
+      // Skip directory entries that happen to end in `.md` — e.g. a stray
+      // `archive.md/` folder. readFile would have already errored on a
+      // directory, but belt-and-suspenders: bail cleanly if it didn't.
+      if (!stats.isFile()) return null;
       const parsed = this.parseMarkdownContent(content);
       const fileBase = path.basename(filePath, '.md');
 

--- a/backend/src/services/session/pty/pty-session-backend.test.ts
+++ b/backend/src/services/session/pty/pty-session-backend.test.ts
@@ -122,6 +122,22 @@ describe('PtySessionBackend', () => {
 			await backend!.killSession('test-session');
 			expect(backend!.sessionExists('test-session')).toBe(false);
 		});
+
+		it('should call forceKill instead of kill when killing a session', async () => {
+			const session = await backend!.createSession('force-kill-test', createTestOptions());
+
+			// Spy on forceKill and kill methods on the session instance
+			const forceKillSpy = jest.spyOn(session, 'forceKill').mockResolvedValue(undefined);
+			const killSpy = jest.spyOn(session, 'kill');
+
+			await backend!.killSession('force-kill-test');
+
+			expect(forceKillSpy).toHaveBeenCalledTimes(1);
+			expect(killSpy).not.toHaveBeenCalled();
+
+			forceKillSpy.mockRestore();
+			killSpy.mockRestore();
+		});
 	});
 
 	describe('listSessions', () => {

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { Dashboard } from './Dashboard';
+import { Dashboard, SAFETY_TIMEOUT_MS } from './Dashboard';
 import { apiService } from '../services/api.service';
 
 // Mock the navigate hook
@@ -477,7 +477,12 @@ describe('Dashboard Page', () => {
    * timer stay unaffected.
    */
   describe('Safety timeout', () => {
-    it('surfaces an error after 15s if loading never resolves', async () => {
+    it('exports SAFETY_TIMEOUT_MS as a positive millisecond duration', () => {
+      expect(typeof SAFETY_TIMEOUT_MS).toBe('number');
+      expect(SAFETY_TIMEOUT_MS).toBeGreaterThan(0);
+    });
+
+    it('surfaces an error after the deadline if loading never resolves', async () => {
       vi.useFakeTimers();
       try {
         vi.mocked(apiService.getProjects).mockImplementation(
@@ -495,8 +500,8 @@ describe('Dashboard Page', () => {
 
         expect(screen.getByText('Loading dashboard...')).toBeInTheDocument();
 
-        // Jump past the 15s safety deadline
-        await vi.advanceTimersByTimeAsync(15_001);
+        // Jump past the safety deadline (+1ms headroom)
+        await vi.advanceTimersByTimeAsync(SAFETY_TIMEOUT_MS + 1);
 
         expect(
           screen.getByText(/took too long to load/i),

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -510,5 +510,48 @@ describe('Dashboard Page', () => {
         vi.useRealTimers();
       }
     });
+
+    /**
+     * Edge case introduced by the safety-timeout feature: if the
+     * real API eventually completes AFTER the deadline fired, the
+     * success path must clear the stale "took too long" error so
+     * the user doesn't see fresh data sitting under an error banner.
+     */
+    it('clears the stale safety-timeout error if the real load later succeeds', async () => {
+      vi.useFakeTimers();
+      try {
+        let resolveProjects!: (v: typeof mockProjects) => void;
+        vi.mocked(apiService.getProjects).mockImplementation(
+          () =>
+            new Promise((r) => {
+              resolveProjects = r;
+            }),
+        );
+        vi.mocked(apiService.getTeams).mockResolvedValue(mockTeams);
+
+        render(
+          <TestWrapper>
+            <Dashboard />
+          </TestWrapper>,
+        );
+
+        // Deadline fires first → error is shown
+        await vi.advanceTimersByTimeAsync(SAFETY_TIMEOUT_MS + 1);
+        expect(screen.getByText(/took too long to load/i)).toBeInTheDocument();
+
+        // Now the real request completes. Switch to real timers so
+        // waitFor can poll, then resolve the pending projects promise.
+        vi.useRealTimers();
+        resolveProjects(mockProjects);
+
+        await waitFor(() => {
+          expect(
+            screen.queryByText(/took too long to load/i),
+          ).not.toBeInTheDocument();
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -466,4 +466,44 @@ describe('Dashboard Page', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/projects?create=true');
     });
   });
+
+  /**
+   * Safety timeout: if the initial data load exceeds 15s (e.g. the API is
+   * frozen), the Dashboard bails out of the loading skeleton and shows an
+   * error instead of leaving the user staring at a hung loader.
+   *
+   * Placed in its own describe so `vi.useFakeTimers` / `vi.useRealTimers`
+   * are fully isolated — earlier siblings that rely on `waitFor`'s real
+   * timer stay unaffected.
+   */
+  describe('Safety timeout', () => {
+    it('surfaces an error after 15s if loading never resolves', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(apiService.getProjects).mockImplementation(
+          () => new Promise(() => {}),
+        );
+        vi.mocked(apiService.getTeams).mockImplementation(
+          () => new Promise(() => {}),
+        );
+
+        render(
+          <TestWrapper>
+            <Dashboard />
+          </TestWrapper>,
+        );
+
+        expect(screen.getByText('Loading dashboard...')).toBeInTheDocument();
+
+        // Jump past the 15s safety deadline
+        await vi.advanceTimersByTimeAsync(15_001);
+
+        expect(
+          screen.getByText(/took too long to load/i),
+        ).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -23,6 +23,17 @@ import { Alert } from '@/components/UI/Alert';
 import { Button } from '@/components/UI/Button';
 
 
+/**
+ * Hard upper bound on initial-load latency. If `loadData` hasn't settled
+ * by this deadline, we drop the skeleton and show an error so the user
+ * isn't staring at a frozen loader. Tuned to cover reasonably slow
+ * networks while still surfacing genuinely stuck requests.
+ *
+ * Exported for tests that want to pin the contract without hardcoding
+ * the value.
+ */
+export const SAFETY_TIMEOUT_MS = 15_000;
+
 interface ProjectProgress {
   projectId: string;
   progressPercent: number;
@@ -84,13 +95,13 @@ export const Dashboard: React.FC = () => {
   }, []);
 
   /**
-   * Safety timeout: if loading exceeds 15s, force-stop and show error.
-   * Prevents the skeleton from being stuck indefinitely on slow/failed requests.
+   * Safety timeout: if loading exceeds SAFETY_TIMEOUT_MS, bail out of the
+   * skeleton and surface an error. Cleanup cancels the timer the moment
+   * loading flips false, so the happy path pays nothing.
    */
   useEffect(() => {
     if (!loading) return;
 
-    const SAFETY_TIMEOUT_MS = 15_000;
     const timer = setTimeout(() => {
       setLoading(false);
       setError('Dashboard took too long to load. Please try again.');

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -83,6 +83,22 @@ export const Dashboard: React.FC = () => {
     loadData();
   }, []);
 
+  /**
+   * Safety timeout: if loading exceeds 15s, force-stop and show error.
+   * Prevents the skeleton from being stuck indefinitely on slow/failed requests.
+   */
+  useEffect(() => {
+    if (!loading) return;
+
+    const SAFETY_TIMEOUT_MS = 15_000;
+    const timer = setTimeout(() => {
+      setLoading(false);
+      setError('Dashboard took too long to load. Please try again.');
+    }, SAFETY_TIMEOUT_MS);
+
+    return () => clearTimeout(timer);
+  }, [loading]);
+
   const calculateProjectProgress = async (projectId: string): Promise<ProjectProgress> => {
     try {
       const tasks = await apiService.getAllTasks(projectId);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -211,6 +211,10 @@ export const Dashboard: React.FC = () => {
         return acc;
       }, {} as Record<string, Team[]>);
       setTeamsMap(teamsMapping);
+      // Clear any error that was set by the safety timeout before this
+      // (slow) request eventually succeeded — otherwise the user would
+      // see fresh data sitting under a stale "took too long" banner.
+      setError(null);
     } catch (err) {
       logSilentError(err, { context: 'Loading dashboard data', level: 'error' });
       setError('Failed to load dashboard data. Please try again.');


### PR DESCRIPTION
## Summary

Three small, independent pieces surgically extracted from the stale `feat/computer-use-v2-and-zombie-fix` stash — each a real net-new bug/UX fix against current `main`.

- **`backend/src/services/project/task.service.ts`** — `readTaskFile` now short-circuits with an `isFile()` check before parsing, so symlinks, FIFOs, and stray `.md`-suffixed directories can't crash the reader loop.
- **`frontend/src/pages/Dashboard.tsx`** — exports `SAFETY_TIMEOUT_MS` (15s) and wires a bail-out useEffect: if loading never resolves, the skeleton is replaced with an error so the user isn't staring at a frozen loader. Success path also clears any stale safety-timeout error for the slow-but-eventually-succeeded case.
- **`backend/src/services/session/pty/pty-session-backend.test.ts`** — regression guard for the zombie-fix: pins that `killSession` calls `forceKill()` (immediate SIGKILL) rather than `kill()` (which node-pty can defer).

## Three-round review

### Round 1 — refactor & consistency
- **R1.1** Hoist `SAFETY_TIMEOUT_MS` from inside the useEffect to a module-level, exported const with a doc comment. Easier to spot for future tuning; tests pin the contract via the export instead of hardcoding `15_000`.

### Round 2 — efficiency & reliability
- **R2.1** Dashboard: clear the stale safety-timeout error when the real load eventually succeeds AFTER the deadline fired. Without this, the user sees fresh data rendered under a "took too long to load" banner.

### Round 3 — overall quality
- **Q3.1** Tighten the `isFile()` comment in `readTaskFile`: clarify that the guard is *defensive* (catches symlinks, FIFOs, future reader drift), not merely "belt-and-suspenders". Adds a FIFO-style test case to lock the broader defensive claim.

## Verification

- Backend: `npx jest backend/src/services/project/task.service.test.ts` — **15/15 pass**
- Backend pty: `npm run test:pty` — **45/45 pass**
- Frontend: `npx vitest run src/pages/Dashboard.test.tsx` — **22/22 pass**
- Typechecks clean on both sides
- `npm run build:backend` and `cd frontend && npm run build` — both clean

## What was NOT extracted

The original stash touched 38 files / 1077 insertions; 35 of those were already-landed variants on main. Dropped from scope: `v3-data.service.ts` auto-claim (main already has a better version with `{ types: ['delegate'] }` filter), `brand-onboarding.*`, `mission.types.ts`, `api.routes.ts` / `slack-orchestrator-bridge.ts` new methods, `frontend/api.service.ts` onboarding methods, and the frontend Chat/Navigation/MissionDetail renames — all already on main.

## Test plan

- [x] Unit tests pass across all three modules
- [x] Typechecks + builds clean
- [ ] Smoke: put a `weird-dir.md/` folder under `.crewly/tasks/` — verify the task loader doesn't crash
- [ ] Smoke: simulate a hung `/api/projects` endpoint — verify the 15s error surfaces and the skeleton goes away

🤖 Generated with [Claude Code](https://claude.com/claude-code)