### PR TITLE
fix(slack): wire completion reaction + align offline-both test

### DIFF
--- a/backend/src/controllers/chat/chat.controller.ts
+++ b/backend/src/controllers/chat/chat.controller.ts
@@ -447,7 +447,10 @@ export async function agentResponse(
                 threadTs: threads[0].threadTs,
               });
 
-              // Add ✅ reaction to the original message that triggered this task
+              // If a pending reaction was stored when the message arrived
+              // (orchestrator-routed path sets a 👀 on the trigger message),
+              // flip it to ✅ now that the agent reply has been delivered.
+              // No-op when there's no pending entry for this thread.
               await bridge.addCompletionReaction(threads[0].channelId, threads[0].threadTs);
             }
           }

--- a/backend/src/controllers/chat/chat.controller.ts
+++ b/backend/src/controllers/chat/chat.controller.ts
@@ -446,6 +446,9 @@ export async function agentResponse(
                 channelId: threads[0].channelId,
                 threadTs: threads[0].threadTs,
               });
+
+              // Add ✅ reaction to the original message that triggered this task
+              await bridge.addCompletionReaction(threads[0].channelId, threads[0].threadTs);
             }
           }
         }

--- a/backend/src/services/slack/slack-orchestrator-bridge.test.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.test.ts
@@ -1396,16 +1396,22 @@ describe('SlackOrchestratorBridge', () => {
       expect((bridge as any).pendingReactions.has('C123:1707.001')).toBe(false);
     });
 
-    it('should not react when no pending reaction exists', async () => {
+    it('should not react when no pending reaction exists (no-op contract)', async () => {
       const bridge = new SlackOrchestratorBridge({ showTypingIndicator: true });
       await bridge.initialize();
 
       const slackService = (bridge as any).slackService;
       jest.spyOn(slackService, 'addReaction').mockResolvedValue(undefined);
 
-      await (bridge as any).addCompletionReaction('C123', '1707.001');
+      // Contract (R1 comment in chat.controller.ts): calling with a thread
+      // that has no pending reaction is a no-op — no addReaction call, no
+      // throw, and the Map stays unchanged.
+      await expect(
+        (bridge as any).addCompletionReaction('C123', '1707.001'),
+      ).resolves.toBeUndefined();
 
       expect(slackService.addReaction).not.toHaveBeenCalled();
+      expect((bridge as any).pendingReactions.size).toBe(0);
     });
 
     it('should handle addReaction errors gracefully', async () => {

--- a/backend/src/services/slack/slack-orchestrator-bridge.test.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.test.ts
@@ -1109,10 +1109,11 @@ describe('SlackOrchestratorBridge', () => {
 
       const event = await handledPromise;
 
-      // Should NOT route to auditor queue
-      expect(mockQueueService.enqueue).not.toHaveBeenCalled();
-      // Response is the offline message
+      // #247: Should route to the orchestrator queue for replay when both are offline
+      expect(mockQueueService.enqueue).toHaveBeenCalled();
+      // Response is the offline/queued message
       expect(event.response).toContain('offline');
+      expect(event.response).toContain('queued');
     }, 15000);
 
     it('should include FALLBACK marker in auditor-routed messages', () => {

--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -1222,6 +1222,37 @@ Just type naturally to chat with the orchestrator!`;
   }
 
   /**
+   * Add a completion reaction (✅) to a message that was previously
+   * stored as a pending reaction. Consumes the pending reaction.
+   *
+   * @param channelId - Slack channel ID
+   * @param threadTs - Thread timestamp (key for lookup)
+   */
+  public async addCompletionReaction(channelId: string, threadTs: string): Promise<void> {
+    const key = `${channelId}:${threadTs}`;
+    const messageTs = this.pendingReactions.get(key);
+
+    if (messageTs) {
+      // Consume the pending reaction
+      this.pendingReactions.delete(key);
+
+      try {
+        await this.slackService.addReaction(channelId, messageTs, 'white_check_mark');
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        // Suppress "already_reacted" errors as they are common and non-fatal
+        if (errMsg.includes('already_reacted')) {
+          return;
+        }
+        // Suppress "missing_scope" since we already log/warn about that elsewhere
+        if (!errMsg.includes('missing_scope')) {
+          this.logger.warn('Failed to add completion reaction', { channelId, messageTs, error: errMsg });
+        }
+      }
+    }
+  }
+
+  /**
    * Record response to thread store. Slack delivery is handled exclusively
    * by the reply-slack skill via the API — no terminal output fallback needed.
    *


### PR DESCRIPTION
## Summary

Closes two latent gaps around the Slack orchestrator bridge that were sitting in a working-tree stash from earlier today:

### 1. Consume `pendingReactions` — the half-wired ✅ reaction

The bridge stores `pendingReactions.set(key, message.ts)` for every orchestrator-routed message (`slack-orchestrator-bridge.ts:410`), with a comment that says `"so addCompletionReaction() can find it when the reply arrives."` But `addCompletionReaction()` **didn't exist on main** — the Map was populated and never consumed. Symptom: users never saw a ✅ reaction after the orchestrator replied, even though the infrastructure was wired up.

This PR adds the missing public method and a call site in the chat controller that fires after the agent response is delivered.

### 2. Align the offline-both test with actual production behavior (`#247`)

The production path at `slack-orchestrator-bridge.ts:632` already implements `#247` — when both the orchestrator and the auditor are offline, the message is enqueued for replay and the response contains "queued". The matching test still expected the old "drop silently, return plain offline message" behavior, so it was a **stable failing test** on main.

Before (failing on main):
```ts
expect(mockQueueService.enqueue).not.toHaveBeenCalled();
expect(event.response).toContain('offline');
```

After:
```ts
expect(mockQueueService.enqueue).toHaveBeenCalled();
expect(event.response).toContain('offline');
expect(event.response).toContain('queued');
```

## Verification

- Previously failing test — `should return offline message when both orchestrator and auditor are inactive` — now passes (`1 passed, 92 skipped` with the testNamePattern filter).
- `npx tsc --noEmit -p backend/tsconfig.json` — clean.

## Review approach

Standard 3-round code review on this small surface area:
- Round 1: refactor & consistency
- Round 2: efficiency & reliability
- Round 3: overall quality

## Test plan

- [x] The named test passes
- [x] Typecheck clean
- [ ] Smoke: trigger an orchestrator-routed Slack message, see the 👀 → ✅ transition on the original message after the agent replies
- [ ] Smoke: with both orchestrator + auditor offline, send a Slack message, confirm response contains both "offline" and "queued"

🤖 Generated with [Claude Code](https://claude.com/claude-code)