### PR TITLE
fix(agent): guard against role=undefined silent prompt-delivery failure

### DIFF
--- a/backend/src/controllers/team/team.controller.test.ts
+++ b/backend/src/controllers/team/team.controller.test.ts
@@ -2810,6 +2810,154 @@ describe('Teams Handlers', () => {
     });
   });
 
+  // ────────────────────────────────────────────────────────────────────
+  // Bug #1: start-agent role=undefined silent failure
+  // Reproducer: stevesprompt-ryan-986b2d51 — member has no `role` field,
+  // session spawns but env CREWLY_ROLE="undefined" and prompt never delivers.
+  // Fix: refuse to start the member, mark inactive with dropoutReason='invalid_role'.
+  // ────────────────────────────────────────────────────────────────────
+  describe('startTeamMember role validation (Bug #1)', () => {
+    beforeEach(() => {
+      mockRequest = {
+        params: { teamId: 'team-1', memberId: 'member-1' },
+        body: {}
+      };
+      mockResponse = responseMock as any;
+      mockStorageService.getProjects.mockResolvedValue([]);
+    });
+
+    const buildTeamWithRole = (role: unknown): Team => ({
+      id: 'team-1',
+      name: 'Test Team',
+      description: 'Test Description',
+      members: [{
+        id: 'member-1',
+        name: 'Broken Member',
+        sessionName: '',
+        role: role as any,
+        systemPrompt: 'Test prompt',
+        agentStatus: 'inactive',
+        workingStatus: 'idle',
+        runtimeType: 'claude-code',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }],
+      projectIds: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    it('refuses to start a member whose role is undefined (the original bug)', async () => {
+      mockStorageService.getTeams.mockResolvedValue([buildTeamWithRole(undefined)]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>(),
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      // Critical: the registration service must NEVER be called with a bad role
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).not.toHaveBeenCalled();
+
+      // Operator should see a clear failure response
+      expect(responseMock.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining('Invalid agent role'),
+        })
+      );
+    });
+
+    it('refuses to start a member whose role is the literal string "undefined"', async () => {
+      mockStorageService.getTeams.mockResolvedValue([buildTeamWithRole('undefined')]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>(),
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).not.toHaveBeenCalled();
+      expect(responseMock.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false }),
+      );
+    });
+
+    it('refuses to start a member whose role is an empty string', async () => {
+      mockStorageService.getTeams.mockResolvedValue([buildTeamWithRole('')]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>(),
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).not.toHaveBeenCalled();
+    });
+
+    it('resets agentStatus to inactive with dropoutReason=invalid_role on failure', async () => {
+      const team = buildTeamWithRole(undefined);
+      mockStorageService.getTeams.mockResolvedValue([team]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>(),
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      // The controller flips status to STARTING for instant UI feedback BEFORE the
+      // role check. The guard must reset it back to INACTIVE with a clear reason
+      // so the orchestrator/operator can act on it.
+      const saveCall = (mockStorageService.saveTeam as jest.Mock).mock.calls.find(call => {
+        const t = call[0] as any;
+        return t?.members?.[0]?.dropoutReason === 'invalid_role';
+      });
+      expect(saveCall).toBeDefined();
+      const saved = saveCall![0] as any;
+      expect(saved.members[0].agentStatus).toBe(CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE);
+      expect(saved.members[0].dropoutReason).toBe('invalid_role');
+    });
+
+    it('still allows valid roles through (regression guard)', async () => {
+      mockStorageService.getTeams.mockResolvedValue([buildTeamWithRole('developer')]);
+
+      mockApiContext.agentRegistrationService = {
+        createAgentSession: jest.fn<any>().mockResolvedValue({
+          success: true,
+          sessionName: 'good-session',
+          message: 'ok',
+        }),
+      } as any;
+
+      await teamsHandlers.startTeamMember.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).toHaveBeenCalledTimes(1);
+      expect((mockApiContext.agentRegistrationService as any).createAgentSession).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'developer' })
+      );
+    });
+  });
+
   describe('startTeamMember with orchestrator virtual team', () => {
     it('should start Assistant (crewly-agent runtime) via agentRegistrationService', async () => {
       mockRequest.params = { teamId: 'orchestrator', memberId: 'crewly-orc-assistant-member-001' };

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -31,6 +31,10 @@ import { getSettingsService } from '../../services/settings/settings.service.js'
 import { getTerminalGateway } from '../../websocket/terminal.gateway.js';
 import { ActivityMonitorService } from '../../services/monitoring/activity-monitor.service.js';
 import { MemoryService } from '../../services/memory/memory.service.js';
+import {
+  validateAgentRole,
+  InvalidAgentRoleError,
+} from '../../services/agent/agent-registration.service.js';
 import { SubAgentMessageQueue } from '../../services/messaging/sub-agent-message-queue.service.js';
 import { SUB_AGENT_QUEUE_CONSTANTS } from '../../constants.js';
 import type { EventBusService } from '../../services/event-bus/event-bus.service.js';
@@ -332,6 +336,50 @@ async function _startTeamMemberCore(
   projectPath?: string
 ): Promise<TeamMemberOperationResult> {
   try {
+    // Guard against members with no role — without this, undefined flows into
+    // session creation, gets stringified to "undefined" in CREWLY_ROLE, and
+    // produces the silent "empty Claude prompt" failure. Surface the misconfig
+    // immediately so the operator can fix the team config (Bug #1).
+    try {
+      validateAgentRole(member.role, `_startTeamMemberCore[team=${team.id} member=${member.id}]`);
+    } catch (err) {
+      const errMessage = err instanceof InvalidAgentRoleError ? err.message
+        : err instanceof Error ? err.message
+        : String(err);
+      logger.error('Refusing to start team member with invalid role', {
+        teamId: team.id,
+        memberId: member.id,
+        memberName: member.name,
+        receivedRole: member.role,
+        error: errMessage,
+      });
+      // Reset agentStatus so we don't leave the member stuck in 'starting'
+      try {
+        const resetTeams = await context.storageService.getTeams();
+        const resetTeam = resetTeams.find(t => t.id === team.id);
+        const resetMember = resetTeam?.members.find(m => m.id === member.id) as MutableTeamMember | undefined;
+        if (resetTeam && resetMember && resetMember.agentStatus === CREWLY_CONSTANTS.AGENT_STATUSES.STARTING) {
+          resetMember.agentStatus = CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE;
+          resetMember.dropoutReason = 'invalid_role';
+          resetMember.updatedAt = new Date().toISOString();
+          await context.storageService.saveTeam(resetTeam);
+        }
+      } catch (resetErr) {
+        logger.warn('Failed to reset member status after role validation failure', {
+          memberId: member.id,
+          error: resetErr instanceof Error ? resetErr.message : String(resetErr),
+        });
+      }
+      return {
+        success: false,
+        memberName: member.name,
+        memberId: member.id,
+        sessionName: null,
+        status: 'failed',
+        error: errMessage,
+      };
+    }
+
     // Check if member already has an active session
     if (member.sessionName) {
       const sessions = await context.tmuxService.listSessions();

--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -4,7 +4,11 @@
  * Tests the multi-step agent initialization and registration process
  */
 
-import { AgentRegistrationService } from './agent-registration.service.js';
+import {
+	AgentRegistrationService,
+	validateAgentRole,
+	InvalidAgentRoleError,
+} from './agent-registration.service.js';
 import { StorageService } from '../core/storage.service.js';
 import { LoggerService } from '../core/logger.service.js';
 import * as sessionModule from '../session/index.js';
@@ -3204,6 +3208,163 @@ describe('AgentRegistrationService', () => {
 			);
 
 			expect(result).toBe(false);
+		});
+	});
+
+	// ──────────────────────────────────────────────────────────────────────
+	// Bug #1: start-agent role=undefined silent failure
+	// Guards added at three layers: validateAgentRole (utility),
+	// getPromptFileForRole (path resolver), createAgentSession (service entry).
+	// ──────────────────────────────────────────────────────────────────────
+	describe('validateAgentRole (Bug #1 guard)', () => {
+		it('accepts a valid string role', () => {
+			expect(() => validateAgentRole('developer')).not.toThrow();
+			expect(() => validateAgentRole('orchestrator')).not.toThrow();
+			expect(() => validateAgentRole('team-leader')).not.toThrow();
+		});
+
+		it('rejects undefined', () => {
+			expect(() => validateAgentRole(undefined)).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects null', () => {
+			expect(() => validateAgentRole(null)).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects empty string', () => {
+			expect(() => validateAgentRole('')).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects whitespace-only string', () => {
+			expect(() => validateAgentRole('   ')).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects literal string "undefined" (the actual reproducer)', () => {
+			// This is the bug: when JS undefined gets stringified into a template
+			// literal, it becomes the literal string "undefined" — which would
+			// pass a naive `typeof === "string"` check but is still unusable.
+			expect(() => validateAgentRole('undefined')).toThrow(InvalidAgentRoleError);
+			expect(() => validateAgentRole('UNDEFINED')).toThrow(InvalidAgentRoleError);
+			expect(() => validateAgentRole('Undefined')).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects literal string "null"', () => {
+			expect(() => validateAgentRole('null')).toThrow(InvalidAgentRoleError);
+		});
+
+		it('rejects non-string types (number, object, array)', () => {
+			expect(() => validateAgentRole(42)).toThrow(InvalidAgentRoleError);
+			expect(() => validateAgentRole({})).toThrow(InvalidAgentRoleError);
+			expect(() => validateAgentRole([])).toThrow(InvalidAgentRoleError);
+			expect(() => validateAgentRole(true)).toThrow(InvalidAgentRoleError);
+		});
+
+		it('error message includes the received value and caller context', () => {
+			try {
+				validateAgentRole(undefined, 'startTeamMember');
+				fail('should have thrown');
+			} catch (err) {
+				expect(err).toBeInstanceOf(InvalidAgentRoleError);
+				expect((err as Error).message).toContain('undefined');
+				expect((err as Error).message).toContain('startTeamMember');
+				expect((err as Error).message).toContain('config/roles/');
+			}
+		});
+
+		it('error message preserves the literal "undefined" string for diagnostic clarity', () => {
+			try {
+				validateAgentRole('undefined');
+				fail('should have thrown');
+			} catch (err) {
+				expect((err as Error).message).toContain('"undefined"');
+			}
+		});
+
+		it('InvalidAgentRoleError exposes the received value for downstream handling', () => {
+			const err = new InvalidAgentRoleError(42, 'unit-test');
+			expect(err.received).toBe(42);
+			expect(err.name).toBe('InvalidAgentRoleError');
+			expect(err instanceof Error).toBe(true);
+		});
+	});
+
+	describe('getPromptFileForRole (Bug #1 guard at path resolver)', () => {
+		it('resolves a valid role to config/roles/{role}/prompt.md', async () => {
+			const result = await (service as any).getPromptFileForRole('developer');
+			expect(result).toContain('config/roles/developer/prompt.md');
+		});
+
+		it('normalizes case and whitespace in role names', async () => {
+			const result = await (service as any).getPromptFileForRole('Team Leader');
+			expect(result).toContain('config/roles/team-leader/prompt.md');
+		});
+
+		it('throws InvalidAgentRoleError when role is undefined (was: silent fallback)', async () => {
+			await expect(
+				(service as any).getPromptFileForRole(undefined)
+			).rejects.toThrow(InvalidAgentRoleError);
+		});
+
+		it('throws InvalidAgentRoleError when role is the literal "undefined"', async () => {
+			await expect(
+				(service as any).getPromptFileForRole('undefined')
+			).rejects.toThrow(InvalidAgentRoleError);
+		});
+
+		it('throws InvalidAgentRoleError when role is empty', async () => {
+			await expect(
+				(service as any).getPromptFileForRole('')
+			).rejects.toThrow(InvalidAgentRoleError);
+		});
+	});
+
+	describe('createAgentSession role validation (Bug #1 fail-fast)', () => {
+		it('refuses to create a session when role is undefined', async () => {
+			const result = await service.createAgentSession({
+				sessionName: 'broken-session',
+				role: undefined as any,
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid agent role');
+			// Critically: tmux session should NEVER be created
+			expect(mockSessionHelper.createSession).not.toHaveBeenCalled();
+			// And CREWLY_ROLE env should NEVER be set with the bad value
+			expect(mockSessionHelper.setEnvironmentVariable).not.toHaveBeenCalledWith(
+				expect.anything(),
+				expect.stringContaining('CREWLY_ROLE'),
+				expect.anything(),
+			);
+		});
+
+		it('refuses to create a session when role is the literal string "undefined"', async () => {
+			const result = await service.createAgentSession({
+				sessionName: 'broken-session',
+				role: 'undefined',
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid agent role');
+			expect(mockSessionHelper.createSession).not.toHaveBeenCalled();
+		});
+
+		it('refuses to create a session when role is empty', async () => {
+			const result = await service.createAgentSession({
+				sessionName: 'broken-session',
+				role: '',
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.error).toContain('Invalid agent role');
+		});
+
+		it('returns the failing sessionName so caller can correlate logs', async () => {
+			const result = await service.createAgentSession({
+				sessionName: 'broken-session-xyz',
+				role: undefined as any,
+			});
+
+			expect(result.sessionName).toBe('broken-session-xyz');
 		});
 	});
 });

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -65,6 +65,53 @@ export interface OrchestratorConfig {
 }
 
 /**
+ * Error thrown when an agent role cannot be resolved to a valid value.
+ *
+ * Indicates a member with no `role` field in storage, or a caller passing
+ * `undefined`/empty/literal-"undefined". Surfaces the failure loudly so it
+ * cannot manifest as the silent "empty Claude prompt" symptom (Bug #1).
+ */
+export class InvalidAgentRoleError extends Error {
+	constructor(public readonly received: unknown, context?: string) {
+		const ctx = context ? ` (${context})` : '';
+		const display =
+			received === undefined ? 'undefined'
+			: received === null ? 'null'
+			: typeof received === 'string' ? `"${received}"`
+			: String(received);
+		super(
+			`Invalid agent role${ctx}: received ${display}. Role must be a non-empty string ` +
+			`matching a directory under config/roles/. ` +
+			`Common cause: team member.role field missing or unset in storage.`
+		);
+		this.name = 'InvalidAgentRoleError';
+	}
+}
+
+/**
+ * Validate that an agent role is a usable string before it flows into session
+ * creation, env-var injection, or prompt-template path resolution.
+ *
+ * Rejects: undefined, null, non-strings, empty/whitespace strings, and the
+ * literal string "undefined" (which results from JS coercion when an undefined
+ * is interpolated into a template literal — the exact failure mode behind
+ * `CREWLY_ROLE="undefined"` in tmux env).
+ *
+ * @param role - The candidate role value
+ * @param context - Optional caller context for the error message (e.g. "startTeamMember")
+ * @throws {InvalidAgentRoleError} when role is unusable
+ */
+export function validateAgentRole(role: unknown, context?: string): asserts role is string {
+	if (typeof role !== 'string') {
+		throw new InvalidAgentRoleError(role, context);
+	}
+	const trimmed = role.trim();
+	if (trimmed.length === 0 || trimmed.toLowerCase() === 'undefined' || trimmed.toLowerCase() === 'null') {
+		throw new InvalidAgentRoleError(role, context);
+	}
+}
+
+/**
  * Service responsible for the complex, multi-step process of agent initialization and registration.
  * Isolates the complex state management of agent startup with progressive escalation.
  *
@@ -506,6 +553,10 @@ export class AgentRegistrationService {
 	 * Uses the unified config/roles/{role}/prompt.md structure
 	 */
 	private async getPromptFileForRole(role: string): Promise<string> {
+		// Defensive: reject empty/undefined/literal-"undefined" before path concat,
+		// which would otherwise resolve to a non-existent `config/roles/undefined/prompt.md`
+		// and trigger the silent fallback path that left agents with empty prompts (Bug #1).
+		validateAgentRole(role, 'getPromptFileForRole');
 		// Normalize role name to directory name format
 		const roleName = role.toLowerCase().replace(/\s+/g, '-');
 		return path.join(process.cwd(), 'config', 'roles', roleName, 'prompt.md');
@@ -2068,6 +2119,28 @@ After checking in, just say "Ready for tasks" and wait for me to send you work.`
 		message?: string;
 		error?: string;
 	}> {
+		// Fail fast if role is unusable. Without this guard, an undefined role
+		// flows through the entire pipeline, gets stringified to "undefined" in
+		// the CREWLY_ROLE env var, and silently breaks prompt resolution. We
+		// surface the misconfiguration here instead of spawning a dead session.
+		try {
+			validateAgentRole(config.role, 'createAgentSession');
+		} catch (err) {
+			const error = err instanceof Error ? err.message : String(err);
+			this.logger.error('Refusing to create agent session with invalid role', {
+				sessionName: config.sessionName,
+				memberId: config.memberId,
+				teamId: config.teamId,
+				receivedRole: config.role,
+				error,
+			});
+			return {
+				success: false,
+				sessionName: config.sessionName,
+				error,
+			};
+		}
+
 		// If another creation is in progress for this session, wait for it
 		const existingLock = this.sessionCreationLocks.get(config.sessionName);
 		if (existingLock) {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -63,7 +63,7 @@ export interface TeamMember {
   maxConcurrentTasks?: number;
 
   /** #235: Reason the agent last went inactive */
-  dropoutReason?: 'idle_exit' | 'update_exit' | 'crash' | 'manual' | 'task_complete' | 'loop_detected' | 'startup_timeout';
+  dropoutReason?: 'idle_exit' | 'update_exit' | 'crash' | 'manual' | 'task_complete' | 'loop_detected' | 'startup_timeout' | 'invalid_role';
 
   // === Architecture Upgrade fields ===
 


### PR DESCRIPTION
## Summary

Surgical fix for **Item 1 of the 2026-04-25 silent-lifecycle-failure backlog** (start-agent role=undefined reproducer: `stevesprompt-ryan-986b2d51`).

A team member with no `role` field in storage caused start-agent to spawn a session with literal `CREWLY_ROLE="undefined"`, the prompt template path resolved to nonexistent `config/roles/undefined/prompt.md`, and the agent sat at an empty Claude prompt without ever registering.

## What changed

Three-layer defensive guard:

1. **New `validateAgentRole` + `InvalidAgentRoleError`** (exported from `agent-registration.service.ts`) — rejects:
   - `undefined`, `null`
   - Empty / whitespace-only strings
   - Literal `"undefined"` / `"null"` strings (the actual JS-coercion failure mode)
   - Non-string types (number, object, array, boolean)

2. **Controller guard in `_startTeamMemberCore`** (catches every code path that spawns a member). On failure, resets `agentStatus` → `inactive` with `dropoutReason='invalid_role'` so the operator/orchestrator can act.

3. **Service-entry guards** in `getPromptFileForRole` and `createAgentSession` — defense in depth even if a future caller skips the controller path.

Type extension: added `'invalid_role'` to `TeamMember.dropoutReason` union.

## Why three layers

Each layer is the right place to catch a different mistake class:

| Layer | Catches |
|---|---|
| `validateAgentRole` (utility) | All invalid forms, single-source-of-truth |
| `_startTeamMemberCore` (controller) | The reproducer — bad team config |
| `createAgentSession` (service entry) | Future direct callers, internal callers, integration tests |
| `getPromptFileForRole` (path resolver) | Code that bypasses both above (recovery / restart paths) |

## Tests — 25 new, all passing

- **11 unit tests** for `validateAgentRole` covering each rejection class + error message format
- **5 tests** for `getPromptFileForRole` (1 valid form + 3 invalid forms + case normalization)
- **4 tests** for `createAgentSession` (refuses session create, no env-var side effects, returns failing sessionName for log correlation)
- **5 controller-level tests** asserting `startTeamMember`:
  - refuses the bad member
  - never calls `createAgentSession`
  - resets `agentStatus` to inactive with `dropoutReason='invalid_role'`
  - still allows valid roles through (regression guard)

```bash
$ npx jest backend/src/services/agent/agent-registration.service.test.ts -t 'Bug #1'
Tests: 151 skipped, 20 passed, 171 total

$ npx jest backend/src/controllers/team/team.controller.test.ts -t 'role validation'
Tests: 94 skipped, 5 passed, 99 total
```

## Test plan

- [x] Service-level tests pass (20/20)
- [x] Controller-level tests pass (5/5)
- [ ] Steve approves merge (this is OSS code change, no production routing impact, but TL gate per project policy)
- [ ] Manual repro on `stevesprompt-ryan-986b2d51` after merge confirms fix delivers a clear error instead of empty Claude prompt

## Out of scope

- Items 2 (backend graceful-restart procedure) and 3 (team-health-watchdog) are tracked separately. Item 3 design doc landed at `.crewly/knowledge/team-health-watchdog-design-2026-04-25.md` (co-authored with Architect).
- Item 4 (Portal chat-ui WS wire) deferred until Mia/Ava UI plan lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)