### PR TITLE
feat(gmail): v1.1.0 — 9-action Gmail skill (labels + read/unread + scope fix)

### DIFF
--- a/backend/src/constants.test.ts
+++ b/backend/src/constants.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for backend/src/constants.ts.
+ *
+ * `constants.ts` is a large central config file. Rather than asserting on
+ * every value (which would just duplicate the source), this test focuses on
+ * the constants where wrong values would silently break a flow — most
+ * critically the OAuth scope set used to issue new Google credentials.
+ */
+import {
+  GOOGLE_OAUTH_CONSTANTS,
+} from './constants.js';
+
+describe('GOOGLE_OAUTH_CONSTANTS', () => {
+  describe('DEFAULT_SCOPES', () => {
+    const scopes = GOOGLE_OAUTH_CONSTANTS.DEFAULT_SCOPES;
+
+    it('uses gmail.modify as the single Gmail scope so all 9 actions of the agent gmail skill work without re-auth', () => {
+      // gmail.modify is a Google-side functional superset that covers
+      // gmail.readonly + gmail.send + label/state mutations. Crewly's
+      // skill-executor does string-exact scope matching, so declaring
+      // gmail.modify alone is what makes the agent gmail skill (which
+      // requires gmail.modify) accept credentials minted via this flow.
+      const gmailScopes = scopes.filter((s) => s.includes('gmail'));
+      expect(gmailScopes).toEqual(['https://www.googleapis.com/auth/gmail.modify']);
+    });
+
+    it('does NOT request gmail.readonly or gmail.send separately (gmail.modify covers them)', () => {
+      expect(scopes).not.toContain('https://www.googleapis.com/auth/gmail.readonly');
+      expect(scopes).not.toContain('https://www.googleapis.com/auth/gmail.send');
+    });
+
+    it('includes openid + email for user identity resolution', () => {
+      expect(scopes).toContain('openid');
+      expect(scopes).toContain('email');
+    });
+
+    it('is non-empty (defaults must be populated)', () => {
+      expect(scopes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('endpoint URLs', () => {
+    it('points AUTH_BASE_URL at Google production OAuth endpoint', () => {
+      expect(GOOGLE_OAUTH_CONSTANTS.AUTH_BASE_URL).toBe(
+        'https://accounts.google.com/o/oauth2/v2/auth',
+      );
+    });
+
+    it('points TOKEN_ENDPOINT at the Google token endpoint', () => {
+      expect(GOOGLE_OAUTH_CONSTANTS.TOKEN_ENDPOINT).toBe(
+        'https://oauth2.googleapis.com/token',
+      );
+    });
+
+    it('points USERINFO_ENDPOINT at the Google userinfo endpoint', () => {
+      expect(GOOGLE_OAUTH_CONSTANTS.USERINFO_ENDPOINT).toBe(
+        'https://www.googleapis.com/oauth2/v2/userinfo',
+      );
+    });
+  });
+
+  describe('WORKSPACE_SCOPES', () => {
+    it('exposes a broader workspace set for skills that need Drive/Calendar/Docs', () => {
+      // This is intentionally separate from DEFAULT_SCOPES — skills that
+      // need broader access can request these via the explicit override
+      // path on /credentials/oauth/google/start.
+      const ws = GOOGLE_OAUTH_CONSTANTS.WORKSPACE_SCOPES;
+      expect(Array.isArray(ws)).toBe(true);
+      expect(ws.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1109,11 +1109,20 @@ export const GOOGLE_OAUTH_CONSTANTS = {
 	AUTH_BASE_URL: 'https://accounts.google.com/o/oauth2/v2/auth',
 	TOKEN_ENDPOINT: 'https://oauth2.googleapis.com/token',
 	USERINFO_ENDPOINT: 'https://www.googleapis.com/oauth2/v2/userinfo',
+	/**
+	 * Default OAuth scopes requested by the standalone /api/oauth/google flow.
+	 *
+	 * `gmail.modify` is a Google-side functional superset that covers
+	 * `gmail.readonly`, `gmail.send`, and label/state mutations. Declaring
+	 * the single most-capable Gmail scope here means new credentials issued
+	 * via this flow can drive all 9 actions of the agent `gmail` skill on
+	 * one OAuth grant — no re-auth required when an agent moves from
+	 * read-only to send to label management.
+	 */
 	DEFAULT_SCOPES: [
 		'openid',
 		'email',
-		'https://www.googleapis.com/auth/gmail.readonly',
-		'https://www.googleapis.com/auth/gmail.send',
+		'https://www.googleapis.com/auth/gmail.modify',
 	],
 	/** Google Workspace scopes for agent-driven operations (Phase 1). */
 	WORKSPACE_SCOPES: [

--- a/config/skills/agent/marketplace/gmail/SKILL.md
+++ b/config/skills/agent/marketplace/gmail/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: Gmail
+description: "List, read, search, and send Gmail messages for a Google account. Requires a google-oauth credential bound to the 'gmail' slot."
+version: 1.0.0
+category: communication
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+  - assistant
+triggers:
+  - send email
+  - reply to email
+  - search gmail
+  - list emails
+  - read email
+  - check inbox
+  - find email
+tags:
+  - gmail
+  - email
+  - oauth
+  - google
+  - send
+  - search
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 30000
+credentials:
+  - slot: gmail
+    type: google-oauth
+    provider: google
+    required: true
+    requiredScopes:
+      - https://www.googleapis.com/auth/gmail.readonly
+      - https://www.googleapis.com/auth/gmail.send
+    description: "Google account for Gmail operations (list, read, search, send)."
+notices:
+  - type: requirement
+    message: "Requires a Google account added in Settings → Credentials with both gmail.readonly and gmail.send scopes."
+---
+
+# Gmail (multi-action)
+
+Multi-action Gmail skill that lets agents `list`, `read`, `search`, and `send`
+messages on behalf of a connected Google account. The account is selected at
+execution time via the `gmail` credential slot, so the same skill can be reused
+across multiple Google accounts.
+
+> Note: a separate `gmail-reader` skill (read-only, plain-text output) is kept
+> for the orchestrator's `credential-manager read-gmail` action. This skill is
+> the structured-JSON, full-feature version intended for direct agent use.
+
+## Usage
+
+Run via `crewly_execute_skill` with `credentialBindings.gmail` set to the
+credential UUID of the Google account to use. Pass a JSON object on argv[1]
+specifying the action and its parameters.
+
+```bash
+# Direct invocation (env vars must be set by the executor)
+bash execute.sh '{"action":"list","q":"is:unread in:inbox","maxResults":10}'
+bash execute.sh '{"action":"read","id":"18fa7b..."}'
+bash execute.sh '{"action":"search","q":"from:foo@bar.com","maxResults":5}'
+bash execute.sh '{"action":"send","to":"a@b.com","subject":"Hello","body":"Hi there."}'
+```
+
+## Actions
+
+### `list` / `search`
+
+List messages matching a Gmail search query. `search` is an alias for `list`.
+
+**Input:**
+```json
+{"action":"list", "q":"is:unread in:inbox", "maxResults":10}
+```
+- `q` (optional) — Gmail search query. Defaults to `is:unread in:inbox`.
+- `maxResults` (optional) — Number of messages to return. Clamped 1..50, default 10.
+
+**Output:**
+```json
+{
+  "success": true,
+  "account": "info@steam-fun.com",
+  "query": "is:unread in:inbox",
+  "count": 3,
+  "messages": [
+    {"id":"18f...", "threadId":"18e...", "subject":"...", "from":"...", "date":"...", "snippet":"..."}
+  ]
+}
+```
+
+### `read`
+
+Fetch a single message by ID and return decoded headers + body.
+
+**Input:**
+```json
+{"action":"read", "id":"18fa7b..."}
+```
+- `id` (required) — Gmail message id (from a `list` result).
+
+**Output:**
+```json
+{
+  "success": true,
+  "id": "18fa7b...",
+  "threadId": "...",
+  "headers": {"from":"...", "to":"...", "cc":"...", "subject":"...", "date":"..."},
+  "body": "decoded plain text body",
+  "bodyHtml": "<...> (only if no text/plain part exists)",
+  "snippet": "..."
+}
+```
+
+### `send`
+
+Send a new email via the bound Google account.
+
+**Input:**
+```json
+{"action":"send", "to":"a@b.com", "subject":"Hello", "body":"Plain text.", "cc":"x@y.com", "bcc":"z@y.com"}
+```
+- `to` (required) — Recipient address. Comma-separated list allowed.
+- `subject` (required) — Subject line.
+- `body` (required) — Plain-text body.
+- `cc`, `bcc` (optional) — CC / BCC recipients.
+
+**Output:**
+```json
+{"success": true, "id": "18fa...", "threadId": "..."}
+```
+
+## Required Env (injected by the skill executor)
+
+- `CREWLY_CRED_GMAIL_ACCESS_TOKEN` — valid OAuth access token with `gmail.readonly` and `gmail.send`
+- `CREWLY_CRED_GMAIL_EMAIL` — account email (used as `From:` in `send`)
+
+The Crewly skill executor refreshes the access token before spawning this
+script. Token refresh failures and missing-scope errors are surfaced by the
+executor before this script ever runs — this script does NOT touch refresh
+tokens or scope checks.
+
+## Errors
+
+- **Exit 1** — input/usage error (missing token, missing required field, unknown action).
+- **Exit 2** — Gmail API error (4xx/5xx).
+
+Raw access tokens and refresh tokens are never printed to stdout/stderr.

--- a/config/skills/agent/marketplace/gmail/SKILL.md
+++ b/config/skills/agent/marketplace/gmail/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Gmail
-description: "List, read, search, and send Gmail messages for a Google account. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope."
-version: 1.0.0
+description: "Multi-action Gmail skill for agents — list/read/search/send messages, manage labels (add/remove/list), and toggle read/unread. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope."
+version: 1.1.0
 category: communication
 skillType: claude-skill
 assignableRoles:
@@ -15,6 +15,11 @@ triggers:
   - read email
   - check inbox
   - find email
+  - mark email as read
+  - mark email as unread
+  - add label to email
+  - remove label from email
+  - list gmail labels
 tags:
   - gmail
   - email
@@ -22,6 +27,8 @@ tags:
   - google
   - send
   - search
+  - labels
+  - modify
 execution:
   type: script
   script:
@@ -35,22 +42,30 @@ credentials:
     required: true
     requiredScopes:
       - https://www.googleapis.com/auth/gmail.modify
-    description: "Google account for Gmail operations. gmail.modify is a functional superset that covers read, send, and modify — one scope unlocks every action."
+    description: "Google account for Gmail operations. gmail.modify is a functional superset that covers read, send, label management, and read/unread toggling — one scope unlocks all 9 actions."
 notices:
   - type: requirement
     message: "Requires a Google account added in Settings → Credentials with the gmail.modify scope (the default Crewly OAuth flow grants it automatically)."
 ---
 
-# Gmail (multi-action)
+# Gmail (multi-action, v1.1.0)
 
-Multi-action Gmail skill that lets agents `list`, `read`, `search`, and `send`
-messages on behalf of a connected Google account. The account is selected at
-execution time via the `gmail` credential slot, so the same skill can be reused
-across multiple Google accounts.
+Multi-action Gmail skill that lets agents manage messages and labels on behalf
+of a connected Google account. The account is selected at execution time via
+the `gmail` credential slot, so the same skill can be reused across multiple
+Google accounts (e.g., work vs personal).
 
 > Note: a separate `gmail-reader` skill (read-only, plain-text output) is kept
 > for the orchestrator's `credential-manager read-gmail` action. This skill is
 > the structured-JSON, full-feature version intended for direct agent use.
+
+## Why a single `gmail.modify` scope?
+
+`gmail.modify` is a Google-side functional superset that covers `gmail.readonly`,
+`gmail.send`, and label/state mutations. The Crewly skill executor performs
+**string-exact** scope matching (no superset awareness), so declaring the
+single most-capable scope keeps the requirement check simple and lets all 9
+actions share one OAuth grant.
 
 ## Usage
 
@@ -64,13 +79,21 @@ bash execute.sh '{"action":"list","q":"is:unread in:inbox","maxResults":10}'
 bash execute.sh '{"action":"read","id":"18fa7b..."}'
 bash execute.sh '{"action":"search","q":"from:foo@bar.com","maxResults":5}'
 bash execute.sh '{"action":"send","to":"a@b.com","subject":"Hello","body":"Hi there."}'
+bash execute.sh '{"action":"list-labels"}'
+bash execute.sh '{"action":"add-label","id":"18fa...","labelId":"Label_5"}'
+bash execute.sh '{"action":"remove-label","id":"18fa...","labelId":"Label_5"}'
+bash execute.sh '{"action":"mark-as-read","id":"18fa..."}'
+bash execute.sh '{"action":"mark-as-unread","id":"18fa..."}'
 ```
 
 ## Actions
 
-### `list` / `search`
+### Email operations
 
-List messages matching a Gmail search query. `search` is an alias for `list`.
+#### `list` / `search`
+
+List messages matching a Gmail search query. `search` is an alias for
+`list` (shares code).
 
 **Input:**
 ```json
@@ -92,7 +115,7 @@ List messages matching a Gmail search query. `search` is an alias for `list`.
 }
 ```
 
-### `read`
+#### `read`
 
 Fetch a single message by ID and return decoded headers + body.
 
@@ -108,6 +131,7 @@ Fetch a single message by ID and return decoded headers + body.
   "success": true,
   "id": "18fa7b...",
   "threadId": "...",
+  "labelIds": ["INBOX","UNREAD"],
   "headers": {"from":"...", "to":"...", "cc":"...", "subject":"...", "date":"..."},
   "body": "decoded plain text body",
   "bodyHtml": "<...> (only if no text/plain part exists)",
@@ -115,7 +139,11 @@ Fetch a single message by ID and return decoded headers + body.
 }
 ```
 
-### `send`
+The body extraction walks `payload.parts[]` recursively and prefers
+`text/plain`. If only `text/html` is available, the HTML is returned as
+`bodyHtml` and a tag-stripped plaintext fallback is placed in `body`.
+
+#### `send`
 
 Send a new email via the bound Google account.
 
@@ -133,13 +161,64 @@ Send a new email via the bound Google account.
 {"success": true, "id": "18fa...", "threadId": "..."}
 ```
 
-## Why a single `gmail.modify` scope?
+### Label management
 
-`gmail.modify` is a Google-side functional superset that covers `gmail.readonly`,
-`gmail.send`, and label/state mutations. The Crewly skill executor performs
-**string-exact** scope matching (no superset awareness), so declaring the
-single most-capable scope keeps the requirement check simple and lets all
-present and future actions share one OAuth grant.
+#### `list-labels`
+
+List all labels on the account (system + user-defined). Call this before
+`add-label` to discover valid label IDs.
+
+**Input:**
+```json
+{"action":"list-labels"}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "account": "info@steam-fun.com",
+  "count": 12,
+  "labels": [
+    {"id":"INBOX", "name":"INBOX", "type":"system"},
+    {"id":"UNREAD", "name":"UNREAD", "type":"system"},
+    {"id":"Label_5", "name":"Work", "type":"user"}
+  ]
+}
+```
+
+#### `add-label` / `remove-label`
+
+Add or remove one or more labels on a message.
+
+**Input:**
+```json
+{"action":"add-label", "id":"18fa7b...", "labelId":"Label_5"}
+{"action":"remove-label", "id":"18fa7b...", "labelIds":["Label_5","Label_7"]}
+```
+- `id` (required) — Gmail message id.
+- `labelId` (string) OR `labelIds` (array) (required, at least one) — Label IDs to add/remove. The script accepts either form.
+
+**Output:**
+```json
+{"success": true, "id":"18fa7b...", "threadId":"...", "labelIds":["INBOX","Label_5","UNREAD"]}
+```
+The `labelIds` array reflects the post-modification state of the message.
+
+### Status management
+
+#### `mark-as-read` / `mark-as-unread`
+
+Convenience wrappers that toggle the system `UNREAD` label.
+
+**Input:**
+```json
+{"action":"mark-as-read", "id":"18fa7b..."}
+{"action":"mark-as-unread", "id":"18fa7b..."}
+```
+- `id` (required) — Gmail message id.
+
+**Output:** identical to `add-label` / `remove-label` (includes `labelIds` so the agent can confirm the transition).
 
 ## Required Env (injected by the skill executor)
 
@@ -153,7 +232,21 @@ tokens or scope checks.
 
 ## Errors
 
-- **Exit 1** — input/usage error (missing token, missing required field, unknown action).
-- **Exit 2** — Gmail API error (4xx/5xx).
+- **Exit 1** — input/usage error (missing token, missing required field, unknown action). JSON `{"success":false,"error":"..."}` on stdout, human message on stderr.
+- **Exit 2** — Gmail API error (4xx/5xx). JSON `{"success":false,"error":"..."}` on stdout, status + Google's error message on stderr.
 
 Raw access tokens and refresh tokens are never printed to stdout/stderr.
+
+## How the credential is resolved
+
+Crewly's skill executor reads the `credentials:` frontmatter above, looks up
+the credential bound to the `gmail` slot (either from `credentialBindings`
+passed to `crewly_execute_skill`, or this skill's default), refreshes the
+access token if needed, and injects it as `CREWLY_CRED_GMAIL_ACCESS_TOKEN`
+before spawning this script. Output is auto-redacted of any injected secrets
+before being returned to the agent.
+
+## Changelog
+
+- **1.1.0** — added `add-label`, `remove-label`, `list-labels`, `mark-as-read`, `mark-as-unread`. Reduced `requiredScopes` to single `gmail.modify` (functional superset for all 9 actions).
+- **1.0.0** — initial release with `list`, `read`, `search`, `send`.

--- a/config/skills/agent/marketplace/gmail/SKILL.md
+++ b/config/skills/agent/marketplace/gmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Gmail
-description: "List, read, search, and send Gmail messages for a Google account. Requires a google-oauth credential bound to the 'gmail' slot."
+description: "List, read, search, and send Gmail messages for a Google account. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope."
 version: 1.0.0
 category: communication
 skillType: claude-skill
@@ -34,12 +34,11 @@ credentials:
     provider: google
     required: true
     requiredScopes:
-      - https://www.googleapis.com/auth/gmail.readonly
-      - https://www.googleapis.com/auth/gmail.send
-    description: "Google account for Gmail operations (list, read, search, send)."
+      - https://www.googleapis.com/auth/gmail.modify
+    description: "Google account for Gmail operations. gmail.modify is a functional superset that covers read, send, and modify — one scope unlocks every action."
 notices:
   - type: requirement
-    message: "Requires a Google account added in Settings → Credentials with both gmail.readonly and gmail.send scopes."
+    message: "Requires a Google account added in Settings → Credentials with the gmail.modify scope (the default Crewly OAuth flow grants it automatically)."
 ---
 
 # Gmail (multi-action)
@@ -134,9 +133,17 @@ Send a new email via the bound Google account.
 {"success": true, "id": "18fa...", "threadId": "..."}
 ```
 
+## Why a single `gmail.modify` scope?
+
+`gmail.modify` is a Google-side functional superset that covers `gmail.readonly`,
+`gmail.send`, and label/state mutations. The Crewly skill executor performs
+**string-exact** scope matching (no superset awareness), so declaring the
+single most-capable scope keeps the requirement check simple and lets all
+present and future actions share one OAuth grant.
+
 ## Required Env (injected by the skill executor)
 
-- `CREWLY_CRED_GMAIL_ACCESS_TOKEN` — valid OAuth access token with `gmail.readonly` and `gmail.send`
+- `CREWLY_CRED_GMAIL_ACCESS_TOKEN` — valid OAuth access token with `gmail.modify`
 - `CREWLY_CRED_GMAIL_EMAIL` — account email (used as `From:` in `send`)
 
 The Crewly skill executor refreshes the access token before spawning this

--- a/config/skills/agent/marketplace/gmail/execute.live.test.sh
+++ b/config/skills/agent/marketplace/gmail/execute.live.test.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+#
+# Happy-path tests for the gmail multi-action skill.
+#
+# Why this file exists (in addition to execute.test.sh):
+#
+# `execute.test.sh` covers input/usage error paths only — every API-touching
+# test there uses a fake token and asserts only `exit != 0`. That is NOT
+# sufficient to catch bugs in the success path. The v1.1.0 ship had a
+# subshell-scope bug in the HTTP status capture that mis-classified every
+# successful 200 as a failure; the 52-test suite passed anyway because the
+# fake token genuinely caused a 401 from Google, which yielded the same
+# non-zero exit code (for a different reason). False green.
+#
+# This file boots a local Python mock server that mirrors the Gmail API
+# routes the skill calls, points the skill at it via the GMAIL_API_BASE env
+# var, and asserts on the actual JSON output of every action — including a
+# 401 negative path that confirms the error branch fires for the *real*
+# reason and not an artifact of broken parsing.
+#
+# Requirements: python3 (stdlib only — http.server / json / threading).
+#
+# Run from anywhere:
+#     bash config/skills/agent/marketplace/gmail/execute.live.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXECUTE="$SCRIPT_DIR/execute.sh"
+MOCK_PY="$SCRIPT_DIR/mock-gmail-server.py"
+
+PASS=0
+FAIL=0
+MOCK_PID=""
+MOCK_PORT=""
+
+cleanup() {
+  if [ -n "$MOCK_PID" ]; then
+    kill -TERM "$MOCK_PID" 2>/dev/null || true
+    sleep 0.2
+    kill -9 "$MOCK_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+start_mock() {
+  local mode="${1:-pass}"
+  local port_file
+  port_file=$(mktemp)
+
+  # Boot mock and read the LISTENING line for its bound port.
+  python3 "$MOCK_PY" --port 0 --token-mode "$mode" >"$port_file" 2>/dev/null &
+  MOCK_PID=$!
+
+  # Wait up to 5s for the LISTENING line.
+  local i=0
+  while [ "$i" -lt 50 ]; do
+    if grep -q "^LISTENING " "$port_file" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+
+  if ! grep -q "^LISTENING " "$port_file" 2>/dev/null; then
+    echo "FAIL: mock server did not announce LISTENING within 5s"
+    rm -f "$port_file"
+    return 1
+  fi
+
+  MOCK_PORT=$(awk '/^LISTENING / {print $2; exit}' "$port_file")
+  rm -f "$port_file"
+  return 0
+}
+
+stop_mock() {
+  if [ -n "$MOCK_PID" ]; then
+    # SIGTERM first; if that doesn't kill it within a short grace period the
+    # SIGKILL falls back. We bypass `wait` because Python's http.server can
+    # block on its own thread shutdown longer than the test wants to wait.
+    kill -TERM "$MOCK_PID" 2>/dev/null || true
+    local i=0
+    while kill -0 "$MOCK_PID" 2>/dev/null; do
+      [ "$i" -ge 10 ] && break
+      sleep 0.1
+      i=$((i + 1))
+    done
+    if kill -0 "$MOCK_PID" 2>/dev/null; then
+      kill -9 "$MOCK_PID" 2>/dev/null || true
+    fi
+  fi
+  MOCK_PID=""
+}
+
+# call INPUT_JSON OUT_BODY_VAR OUT_EXIT_VAR
+#
+# Invoke the skill with the given JSON input against the running mock,
+# writing the skill's stdout into the caller-named OUT_BODY_VAR and its
+# exit code into OUT_EXIT_VAR. MUST be called directly (no `$(...)`) so the
+# `printf -v` writes into the caller's shell scope. (The same lesson the
+# v1.1.0 fix taught us — see execute.sh's gmail_call docstring.)
+call() {
+  local input="$1" out_var="$2" exit_var="$3"
+  local out
+  out=$(GMAIL_API_BASE="http://127.0.0.1:${MOCK_PORT}/gmail/v1/users/me" \
+    CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.mock-token-for-tests" \
+    CREWLY_CRED_GMAIL_EMAIL="test@example.com" \
+    bash "$EXECUTE" "$input" 2>/dev/null)
+  local code=$?
+  printf -v "$out_var" '%s' "$out"
+  printf -v "$exit_var" '%s' "$code"
+}
+
+assert() {
+  local desc="$1" cond="$2"
+  if [ "$cond" = "1" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# jget JSON JQ_FILTER  -> echoes value or empty
+jget() {
+  printf '%s' "$1" | jq -r "$2" 2>/dev/null
+}
+
+echo "=== gmail skill happy-path tests (against local mock server) ==="
+
+# --- Boot the mock in pass-through mode ------------------------------------
+if ! start_mock pass; then
+  echo "FATAL: could not start mock server — aborting"
+  exit 1
+fi
+echo "Mock listening on 127.0.0.1:${MOCK_PORT}"
+
+# --- 1. list ---------------------------------------------------------------
+echo ""
+echo "Test 1: list returns success:true with messages array"
+call '{"action":"list","q":"is:unread in:inbox","maxResults":3}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "count >= 1" "$([ "$(jget "$OUT" '.count')" -ge 1 ] && echo 1)"
+assert "first message id matches mock" \
+  "$([ "$(jget "$OUT" '.messages[0].id')" = "MSG_TEST_001" ] && echo 1)"
+assert "first message subject populated" \
+  "$([ -n "$(jget "$OUT" '.messages[0].subject')" ] && echo 1)"
+
+# --- 2. search (alias of list) ---------------------------------------------
+echo ""
+echo "Test 2: search returns success:true (same shape as list)"
+call '{"action":"search","q":"subject:mock","maxResults":2}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "echo of query in payload" "$([ "$(jget "$OUT" '.query')" = "subject:mock" ] && echo 1)"
+
+# --- 3. read ---------------------------------------------------------------
+echo ""
+echo "Test 3: read returns success:true with decoded body"
+call '{"action":"read","id":"MSG_TEST_001"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "id matches" "$([ "$(jget "$OUT" '.id')" = "MSG_TEST_001" ] && echo 1)"
+assert "subject in headers" \
+  "$([ -n "$(jget "$OUT" '.headers.subject')" ] && echo 1)"
+assert "body decoded from base64url" \
+  "$(echo "$(jget "$OUT" '.body')" | grep -q 'Hello from the mock server' && echo 1)"
+assert "labelIds present" \
+  "$([ "$(jget "$OUT" '.labelIds | length')" -ge 1 ] && echo 1)"
+
+# --- 4. list-labels --------------------------------------------------------
+echo ""
+echo "Test 4: list-labels returns success:true with system + user labels"
+call '{"action":"list-labels"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "count == 6" "$([ "$(jget "$OUT" '.count')" = "6" ] && echo 1)"
+assert "INBOX present" \
+  "$(echo "$OUT" | jq -e '.labels | map(.id) | index("INBOX")' >/dev/null && echo 1)"
+assert "Label_5 (user) present" \
+  "$(echo "$OUT" | jq -e '.labels | map(.id) | index("Label_5")' >/dev/null && echo 1)"
+
+# --- 5. mark-as-read (UNREAD removed) --------------------------------------
+echo ""
+echo "Test 5: mark-as-read removes UNREAD"
+call '{"action":"mark-as-read","id":"MSG_TEST_001"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "UNREAD no longer in labelIds" \
+  "$(echo "$OUT" | jq -e '.labelIds | index("UNREAD") | not' >/dev/null && echo 1)"
+assert "INBOX still in labelIds" \
+  "$(echo "$OUT" | jq -e '.labelIds | index("INBOX")' >/dev/null && echo 1)"
+
+# --- 6. mark-as-unread (UNREAD added back) ---------------------------------
+echo ""
+echo "Test 6: mark-as-unread restores UNREAD"
+call '{"action":"mark-as-unread","id":"MSG_TEST_001"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "UNREAD back in labelIds" \
+  "$(echo "$OUT" | jq -e '.labelIds | index("UNREAD")' >/dev/null && echo 1)"
+
+# --- 7. add-label (single string form) -------------------------------------
+echo ""
+echo "Test 7: add-label (labelId string) adds STARRED"
+call '{"action":"add-label","id":"MSG_TEST_001","labelId":"STARRED"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "STARRED added" \
+  "$(echo "$OUT" | jq -e '.labelIds | index("STARRED")' >/dev/null && echo 1)"
+
+# --- 8. remove-label (array form) ------------------------------------------
+echo ""
+echo "Test 8: remove-label (labelIds array) removes STARRED"
+call '{"action":"remove-label","id":"MSG_TEST_001","labelIds":["STARRED"]}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "STARRED removed" \
+  "$(echo "$OUT" | jq -e '.labelIds | index("STARRED") | not' >/dev/null && echo 1)"
+
+# --- 9. send ---------------------------------------------------------------
+echo ""
+echo "Test 9: send returns success:true with id"
+call '{"action":"send","to":"a@b.com","subject":"Mock test","body":"Hello world"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+assert "returned id matches mock" "$([ "$(jget "$OUT" '.id')" = "MOCK_SENT_001" ] && echo 1)"
+assert "returned threadId" "$([ "$(jget "$OUT" '.threadId')" = "THREAD_SENT_001" ] && echo 1)"
+
+# --- 10. send (cc + bcc) ---------------------------------------------------
+echo ""
+echo "Test 10: send with cc+bcc still succeeds"
+call '{"action":"send","to":"a@b.com","subject":"cc test","body":"hi","cc":"c@b.com","bcc":"d@b.com"}' OUT EXIT
+assert "exit=0" "$([ "$EXIT" = "0" ] && echo 1)"
+assert "success:true" "$([ "$(jget "$OUT" '.success')" = "true" ] && echo 1)"
+
+# --- Switch to 401 mode, confirm error path is exercised for the RIGHT reason
+stop_mock
+echo ""
+echo "Test 11: 401-mode mock — error branch fires with HTTP 401 (not '?')"
+if ! start_mock 401; then
+  echo "FATAL: could not start 401-mode mock"
+  exit 1
+fi
+echo "Mock listening on 127.0.0.1:${MOCK_PORT} in 401-mode"
+
+call '{"action":"list-labels"}' OUT EXIT
+assert "exit=2 (api error)" "$([ "$EXIT" = "2" ] && echo 1)"
+assert "success:false" "$([ "$(jget "$OUT" '.success')" = "false" ] && echo 1)"
+# The crucial assertion that would have caught the v1.1.0 bug: the error
+# message must surface the REAL HTTP status (401), not the "?" placeholder
+# that came from a missing _LAST_HTTP propagation.
+assert "error message contains 'HTTP 401' (real status, not '?')" \
+  "$(echo "$OUT" | jq -r '.error' | grep -q 'HTTP 401' && echo 1)"
+assert "error message does NOT contain 'HTTP ?' placeholder" \
+  "$(echo "$OUT" | jq -r '.error' | grep -qv 'HTTP ?' && echo 1)"
+
+# --- Same for send (POST path uses the same gmail_call) --------------------
+echo ""
+echo "Test 12: 401-mode mock — send surfaces real 401, not '?'"
+call '{"action":"send","to":"a@b.com","subject":"x","body":"y"}' OUT EXIT
+assert "exit=2" "$([ "$EXIT" = "2" ] && echo 1)"
+assert "error contains HTTP 401" \
+  "$(echo "$OUT" | jq -r '.error' | grep -q 'HTTP 401' && echo 1)"
+
+# --- 500 mode — confirm parser handles 5xx the same way --------------------
+stop_mock
+echo ""
+echo "Test 13: 500-mode mock — error branch surfaces 500"
+if ! start_mock 500; then
+  echo "FATAL: could not start 500-mode mock"
+  exit 1
+fi
+call '{"action":"list-labels"}' OUT EXIT
+assert "exit=2" "$([ "$EXIT" = "2" ] && echo 1)"
+assert "error contains HTTP 500" \
+  "$(echo "$OUT" | jq -r '.error' | grep -q 'HTTP 500' && echo 1)"
+
+stop_mock
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "Summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/config/skills/agent/marketplace/gmail/execute.sh
+++ b/config/skills/agent/marketplace/gmail/execute.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+#
+# gmail multi-action skill (v1.0.0) — list / read / search / send.
+#
+# Credentials are injected by the Crewly skill executor based on the
+# credentialBindings.gmail resolution; this script does NOT handle OAuth or
+# token refresh.
+#
+# Usage:
+#   bash execute.sh '{"action":"list","q":"is:unread in:inbox","maxResults":10}'
+#   bash execute.sh '{"action":"read","id":"18fa..."}'
+#   bash execute.sh '{"action":"search","q":"from:a@b.com","maxResults":5}'
+#   bash execute.sh '{"action":"send","to":"a@b.com","subject":"Hi","body":"..."}'
+#
+# Env (injected by the executor):
+#   CREWLY_CRED_GMAIL_ACCESS_TOKEN  — OAuth access token (required)
+#   CREWLY_CRED_GMAIL_EMAIL         — account email (used as From: for send)
+#
+# Exit codes:
+#   0 — success
+#   1 — input/usage error (missing token, bad action, missing required param)
+#   2 — Gmail API error (4xx/5xx)
+#
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../_common/lib.sh
+source "${SCRIPT_DIR}/../../_common/lib.sh"
+
+VALID_ACTIONS="list, read, search, send"
+
+# --- Helpers ----------------------------------------------------------------
+
+# emit_success: print success JSON on stdout (consumed by skill executor / agent).
+emit_success() {
+  printf '%s\n' "$1"
+}
+
+# emit_error CODE STDERR_MSG STDOUT_JSON_MSG
+# Always prints stderr message, prints structured JSON on stdout, exits CODE.
+emit_error() {
+  local code="$1" stderr_msg="$2" stdout_msg="$3"
+  echo "$stderr_msg" >&2
+  jq -nc --arg e "$stdout_msg" '{success:false, error:$e}'
+  exit "$code"
+}
+
+# gmail_get PATH_AND_QUERY  -> echoes JSON body, sets _LAST_HTTP
+gmail_get() {
+  local path="$1"
+  local response http body
+  response=$(curl -s -w "\n%{http_code}" \
+    -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
+    "https://gmail.googleapis.com/gmail/v1/users/me${path}")
+  http="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+  _LAST_HTTP="$http"
+  printf '%s' "$body"
+}
+
+# gmail_post PATH JSON_BODY  -> echoes JSON body, sets _LAST_HTTP
+gmail_post() {
+  local path="$1" body="$2"
+  local response http resp_body
+  response=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$body" \
+    "https://gmail.googleapis.com/gmail/v1/users/me${path}")
+  http="${response##*$'\n'}"
+  resp_body="${response%$'\n'*}"
+  _LAST_HTTP="$http"
+  printf '%s' "$resp_body"
+}
+
+# api_error_message BODY -> best-effort plain string of the Gmail error
+api_error_message() {
+  local body="$1"
+  printf '%s' "$body" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    err = d.get('error', {})
+    print(err.get('message') or json.dumps(d))
+except Exception:
+    print('(unparseable response)')
+" 2>/dev/null || echo "(unparseable response)"
+}
+
+# --- Token + input validation ----------------------------------------------
+
+if [ -z "${CREWLY_CRED_GMAIL_ACCESS_TOKEN:-}" ]; then
+  emit_error 1 \
+    "Error: CREWLY_CRED_GMAIL_ACCESS_TOKEN is not set. Bind a google-oauth credential to the 'gmail' slot when calling this skill." \
+    "CREWLY_CRED_GMAIL_ACCESS_TOKEN is not set"
+fi
+
+INPUT=$(read_json_input "${1:-}")
+if [ -z "$INPUT" ]; then
+  emit_error 1 \
+    "Usage: execute.sh '{\"action\":\"<one of: ${VALID_ACTIONS}>\", ...}'" \
+    "No input provided. Expected JSON with 'action' field. Valid actions: ${VALID_ACTIONS}"
+fi
+
+if ! printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1; then
+  emit_error 1 \
+    "Error: input is not valid JSON." \
+    "Input is not valid JSON. Expected: {\"action\":\"<one of: ${VALID_ACTIONS}>\", ...}"
+fi
+
+ACTION=$(printf '%s' "$INPUT" | jq -r '.action // empty')
+if [ -z "$ACTION" ]; then
+  emit_error 1 \
+    "Error: missing required field 'action'. Valid actions: ${VALID_ACTIONS}" \
+    "Missing required field 'action'. Valid actions: ${VALID_ACTIONS}"
+fi
+
+ACCOUNT="${CREWLY_CRED_GMAIL_EMAIL:-me}"
+
+# --- Action dispatch -------------------------------------------------------
+
+case "$ACTION" in
+  list|search)
+    Q=$(printf '%s' "$INPUT" | jq -r '.q // "is:unread in:inbox"')
+    MAX=$(printf '%s' "$INPUT" | jq -r '.maxResults // 10')
+    if ! [[ "$MAX" =~ ^[0-9]+$ ]]; then MAX=10; fi
+    if [ "$MAX" -lt 1 ]; then MAX=1; fi
+    if [ "$MAX" -gt 50 ]; then MAX=50; fi
+
+    Q_ENC=$(printf '%s' "$Q" | python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read()))")
+
+    LIST_BODY=$(gmail_get "/messages?q=${Q_ENC}&maxResults=${MAX}")
+    if [ "${_LAST_HTTP:-}" != "200" ]; then
+      MSG=$(api_error_message "$LIST_BODY")
+      emit_error 2 \
+        "Error: Gmail API returned status ${_LAST_HTTP:-?} when listing messages: ${MSG}" \
+        "Gmail API error (HTTP ${_LAST_HTTP:-?}): ${MSG}"
+    fi
+
+    IDS=$(printf '%s' "$LIST_BODY" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for m in d.get('messages', []):
+    print(m['id'] + '\t' + m.get('threadId',''))
+" 2>/dev/null || echo "")
+
+    MESSAGES_JSON='[]'
+    if [ -n "$IDS" ]; then
+      ENTRIES=()
+      while IFS=$'\t' read -r id tid; do
+        [ -z "$id" ] && continue
+        MSG=$(gmail_get "/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date")
+        if [ "${_LAST_HTTP:-}" != "200" ]; then
+          continue
+        fi
+        ENTRY=$(printf '%s' "$MSG" | python3 -c "
+import json, sys
+m = json.load(sys.stdin)
+headers = {h['name'].lower(): h['value'] for h in m.get('payload', {}).get('headers', [])}
+snippet = (m.get('snippet') or '').strip()
+if len(snippet) > 120:
+    snippet = snippet[:117] + '...'
+out = {
+  'id': m.get('id',''),
+  'threadId': m.get('threadId',''),
+  'subject': headers.get('subject',''),
+  'from': headers.get('from',''),
+  'date': headers.get('date',''),
+  'snippet': snippet,
+}
+print(json.dumps(out))
+" 2>/dev/null || echo "")
+        if [ -n "$ENTRY" ]; then
+          ENTRIES+=("$ENTRY")
+        fi
+      done <<< "$IDS"
+
+      if [ "${#ENTRIES[@]}" -gt 0 ]; then
+        MESSAGES_JSON=$(printf '%s\n' "${ENTRIES[@]}" | jq -s '.')
+      fi
+    fi
+
+    COUNT=$(printf '%s' "$MESSAGES_JSON" | jq 'length')
+    OUT=$(jq -nc \
+      --arg account "$ACCOUNT" \
+      --arg query "$Q" \
+      --argjson count "$COUNT" \
+      --argjson messages "$MESSAGES_JSON" \
+      '{success:true, account:$account, query:$query, count:$count, messages:$messages}')
+    emit_success "$OUT"
+    ;;
+
+  read)
+    ID=$(printf '%s' "$INPUT" | jq -r '.id // empty')
+    if [ -z "$ID" ]; then
+      emit_error 1 \
+        "Error: 'read' action requires 'id' field (Gmail message id)." \
+        "Missing required parameter: id"
+    fi
+
+    BODY=$(gmail_get "/messages/${ID}?format=full")
+    if [ "${_LAST_HTTP:-}" != "200" ]; then
+      MSG=$(api_error_message "$BODY")
+      emit_error 2 \
+        "Error: Gmail API returned status ${_LAST_HTTP:-?} when reading message ${ID}: ${MSG}" \
+        "Gmail API error (HTTP ${_LAST_HTTP:-?}): ${MSG}"
+    fi
+
+    OUT=$(printf '%s' "$BODY" | python3 -c "
+import json, sys, base64, re
+
+def b64url_decode(s):
+    if not s:
+        return ''
+    s = s.replace('-', '+').replace('_', '/')
+    pad = (-len(s)) % 4
+    s += '=' * pad
+    try:
+        return base64.b64decode(s).decode('utf-8', errors='replace')
+    except Exception:
+        return ''
+
+def walk_parts(part, plain_acc, html_acc):
+    mime = part.get('mimeType','') or ''
+    body = part.get('body', {}) or {}
+    data = body.get('data')
+    if data:
+        if mime == 'text/plain':
+            plain_acc.append(b64url_decode(data))
+        elif mime == 'text/html':
+            html_acc.append(b64url_decode(data))
+    for sub in part.get('parts', []) or []:
+        walk_parts(sub, plain_acc, html_acc)
+
+m = json.load(sys.stdin)
+payload = m.get('payload', {}) or {}
+headers = {h['name'].lower(): h['value'] for h in payload.get('headers', [])}
+plain_acc, html_acc = [], []
+walk_parts(payload, plain_acc, html_acc)
+
+plain = '\n'.join([p for p in plain_acc if p]).strip()
+html = '\n'.join([p for p in html_acc if p]).strip()
+
+result = {
+  'success': True,
+  'id': m.get('id',''),
+  'threadId': m.get('threadId',''),
+  'headers': {
+    'from': headers.get('from',''),
+    'to': headers.get('to',''),
+    'cc': headers.get('cc',''),
+    'subject': headers.get('subject',''),
+    'date': headers.get('date',''),
+  },
+  'snippet': (m.get('snippet') or '').strip(),
+}
+if plain:
+    result['body'] = plain
+elif html:
+    text = re.sub(r'<\s*br\s*/?\s*>', '\n', html, flags=re.IGNORECASE)
+    text = re.sub(r'</\s*p\s*>', '\n', text, flags=re.IGNORECASE)
+    text = re.sub(r'<[^>]+>', '', text)
+    text = re.sub(r'[ \t]+\n', '\n', text)
+    text = re.sub(r'\n{3,}', '\n\n', text).strip()
+    result['body'] = text
+    result['bodyHtml'] = html
+else:
+    result['body'] = ''
+print(json.dumps(result))
+" 2>/dev/null || echo "")
+
+    if [ -z "$OUT" ]; then
+      emit_error 2 \
+        "Error: failed to parse Gmail response for message ${ID}" \
+        "Failed to parse Gmail response"
+    fi
+    emit_success "$OUT"
+    ;;
+
+  send)
+    TO=$(printf '%s' "$INPUT" | jq -r '.to // empty')
+    SUBJECT=$(printf '%s' "$INPUT" | jq -r '.subject // empty')
+    BODY_TEXT=$(printf '%s' "$INPUT" | jq -r '.body // empty')
+
+    MISSING=()
+    [ -z "$TO" ] && MISSING+=("to")
+    [ -z "$SUBJECT" ] && MISSING+=("subject")
+    [ -z "$BODY_TEXT" ] && MISSING+=("body")
+    if [ "${#MISSING[@]}" -gt 0 ]; then
+      MISSING_STR=$(IFS=,; echo "${MISSING[*]}")
+      emit_error 1 \
+        "Error: 'send' action requires fields: ${MISSING_STR}" \
+        "Missing required parameter(s): ${MISSING_STR}"
+    fi
+
+    RAW=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys, base64, os
+from email.mime.text import MIMEText
+from email.utils import formatdate, make_msgid
+
+d = json.load(sys.stdin)
+msg = MIMEText((d.get('body') or ''), 'plain', 'utf-8')
+sender = os.environ.get('CREWLY_CRED_GMAIL_EMAIL', '')
+if sender:
+    msg['From'] = sender
+msg['To'] = d.get('to') or ''
+if d.get('cc'):
+    msg['Cc'] = d['cc']
+if d.get('bcc'):
+    msg['Bcc'] = d['bcc']
+msg['Subject'] = d.get('subject') or ''
+msg['Date'] = formatdate(localtime=True)
+msg['Message-ID'] = make_msgid()
+
+raw = base64.urlsafe_b64encode(msg.as_bytes()).decode('ascii').rstrip('=')
+print(raw)
+" 2>/dev/null || echo "")
+
+    if [ -z "$RAW" ]; then
+      emit_error 1 \
+        "Error: failed to encode MIME message for send." \
+        "Failed to encode MIME message"
+    fi
+
+    SEND_BODY=$(jq -nc --arg raw "$RAW" '{raw:$raw}')
+    SEND_RESP=$(gmail_post "/messages/send" "$SEND_BODY")
+    if [ "${_LAST_HTTP:-}" != "200" ]; then
+      MSG=$(api_error_message "$SEND_RESP")
+      emit_error 2 \
+        "Error: Gmail API returned status ${_LAST_HTTP:-?} when sending message: ${MSG}" \
+        "Gmail API error (HTTP ${_LAST_HTTP:-?}): ${MSG}"
+    fi
+
+    OUT=$(printf '%s' "$SEND_RESP" | jq -c '{success:true, id:.id, threadId:.threadId}')
+    emit_success "$OUT"
+    ;;
+
+  *)
+    emit_error 1 \
+      "Error: Unknown action '${ACTION}'. Valid actions: ${VALID_ACTIONS}" \
+      "Unknown action '${ACTION}'. Valid actions: ${VALID_ACTIONS}"
+    ;;
+esac

--- a/config/skills/agent/marketplace/gmail/execute.sh
+++ b/config/skills/agent/marketplace/gmail/execute.sh
@@ -41,6 +41,10 @@ source "${SCRIPT_DIR}/../../_common/lib.sh"
 
 VALID_ACTIONS="list, read, search, send, add-label, remove-label, list-labels, mark-as-read, mark-as-unread"
 
+# Base URL for the Gmail v1 "users/me" endpoint. Overridable via env so tests
+# can point the skill at a local mock HTTP server (see execute.live.test.sh).
+GMAIL_API_BASE="${GMAIL_API_BASE:-https://gmail.googleapis.com/gmail/v1/users/me}"
+
 # --- Helpers ----------------------------------------------------------------
 
 # emit_success: print success JSON on stdout (consumed by skill executor / agent).
@@ -57,33 +61,43 @@ emit_error() {
   exit "$code"
 }
 
-# gmail_get PATH_AND_QUERY  -> echoes JSON body, sets _LAST_HTTP
-# Uses the bound CREWLY_CRED_GMAIL_ACCESS_TOKEN. Does NOT print the token.
-gmail_get() {
-  local path="$1"
-  local response http body
-  response=$(curl -s -w "\n%{http_code}" \
-    -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
-    "https://gmail.googleapis.com/gmail/v1/users/me${path}")
-  http="${response##*$'\n'}"
-  body="${response%$'\n'*}"
-  _LAST_HTTP="$http"
-  printf '%s' "$body"
-}
+# gmail_call OUT_BODY_VAR METHOD PATH [JSON_BODY]
+#
+# Make a Gmail API request against ${GMAIL_API_BASE}${PATH}, write the response
+# body into the variable named by OUT_BODY_VAR, and set the global _LAST_HTTP
+# to the response's HTTP status code.
+#
+# IMPORTANT: this function MUST be invoked directly (e.g. `gmail_call RESP GET "/labels"`)
+# and MUST NOT be wrapped in command substitution (e.g. `RESP=$(gmail_call ... )`).
+# The function relies on parent-shell scope to write _LAST_HTTP and the named
+# output variable; command substitution forks a subshell, which would silently
+# discard those writes the moment the substitution returns. The previous
+# implementation (helpers `gmail_get` / `gmail_post` invoked via `$()`) hit
+# exactly this pitfall and silently mis-classified every successful 200 as a
+# failure with HTTP "?" because _LAST_HTTP never propagated out of the subshell.
+#
+# Authorization header is built from CREWLY_CRED_GMAIL_ACCESS_TOKEN. The token
+# is never echoed to stdout/stderr.
+gmail_call() {
+  local _out_var="$1" method="$2" path="$3" body="${4:-}"
+  local raw
 
-# gmail_post PATH JSON_BODY  -> echoes JSON body, sets _LAST_HTTP
-gmail_post() {
-  local path="$1" body="$2"
-  local response http resp_body
-  response=$(curl -s -w "\n%{http_code}" -X POST \
-    -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "$body" \
-    "https://gmail.googleapis.com/gmail/v1/users/me${path}")
-  http="${response##*$'\n'}"
-  resp_body="${response%$'\n'*}"
-  _LAST_HTTP="$http"
-  printf '%s' "$resp_body"
+  if [ "$method" = "GET" ]; then
+    raw=$(curl -s -w "\n%{http_code}" \
+      -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
+      "${GMAIL_API_BASE}${path}")
+  else
+    raw=$(curl -s -w "\n%{http_code}" -X "$method" \
+      -H "Authorization: Bearer ${CREWLY_CRED_GMAIL_ACCESS_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$body" \
+      "${GMAIL_API_BASE}${path}")
+  fi
+
+  # Both writes happen in the caller's shell scope because this function is
+  # called directly, not via $().
+  _LAST_HTTP="${raw##*$'\n'}"
+  printf -v "$_out_var" '%s' "${raw%$'\n'*}"
 }
 
 # api_error_message BODY -> best-effort plain string of the Gmail error
@@ -139,7 +153,7 @@ modify_message() {
     '{addLabelIds:$add, removeLabelIds:$remove}')
 
   local resp
-  resp=$(gmail_post "/messages/${id}/modify" "$body")
+  gmail_call resp POST "/messages/${id}/modify" "$body"
   if [ "${_LAST_HTTP:-}" != "200" ]; then
     local msg
     msg=$(api_error_message "$resp")
@@ -196,7 +210,7 @@ case "$ACTION" in
 
     Q_ENC=$(printf '%s' "$Q" | python3 -c "import sys,urllib.parse; print(urllib.parse.quote(sys.stdin.read()))")
 
-    LIST_BODY=$(gmail_get "/messages?q=${Q_ENC}&maxResults=${MAX}")
+    gmail_call LIST_BODY GET "/messages?q=${Q_ENC}&maxResults=${MAX}"
     if [ "${_LAST_HTTP:-}" != "200" ]; then
       MSG=$(api_error_message "$LIST_BODY")
       emit_error 2 \
@@ -216,7 +230,7 @@ for m in d.get('messages', []):
       ENTRIES=()
       while IFS=$'\t' read -r id tid; do
         [ -z "$id" ] && continue
-        MSG=$(gmail_get "/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date")
+        gmail_call MSG GET "/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date"
         if [ "${_LAST_HTTP:-}" != "200" ]; then
           continue
         fi
@@ -265,7 +279,7 @@ print(json.dumps(out))
         "Missing required parameter: id"
     fi
 
-    BODY=$(gmail_get "/messages/${ID}?format=full")
+    gmail_call BODY GET "/messages/${ID}?format=full"
     if [ "${_LAST_HTTP:-}" != "200" ]; then
       MSG=$(api_error_message "$BODY")
       emit_error 2 \
@@ -394,7 +408,7 @@ print(raw)
     fi
 
     SEND_BODY=$(jq -nc --arg raw "$RAW" '{raw:$raw}')
-    SEND_RESP=$(gmail_post "/messages/send" "$SEND_BODY")
+    gmail_call SEND_RESP POST "/messages/send" "$SEND_BODY"
     if [ "${_LAST_HTTP:-}" != "200" ]; then
       MSG=$(api_error_message "$SEND_RESP")
       emit_error 2 \
@@ -407,7 +421,7 @@ print(raw)
     ;;
 
   list-labels)
-    RESP=$(gmail_get "/labels")
+    gmail_call RESP GET "/labels"
     if [ "${_LAST_HTTP:-}" != "200" ]; then
       MSG=$(api_error_message "$RESP")
       emit_error 2 \

--- a/config/skills/agent/marketplace/gmail/execute.sh
+++ b/config/skills/agent/marketplace/gmail/execute.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #
-# gmail multi-action skill (v1.0.0) — list / read / search / send.
+# gmail multi-action skill (v1.1.0) — 9 actions.
+#
+# Email ops:           list, read, search, send
+# Label management:    add-label, remove-label, list-labels
+# Status management:   mark-as-read, mark-as-unread
 #
 # Credentials are injected by the Crewly skill executor based on the
 # credentialBindings.gmail resolution; this script does NOT handle OAuth or
@@ -11,10 +15,17 @@
 #   bash execute.sh '{"action":"read","id":"18fa..."}'
 #   bash execute.sh '{"action":"search","q":"from:a@b.com","maxResults":5}'
 #   bash execute.sh '{"action":"send","to":"a@b.com","subject":"Hi","body":"..."}'
+#   bash execute.sh '{"action":"list-labels"}'
+#   bash execute.sh '{"action":"add-label","id":"18fa...","labelId":"Label_5"}'
+#   bash execute.sh '{"action":"remove-label","id":"18fa...","labelId":"Label_5"}'
+#   bash execute.sh '{"action":"mark-as-read","id":"18fa..."}'
+#   bash execute.sh '{"action":"mark-as-unread","id":"18fa..."}'
 #
 # Env (injected by the executor):
 #   CREWLY_CRED_GMAIL_ACCESS_TOKEN  — OAuth access token (required)
 #   CREWLY_CRED_GMAIL_EMAIL         — account email (used as From: for send)
+#
+# Required scope: https://www.googleapis.com/auth/gmail.modify (covers all 9 actions)
 #
 # Exit codes:
 #   0 — success
@@ -28,7 +39,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../_common/lib.sh
 source "${SCRIPT_DIR}/../../_common/lib.sh"
 
-VALID_ACTIONS="list, read, search, send"
+VALID_ACTIONS="list, read, search, send, add-label, remove-label, list-labels, mark-as-read, mark-as-unread"
 
 # --- Helpers ----------------------------------------------------------------
 
@@ -47,6 +58,7 @@ emit_error() {
 }
 
 # gmail_get PATH_AND_QUERY  -> echoes JSON body, sets _LAST_HTTP
+# Uses the bound CREWLY_CRED_GMAIL_ACCESS_TOKEN. Does NOT print the token.
 gmail_get() {
   local path="$1"
   local response http body
@@ -88,6 +100,59 @@ except Exception:
 " 2>/dev/null || echo "(unparseable response)"
 }
 
+# extract_label_ids_array -> stdout: JSON array of label IDs from INPUT
+# Reads the parsed INPUT and returns a JSON array of label IDs from either
+# `labelId` (string) or `labelIds` (array). Returns "[]" if neither field is set.
+extract_label_ids_array() {
+  printf '%s' "$INPUT" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+ids = []
+single = d.get('labelId')
+multi = d.get('labelIds')
+if isinstance(multi, list):
+    ids.extend([str(x) for x in multi if x])
+if isinstance(single, str) and single:
+    ids.append(single)
+# de-dup, preserve order
+seen = set(); out = []
+for x in ids:
+    if x not in seen:
+        seen.add(x); out.append(x)
+print(json.dumps(out))
+" 2>/dev/null || echo '[]'
+}
+
+# modify_message ID ADD_JSON_ARRAY REMOVE_JSON_ARRAY
+# Calls /messages/{id}/modify with the given add/remove label arrays.
+# Emits the success/failure JSON to stdout and exits accordingly.
+modify_message() {
+  local id="$1" add_arr="$2" remove_arr="$3"
+  if [ -z "$id" ]; then
+    emit_error 1 \
+      "Error: 'id' (Gmail message id) is required for modify operations." \
+      "Missing required parameter: id"
+  fi
+
+  local body
+  body=$(jq -nc --argjson add "$add_arr" --argjson remove "$remove_arr" \
+    '{addLabelIds:$add, removeLabelIds:$remove}')
+
+  local resp
+  resp=$(gmail_post "/messages/${id}/modify" "$body")
+  if [ "${_LAST_HTTP:-}" != "200" ]; then
+    local msg
+    msg=$(api_error_message "$resp")
+    emit_error 2 \
+      "Error: Gmail API returned status ${_LAST_HTTP:-?} when modifying message ${id}: ${msg}" \
+      "Gmail API error (HTTP ${_LAST_HTTP:-?}): ${msg}"
+  fi
+
+  local out
+  out=$(printf '%s' "$resp" | jq -c '{success:true, id:.id, threadId:.threadId, labelIds:(.labelIds // [])}')
+  emit_success "$out"
+}
+
 # --- Token + input validation ----------------------------------------------
 
 if [ -z "${CREWLY_CRED_GMAIL_ACCESS_TOKEN:-}" ]; then
@@ -103,6 +168,7 @@ if [ -z "$INPUT" ]; then
     "No input provided. Expected JSON with 'action' field. Valid actions: ${VALID_ACTIONS}"
 fi
 
+# Validate JSON parses
 if ! printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1; then
   emit_error 1 \
     "Error: input is not valid JSON." \
@@ -246,6 +312,7 @@ result = {
   'success': True,
   'id': m.get('id',''),
   'threadId': m.get('threadId',''),
+  'labelIds': m.get('labelIds', []),
   'headers': {
     'from': headers.get('from',''),
     'to': headers.get('to',''),
@@ -294,6 +361,9 @@ print(json.dumps(result))
         "Missing required parameter(s): ${MISSING_STR}"
     fi
 
+    # Build RFC-2822 MIME + base64url-encode via python (safe handling of unicode/CRLF).
+    # Reading INPUT from stdin avoids any shell-arg escaping issues with embedded
+    # quotes / backticks / $ in the body.
     RAW=$(printf '%s' "$INPUT" | python3 -c "
 import json, sys, base64, os
 from email.mime.text import MIMEText
@@ -334,6 +404,57 @@ print(raw)
 
     OUT=$(printf '%s' "$SEND_RESP" | jq -c '{success:true, id:.id, threadId:.threadId}')
     emit_success "$OUT"
+    ;;
+
+  list-labels)
+    RESP=$(gmail_get "/labels")
+    if [ "${_LAST_HTTP:-}" != "200" ]; then
+      MSG=$(api_error_message "$RESP")
+      emit_error 2 \
+        "Error: Gmail API returned status ${_LAST_HTTP:-?} when listing labels: ${MSG}" \
+        "Gmail API error (HTTP ${_LAST_HTTP:-?}): ${MSG}"
+    fi
+
+    LABELS=$(printf '%s' "$RESP" | jq -c '[.labels[]? | {id, name, type}]')
+    COUNT=$(printf '%s' "$LABELS" | jq 'length')
+    OUT=$(jq -nc \
+      --arg account "$ACCOUNT" \
+      --argjson count "$COUNT" \
+      --argjson labels "$LABELS" \
+      '{success:true, account:$account, count:$count, labels:$labels}')
+    emit_success "$OUT"
+    ;;
+
+  add-label)
+    ID=$(printf '%s' "$INPUT" | jq -r '.id // empty')
+    LABEL_IDS=$(extract_label_ids_array)
+    if [ "$LABEL_IDS" = "[]" ]; then
+      emit_error 1 \
+        "Error: 'add-label' requires 'labelId' (string) or 'labelIds' (array)." \
+        "Missing required parameter: labelId or labelIds"
+    fi
+    modify_message "$ID" "$LABEL_IDS" '[]'
+    ;;
+
+  remove-label)
+    ID=$(printf '%s' "$INPUT" | jq -r '.id // empty')
+    LABEL_IDS=$(extract_label_ids_array)
+    if [ "$LABEL_IDS" = "[]" ]; then
+      emit_error 1 \
+        "Error: 'remove-label' requires 'labelId' (string) or 'labelIds' (array)." \
+        "Missing required parameter: labelId or labelIds"
+    fi
+    modify_message "$ID" '[]' "$LABEL_IDS"
+    ;;
+
+  mark-as-read)
+    ID=$(printf '%s' "$INPUT" | jq -r '.id // empty')
+    modify_message "$ID" '[]' '["UNREAD"]'
+    ;;
+
+  mark-as-unread)
+    ID=$(printf '%s' "$INPUT" | jq -r '.id // empty')
+    modify_message "$ID" '["UNREAD"]' '[]'
     ;;
 
   *)

--- a/config/skills/agent/marketplace/gmail/execute.test.sh
+++ b/config/skills/agent/marketplace/gmail/execute.test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Tests for gmail multi-action skill (execute.sh) — v1.0.0 (4 actions).
+# Verifies error paths only — no live Gmail calls (would need a real token).
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXECUTE="$SCRIPT_DIR/execute.sh"
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected substring '$needle' in output)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc (exit=$expected)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    echo "  FAIL: $desc (unexpected substring '$needle' in output)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc (no '$needle' leaked)"
+    PASS=$((PASS + 1))
+  fi
+}
+
+run_with_token() {
+  CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake" bash "$EXECUTE" "$1" 2>&1
+}
+
+echo "=== gmail multi-action skill tests (v1.0.0 — 4 actions) ==="
+
+echo ""
+echo "Test 1: missing CREWLY_CRED_GMAIL_ACCESS_TOKEN"
+set +e
+OUTPUT=$(unset CREWLY_CRED_GMAIL_ACCESS_TOKEN; bash "$EXECUTE" '{"action":"list"}' 2>&1)
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions CREWLY_CRED_GMAIL_ACCESS_TOKEN" "CREWLY_CRED_GMAIL_ACCESS_TOKEN" "$OUTPUT"
+
+echo ""
+echo "Test 2: missing 'action' field"
+set +e
+OUTPUT=$(run_with_token '{}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions list action" "list" "$OUTPUT"
+assert_contains "mentions read action" "read" "$OUTPUT"
+assert_contains "mentions send action" "send" "$OUTPUT"
+
+echo ""
+echo "Test 3: unknown action"
+set +e
+OUTPUT=$(run_with_token '{"action":"foo-bar"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions Unknown action" "Unknown action" "$OUTPUT"
+for valid in list read search send; do
+  assert_contains "lists '$valid' as valid" "$valid" "$OUTPUT"
+done
+
+echo ""
+echo "Test 4: invalid JSON input"
+set +e
+OUTPUT=$(run_with_token 'not-json{')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions JSON" "JSON" "$OUTPUT"
+
+echo ""
+echo "Test 5: empty input"
+set +e
+OUTPUT=$(run_with_token '')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions action" "action" "$OUTPUT"
+
+echo ""
+echo "Test 6: list with invalid token (expect API error, exit 2)"
+set +e
+OUTPUT=$(CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake-token-xyz" bash "$EXECUTE" '{"action":"list","maxResults":1}' 2>&1)
+EXIT=$?
+set -e
+if [ "$EXIT" -ne 0 ]; then
+  echo "  PASS: non-zero exit with invalid token (exit=$EXIT)"
+  PASS=$((PASS + 1))
+fi
+assert_not_contains "fake token not leaked" "ya29.fake-token-xyz" "$OUTPUT"
+
+echo ""
+echo "Test 7: read action missing 'id'"
+set +e
+OUTPUT=$(run_with_token '{"action":"read"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions id" "id" "$OUTPUT"
+
+echo ""
+echo "Test 8: send missing 'to'"
+set +e
+OUTPUT=$(run_with_token '{"action":"send","subject":"hi","body":"hi"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions to" "to" "$OUTPUT"
+
+echo ""
+echo "Test 9: send missing 'subject'"
+set +e
+OUTPUT=$(run_with_token '{"action":"send","to":"a@b.com","body":"hi"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions subject" "subject" "$OUTPUT"
+
+echo ""
+echo "Test 10: send missing 'body'"
+set +e
+OUTPUT=$(run_with_token '{"action":"send","to":"a@b.com","subject":"hi"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions body" "body" "$OUTPUT"
+
+echo ""
+echo "Test 11: error responses emit JSON success:false on stdout"
+set +e
+STDOUT=$(CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake" bash "$EXECUTE" '{"action":"read"}' 2>/dev/null)
+set -e
+if echo "$STDOUT" | jq -e '.success == false' >/dev/null 2>&1; then
+  echo "  PASS: stdout JSON has success:false on missing id"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: stdout JSON did not have success:false (got: $STDOUT)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/config/skills/agent/marketplace/gmail/execute.test.sh
+++ b/config/skills/agent/marketplace/gmail/execute.test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Tests for gmail multi-action skill (execute.sh) — v1.0.0 (4 actions).
+# Tests for gmail multi-action skill (execute.sh).
 # Verifies error paths only — no live Gmail calls (would need a real token).
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,6 +14,9 @@ assert_contains() {
     PASS=$((PASS + 1))
   else
     echo "  FAIL: $desc (expected substring '$needle' in output)"
+    echo "  ----- actual output -----"
+    echo "$haystack" | sed 's/^/  | /'
+    echo "  -------------------------"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -44,7 +47,11 @@ run_with_token() {
   CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake" bash "$EXECUTE" "$1" 2>&1
 }
 
-echo "=== gmail multi-action skill tests (v1.0.0 — 4 actions) ==="
+echo "=== gmail multi-action skill tests (v1.1.0 — 9 actions) ==="
+
+# -----------------------------------------------------------------------------
+# Token / input validation
+# -----------------------------------------------------------------------------
 
 echo ""
 echo "Test 1: missing CREWLY_CRED_GMAIL_ACCESS_TOKEN"
@@ -56,6 +63,14 @@ assert_exit "exits 1" "1" "$EXIT"
 assert_contains "mentions CREWLY_CRED_GMAIL_ACCESS_TOKEN" "CREWLY_CRED_GMAIL_ACCESS_TOKEN" "$OUTPUT"
 
 echo ""
+echo "Test 1b: list-labels also needs token"
+set +e
+OUTPUT=$(unset CREWLY_CRED_GMAIL_ACCESS_TOKEN; bash "$EXECUTE" '{"action":"list-labels"}' 2>&1)
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+
+echo ""
 echo "Test 2: missing 'action' field"
 set +e
 OUTPUT=$(run_with_token '{}')
@@ -65,16 +80,20 @@ assert_exit "exits 1" "1" "$EXIT"
 assert_contains "mentions list action" "list" "$OUTPUT"
 assert_contains "mentions read action" "read" "$OUTPUT"
 assert_contains "mentions send action" "send" "$OUTPUT"
+assert_contains "mentions list-labels action" "list-labels" "$OUTPUT"
+assert_contains "mentions add-label action" "add-label" "$OUTPUT"
+assert_contains "mentions mark-as-read action" "mark-as-read" "$OUTPUT"
 
 echo ""
-echo "Test 3: unknown action"
+echo "Test 3: unknown action lists ALL valid actions"
 set +e
 OUTPUT=$(run_with_token '{"action":"foo-bar"}')
 EXIT=$?
 set -e
 assert_exit "exits 1" "1" "$EXIT"
 assert_contains "mentions Unknown action" "Unknown action" "$OUTPUT"
-for valid in list read search send; do
+# Spot-check that several valid actions appear in the error message:
+for valid in list read search send list-labels add-label remove-label mark-as-read mark-as-unread; do
   assert_contains "lists '$valid' as valid" "$valid" "$OUTPUT"
 done
 
@@ -94,7 +113,11 @@ OUTPUT=$(run_with_token '')
 EXIT=$?
 set -e
 assert_exit "exits 1" "1" "$EXIT"
-assert_contains "mentions action" "action" "$OUTPUT"
+assert_contains "mentions action / usage" "action" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# list (existing v1.0.0 action)
+# -----------------------------------------------------------------------------
 
 echo ""
 echo "Test 6: list with invalid token (expect API error, exit 2)"
@@ -105,8 +128,18 @@ set -e
 if [ "$EXIT" -ne 0 ]; then
   echo "  PASS: non-zero exit with invalid token (exit=$EXIT)"
   PASS=$((PASS + 1))
+  if [ "$EXIT" -eq 2 ]; then
+    echo "  PASS: exit code 2 (api error) as expected"
+    PASS=$((PASS + 1))
+  fi
+else
+  echo "  NOTE: exit was 0 (likely offline) — skipping strict assertion"
 fi
 assert_not_contains "fake token not leaked" "ya29.fake-token-xyz" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# read (existing v1.0.0 action)
+# -----------------------------------------------------------------------------
 
 echo ""
 echo "Test 7: read action missing 'id'"
@@ -116,6 +149,10 @@ EXIT=$?
 set -e
 assert_exit "exits 1" "1" "$EXIT"
 assert_contains "mentions id" "id" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# send (existing v1.0.0 action)
+# -----------------------------------------------------------------------------
 
 echo ""
 echo "Test 8: send missing 'to'"
@@ -144,8 +181,90 @@ set -e
 assert_exit "exits 1" "1" "$EXIT"
 assert_contains "mentions body" "body" "$OUTPUT"
 
+# -----------------------------------------------------------------------------
+# list-labels (new v1.1.0 action)
+# -----------------------------------------------------------------------------
+
 echo ""
-echo "Test 11: error responses emit JSON success:false on stdout"
+echo "Test 11: list-labels with invalid token surfaces API error"
+set +e
+OUTPUT=$(CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake-list-labels" bash "$EXECUTE" '{"action":"list-labels"}' 2>&1)
+EXIT=$?
+set -e
+if [ "$EXIT" -ne 0 ]; then
+  echo "  PASS: non-zero exit on bad token for list-labels (exit=$EXIT)"
+  PASS=$((PASS + 1))
+fi
+assert_not_contains "fake token not leaked from list-labels" "ya29.fake-list-labels" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# add-label / remove-label (new v1.1.0 actions)
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "Test 12: add-label missing 'id'"
+set +e
+OUTPUT=$(run_with_token '{"action":"add-label","labelId":"Label_5"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions id" "id" "$OUTPUT"
+
+echo ""
+echo "Test 13: add-label missing labelId AND labelIds"
+set +e
+OUTPUT=$(run_with_token '{"action":"add-label","id":"18fa..."}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions labelId or labelIds" "labelId" "$OUTPUT"
+
+echo ""
+echo "Test 14: remove-label missing 'id'"
+set +e
+OUTPUT=$(run_with_token '{"action":"remove-label","labelId":"Label_5"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions id" "id" "$OUTPUT"
+
+echo ""
+echo "Test 15: remove-label with both empty (labelId='', labelIds=[])"
+set +e
+OUTPUT=$(run_with_token '{"action":"remove-label","id":"18fa...","labelId":"","labelIds":[]}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions labelId or labelIds" "labelId" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# mark-as-read / mark-as-unread (new v1.1.0 actions)
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "Test 16: mark-as-read missing 'id'"
+set +e
+OUTPUT=$(run_with_token '{"action":"mark-as-read"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions id" "id" "$OUTPUT"
+
+echo ""
+echo "Test 17: mark-as-unread missing 'id'"
+set +e
+OUTPUT=$(run_with_token '{"action":"mark-as-unread"}')
+EXIT=$?
+set -e
+assert_exit "exits 1" "1" "$EXIT"
+assert_contains "mentions id" "id" "$OUTPUT"
+
+# -----------------------------------------------------------------------------
+# Cross-action: stdout always emits {"success":false, ...} on errors
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "Test 18: error responses emit JSON success:false on stdout"
 set +e
 STDOUT=$(CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake" bash "$EXECUTE" '{"action":"read"}' 2>/dev/null)
 set -e
@@ -157,6 +276,22 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+echo ""
+echo "Test 19: error responses emit JSON success:false on stdout (label action)"
+set +e
+STDOUT=$(CREWLY_CRED_GMAIL_ACCESS_TOKEN="ya29.fake" bash "$EXECUTE" '{"action":"add-label","id":"x"}' 2>/dev/null)
+set -e
+if echo "$STDOUT" | jq -e '.success == false' >/dev/null 2>&1; then
+  echo "  PASS: stdout JSON has success:false on missing labelId"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: stdout JSON did not have success:false (got: $STDOUT)"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
 echo ""
 echo "Summary: $PASS passed, $FAIL failed"
 if [ "$FAIL" -gt 0 ]; then

--- a/config/skills/agent/marketplace/gmail/instructions.md
+++ b/config/skills/agent/marketplace/gmail/instructions.md
@@ -1,0 +1,59 @@
+# Gmail Suite (v1.0.0)
+
+Multi-action Gmail skill that supports listing, reading, searching, and sending
+emails on behalf of a connected Google account.
+
+## Prerequisites
+
+This skill requires a Google OAuth credential bound to the `gmail` slot with
+both `https://www.googleapis.com/auth/gmail.readonly` and
+`https://www.googleapis.com/auth/gmail.send` scopes.
+
+## Usage
+
+```bash
+bash config/skills/agent/marketplace/gmail/execute.sh '{"action":"<one of: list|read|search|send>", ...}'
+```
+
+## Action reference
+
+| Action | Required params | Description |
+|--------|-----------------|-------------|
+| `list` | — | List messages matching `q`. Defaults to `is:unread in:inbox`, `maxResults=10`. |
+| `search` | — | Alias for `list` (shares code). |
+| `read` | `id` | Fetch full message by ID with decoded headers + body. |
+| `send` | `to`, `subject`, `body` | Send a new email. Optional `cc`, `bcc`. |
+
+## Examples
+
+```bash
+# List unread inbox messages
+bash execute.sh '{"action":"list","maxResults":5}'
+
+# Search by sender + subject
+bash execute.sh '{"action":"search","q":"from:steve subject:report"}'
+
+# Read a specific message
+bash execute.sh '{"action":"read","id":"18f1a2b3c4d5e6f7"}'
+
+# Send a message
+bash execute.sh '{"action":"send","to":"user@example.com","subject":"Hello from Crewly","body":"This is a test email."}'
+```
+
+## Output
+
+JSON object with `success: true` on success. See `SKILL.md` Actions section for
+per-action schemas.
+
+On error, JSON `{"success":false,"error":"..."}` on stdout, human-readable
+message on stderr, and a non-zero exit code (1 = input/usage error, 2 = Gmail
+API error).
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `CREWLY_CRED_GMAIL_ACCESS_TOKEN is not set` | No credential bound | Bind a google-oauth credential to the `gmail` slot |
+| `Gmail API returned status 401` | Token expired or scope insufficient | Re-authorize |
+| `Missing required parameter: id` | Required param missing | Provide all required parameters |
+| `Unknown action '<x>'` | Action not in the valid set | Use one of `list`, `read`, `search`, `send` |

--- a/config/skills/agent/marketplace/gmail/instructions.md
+++ b/config/skills/agent/marketplace/gmail/instructions.md
@@ -1,18 +1,20 @@
-# Gmail Suite (v1.0.0)
+# Gmail Suite (v1.1.0)
 
-Multi-action Gmail skill that supports listing, reading, searching, and sending
-emails on behalf of a connected Google account.
+Comprehensive Gmail management skill. Supports listing, reading, searching, and
+sending emails plus label management and read/unread toggling — 9 actions in
+total.
 
 ## Prerequisites
 
 This skill requires a Google OAuth credential bound to the `gmail` slot with
-both `https://www.googleapis.com/auth/gmail.readonly` and
-`https://www.googleapis.com/auth/gmail.send` scopes.
+the `https://www.googleapis.com/auth/gmail.modify` scope. `gmail.modify` is a
+functional superset that covers read, send, and modify operations — one scope
+unlocks all 9 actions.
 
 ## Usage
 
 ```bash
-bash config/skills/agent/marketplace/gmail/execute.sh '{"action":"<one of: list|read|search|send>", ...}'
+bash config/skills/agent/marketplace/gmail/execute.sh '{"action":"<one of: list|read|search|send|list-labels|add-label|remove-label|mark-as-read|mark-as-unread>", ...}'
 ```
 
 ## Action reference
@@ -23,27 +25,63 @@ bash config/skills/agent/marketplace/gmail/execute.sh '{"action":"<one of: list|
 | `search` | — | Alias for `list` (shares code). |
 | `read` | `id` | Fetch full message by ID with decoded headers + body. |
 | `send` | `to`, `subject`, `body` | Send a new email. Optional `cc`, `bcc`. |
+| `list-labels` | — | List all labels on the account (system + user). |
+| `add-label` | `id`, `labelId` or `labelIds` | Add labels to a message. |
+| `remove-label` | `id`, `labelId` or `labelIds` | Remove labels from a message. |
+| `mark-as-read` | `id` | Remove the system `UNREAD` label from a message. |
+| `mark-as-unread` | `id` | Add the system `UNREAD` label to a message. |
 
 ## Examples
 
+### Email operations
+
 ```bash
-# List unread inbox messages
+# 1. List unread inbox messages
 bash execute.sh '{"action":"list","maxResults":5}'
 
-# Search by sender + subject
+# 2. Search by sender + subject
 bash execute.sh '{"action":"search","q":"from:steve subject:report"}'
 
-# Read a specific message
+# 3. Read a specific message
 bash execute.sh '{"action":"read","id":"18f1a2b3c4d5e6f7"}'
 
-# Send a message
+# 4. Send a message
 bash execute.sh '{"action":"send","to":"user@example.com","subject":"Hello from Crewly","body":"This is a test email."}'
+
+# 4a. Send with CC + BCC
+bash execute.sh '{"action":"send","to":"a@b.com","subject":"Hi","body":"Hello","cc":"c@b.com","bcc":"d@b.com"}'
+```
+
+### Label management
+
+```bash
+# 5. List all labels (call this first to discover label IDs)
+bash execute.sh '{"action":"list-labels"}'
+
+# 6. Add a label to a message (string form)
+bash execute.sh '{"action":"add-label","id":"18f1...","labelId":"Label_5"}'
+
+# 6a. Add multiple labels (array form)
+bash execute.sh '{"action":"add-label","id":"18f1...","labelIds":["Label_5","Label_7"]}'
+
+# 7. Remove a label
+bash execute.sh '{"action":"remove-label","id":"18f1...","labelId":"Label_5"}'
+```
+
+### Status management
+
+```bash
+# 8. Mark a message as read (removes UNREAD)
+bash execute.sh '{"action":"mark-as-read","id":"18f1..."}'
+
+# 9. Mark a message as unread (adds UNREAD)
+bash execute.sh '{"action":"mark-as-unread","id":"18f1..."}'
 ```
 
 ## Output
 
-JSON object with `success: true` on success. See `SKILL.md` Actions section for
-per-action schemas.
+JSON object with `success: true` on success. Specifics vary by action — see
+`SKILL.md` Actions section for per-action schemas.
 
 On error, JSON `{"success":false,"error":"..."}` on stdout, human-readable
 message on stderr, and a non-zero exit code (1 = input/usage error, 2 = Gmail
@@ -54,6 +92,7 @@ API error).
 | Error | Cause | Solution |
 |-------|-------|----------|
 | `CREWLY_CRED_GMAIL_ACCESS_TOKEN is not set` | No credential bound | Bind a google-oauth credential to the `gmail` slot |
-| `Gmail API returned status 401` | Token expired or scope insufficient | Re-authorize |
-| `Missing required parameter: id` | Required param missing | Provide all required parameters |
-| `Unknown action '<x>'` | Action not in the valid set | Use one of `list`, `read`, `search`, `send` |
+| `Gmail API returned status 401` | Token expired or scope insufficient | Re-authorize; ensure the credential has `gmail.modify` |
+| `Missing required parameter: id` | Required param missing | Provide all required parameters for the chosen action |
+| `Missing required parameter: labelId or labelIds` | Neither given for add/remove-label | Pass `labelId` (string) or `labelIds` (array) |
+| `Unknown action '<x>'` | Action not in the valid set | Use one of the 9 valid action names (see table above) |

--- a/config/skills/agent/marketplace/gmail/mock-gmail-server.py
+++ b/config/skills/agent/marketplace/gmail/mock-gmail-server.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Local mock of the Gmail v1 users/me API surface, used by execute.live.test.sh
+to exercise the happy path of the gmail skill without hitting Google.
+
+Routing is path-prefix based and matches the routes that execute.sh actually
+calls. Each route returns a canned 200 JSON body that mirrors the shape of a
+real Gmail response, just enough for the skill's `jq` / `python3` parsers.
+
+The server stores a small in-memory state for label management actions so a
+test can call mark-as-read / mark-as-unread / add-label / remove-label and
+observe the labelIds round-trip.
+
+Usage (test driver):
+    python3 mock-gmail-server.py --port 0 --token-mode pass     # any token works
+    python3 mock-gmail-server.py --port 0 --token-mode 401      # always 401
+
+Stdout: a single line `LISTENING <port>` once the socket is bound, then HTTP
+access logs. SIGTERM / SIGINT shuts down cleanly.
+"""
+
+import argparse
+import json
+import os
+import signal
+import sys
+import threading
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# Mutated by handlers; protected by a lock since ThreadingHTTPServer spawns
+# one thread per request.
+_state_lock = threading.Lock()
+_message_state = {
+    # Default test message — labels evolve across mark-as-read / add-label calls.
+    "MSG_TEST_001": {
+        "id": "MSG_TEST_001",
+        "threadId": "THREAD_TEST_001",
+        "labelIds": ["INBOX", "UNREAD"],
+        "snippet": "Mocked test message snippet.",
+        "subject": "Mock subject — happy path",
+        "from": "mock-sender@example.com",
+        "to": "test@example.com",
+        "date": "Thu, 24 Apr 2026 18:00:00 -0400",
+        "body_plain": "Hello from the mock server.\nThis is the plain-text body.\n",
+    },
+}
+
+_TOKEN_MODE = "pass"  # set from CLI; "pass" | "401" | "500"
+
+
+def _ok(handler, body):
+    raw = json.dumps(body).encode("utf-8")
+    handler.send_response(200)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+
+
+def _err(handler, code, message):
+    body = {
+        "error": {"code": code, "message": message, "status": "ERROR"},
+    }
+    raw = json.dumps(body).encode("utf-8")
+    handler.send_response(code)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(raw)))
+    handler.end_headers()
+    handler.wfile.write(raw)
+
+
+def _check_auth(handler):
+    """Return True iff the request has any Bearer token (in pass mode), else
+    return False after writing the configured error response."""
+    auth = handler.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        _err(handler, 401, "Missing or malformed Authorization header")
+        return False
+    if _TOKEN_MODE == "401":
+        _err(handler, 401, "Invalid Credentials")
+        return False
+    if _TOKEN_MODE == "500":
+        _err(handler, 500, "Backend error")
+        return False
+    return True
+
+
+def _build_full_message(state):
+    """Build a Gmail-shaped message payload (format=full) from internal state."""
+    import base64
+
+    body_b64 = base64.urlsafe_b64encode(
+        state["body_plain"].encode("utf-8")
+    ).decode("ascii").rstrip("=")
+    return {
+        "id": state["id"],
+        "threadId": state["threadId"],
+        "labelIds": state["labelIds"],
+        "snippet": state["snippet"],
+        "payload": {
+            "headers": [
+                {"name": "From", "value": state["from"]},
+                {"name": "To", "value": state["to"]},
+                {"name": "Subject", "value": state["subject"]},
+                {"name": "Date", "value": state["date"]},
+            ],
+            "mimeType": "text/plain",
+            "body": {"data": body_b64, "size": len(state["body_plain"])},
+        },
+    }
+
+
+def _build_metadata_message(state):
+    """Build a Gmail-shaped message payload (format=metadata)."""
+    return {
+        "id": state["id"],
+        "threadId": state["threadId"],
+        "labelIds": state["labelIds"],
+        "snippet": state["snippet"],
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": state["subject"]},
+                {"name": "From", "value": state["from"]},
+                {"name": "Date", "value": state["date"]},
+            ],
+        },
+    }
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    # Quiet the default access log (line per request to stderr) — comment out
+    # this method to debug routing.
+    def log_message(self, fmt, *args):
+        sys.stderr.write("[mock] " + (fmt % args) + "\n")
+
+    # ---- GET --------------------------------------------------------------
+
+    def do_GET(self):
+        if not _check_auth(self):
+            return
+
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        qs = urllib.parse.parse_qs(parsed.query)
+
+        # /gmail/v1/users/me/messages?q=...&maxResults=...
+        if path.endswith("/messages"):
+            max_n = int(qs.get("maxResults", ["10"])[0])
+            with _state_lock:
+                ids = list(_message_state.keys())[:max_n]
+            return _ok(
+                self,
+                {
+                    "messages": [
+                        {"id": i, "threadId": _message_state[i]["threadId"]} for i in ids
+                    ],
+                    "resultSizeEstimate": len(ids),
+                },
+            )
+
+        # /gmail/v1/users/me/messages/{id}?format=full|metadata
+        if "/messages/" in path:
+            mid = path.rsplit("/", 1)[-1]
+            with _state_lock:
+                state = _message_state.get(mid)
+            if not state:
+                return _err(self, 404, f"Message {mid} not found")
+            fmt = qs.get("format", ["full"])[0]
+            if fmt == "metadata":
+                return _ok(self, _build_metadata_message(state))
+            return _ok(self, _build_full_message(state))
+
+        # /gmail/v1/users/me/labels
+        if path.endswith("/labels"):
+            return _ok(
+                self,
+                {
+                    "labels": [
+                        {"id": "INBOX", "name": "INBOX", "type": "system"},
+                        {"id": "UNREAD", "name": "UNREAD", "type": "system"},
+                        {"id": "SENT", "name": "SENT", "type": "system"},
+                        {"id": "STARRED", "name": "STARRED", "type": "system"},
+                        {"id": "Label_5", "name": "Work", "type": "user"},
+                        {"id": "Label_7", "name": "Personal", "type": "user"},
+                    ]
+                },
+            )
+
+        return _err(self, 404, f"Mock has no route for GET {path}")
+
+    # ---- POST -------------------------------------------------------------
+
+    def do_POST(self):
+        if not _check_auth(self):
+            return
+
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            payload = json.loads(raw.decode("utf-8")) if raw else {}
+        except Exception:
+            payload = {}
+
+        # /gmail/v1/users/me/messages/send
+        if path.endswith("/messages/send"):
+            # Decode the base64url-encoded RFC-2822 payload just enough to
+            # confirm the skill produced something parseable.
+            import base64
+
+            raw_b64 = payload.get("raw", "")
+            try:
+                pad = "=" * (-len(raw_b64) % 4)
+                base64.urlsafe_b64decode(raw_b64 + pad).decode("utf-8", errors="ignore")
+            except Exception:
+                return _err(self, 400, "Invalid raw MIME — base64 decode failed")
+            return _ok(
+                self,
+                {
+                    "id": "MOCK_SENT_001",
+                    "threadId": "THREAD_SENT_001",
+                    "labelIds": ["SENT"],
+                },
+            )
+
+        # /gmail/v1/users/me/messages/{id}/modify
+        if "/messages/" in path and path.endswith("/modify"):
+            # Path is .../messages/{id}/modify
+            mid = path.rsplit("/", 2)[-2]
+            add = payload.get("addLabelIds") or []
+            remove = payload.get("removeLabelIds") or []
+            with _state_lock:
+                state = _message_state.get(mid)
+                if not state:
+                    return _err(self, 404, f"Message {mid} not found")
+                # Apply removes first, then adds. De-dupe.
+                new_labels = [lab for lab in state["labelIds"] if lab not in remove]
+                for lab in add:
+                    if lab not in new_labels:
+                        new_labels.append(lab)
+                state["labelIds"] = new_labels
+            return _ok(
+                self,
+                {
+                    "id": state["id"],
+                    "threadId": state["threadId"],
+                    "labelIds": state["labelIds"],
+                },
+            )
+
+        return _err(self, 404, f"Mock has no route for POST {path}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--token-mode", choices=["pass", "401", "500"], default="pass")
+    args = parser.parse_args()
+
+    global _TOKEN_MODE
+    _TOKEN_MODE = args.token_mode
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), MockHandler)
+    bound_port = server.server_address[1]
+    # Single line on stdout so the test driver can grep it and learn the port.
+    sys.stdout.write(f"LISTENING {bound_port}\n")
+    sys.stdout.flush()
+
+    def _shutdown(signum, frame):
+        sys.stderr.write("[mock] shutting down\n")
+        server.shutdown()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/config/skills/agent/marketplace/gmail/skill.json
+++ b/config/skills/agent/marketplace/gmail/skill.json
@@ -1,7 +1,7 @@
 {
   "id": "agent-gmail",
   "name": "Gmail Suite",
-  "description": "Multi-action Gmail skill for agents — list, read, search, and send emails. Requires a google-oauth credential bound to the 'gmail' slot.",
+  "description": "Multi-action Gmail skill for agents — list/read/search/send messages, manage labels (add/remove/list), and toggle read/unread. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope.",
   "category": "communication",
   "skillType": "claude-skill",
   "promptFile": "instructions.md",
@@ -19,8 +19,13 @@
     "check my gmail",
     "search emails",
     "read email content",
-    "list recent messages"
+    "list recent messages",
+    "mark email as read",
+    "mark email as unread",
+    "add label to email",
+    "remove label from email",
+    "list gmail labels"
   ],
-  "tags": ["email", "gmail", "google", "communication"],
-  "version": "1.0.0"
+  "tags": ["email", "gmail", "google", "communication", "labels", "modify"],
+  "version": "1.1.0"
 }

--- a/config/skills/agent/marketplace/gmail/skill.json
+++ b/config/skills/agent/marketplace/gmail/skill.json
@@ -1,0 +1,26 @@
+{
+  "id": "agent-gmail",
+  "name": "Gmail Suite",
+  "description": "Multi-action Gmail skill for agents — list, read, search, and send emails. Requires a google-oauth credential bound to the 'gmail' slot.",
+  "category": "communication",
+  "skillType": "claude-skill",
+  "promptFile": "instructions.md",
+  "execution": {
+    "type": "script",
+    "script": {
+      "file": "execute.sh",
+      "interpreter": "bash",
+      "timeoutMs": 30000
+    }
+  },
+  "assignableRoles": ["generalist", "support", "sales", "product-manager", "developer", "orchestrator", "assistant"],
+  "triggers": [
+    "send an email",
+    "check my gmail",
+    "search emails",
+    "read email content",
+    "list recent messages"
+  ],
+  "tags": ["email", "gmail", "google", "communication"],
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

Adds the agent **Gmail skill v1.1.0** at `config/skills/agent/marketplace/gmail/`, a 9-action skill that lets agents `list`, `read`, `search`, `send` messages, plus manage labels (`add-label`, `remove-label`, `list-labels`) and toggle status (`mark-as-read`, `mark-as-unread`) on a connected Google account. Companion to (not replacement for) the existing `gmail-reader` skill — that one stays wired into the orchestrator's `credential-manager read-gmail` action.

Also includes a backend OAuth scope fix so new credentials minted via `start-google-oauth` automatically work end-to-end with all 9 actions on a single consent.

## Three commits, three review rounds

Per the team's Code Commit SOP, this PR is structured as three logical commits to make review tractable:

1. **`feat(gmail): v1.0.0 — list / read / search / send`** — base 4 actions with structured JSON output, RFC-2822 MIME `send` (with cc/bcc), text/plain-preferred body extraction with HTML→plain fallback for `read`. 27 co-located error-path tests.
2. **`fix(gmail): use gmail.modify as single required scope`** — drops dual `[gmail.readonly, gmail.send]` to single `gmail.modify` (functional superset). Crewly's skill-executor does **string-exact** scope matching, so this is required for the skill to work with credentials that only have `gmail.modify` (which is what the default Crewly OAuth flow grants going forward). Updates `backend/src/constants.ts` `DEFAULT_SCOPES` to match. Adds new co-located `backend/src/constants.test.ts` (per the project's 1:1 source-to-test policy) asserting the new scope set + endpoint URL pinning.
3. **`feat(gmail): v1.1.0 — labels + mark-as-read/unread`** — adds 5 new actions, all sharing one `modify_message` internal helper that hits `messages.modify` with different add/remove arrays. `add-label`/`remove-label` accept either `labelId` (string) or `labelIds` (array). Bumps version to 1.1.0 across SKILL.md, skill.json, instructions.md. Tests grow to 52 passing.

## Why `gmail.modify` (single scope)

`gmail.modify` is a Google-side functional superset that covers `gmail.readonly` + `gmail.send` + label/state mutations. The Crewly skill-executor performs string-exact scope matching — it does NOT treat modify as a superset of readonly. So declaring `gmail.modify` alone (instead of the dual scope) is what lets a credential bound with only `gmail.modify` actually pass `InsufficientScopeError`. New credentials minted via `/api/oauth/google/start` now request just `[openid, email, gmail.modify]`, so all 9 actions work without re-consent.

## Files changed

- **New skill files:** `config/skills/agent/marketplace/gmail/{SKILL.md, skill.json, instructions.md, execute.sh, execute.test.sh}`
- **Backend scope:** `backend/src/constants.ts` (DEFAULT_SCOPES gmail dual → single)
- **Backend test:** `backend/src/constants.test.ts` (new, asserts the gmail.modify-only default + endpoint URL pins)

## Test plan

- [x] `bash config/skills/agent/marketplace/gmail/execute.test.sh` — 52 passed, 0 failed (covers token-missing, JSON-invalid, action-missing, unknown-action, all 9 action input-validation paths, no-token-leak, success:false JSON contract on errors)
- [x] `bash config/skills/agent/marketplace/gmail-reader/execute.test.sh` — 3 passed, 0 failed (no regression)
- [x] `npx jest backend/src/constants.test.ts` — 8 passed, 0 failed
- [x] `npx jest backend/src/controllers/oauth/oauth.routes.test.ts` — 2 passed, 0 failed (consumer of `DEFAULT_SCOPES`)
- [x] `npm run build` — passes (backend tsc + frontend vite + cli tsc all green)
- [ ] **Live validation against Steve's `yellowsunhy0115@gmail.com` credential (TL to run):**
  - [ ] `list` returns inbox messages
  - [ ] `list-labels` returns the label list
  - [ ] `mark-as-read` on a known unread message — `read` after shows `UNREAD` removed from `labelIds`
  - [ ] `send` to a test recipient delivers
  - [ ] No secrets in returned skill output

## Acceptance criteria status

- [x] All 9 actions implemented in single `case "$ACTION"` dispatch
- [x] `requiredScopes` reduced to single `gmail.modify`
- [x] `DEFAULT_SCOPES` updated + co-located test added + `npm run build` passes
- [x] SKILL.md / instructions.md / skill.json all bumped to `1.1.0` with extended descriptions/triggers/tags
- [x] `execute.test.sh` covers error paths for ALL 9 actions
- [x] No regression to `gmail-reader`
- [ ] Live validation (TL to run with Steve's credential)

## Review rounds

I ran the equivalent of the team's three internal review rounds (refactor & consistency / efficiency & reliability / overall quality) inline as I built:

- **Reuse:** all 4 modify-based actions go through one `modify_message` helper; `add-label`/`remove-label` share `extract_label_ids_array`
- **Reliability:** every Gmail API call propagates HTTP status into `_LAST_HTTP` and surfaces non-200 as exit 2 with Google's error message; tokens never echoed to stdout/stderr (asserted in tests)
- **Consistency:** action naming follows the spec (existing four kept un-hyphenated for back-compat, five new hyphenated); error contract is identical across actions (stdout `{success:false,error}` + stderr human msg + exit code)

Anything you want refactored after live validation, ping me and I'll spin a follow-up commit on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)