### PR TITLE
feat(chat-v2): Slack-like team-chat backend migration (Phase A)

### DIFF
--- a/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
@@ -193,6 +193,170 @@ describe('chat-v2 controller (REST)', () => {
     }
   });
 
+  // ---------------------------------------------------------------------
+  // Phase A — Slack-like team-chat surfaces (SEALED §3.1 + §3.2)
+  // ---------------------------------------------------------------------
+
+  it("POST /api/chat/channels — creates a type='channel' row with teamId", async () => {
+    const { app, service } = buildApp();
+    try {
+      const res = await request(app)
+        .post('/api/chat/channels')
+        .send({ name: '#general', type: 'channel', teamId: 'team-1' });
+      expect(res.status).toBe(201);
+      expect(res.body.data.type).toBe('channel');
+      expect(res.body.data.teamId).toBe('team-1');
+      // Channel rows server-erase agentSession to ''.
+      expect(res.body.data.agentSession).toBe('');
+    } finally {
+      service.close();
+    }
+  });
+
+  it("POST /api/chat/channels — 400 when type='channel' but teamId omitted", async () => {
+    const { app, service } = buildApp();
+    try {
+      const res = await request(app)
+        .post('/api/chat/channels')
+        .send({ name: '#orphan', type: 'channel' });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('validation_error');
+      expect(res.body.error.message).toMatch(/teamId is required/);
+    } finally {
+      service.close();
+    }
+  });
+
+  it("POST /api/chat/channels — 400 when type='dm' but teamId is provided", async () => {
+    const { app, service } = buildApp();
+    try {
+      const res = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Cross-typed', type: 'dm', teamId: 'team-1' });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('validation_error');
+    } finally {
+      service.close();
+    }
+  });
+
+  it("POST /api/chat/channels — type='dm' with targetMemberId persists it", async () => {
+    const { app, service } = buildApp();
+    try {
+      const res = await request(app)
+        .post('/api/chat/channels')
+        .send({
+          agentSession: 'sess-sam',
+          name: 'DM with Sam',
+          type: 'dm',
+          targetMemberId: 'member-sam',
+        });
+      expect(res.status).toBe(201);
+      expect(res.body.data.targetMemberId).toBe('member-sam');
+      expect(res.body.data.type).toBe('dm');
+    } finally {
+      service.close();
+    }
+  });
+
+  it('POST /api/chat/channels/:id/messages — persists mentions on the wire', async () => {
+    const { app, service } = buildApp();
+    try {
+      const created = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Ch' });
+      const chId = created.body.data.id;
+
+      const sent = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({
+          content: 'hi @Sam',
+          mentions: ['member-sam-uuid'],
+        });
+      expect(sent.status).toBe(201);
+      expect(sent.body.data.mentions).toEqual(['member-sam-uuid']);
+    } finally {
+      service.close();
+    }
+  });
+
+  it('POST /api/chat/channels/:id/messages — empty mentions emits []', async () => {
+    const { app, service } = buildApp();
+    try {
+      const created = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Ch' });
+      const chId = created.body.data.id;
+
+      const sent = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({ content: 'no mentions' });
+      expect(sent.status).toBe(201);
+      expect(sent.body.data.mentions).toEqual([]);
+    } finally {
+      service.close();
+    }
+  });
+
+  it('POST /api/chat/channels/:id/messages — 400 on non-array mentions', async () => {
+    const { app, service } = buildApp();
+    try {
+      const created = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Ch' });
+      const chId = created.body.data.id;
+
+      const sent = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({ content: 'x', mentions: 'not-an-array' });
+      expect(sent.status).toBe(400);
+      expect(sent.body.error.code).toBe('validation_error');
+    } finally {
+      service.close();
+    }
+  });
+
+  it('POST /api/chat/channels/:id/messages — threadId persists for replies', async () => {
+    const { app, service } = buildApp();
+    try {
+      const created = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Ch' });
+      const chId = created.body.data.id;
+
+      const root = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({ content: 'thread root' });
+      expect(root.status).toBe(201);
+
+      const reply = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({ content: 'reply within thread', threadId: root.body.data.id });
+      expect(reply.status).toBe(201);
+      expect(reply.body.data.threadId).toBe(root.body.data.id);
+    } finally {
+      service.close();
+    }
+  });
+
+  it('POST /api/chat/channels/:id/messages — 400 on non-existent threadId', async () => {
+    const { app, service } = buildApp();
+    try {
+      const created = await request(app)
+        .post('/api/chat/channels')
+        .send({ agentSession: 'sess-a', name: 'Ch' });
+      const chId = created.body.data.id;
+
+      const sent = await request(app)
+        .post(`/api/chat/channels/${chId}/messages`)
+        .send({ content: 'orphan reply', threadId: 'no-such-id' });
+      expect(sent.status).toBe(400);
+      expect(sent.body.error.code).toBe('validation_error');
+    } finally {
+      service.close();
+    }
+  });
+
   it('GET /api/chat/channels/:id — 404 for unknown id', async () => {
     const { app, service } = buildApp();
     try {

--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -179,6 +179,12 @@ export function createChatV2Controller(
           name: body.name,
           purpose: body.purpose,
           principal,
+          // Phase A (SEALED §3.1) — Slack-like channel surfaces. Service
+          // layer validates the type↔teamId↔targetMemberId combinations.
+          type: body.type,
+          teamId: body.teamId,
+          projectId: body.projectId,
+          targetMemberId: body.targetMemberId,
         });
         res.status(201).json({ success: true, data: channel });
       }),
@@ -259,6 +265,10 @@ export function createChatV2Controller(
           contentType: body.contentType,
           clientMessageId: body.clientMessageId,
           attachments: [],
+          // Phase A (SEALED §3.2) — mentions + threadId are forwarded to
+          // the service which validates and persists them.
+          mentions: body.mentions,
+          threadId: body.threadId,
         });
         res.status(201).json({ success: true, data: message });
         persisted = message;

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -18,6 +18,9 @@ function makeChannel(overrides: Partial<ChatChannelDTO> = {}): ChatChannelDTO {
     name: 'Chat with Sam',
     createdAt: 0,
     agentPresence: { status: 'online', lastSeenAt: null },
+    // Phase A — `type` is required on the wire from A1 onward; default
+    // legacy DM channels in fixtures.
+    type: 'dm',
     ...overrides,
   };
 }
@@ -34,6 +37,9 @@ function makeMessage(overrides: Partial<ChatMessageDTO> = {}): ChatMessageDTO {
     createdAt: 0,
     attachments: [],
     metadata: { clientMessageId: 'cmid-xyz' },
+    // Phase A — `mentions` is required on the wire (never null); default to
+    // an empty array for non-mention test fixtures.
+    mentions: [],
     ...overrides,
   };
 }

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -93,6 +93,115 @@ describe('ChatV2Service', () => {
         expect((err as ChatError).httpStatus).toBe(409);
       }
     });
+
+    // -----------------------------------------------------------------------
+    // Phase A — type='channel' / Slack-like surfaces (SEALED §3.1)
+    // -----------------------------------------------------------------------
+
+    it("Phase A: creates a type='channel' row with teamId; agentSession is server-erased", () => {
+      const dto = service.createChannel({
+        // Caller may or may not pass agentSession on channel rows; server
+        // discards it either way and stores '' as the wire-binding sentinel.
+        agentSession: 'whatever-this-is-ignored',
+        name: '#general',
+        type: 'channel',
+        teamId: 'team-1',
+        principal: owner,
+      });
+      expect(dto.type).toBe('channel');
+      expect(dto.teamId).toBe('team-1');
+      expect(dto.agentSession).toBe('');
+    });
+
+    it("Phase A: type='channel' without teamId fails validation", () => {
+      try {
+        service.createChannel({
+          name: '#orphan',
+          type: 'channel',
+          principal: owner,
+        });
+        fail('expected ChatError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatError);
+        expect((err as ChatError).code).toBe('validation_error');
+        expect((err as ChatError).httpStatus).toBe(400);
+        expect((err as ChatError).message).toMatch(/teamId is required/);
+      }
+    });
+
+    it("Phase A: type='dm' with teamId fails validation (DMs are not team-scoped)", () => {
+      expect(() =>
+        service.createChannel({
+          agentSession: 'sess-a',
+          name: 'Cross-typed DM',
+          type: 'dm',
+          teamId: 'team-1',
+          principal: owner,
+        }),
+      ).toThrow(/teamId must be omitted/);
+    });
+
+    it("Phase A: type='channel' with targetMemberId fails validation", () => {
+      expect(() =>
+        service.createChannel({
+          name: '#x',
+          type: 'channel',
+          teamId: 'team-1',
+          targetMemberId: 'member-x',
+          principal: owner,
+        }),
+      ).toThrow(/targetMemberId must be omitted/);
+    });
+
+    it("Phase A: type='dm' with targetMemberId persists it", () => {
+      const dto = service.createChannel({
+        agentSession: 'sess-sam',
+        name: 'DM with Sam',
+        type: 'dm',
+        targetMemberId: 'member-sam-uuid',
+        principal: owner,
+      });
+      expect(dto.targetMemberId).toBe('member-sam-uuid');
+      expect(dto.type).toBe('dm');
+    });
+
+    it('Phase A: rejects unknown channel type values', () => {
+      expect(() =>
+        service.createChannel({
+          name: 'x',
+          // Cast through unknown to escape the typed contract for the test.
+          type: 'group' as unknown as 'dm',
+          principal: owner,
+        }),
+      ).toThrow(/unknown channel type/);
+    });
+
+    it("Phase A: type='channel' rows allow multiple per team (no 1:1 binding)", () => {
+      service.createChannel({
+        name: '#general',
+        type: 'channel',
+        teamId: 'team-1',
+        principal: owner,
+      });
+      // Same owner + same teamId, different name — must NOT trip the
+      // dm-scoped unique index. Different team is also fine.
+      expect(() =>
+        service.createChannel({
+          name: '#random',
+          type: 'channel',
+          teamId: 'team-1',
+          principal: owner,
+        }),
+      ).not.toThrow();
+      expect(() =>
+        service.createChannel({
+          name: '#general',
+          type: 'channel',
+          teamId: 'team-2',
+          principal: owner,
+        }),
+      ).not.toThrow();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -265,6 +374,131 @@ describe('ChatV2Service', () => {
       });
       expect(a.id).toBe(b.id);
       expect(a.seq).toBe(b.seq);
+    });
+
+    // -----------------------------------------------------------------------
+    // Phase A — mentions + threadId (SEALED §3.2)
+    // -----------------------------------------------------------------------
+
+    it('Phase A: persists mentions and emits them on the wire DTO', () => {
+      const ch = createSam();
+      const dto = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'pinging @Sam and @team',
+        mentions: ['member-sam-uuid', 'team-1'],
+      });
+      expect(dto.mentions).toEqual(['member-sam-uuid', 'team-1']);
+    });
+
+    it('Phase A: empty/omitted mentions yield empty array on the wire (never null)', () => {
+      const ch = createSam();
+      const omitted = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'no mentions',
+      });
+      expect(omitted.mentions).toEqual([]);
+
+      const empty = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'still no mentions',
+        mentions: [],
+      });
+      expect(empty.mentions).toEqual([]);
+    });
+
+    it('Phase A: mentions exceeding the count cap fail validation', () => {
+      const ch = createSam();
+      const tooMany = Array.from({ length: 51 }, (_, i) => `m-${i}`);
+      expect(() =>
+        service.sendMessage({
+          channelId: ch.id,
+          principal: owner,
+          content: 'x',
+          mentions: tooMany,
+        }),
+      ).toThrow(/mentions exceeds max count/);
+    });
+
+    it('Phase A: rejects non-string mention entries', () => {
+      const ch = createSam();
+      expect(() =>
+        service.sendMessage({
+          channelId: ch.id,
+          principal: owner,
+          content: 'x',
+          // Cast through unknown to bypass the typed contract.
+          mentions: ['ok', 42 as unknown as string],
+        }),
+      ).toThrow(/mentions entries must be strings/);
+    });
+
+    it('Phase A: rejects mentions that aren’t an array', () => {
+      const ch = createSam();
+      expect(() =>
+        service.sendMessage({
+          channelId: ch.id,
+          principal: owner,
+          content: 'x',
+          mentions: 'not-an-array' as unknown as string[],
+        }),
+      ).toThrow(/mentions must be an array/);
+    });
+
+    it('Phase A: persists threadId for replies and emits it on the wire DTO', () => {
+      const ch = createSam();
+      const root = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'thread root',
+      });
+      const reply = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'reply',
+        threadId: root.id,
+      });
+      expect(reply.threadId).toBe(root.id);
+      // Top-level messages omit threadId on the wire.
+      expect(root.threadId).toBeUndefined();
+    });
+
+    it('Phase A: rejects threadId that does not reference an existing message', () => {
+      const ch = createSam();
+      expect(() =>
+        service.sendMessage({
+          channelId: ch.id,
+          principal: owner,
+          content: 'orphan reply',
+          threadId: 'non-existent-id',
+        }),
+      ).toThrow(/non-existent message/);
+    });
+
+    it('Phase A: rejects threadId that references a message in a different channel', () => {
+      // Set up two channels owned by the same user. A reply in channel B
+      // pointing at a thread root in channel A must be rejected.
+      const chA = createSam();
+      const chB = service.createChannel({
+        agentSession: 'sess-b',
+        name: 'Other DM',
+        principal: owner,
+      });
+      const rootInA = service.sendMessage({
+        channelId: chA.id,
+        principal: owner,
+        content: 'root in A',
+      });
+      expect(() =>
+        service.sendMessage({
+          channelId: chB.id,
+          principal: owner,
+          content: 'cross-channel reply',
+          threadId: rootInA.id,
+        }),
+      ).toThrow(/different channel/);
     });
   });
 

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -15,12 +15,14 @@ import { ChannelStore } from './sqlite/channel.store.js';
 import { MessageStore } from './sqlite/message.store.js';
 import { openChatDatabase, type ChatDatabase } from './sqlite/chat-db.js';
 import {
+  CHAT_CHANNEL_TYPES,
   CHAT_CONTENT_TYPES,
   CHAT_ERROR_CODES,
   ChatError,
   type ChatAttachmentDTO,
   type ChatChannelDTO,
   type ChatChannelRow,
+  type ChatChannelType,
   type ChatContentType,
   type ChatMessageDTO,
   type ChatMessageListResult,
@@ -61,10 +63,25 @@ export interface ChatPresenceProvider {
 
 /** Arguments for `createChannel`. */
 export interface CreateChannelArgs {
-  agentSession: string;
+  /**
+   * Wire-level session binding. Required when `type='dm'` (default);
+   * for `type='channel'`, callers may omit it (server stores '').
+   */
+  agentSession?: string;
   name: string;
   purpose?: string;
   principal: ChatPrincipal;
+  /**
+   * Phase A (SEALED §3.1) — channel kind. Defaults to `'dm'` to preserve
+   * the Phase 1 contract for callers that omit this field.
+   */
+  type?: ChatChannelType;
+  /** Phase A — required when `type='channel'`. */
+  teamId?: string;
+  /** Phase A — optional even when `type='channel'`. */
+  projectId?: string;
+  /** Phase A — optional when `type='dm'`. */
+  targetMemberId?: string;
 }
 
 /** Arguments for `listChannels`. */
@@ -83,6 +100,19 @@ export interface SendMessageArgs {
   clientMessageId?: string;
   /** Attachment hooks — the store is added in a later step, so pre-resolved DTOs are accepted. */
   attachments?: ChatAttachmentDTO[];
+  /**
+   * Phase A (SEALED §3.2) — array of mention IDs (member or team)
+   * referenced inline in `content`. Persisted as JSON; emitted on the
+   * outbound message DTO. Empty / omitted → no mentions.
+   */
+  mentions?: string[];
+  /**
+   * Phase A (SEALED §3.2) — Slack-style thread reply root. When set,
+   * the new message is a reply within the thread rooted at this id;
+   * the service validates that the thread root lives in the same
+   * channel before persisting.
+   */
+  threadId?: string;
 }
 
 /** Arguments for `listMessages`. */
@@ -114,6 +144,11 @@ const DEFAULT_PRESENCE = () => ({
  * - Fans out to WebSocket / adapters in later phases.
  */
 export class ChatV2Service {
+  /** Phase A spec §3.2: max mention count per message. */
+  static readonly MAX_MENTIONS_PER_MESSAGE = 50;
+  /** Phase A spec §3.2: max JSON-encoded byte size of the mentions array. */
+  static readonly MAX_MENTIONS_JSON_BYTES = 1024;
+
   readonly config: ChatV2Config;
   private readonly db: ChatDatabase;
   private readonly channels: ChannelStore;
@@ -163,9 +198,65 @@ export class ChatV2Service {
         `name exceeds ${this.config.maxChannelNameChars} characters`,
       );
     }
-    const agentSession = (args.agentSession ?? '').trim();
-    if (agentSession.length === 0) {
-      throw new ChatError(CHAT_ERROR_CODES.VALIDATION, 400, 'agentSession is required');
+
+    // Phase A: validate channel type (defaults to 'dm' for backwards compat).
+    const channelType: ChatChannelType = args.type ?? 'dm';
+    if (!CHAT_CHANNEL_TYPES.includes(channelType)) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `unknown channel type: ${channelType}`,
+      );
+    }
+
+    // agentSession requirement is type-dependent:
+    //   - 'dm'      → required (existing Phase 1 contract).
+    //   - 'channel' → not 1:1-bound; server stores '' even if caller passed
+    //                 something. Keep this strict so the wire shape matches
+    //                 the design and we don't accidentally bind a team
+    //                 channel to a single agent.
+    const rawAgentSession = (args.agentSession ?? '').trim();
+    let agentSession: string;
+    if (channelType === 'dm') {
+      if (rawAgentSession.length === 0) {
+        throw new ChatError(
+          CHAT_ERROR_CODES.VALIDATION,
+          400,
+          "agentSession is required when type='dm'",
+        );
+      }
+      agentSession = rawAgentSession;
+    } else {
+      // channel: discard any caller-supplied agentSession.
+      agentSession = '';
+    }
+
+    // Phase A: type='channel' must specify a teamId; type='dm' may
+    // optionally carry a targetMemberId. Reject the contradicting cases.
+    const teamId = args.teamId?.trim() || undefined;
+    const projectId = args.projectId?.trim() || undefined;
+    const targetMemberId = args.targetMemberId?.trim() || undefined;
+
+    if (channelType === 'channel' && !teamId) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        "teamId is required when type='channel'",
+      );
+    }
+    if (channelType === 'dm' && teamId) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        "teamId must be omitted when type='dm'",
+      );
+    }
+    if (channelType === 'channel' && targetMemberId) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        "targetMemberId must be omitted when type='channel'",
+      );
     }
 
     const purpose = args.purpose?.trim();
@@ -182,6 +273,10 @@ export class ChatV2Service {
       ownerUserId: args.principal.userId,
       name,
       purpose: purpose || null,
+      type: channelType,
+      teamId: teamId ?? null,
+      projectId: projectId ?? null,
+      targetMemberId: targetMemberId ?? null,
       nowMs: this.now(),
     });
     return this.toChannelDTO(row);
@@ -271,6 +366,15 @@ export class ChatV2Service {
 
     const { type: senderType, id: senderId } = this.resolveSender(row, args.principal);
 
+    // Phase A: validate mentions array. Bounded count + JSON-byte cap so
+    // a misbehaving client cannot blow past the spec §3.2 1KB ceiling.
+    const mentions = this.validateMentions(args.mentions);
+
+    // Phase A: validate threadId — must reference an existing message in
+    // this channel; refusing dangling thread refs prevents orphan replies
+    // and contains UX confusion if the FE composes against a stale id.
+    const threadId = this.validateThreadId(args.threadId, args.channelId);
+
     const { row: persisted } = this.messages.insert({
       channelId: args.channelId,
       senderType,
@@ -278,10 +382,107 @@ export class ChatV2Service {
       content,
       contentType,
       clientMessageId: args.clientMessageId,
+      mentions,
+      threadId,
       nowMs: this.now(),
     });
 
     return this.toMessageDTO(persisted, args.attachments ?? []);
+  }
+
+  /**
+   * Phase A — validate the mentions array passed to sendMessage.
+   * Returns the cleaned array (or undefined when input is empty/missing).
+   *
+   * @param raw - The raw `mentions` field from the request body
+   * @returns Validated mention IDs (caller passes to messageStore)
+   * @throws {ChatError} `validation_error` (400) on type / size / count violation
+   */
+  private validateMentions(raw: unknown): string[] | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (!Array.isArray(raw)) {
+      throw new ChatError(CHAT_ERROR_CODES.VALIDATION, 400, 'mentions must be an array');
+    }
+    if (raw.length === 0) return undefined;
+    if (raw.length > ChatV2Service.MAX_MENTIONS_PER_MESSAGE) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `mentions exceeds max count (${ChatV2Service.MAX_MENTIONS_PER_MESSAGE})`,
+      );
+    }
+    const cleaned: string[] = [];
+    for (const item of raw) {
+      if (typeof item !== 'string') {
+        throw new ChatError(
+          CHAT_ERROR_CODES.VALIDATION,
+          400,
+          'mentions entries must be strings',
+        );
+      }
+      const trimmed = item.trim();
+      if (trimmed.length === 0) {
+        throw new ChatError(
+          CHAT_ERROR_CODES.VALIDATION,
+          400,
+          'mentions entries must be non-empty',
+        );
+      }
+      cleaned.push(trimmed);
+    }
+    // Bound the JSON size — spec §3.2 caps mentions JSON at 1KB.
+    const jsonByteLen = Buffer.byteLength(JSON.stringify(cleaned), 'utf-8');
+    if (jsonByteLen > ChatV2Service.MAX_MENTIONS_JSON_BYTES) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.PAYLOAD_TOO_LARGE,
+        413,
+        `mentions JSON exceeds max bytes (${ChatV2Service.MAX_MENTIONS_JSON_BYTES})`,
+      );
+    }
+    return cleaned;
+  }
+
+  /**
+   * Phase A — validate the threadId passed to sendMessage.
+   *
+   * Returns the original threadId if it's a valid reference to a message
+   * in the same channel, or undefined when input is empty/missing.
+   * Refuses dangling references and cross-channel thread roots.
+   *
+   * @param raw - The raw `threadId` field from the request body
+   * @param channelId - The channel this message will be inserted into
+   * @returns Validated thread root id (caller passes to messageStore)
+   * @throws {ChatError} `validation_error` (400) when invalid
+   */
+  private validateThreadId(raw: unknown, channelId: string): string | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== 'string') {
+      throw new ChatError(CHAT_ERROR_CODES.VALIDATION, 400, 'threadId must be a string');
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) return undefined;
+
+    const root = this.messages.getById(trimmed);
+    if (!root) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `threadId references a non-existent message`,
+        { threadId: trimmed },
+      );
+    }
+    if (root.channel_id !== channelId) {
+      // Returning validation_error (not channel_not_found) because the
+      // caller's intent IS valid — they're just pointing at the wrong
+      // channel's thread root. Distinct error helps debugging.
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `threadId belongs to a different channel`,
+        { threadId: trimmed, expectedChannelId: channelId },
+      );
+    }
+    return trimmed;
   }
 
   /**

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -366,7 +366,13 @@ export class ChatV2Service {
 
   /** Map a channel row + live presence into the wire DTO. */
   private toChannelDTO(row: ChatChannelRow): ChatChannelDTO {
-    const presence = (this.presence ?? DEFAULT_PRESENCE)(row.agent_session);
+    // Phase B backwards-compat: legacy rows (pre-migration) lack `type` /
+    // team scope fields. The migration backfills `type='dm'` for existing
+    // rows; here we defend the in-memory path against rows that may not
+    // yet have the column populated (e.g. mid-migration test runs).
+    const channelType = row.type ?? 'dm';
+    const presenceSource = channelType === 'dm' ? row.agent_session : '';
+    const presence = (this.presence ?? DEFAULT_PRESENCE)(presenceSource);
     return {
       id: row.id,
       agentSession: row.agent_session,
@@ -379,6 +385,10 @@ export class ChatV2Service {
         status: presence.status,
         lastSeenAt: presence.lastSeenAt,
       },
+      type: channelType,
+      teamId: row.team_id ?? undefined,
+      projectId: row.project_id ?? undefined,
+      targetMemberId: row.target_member_id ?? undefined,
     };
   }
 
@@ -392,6 +402,22 @@ export class ChatV2Service {
         metadata = undefined;
       }
     }
+    // Phase B backwards-compat: parse mentions from JSON-encoded array
+    // column. Legacy rows (pre-migration) have null; we surface as
+    // empty array so the wire contract `mentions: string[]` is never
+    // violated. A malformed JSON column also falls back to `[]` rather
+    // than throwing — the wire contract is the priority.
+    let mentions: string[] = [];
+    if (row.mentions) {
+      try {
+        const parsed = JSON.parse(row.mentions) as unknown;
+        if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) {
+          mentions = parsed as string[];
+        }
+      } catch {
+        mentions = [];
+      }
+    }
     return {
       id: row.id,
       channelId: row.channel_id,
@@ -403,6 +429,8 @@ export class ChatV2Service {
       createdAt: row.created_at,
       attachments,
       metadata,
+      mentions,
+      threadId: row.thread_id ?? undefined,
     };
   }
 }

--- a/backend/src/services/chat-v2/sqlite/channel.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.test.ts
@@ -38,6 +38,61 @@ describe('ChannelStore', () => {
       expect(row.created_at).toBe(100);
       expect(row.archived_at).toBeNull();
       expect(row.last_message_at).toBeNull();
+      // Phase A defaults: omitted type defaults to 'dm'; team/project/target null.
+      expect(row.type).toBe('dm');
+      expect(row.team_id).toBeNull();
+      expect(row.project_id).toBeNull();
+      expect(row.target_member_id).toBeNull();
+    });
+
+    it('persists Phase A fields: type=channel, team_id, project_id', () => {
+      const row = store.create({
+        agentSession: '',
+        ownerUserId: 'user-a',
+        name: '#general',
+        type: 'channel',
+        teamId: 'team-1',
+        projectId: 'proj-x',
+      });
+      expect(row.type).toBe('channel');
+      expect(row.team_id).toBe('team-1');
+      expect(row.project_id).toBe('proj-x');
+      expect(row.target_member_id).toBeNull();
+      // Channel-typed rows carry an empty agent_session sentinel.
+      expect(row.agent_session).toBe('');
+    });
+
+    it('persists target_member_id for type=dm rows', () => {
+      const row = store.create({
+        agentSession: 'sess-sam',
+        ownerUserId: 'user-a',
+        name: 'DM with Sam',
+        targetMemberId: 'member-sam-uuid',
+      });
+      expect(row.type).toBe('dm');
+      expect(row.target_member_id).toBe('member-sam-uuid');
+    });
+
+    it('allows multiple type=channel rows to share the empty agent_session', () => {
+      // The dm-scoped partial unique index excludes type='channel' rows.
+      expect(() =>
+        store.create({
+          agentSession: '',
+          ownerUserId: 'user-a',
+          name: '#general',
+          type: 'channel',
+          teamId: 'team-1',
+        }),
+      ).not.toThrow();
+      expect(() =>
+        store.create({
+          agentSession: '',
+          ownerUserId: 'user-a',
+          name: '#general',
+          type: 'channel',
+          teamId: 'team-2',
+        }),
+      ).not.toThrow();
     });
 
     it('allows purpose to be null', () => {
@@ -103,6 +158,29 @@ describe('ChannelStore', () => {
       const row = store.create({ agentSession: 'sess-a', ownerUserId: 'user-a', name: 'Ch' });
       store.archive(row.id);
       expect(store.findActiveByAgentSession('sess-a')).toBeNull();
+    });
+
+    it('Phase A: ignores type=channel rows even when agent_session matches', () => {
+      // Create a type='channel' row with a non-empty agent_session (edge
+      // case — service layer would normally pass ''). The dm-scoped lookup
+      // must NOT return it since channel rows aren't 1:1-bound to agents.
+      store.create({
+        agentSession: 'sess-shared',
+        ownerUserId: 'user-a',
+        name: '#shared',
+        type: 'channel',
+        teamId: 'team-1',
+      });
+      expect(store.findActiveByAgentSession('sess-shared')).toBeNull();
+
+      // After the channel row, a real DM with the same session is still
+      // findable — the lookup correctly distinguishes by type.
+      const dm = store.create({
+        agentSession: 'sess-shared',
+        ownerUserId: 'user-a',
+        name: 'DM',
+      });
+      expect(store.findActiveByAgentSession('sess-shared')?.id).toBe(dm.id);
     });
   });
 

--- a/backend/src/services/chat-v2/sqlite/channel.store.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.ts
@@ -8,8 +8,28 @@
  */
 
 import { randomUUID } from 'crypto';
-import { CHAT_ERROR_CODES, ChatError, type ChatChannelRow } from '../types.js';
+import {
+  CHAT_ERROR_CODES,
+  ChatError,
+  type ChatChannelRow,
+  type ChatChannelType,
+} from '../types.js';
 import type { ChatDatabase } from './chat-db.js';
+
+// ---------------------------------------------------------------------------
+// Constants — shared SELECT column list, single source of truth
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical column list for `chat_channels` SELECTs. Including all Phase A
+ * columns (type / team_id / project_id / target_member_id) here keeps every
+ * read path in this store mapping to a fully-populated `ChatChannelRow`.
+ */
+const CHANNEL_SELECT_COLUMNS = `
+  id, agent_session, owner_user_id, name, purpose,
+  created_at, archived_at, last_message_at,
+  type, team_id, project_id, target_member_id
+`;
 
 // ---------------------------------------------------------------------------
 // Input shapes
@@ -17,10 +37,27 @@ import type { ChatDatabase } from './chat-db.js';
 
 /** Payload for `ChannelStore.create`. */
 export interface ChannelCreateInput {
+  /**
+   * Wire-level session binding. For `type='dm'` (default), this is the
+   * agent's session ID and the partial unique index enforces 1:1 binding.
+   * For `type='channel'`, callers should pass the empty string `''` —
+   * channel rows are excluded from the dm-binding unique index by design.
+   */
   agentSession: string;
   ownerUserId: string;
   name: string;
   purpose?: string | null;
+  /**
+   * Phase A (SEALED §3.1) — channel type. Defaults to `'dm'` to preserve
+   * the Phase 1 / Week 2 contract for callers that omit this field.
+   */
+  type?: ChatChannelType;
+  /** Phase A — required when `type='channel'`; null/empty for DMs. */
+  teamId?: string | null;
+  /** Phase A — optional project link for project-scoped channels. */
+  projectId?: string | null;
+  /** Phase A — for `type='dm'`, the resolved member-ID being DM'd. */
+  targetMemberId?: string | null;
   /** Override the clock (tests). */
   nowMs?: number;
   /** Override the generated id (tests / deterministic callers). */
@@ -49,14 +86,31 @@ export class ChannelStore {
     const id = input.id ?? randomUUID();
     const createdAt = input.nowMs ?? Date.now();
     const purpose = input.purpose ?? null;
+    const channelType: ChatChannelType = input.type ?? 'dm';
+    const teamId = input.teamId ?? null;
+    const projectId = input.projectId ?? null;
+    const targetMemberId = input.targetMemberId ?? null;
 
     const stmt = this.db.prepare(
-      `INSERT INTO chat_channels (id, agent_session, owner_user_id, name, purpose, created_at)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO chat_channels
+         (id, agent_session, owner_user_id, name, purpose, created_at,
+          type, team_id, project_id, target_member_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
 
     try {
-      stmt.run(id, input.agentSession, input.ownerUserId, input.name, purpose, createdAt);
+      stmt.run(
+        id,
+        input.agentSession,
+        input.ownerUserId,
+        input.name,
+        purpose,
+        createdAt,
+        channelType,
+        teamId,
+        projectId,
+        targetMemberId,
+      );
     } catch (err) {
       // Unique constraint means either the partial index on agent_session fired
       // (the common case — 1:1 binding violated) or we raced an id collision.
@@ -98,8 +152,7 @@ export class ChannelStore {
   getById(id: string): ChatChannelRow | null {
     const row = this.db
       .prepare(
-        `SELECT id, agent_session, owner_user_id, name, purpose,
-                created_at, archived_at, last_message_at
+        `SELECT ${CHANNEL_SELECT_COLUMNS}
          FROM chat_channels
          WHERE id = ?`,
       )
@@ -115,12 +168,15 @@ export class ChannelStore {
    * @returns The active channel row, or null
    */
   findActiveByAgentSession(agentSession: string): ChatChannelRow | null {
+    // Phase A: scope to type='dm' so this method's contract matches the
+    // post-migration `uq_channel_agent_dm_active` partial unique index.
+    // type='channel' rows can share the empty agent_session sentinel; we
+    // never want this lookup to surface those.
     const row = this.db
       .prepare(
-        `SELECT id, agent_session, owner_user_id, name, purpose,
-                created_at, archived_at, last_message_at
+        `SELECT ${CHANNEL_SELECT_COLUMNS}
          FROM chat_channels
-         WHERE agent_session = ? AND archived_at IS NULL
+         WHERE agent_session = ? AND archived_at IS NULL AND type = 'dm'
          LIMIT 1`,
       )
       .get(agentSession) as ChatChannelRow | undefined;
@@ -144,8 +200,7 @@ export class ChannelStore {
     const limit = Math.min(options?.limit ?? 50, 100);
 
     const sql = `
-      SELECT id, agent_session, owner_user_id, name, purpose,
-             created_at, archived_at, last_message_at
+      SELECT ${CHANNEL_SELECT_COLUMNS}
       FROM chat_channels
       WHERE owner_user_id = ?
         ${includeArchived ? '' : 'AND archived_at IS NULL'}

--- a/backend/src/services/chat-v2/sqlite/chat-db.test.ts
+++ b/backend/src/services/chat-v2/sqlite/chat-db.test.ts
@@ -4,7 +4,7 @@
  * @module services/chat-v2/sqlite/chat-db.test
  */
 
-import { openChatDatabase } from './chat-db.js';
+import { applyPhaseAColumnUpgrades, openChatDatabase } from './chat-db.js';
 
 describe('openChatDatabase', () => {
   function openInMemory() {
@@ -40,15 +40,56 @@ describe('openChatDatabase', () => {
       const names = rows.map((r) => r.name);
       expect(names).toEqual(
         expect.arrayContaining([
-          'uq_channel_agent_active',
+          // Phase A renamed `uq_channel_agent_active` -> `uq_channel_agent_dm_active`
+          'uq_channel_agent_dm_active',
           'ix_channels_owner',
+          'ix_channels_team',
           'uq_messages_channel_seq',
           'ix_messages_channel_created',
           'uq_messages_client_id',
+          'ix_messages_thread',
           'ix_attachments_message',
           'ix_queue_pending',
         ]),
       );
+      // Legacy index name must not exist on fresh installs.
+      expect(names).not.toEqual(expect.arrayContaining(['uq_channel_agent_active']));
+    } finally {
+      db.close();
+    }
+  });
+
+  it('creates Phase A columns on chat_channels (type, team_id, project_id, target_member_id)', () => {
+    const db = openInMemory();
+    try {
+      const cols = db.pragma('table_info(chat_channels)') as Array<{
+        name: string;
+        notnull: number;
+        dflt_value: string | null;
+      }>;
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect(byName.has('type')).toBe(true);
+      expect(byName.has('team_id')).toBe(true);
+      expect(byName.has('project_id')).toBe(true);
+      expect(byName.has('target_member_id')).toBe(true);
+
+      // `type` must be NOT NULL with default 'dm' so existing INSERTs that
+      // omit it (and pre-Phase-A backfilled rows) end up on the dm path.
+      const typeCol = byName.get('type')!;
+      expect(typeCol.notnull).toBe(1);
+      // SQLite stores defaults with surrounding quotes for string literals.
+      expect(typeCol.dflt_value).toMatch(/^'?dm'?$/);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('creates Phase A columns on chat_messages (mentions, thread_id)', () => {
+    const db = openInMemory();
+    try {
+      const cols = db.pragma('table_info(chat_messages)') as Array<{ name: string }>;
+      const names = cols.map((c) => c.name);
+      expect(names).toEqual(expect.arrayContaining(['mentions', 'thread_id']));
     } finally {
       db.close();
     }
@@ -98,7 +139,7 @@ describe('openChatDatabase', () => {
     }
   });
 
-  it('enforces the uq_channel_agent_active partial index', () => {
+  it('enforces the uq_channel_agent_dm_active partial index for type=dm rows', () => {
     const db = openInMemory();
     try {
       const now = Date.now();
@@ -108,12 +149,61 @@ describe('openChatDatabase', () => {
       );
       insert.run('ch1', 'shared-agent', 'user-a', 'First', now);
 
-      // Second active channel for the same agent must fail the unique index.
+      // Second active dm channel for the same agent must fail the unique index.
+      // Both rows default `type` to 'dm' so the partial-index WHERE clause
+      // (archived_at IS NULL AND type='dm') matches both.
       expect(() => insert.run('ch2', 'shared-agent', 'user-a', 'Second', now)).toThrow(/UNIQUE/i);
 
       // But once the first is archived, a second active binding is allowed.
       db.prepare('UPDATE chat_channels SET archived_at = ? WHERE id = ?').run(now, 'ch1');
       expect(() => insert.run('ch2', 'shared-agent', 'user-a', 'Second', now)).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('does NOT apply the dm-binding unique index to type=channel rows', () => {
+    // Phase A SEALED §3.1 — multiple type='channel' rows can legitimately
+    // share an empty agent_session ('' wire-binding sentinel). The renamed
+    // partial index `uq_channel_agent_dm_active` excludes type='channel'
+    // rows via `WHERE archived_at IS NULL AND type = 'dm'`.
+    const db = openInMemory();
+    try {
+      const now = Date.now();
+      const insert = db.prepare(
+        `INSERT INTO chat_channels
+           (id, agent_session, owner_user_id, name, created_at, type, team_id)
+         VALUES (?, ?, ?, ?, ?, 'channel', ?)`,
+      );
+      // Two `#general` channels in different teams, both with the empty
+      // agent_session sentinel — no unique-constraint violation.
+      expect(() => {
+        insert.run('cha-team-1', '', 'user-a', '#general', now, 'team-1');
+        insert.run('cha-team-2', '', 'user-a', '#general', now, 'team-2');
+      }).not.toThrow();
+
+      const rows = db
+        .prepare("SELECT id FROM chat_channels WHERE type = 'channel' ORDER BY id")
+        .all() as Array<{ id: string }>;
+      expect(rows.map((r) => r.id)).toEqual(['cha-team-1', 'cha-team-2']);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('rejects type values outside the {dm, channel} CHECK', () => {
+    const db = openInMemory();
+    try {
+      const now = Date.now();
+      expect(() =>
+        db
+          .prepare(
+            `INSERT INTO chat_channels
+               (id, agent_session, owner_user_id, name, created_at, type)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run('cha-bad', '', 'user-a', 'Bogus', now, 'group' /* invalid */),
+      ).toThrow(/CHECK/i);
     } finally {
       db.close();
     }
@@ -145,6 +235,126 @@ describe('openChatDatabase', () => {
     } finally {
       db.close();
     }
+  });
+
+  describe('applyPhaseAColumnUpgrades — pre-Phase-A migration path', () => {
+    /**
+     * Recreate the literal Phase 1 schema (pre-Phase-A) so we can verify
+     * the additive upgrade. The DDL below intentionally omits Phase A
+     * columns and creates the OLD `uq_channel_agent_active` index name,
+     * mirroring what a database created before this migration looks like.
+     */
+    const PRE_PHASE_A_DDL = `
+      CREATE TABLE chat_channels (
+        id              TEXT PRIMARY KEY,
+        agent_session   TEXT NOT NULL,
+        owner_user_id   TEXT NOT NULL,
+        name            TEXT NOT NULL,
+        purpose         TEXT,
+        created_at      INTEGER NOT NULL,
+        archived_at     INTEGER,
+        last_message_at INTEGER
+      );
+      CREATE UNIQUE INDEX uq_channel_agent_active
+        ON chat_channels(agent_session)
+        WHERE archived_at IS NULL;
+      CREATE TABLE chat_messages (
+        id           TEXT PRIMARY KEY,
+        channel_id   TEXT NOT NULL REFERENCES chat_channels(id) ON DELETE CASCADE,
+        seq          INTEGER NOT NULL,
+        sender_type  TEXT NOT NULL CHECK(sender_type IN ('user','agent','system')),
+        sender_id    TEXT NOT NULL,
+        content      TEXT NOT NULL,
+        content_type TEXT NOT NULL DEFAULT 'markdown',
+        created_at   INTEGER NOT NULL,
+        metadata     TEXT
+      );
+    `;
+
+    function openLegacyDb() {
+      // Bypass openChatDatabase so the Phase A upgrade hasn't run yet.
+      // better-sqlite3 is exported as the constructor itself (CJS), not as
+      // `default` — `require('better-sqlite3')` is what we want.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const Database = require('better-sqlite3');
+      const db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      db.exec(PRE_PHASE_A_DDL);
+      return db;
+    }
+
+    it('adds the Phase A columns to a pre-Phase-A database without dropping data', () => {
+      const db = openLegacyDb();
+      try {
+        const now = Date.now();
+        // Insert a row using the OLD schema (no `type` column on the wire).
+        db.prepare(
+          `INSERT INTO chat_channels
+             (id, agent_session, owner_user_id, name, created_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run('legacy-1', 'sess-a', 'user-a', 'Legacy DM', now);
+
+        const report = applyPhaseAColumnUpgrades(db);
+        expect(report.channelsAdded.sort()).toEqual(
+          ['type', 'team_id', 'project_id', 'target_member_id'].sort(),
+        );
+        expect(report.messagesAdded.sort()).toEqual(['mentions', 'thread_id'].sort());
+        expect(report.legacyIndexDropped).toBe(true);
+
+        // Existing row preserved AND backfilled to type='dm' via the
+        // NOT NULL DEFAULT clause on ADD COLUMN.
+        const row = db
+          .prepare('SELECT id, agent_session, type, team_id FROM chat_channels WHERE id = ?')
+          .get('legacy-1') as { id: string; agent_session: string; type: string; team_id: string | null };
+        expect(row.id).toBe('legacy-1');
+        expect(row.agent_session).toBe('sess-a');
+        expect(row.type).toBe('dm');
+        expect(row.team_id).toBeNull();
+      } finally {
+        db.close();
+      }
+    });
+
+    it('is no-op idempotent: running the upgrade twice produces no changes the second time', () => {
+      const db = openLegacyDb();
+      try {
+        const first = applyPhaseAColumnUpgrades(db);
+        expect(first.channelsAdded.length + first.messagesAdded.length).toBeGreaterThan(0);
+
+        const second = applyPhaseAColumnUpgrades(db);
+        expect(second.channelsAdded).toEqual([]);
+        expect(second.messagesAdded).toEqual([]);
+        expect(second.legacyIndexDropped).toBe(false);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('drops the legacy uq_channel_agent_active index in favor of the new dm-scoped index', () => {
+      const db = openLegacyDb();
+      try {
+        // Sanity: legacy index is present in the pre-upgrade state.
+        const legacyBefore = db
+          .prepare(
+            `SELECT name FROM sqlite_master
+             WHERE type = 'index' AND name = 'uq_channel_agent_active'`,
+          )
+          .get();
+        expect(legacyBefore).toBeTruthy();
+
+        applyPhaseAColumnUpgrades(db);
+
+        const legacyAfter = db
+          .prepare(
+            `SELECT name FROM sqlite_master
+             WHERE type = 'index' AND name = 'uq_channel_agent_active'`,
+          )
+          .get();
+        expect(legacyAfter).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    });
   });
 
   it('clientMessageId idempotency index prevents duplicates per channel', () => {

--- a/backend/src/services/chat-v2/sqlite/chat-db.ts
+++ b/backend/src/services/chat-v2/sqlite/chat-db.ts
@@ -66,34 +66,54 @@ function getBetterSqlite3(): typeof import('better-sqlite3') {
 export type ChatDatabase = import('better-sqlite3').Database;
 
 // ---------------------------------------------------------------------------
-// Migration DDL (Phase 1)
+// Migration DDL (Phase 1 base + Phase A Slack-like extensions)
 // ---------------------------------------------------------------------------
 
 /**
- * Idempotent Phase 1 DDL. Safe to run every boot.
+ * Idempotent base DDL — Phase 1 schema with Phase A column additions baked in.
+ *
+ * Safe to run every boot.
  *
  * Differences vs. the literal spec §3.2:
  * - Added `IF NOT EXISTS` on every CREATE so reboots don't fail.
  * - PRAGMAs set outside the transaction (SQLite disallows PRAGMA in txn).
+ *
+ * Phase A additions (SEALED design 2026-04-25 §3.1 + §3.2) are reflected
+ * directly in the CREATE TABLE bodies so a fresh-install database lands on
+ * the new schema in one shot. Pre-existing databases (created under the
+ * Phase 1 schema) get the same columns added by `applyPhaseAColumnUpgrades`
+ * below, which uses `ALTER TABLE ADD COLUMN` guarded by `PRAGMA table_info`.
  */
 export const CHAT_V2_MIGRATION_SQL = `
 CREATE TABLE IF NOT EXISTS chat_channels (
-  id              TEXT PRIMARY KEY,
-  agent_session   TEXT NOT NULL,
-  owner_user_id   TEXT NOT NULL,
-  name            TEXT NOT NULL,
-  purpose         TEXT,
-  created_at      INTEGER NOT NULL,
-  archived_at     INTEGER,
-  last_message_at INTEGER
+  id                TEXT PRIMARY KEY,
+  agent_session     TEXT NOT NULL,
+  owner_user_id     TEXT NOT NULL,
+  name              TEXT NOT NULL,
+  purpose           TEXT,
+  created_at        INTEGER NOT NULL,
+  archived_at       INTEGER,
+  last_message_at   INTEGER,
+  -- Phase A (SEALED §3.1): channel-type discriminator. 'dm' preserves the
+  -- Phase 1 1:1 user↔agent contract; 'channel' is the Slack-like team
+  -- surface. Existing rows backfill to 'dm' via applyPhaseAColumnUpgrades.
+  type              TEXT NOT NULL DEFAULT 'dm' CHECK(type IN ('dm','channel')),
+  -- Phase A (SEALED §3.1): team workspace link. Required at the service
+  -- layer when type='channel'; null for type='dm'.
+  team_id           TEXT,
+  -- Phase A (SEALED §3.1): optional project link for project-scoped channels.
+  project_id        TEXT,
+  -- Phase A (SEALED §3.1): for type='dm', the resolved member-ID being DM'd
+  -- (distinct from agent_session which is the wire-level binding key).
+  target_member_id  TEXT
 );
-
-CREATE UNIQUE INDEX IF NOT EXISTS uq_channel_agent_active
-  ON chat_channels(agent_session)
-  WHERE archived_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS ix_channels_owner
   ON chat_channels(owner_user_id, archived_at);
+
+-- Phase A indexes that reference the new columns (type, team_id, thread_id)
+-- live in CHAT_V2_PHASE_A_INDEX_SQL below — they must be created AFTER
+-- applyPhaseAColumnUpgrades runs so the columns exist on legacy DBs.
 
 CREATE TABLE IF NOT EXISTS chat_messages (
   id           TEXT PRIMARY KEY,
@@ -105,7 +125,14 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   content_type TEXT NOT NULL CHECK(content_type IN ('text','markdown','image_ref','system_note'))
                DEFAULT 'markdown',
   created_at   INTEGER NOT NULL,
-  metadata     TEXT
+  metadata     TEXT,
+  -- Phase A (SEALED §3.2): JSON-encoded array of mention IDs (member or
+  -- team) referenced inline in the content field. Stored as a JSON string;
+  -- service layer treats null as []. Bounded at insert time; see types.ts.
+  mentions     TEXT,
+  -- Phase A (SEALED §3.2): optional Slack-style thread root. When set,
+  -- this message is a reply within the thread rooted at thread_id.
+  thread_id    TEXT
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_channel_seq
@@ -114,7 +141,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_channel_seq
 CREATE INDEX IF NOT EXISTS ix_messages_channel_created
   ON chat_messages(channel_id, created_at DESC);
 
--- Partial unique index for clientMessageId-based idempotency (spec §4.4)
+-- Phase 1: partial unique index for clientMessageId-based idempotency (spec §4.4)
 CREATE UNIQUE INDEX IF NOT EXISTS uq_messages_client_id
   ON chat_messages(channel_id, json_extract(metadata, '$.clientMessageId'))
   WHERE json_extract(metadata, '$.clientMessageId') IS NOT NULL;
@@ -147,6 +174,162 @@ CREATE INDEX IF NOT EXISTS ix_queue_pending
   ON chat_offline_queue(agent_session, delivered_at)
   WHERE delivered_at IS NULL;
 `;
+
+/**
+ * Phase A indexes that reference Phase A columns. Must run AFTER
+ * `applyPhaseAColumnUpgrades` adds those columns on pre-Phase-A databases —
+ * otherwise the partial-index `WHERE` clauses fail with "no such column".
+ *
+ * On a fresh database this runs after `CHAT_V2_MIGRATION_SQL` has already
+ * baked the columns into the CREATE TABLE bodies, so each step is a
+ * harmless no-op (`CREATE INDEX IF NOT EXISTS`).
+ */
+export const CHAT_V2_PHASE_A_INDEX_SQL = `
+-- Phase A (SEALED §3.1): the 1:1 agent-binding only applies to type='dm'
+-- channels. type='channel' rows have agent_session='' and many such rows
+-- can coexist for the same team; the partial index intentionally excludes
+-- them so the unique constraint doesn't fire on multi-agent channels.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_channel_agent_dm_active
+  ON chat_channels(agent_session)
+  WHERE archived_at IS NULL AND type = 'dm';
+
+-- Phase A (SEALED §3.1): scoped lookup for "all channels in team T" and
+-- "project P channels". Indexes by team first because team-scoped reads
+-- are the dominant Phase B+ access pattern.
+CREATE INDEX IF NOT EXISTS ix_channels_team
+  ON chat_channels(team_id, archived_at)
+  WHERE team_id IS NOT NULL;
+
+-- Phase A (SEALED §3.2): thread-pane lookup. Filtered to non-null so the
+-- (smaller) index only covers actual threaded replies.
+CREATE INDEX IF NOT EXISTS ix_messages_thread
+  ON chat_messages(thread_id, seq)
+  WHERE thread_id IS NOT NULL;
+`;
+
+// ---------------------------------------------------------------------------
+// Phase A column-upgrade helpers — additive, idempotent, NOT destructive
+// ---------------------------------------------------------------------------
+
+/**
+ * Spec for one column we want to ensure exists on a table.
+ *
+ * `addClause` is the body of an `ALTER TABLE ... ADD COLUMN <addClause>`
+ * statement (the column name is included). SQLite restricts ADD COLUMN
+ * defaults to constants; that constraint is satisfied by every entry below.
+ */
+interface ColumnSpec {
+  /** Column name, used both for PRAGMA presence-check and the ADD COLUMN clause. */
+  name: string;
+  /** ADD COLUMN clause body, e.g. `team_id TEXT`. Must not include `ALTER TABLE`. */
+  addClause: string;
+}
+
+/** Phase A column additions for `chat_channels`. */
+const CHAT_CHANNELS_PHASE_A_COLUMNS: ColumnSpec[] = [
+  // NOT NULL DEFAULT 'dm' lets ALTER TABLE backfill existing rows in one shot.
+  { name: 'type', addClause: "type TEXT NOT NULL DEFAULT 'dm'" },
+  { name: 'team_id', addClause: 'team_id TEXT' },
+  { name: 'project_id', addClause: 'project_id TEXT' },
+  { name: 'target_member_id', addClause: 'target_member_id TEXT' },
+];
+
+/** Phase A column additions for `chat_messages`. */
+const CHAT_MESSAGES_PHASE_A_COLUMNS: ColumnSpec[] = [
+  { name: 'mentions', addClause: 'mentions TEXT' },
+  { name: 'thread_id', addClause: 'thread_id TEXT' },
+];
+
+/**
+ * Add a column to `table` if (and only if) it isn't already present.
+ *
+ * Uses `PRAGMA table_info(<table>)` to enumerate existing columns. SQLite
+ * does not have an `ADD COLUMN IF NOT EXISTS` form, so this guarded
+ * approach is the standard idempotent shape.
+ *
+ * @param db - The chat database handle
+ * @param table - Target table
+ * @param spec - Column to ensure
+ * @returns `true` if a column was added, `false` if it already existed
+ */
+function ensureColumn(db: ChatDatabase, table: string, spec: ColumnSpec): boolean {
+  // PRAGMA cannot be parameterized; the table name is inlined. Callers
+  // supply only literal table names from the constants above — never
+  // user input — so SQL injection is not a concern here.
+  const cols = db.pragma(`table_info(${table})`) as Array<{ name: string }>;
+  if (cols.some((c) => c.name === spec.name)) {
+    return false;
+  }
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${spec.addClause}`);
+  return true;
+}
+
+/**
+ * Bring a pre-existing chat database up to Phase A's schema by adding
+ * any missing columns and the new indexes / dropping the superseded ones.
+ *
+ * Safe to run on a fresh database too — every step is no-op idempotent.
+ * Specifically:
+ *   - `ensureColumn` is a no-op when the column is already present (the
+ *     fresh-install case, since the columns are baked into the CREATE
+ *     TABLE in `CHAT_V2_MIGRATION_SQL`).
+ *   - `DROP INDEX IF EXISTS uq_channel_agent_active` removes the legacy
+ *     unconditional partial index so the new dm-scoped one isn't shadowed.
+ *     The DROP is metadata-only — no row data is affected.
+ *
+ * Exported (separately from `openChatDatabase`) so tests can simulate the
+ * pre-Phase-A → Phase A migration path explicitly.
+ *
+ * @param db - The chat database handle
+ * @returns A small report describing what changed (for logging)
+ */
+export function applyPhaseAColumnUpgrades(db: ChatDatabase): {
+  channelsAdded: string[];
+  messagesAdded: string[];
+  legacyIndexDropped: boolean;
+} {
+  const channelsAdded: string[] = [];
+  for (const spec of CHAT_CHANNELS_PHASE_A_COLUMNS) {
+    if (ensureColumn(db, 'chat_channels', spec)) {
+      channelsAdded.push(spec.name);
+    }
+  }
+  const messagesAdded: string[] = [];
+  for (const spec of CHAT_MESSAGES_PHASE_A_COLUMNS) {
+    if (ensureColumn(db, 'chat_messages', spec)) {
+      messagesAdded.push(spec.name);
+    }
+  }
+
+  // Drop the legacy `uq_channel_agent_active` partial index — its constraint
+  // (`agent_session unique among archived_at IS NULL`) is too strict in the
+  // post-Phase-A world where multiple type='channel' rows legitimately share
+  // an empty agent_session. The replacement `uq_channel_agent_dm_active`
+  // (created below) carries the same semantics scoped to type='dm' rows only.
+  //
+  // The drop must happen BEFORE creating the new index — if the legacy
+  // index were left in place, an INSERT into a type='dm' row would still
+  // be checked by both indexes (same expression, different WHERE), which
+  // is harmless functionally but wastes write amplification.
+  const legacyIdx = db
+    .prepare(
+      `SELECT name FROM sqlite_master
+       WHERE type = 'index' AND name = 'uq_channel_agent_active'`,
+    )
+    .get() as { name: string } | undefined;
+  let legacyIndexDropped = false;
+  if (legacyIdx) {
+    db.exec('DROP INDEX IF EXISTS uq_channel_agent_active');
+    legacyIndexDropped = true;
+  }
+
+  // Now that all Phase A columns are guaranteed to exist, create the
+  // Phase A indexes that reference them. Idempotent — `CREATE INDEX IF NOT
+  // EXISTS` makes this a no-op on subsequent boots.
+  db.exec(CHAT_V2_PHASE_A_INDEX_SQL);
+
+  return { channelsAdded, messagesAdded, legacyIndexDropped };
+}
 
 // ---------------------------------------------------------------------------
 // Opener
@@ -209,7 +392,22 @@ export function openChatDatabase(options: OpenChatDatabaseOptions): ChatDatabase
   db.pragma('synchronous = NORMAL');
 
   // Apply the Phase 1 migration idempotently. `exec` accepts multiple statements.
+  // For fresh databases this creates every table + index in one shot, including
+  // the Phase A columns baked into the CREATE TABLE bodies.
   db.exec(CHAT_V2_MIGRATION_SQL);
+
+  // For pre-existing databases (created under Phase 1 schema), additively
+  // bring them up to Phase A: add missing columns and drop the superseded
+  // legacy `uq_channel_agent_active` index. Every step is no-op idempotent
+  // on a fresh DB.
+  const upgradeReport = applyPhaseAColumnUpgrades(db);
+  if (
+    upgradeReport.channelsAdded.length > 0 ||
+    upgradeReport.messagesAdded.length > 0 ||
+    upgradeReport.legacyIndexDropped
+  ) {
+    logger.info('Chat DB Phase A schema upgrade applied', upgradeReport);
+  }
 
   if (!options.skipIntegrityCheck) {
     try {

--- a/backend/src/services/chat-v2/sqlite/message.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/message.store.test.ts
@@ -191,6 +191,94 @@ describe('MessageStore', () => {
       expect(messages.count(channelId)).toBe(N);
       expect(messages.getLastSeq(channelId)).toBe(N);
     });
+
+    it('Phase A: persists mentions as JSON and round-trips them on read', () => {
+      const result = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'pinging @Sam and @team',
+        mentions: ['member-sam-uuid', 'team-1'],
+      });
+      // Stored as JSON-encoded array string in the mentions column.
+      expect(result.row.mentions).toBe(JSON.stringify(['member-sam-uuid', 'team-1']));
+
+      const fetched = messages.getById(result.row.id);
+      expect(fetched?.mentions).toBe(JSON.stringify(['member-sam-uuid', 'team-1']));
+    });
+
+    it('Phase A: empty or omitted mentions arrays store as DB-null', () => {
+      const noMentions = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'no mentions here',
+      });
+      expect(noMentions.row.mentions).toBeNull();
+
+      const emptyMentions = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'empty mentions array',
+        mentions: [],
+      });
+      expect(emptyMentions.row.mentions).toBeNull();
+    });
+
+    it('Phase A: persists thread_id for threaded replies', () => {
+      const root = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'thread root',
+      });
+      const reply = messages.insert({
+        channelId,
+        senderType: 'agent',
+        senderId: 'sess-a',
+        content: 'reply within thread',
+        threadId: root.row.id,
+      });
+      expect(reply.row.thread_id).toBe(root.row.id);
+
+      // Top-level (no threadId) stores null.
+      expect(root.row.thread_id).toBeNull();
+    });
+
+    it('Phase A: ix_messages_thread index exists and would serve thread reads', () => {
+      // Insert root + two replies; verify the rows are persisted under
+      // the thread_id and that an indexed query returns them ordered by seq.
+      const root = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'root',
+      });
+      const r1 = messages.insert({
+        channelId,
+        senderType: 'agent',
+        senderId: 'sess-a',
+        content: 'r1',
+        threadId: root.row.id,
+      });
+      const r2 = messages.insert({
+        channelId,
+        senderType: 'user',
+        senderId: 'user-a',
+        content: 'r2',
+        threadId: root.row.id,
+      });
+      // Direct read using the index predicate.
+      const replies = db
+        .prepare(
+          `SELECT id FROM chat_messages
+           WHERE thread_id = ?
+           ORDER BY seq ASC`,
+        )
+        .all(root.row.id) as Array<{ id: string }>;
+      expect(replies.map((r) => r.id)).toEqual([r1.row.id, r2.row.id]);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/sqlite/message.store.ts
+++ b/backend/src/services/chat-v2/sqlite/message.store.ts
@@ -26,6 +26,20 @@ import {
 import type { ChatDatabase } from './chat-db.js';
 
 // ---------------------------------------------------------------------------
+// Constants — shared SELECT column list, single source of truth
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical column list for `chat_messages` SELECTs. Including all Phase A
+ * columns (mentions / thread_id) here keeps every read path in this store
+ * mapping to a fully-populated `ChatMessageRow`.
+ */
+const MESSAGE_SELECT_COLUMNS = `
+  id, channel_id, seq, sender_type, sender_id, content, content_type,
+  created_at, metadata, mentions, thread_id
+`;
+
+// ---------------------------------------------------------------------------
 // Cursor helpers
 // ---------------------------------------------------------------------------
 
@@ -86,6 +100,18 @@ export interface MessageInsertInput {
   metadata?: Record<string, unknown>;
   /** Stable client id for idempotent retries; folded into metadata. */
   clientMessageId?: string;
+  /**
+   * Phase A (SEALED §3.2) — array of mention IDs (member or team)
+   * referenced inline in `content`. Stored as a JSON-encoded string in
+   * the `mentions` column. Empty array or omitted → null in storage.
+   */
+  mentions?: string[];
+  /**
+   * Phase A (SEALED §3.2) — Slack-style thread root. When set, this
+   * message is a reply within the thread rooted at `threadId`. Omitted
+   * for top-level channel messages.
+   */
+  threadId?: string;
   /** Override the insert clock (tests). */
   nowMs?: number;
   /** Override the generated id (tests / deterministic callers). */
@@ -146,13 +172,19 @@ export class MessageStore {
     const metadataHasKeys = Object.keys(metadataObj).length > 0;
     const metadataJson = metadataHasKeys ? JSON.stringify(metadataObj) : null;
 
+    // Phase A: serialize mentions to JSON. Treat null/empty as DB-null so
+    // legacy rows and "no mentions" share a representation; the read-side
+    // mapper translates DB-null back to [].
+    const mentionsJson =
+      input.mentions && input.mentions.length > 0 ? JSON.stringify(input.mentions) : null;
+    const threadId = input.threadId ?? null;
+
     const txn = this.db.transaction((): MessageInsertResult => {
       // Dedupe check — same clientMessageId + channel → return existing row.
       if (input.clientMessageId) {
         const existing = this.db
           .prepare(
-            `SELECT id, channel_id, seq, sender_type, sender_id, content, content_type,
-                    created_at, metadata
+            `SELECT ${MESSAGE_SELECT_COLUMNS}
              FROM chat_messages
              WHERE channel_id = ?
                AND json_extract(metadata, '$.clientMessageId') = ?
@@ -196,8 +228,9 @@ export class MessageStore {
       this.db
         .prepare(
           `INSERT INTO chat_messages
-             (id, channel_id, seq, sender_type, sender_id, content, content_type, created_at, metadata)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             (id, channel_id, seq, sender_type, sender_id, content, content_type,
+              created_at, metadata, mentions, thread_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           id,
@@ -209,6 +242,8 @@ export class MessageStore {
           contentType,
           createdAt,
           metadataJson,
+          mentionsJson,
+          threadId,
         );
 
       // Touch last_message_at on the parent channel.
@@ -223,8 +258,7 @@ export class MessageStore {
 
       const row = this.db
         .prepare(
-          `SELECT id, channel_id, seq, sender_type, sender_id, content, content_type,
-                  created_at, metadata
+          `SELECT ${MESSAGE_SELECT_COLUMNS}
            FROM chat_messages
            WHERE id = ?`,
         )
@@ -244,8 +278,7 @@ export class MessageStore {
   getById(id: string): ChatMessageRow | null {
     const row = this.db
       .prepare(
-        `SELECT id, channel_id, seq, sender_type, sender_id, content, content_type,
-                created_at, metadata
+        `SELECT ${MESSAGE_SELECT_COLUMNS}
          FROM chat_messages
          WHERE id = ?`,
       )
@@ -294,8 +327,7 @@ export class MessageStore {
     direction: 'backward' | 'forward',
     limit: number,
   ): ChatMessageRow[] {
-    const cols = `id, channel_id, seq, sender_type, sender_id, content, content_type,
-                  created_at, metadata`;
+    const cols = MESSAGE_SELECT_COLUMNS;
 
     if (direction === 'backward') {
       // Loading older: newest-first, seq < cursor.

--- a/backend/src/services/chat-v2/types.test.ts
+++ b/backend/src/services/chat-v2/types.test.ts
@@ -10,8 +10,18 @@
 import {
   CHAT_SENDER_TYPES,
   CHAT_CONTENT_TYPES,
+  CHAT_CHANNEL_TYPES,
+  CHAT_MENTION_KINDS,
   CHAT_ERROR_CODES,
   ChatError,
+} from './types.js';
+import type {
+  ChatChannelRow,
+  ChatMessageRow,
+  ChatChannelDTO,
+  ChatMessageDTO,
+  CreateChannelInput,
+  SendMessageInput,
 } from './types.js';
 
 describe('chat-v2/types', () => {
@@ -34,6 +44,102 @@ describe('chat-v2/types', () => {
         'system_note',
         'text',
       ]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase B Slack-like team-chat additions (SEALED design 2026-04-25)
+  // -------------------------------------------------------------------------
+
+  describe('CHAT_CHANNEL_TYPES', () => {
+    it('contains exactly the two channel types — dm + channel', () => {
+      expect([...CHAT_CHANNEL_TYPES].sort()).toEqual(['channel', 'dm']);
+    });
+  });
+
+  describe('CHAT_MENTION_KINDS', () => {
+    it('contains exactly the two mention kinds — team + agent', () => {
+      expect([...CHAT_MENTION_KINDS].sort()).toEqual(['agent', 'team']);
+    });
+  });
+
+  describe('Phase B row shapes — type-only contract checks', () => {
+    it.todo('TODO: ChatChannelRow accepts type/team_id/project_id/target_member_id');
+    it.todo('TODO: ChatMessageRow accepts mentions JSON string + thread_id');
+    it.todo('TODO: ChatChannelDTO requires type field; teamId/projectId/targetMemberId optional');
+    it.todo('TODO: ChatMessageDTO requires mentions array (never null on wire); threadId optional');
+    it.todo('TODO: CreateChannelInput type defaults to dm; channel requires teamId at service-layer validation');
+    it.todo('TODO: SendMessageInput accepts optional mentions[] + threadId');
+
+    // Compile-time-only contract assertions: these never run, but the
+    // types must shape-match for the file to compile. If a future
+    // refactor breaks the contract, tsc fails the build before tests
+    // even start.
+    it('Phase B types compile — contract preserved', () => {
+      const _channelRow: ChatChannelRow = {
+        id: 'c-1',
+        agent_session: '',
+        owner_user_id: 'u-1',
+        name: '#general',
+        purpose: null,
+        created_at: 0,
+        archived_at: null,
+        last_message_at: null,
+        type: 'channel',
+        team_id: 't-1',
+        project_id: null,
+        target_member_id: null,
+      };
+      const _msgRow: ChatMessageRow = {
+        id: 'm-1',
+        channel_id: 'c-1',
+        seq: 1,
+        sender_type: 'user',
+        sender_id: 'u-1',
+        content: 'hi @team',
+        content_type: 'text',
+        created_at: 0,
+        metadata: null,
+        mentions: '["t-1"]',
+        thread_id: null,
+      };
+      const _channelDto: ChatChannelDTO = {
+        id: 'c-1',
+        agentSession: '',
+        name: '#general',
+        createdAt: 0,
+        agentPresence: { status: 'offline', lastSeenAt: null },
+        type: 'channel',
+        teamId: 't-1',
+      };
+      const _msgDto: ChatMessageDTO = {
+        id: 'm-1',
+        channelId: 'c-1',
+        seq: 1,
+        senderType: 'user',
+        senderId: 'u-1',
+        content: 'hi @team',
+        contentType: 'text',
+        createdAt: 0,
+        attachments: [],
+        mentions: ['t-1'],
+      };
+      const _createInput: CreateChannelInput = {
+        name: '#general',
+        type: 'channel',
+        teamId: 't-1',
+      };
+      const _sendInput: SendMessageInput = {
+        content: 'hi @team',
+        mentions: ['t-1'],
+      };
+      // Variables exist solely for type-checking; assert truthy to satisfy lint.
+      expect(_channelRow.type).toBe('channel');
+      expect(_msgRow.thread_id).toBeNull();
+      expect(_channelDto.type).toBe('channel');
+      expect(_msgDto.mentions).toEqual(['t-1']);
+      expect(_createInput.type).toBe('channel');
+      expect(_sendInput.mentions).toEqual(['t-1']);
     });
   });
 

--- a/backend/src/services/chat-v2/types.ts
+++ b/backend/src/services/chat-v2/types.ts
@@ -22,6 +22,25 @@ export type ChatContentType = 'text' | 'markdown' | 'image_ref' | 'system_note';
 /** Agent presence snapshot categories. */
 export type ChatAgentPresenceStatus = 'online' | 'busy' | 'offline' | 'starting';
 
+/**
+ * Channel type — Phase B Slack-like team-chat addition (SEALED design 2026-04-25 §3.1).
+ *
+ *  - `dm`: 1:1 user↔agent direct message channel. Matches the Phase 1 / Week 2
+ *     contract; existing rows default to this. `agent_session` field is the
+ *     1:1 binding key.
+ *  - `channel`: public team-scoped channel (`#general`, `#proj-<name>`, etc.)
+ *     where multiple agents may participate. The `agent_session` field on
+ *     channel-typed rows is left empty (no 1:1 binding).
+ *
+ * The wire-protocol vocabulary intentionally stays narrow at BE; FE adds
+ * `idle` / `inactive` UI states via `@crewly/chat-ui`'s `ChatPresenceStatus`
+ * union (the translation lives at the boundary, not here).
+ */
+export type ChatChannelType = 'dm' | 'channel';
+
+/** Mention target kind — Phase B addition (SEALED design §7.1 chip pattern). */
+export type ChatMentionKind = 'team' | 'agent';
+
 /** Enum values exposed as readonly tuples for runtime validation. */
 export const CHAT_SENDER_TYPES: readonly ChatSenderType[] = ['user', 'agent', 'system'];
 export const CHAT_CONTENT_TYPES: readonly ChatContentType[] = [
@@ -31,6 +50,12 @@ export const CHAT_CONTENT_TYPES: readonly ChatContentType[] = [
   'system_note',
 ];
 
+/** Phase B — channel-type tuple for runtime validation in CreateChannelInput. */
+export const CHAT_CHANNEL_TYPES: readonly ChatChannelType[] = ['dm', 'channel'];
+
+/** Phase B — mention-kind tuple for runtime validation in mention parsing. */
+export const CHAT_MENTION_KINDS: readonly ChatMentionKind[] = ['team', 'agent'];
+
 // ---------------------------------------------------------------------------
 // DB row shapes (1:1 with DDL in sqlite/chat-db.ts)
 // ---------------------------------------------------------------------------
@@ -38,6 +63,11 @@ export const CHAT_CONTENT_TYPES: readonly ChatContentType[] = [
 /** Row shape of `chat_channels`. Timestamps are ms-since-epoch UTC. */
 export interface ChatChannelRow {
   id: string;
+  /**
+   * 1:1 binding to the agent's session for `type='dm'` rows. For
+   * `type='channel'` rows, holds an empty string (`''`) — the row is
+   * not bound to a single agent. Phase B SEALED design §3.1.
+   */
   agent_session: string;
   owner_user_id: string;
   name: string;
@@ -45,6 +75,32 @@ export interface ChatChannelRow {
   created_at: number;
   archived_at: number | null;
   last_message_at: number | null;
+  /**
+   * Phase B addition (SEALED §3.1). `'dm'` for the existing 1:1 channels
+   * (default — preserves backwards-compat); `'channel'` for new
+   * team-scoped surfaces. NOT NULL after migration; existing rows
+   * backfill to `'dm'`.
+   */
+  type: ChatChannelType;
+  /**
+   * Phase B addition (SEALED §3.1). Links a channel to a Crewly team
+   * workspace. Required for `type='channel'`; null/empty for `type='dm'`
+   * (which is user↔agent, not team-scoped).
+   */
+  team_id: string | null;
+  /**
+   * Phase B addition (SEALED §3.1). Optional link to a specific
+   * project for project-scoped channels (e.g. `#proj-<name>`). Null
+   * for team-general channels and DMs.
+   */
+  project_id: string | null;
+  /**
+   * Phase B addition (SEALED §3.1). For `type='dm'` rows, optionally
+   * holds the target member-ID being DM'd (distinct from
+   * `agent_session` which is the wire-level session binding). For
+   * `type='channel'` rows, always null.
+   */
+  target_member_id: string | null;
 }
 
 /** Row shape of `chat_messages`. */
@@ -59,6 +115,20 @@ export interface ChatMessageRow {
   created_at: number;
   /** JSON blob (string) or null. Bounded at 2KB at insert time. */
   metadata: string | null;
+  /**
+   * Phase B addition (SEALED §3.2). JSON-encoded array of mention IDs
+   * referenced inline in `content` (member IDs and/or team IDs). Stored
+   * as JSON string in SQLite (no native JSON column); empty array when
+   * no mentions. Bounded at 1KB at insert time. Null on legacy rows;
+   * service layer treats null as `[]`.
+   */
+  mentions: string | null;
+  /**
+   * Phase B addition (SEALED §3.2). Optional Slack-style threading
+   * within a channel — when set, this message is a reply within the
+   * thread rooted at `thread_id`. Null for top-level messages.
+   */
+  thread_id: string | null;
 }
 
 /** Row shape of `chat_attachments`. */
@@ -80,18 +150,45 @@ export interface ChatAttachmentRow {
 /** Outbound channel shape for `GET /channels` / `POST /channels`. */
 export interface ChatChannelDTO {
   id: string;
+  /**
+   * Wire-level session binding for `type='dm'` channels. Empty string
+   * for `type='channel'` rows.
+   */
   agentSession: string;
   name: string;
   purpose?: string;
   createdAt: number;
   archivedAt?: number | null;
   lastMessageAt?: number | null;
+  /**
+   * Agent-presence summary. Populated for `type='dm'` channels (the
+   * agent on the other side of the DM). For `type='channel'` rows,
+   * `status: 'offline'` and `lastSeenAt: null` until the FE wires
+   * per-member presence in Phase C.
+   */
   agentPresence: {
     status: ChatAgentPresenceStatus;
     lastSeenAt: number | null;
   };
   /** Pending entries in the offline queue for this channel. */
   queuedCount?: number;
+  /**
+   * Phase B (SEALED §3.1) — `'dm'` (existing default) or `'channel'`
+   * (new team-scoped surfaces). Required field on the wire from Phase B
+   * onward; legacy callers that omit it are treated as `'dm'`.
+   */
+  type: ChatChannelType;
+  /** Phase B — team workspace ID. Required when `type='channel'`. */
+  teamId?: string;
+  /** Phase B — project link. Optional even when `type='channel'`. */
+  projectId?: string;
+  /**
+   * Phase B — for `type='dm'`, the target member's ID. Optional in
+   * Week-2 contract because `agentSession` already disambiguates.
+   * Provided when the FE wants to render a member-level handle
+   * (`@Sam`) rather than the session ID.
+   */
+  targetMemberId?: string;
 }
 
 /** Outbound message shape for `GET /messages` / `POST /messages` / WS `message` frame. */
@@ -106,6 +203,20 @@ export interface ChatMessageDTO {
   createdAt: number;
   attachments: ChatAttachmentDTO[];
   metadata?: Record<string, unknown>;
+  /**
+   * Phase B (SEALED §3.2) — array of mention IDs referenced inline in
+   * `content`. Each entry is either a member ID or a team ID; the
+   * `kind` discrimination is left to consumers via a separate lookup
+   * (we do not embed `MentionTarget` shape in the wire to keep DTOs
+   * shallow). Empty array when no mentions; never null on the wire.
+   */
+  mentions: string[];
+  /**
+   * Phase B (SEALED §3.2) — optional Slack-style thread root. When
+   * present, this message is a reply within the thread; consumers
+   * group by `threadId` to render the thread sub-pane.
+   */
+  threadId?: string;
 }
 
 /** Outbound attachment shape — image only in Phase 1. */
@@ -142,9 +253,25 @@ export interface ChatMessageListResult {
 
 /** Body of `POST /channels`. */
 export interface CreateChannelInput {
-  agentSession: string;
+  /**
+   * Wire-level session binding. Required when `type='dm'` (default);
+   * ignored when `type='channel'` (server stores empty string).
+   */
+  agentSession?: string;
   name: string;
   purpose?: string;
+  /**
+   * Phase B addition (SEALED §3.1). `'dm'` (default — preserves
+   * Week-2 contract for callers that omit this field) or `'channel'`.
+   * Service layer rejects `type='channel'` requests that omit `teamId`.
+   */
+  type?: ChatChannelType;
+  /** Phase B — required when `type='channel'`. */
+  teamId?: string;
+  /** Phase B — optional even when `type='channel'`. */
+  projectId?: string;
+  /** Phase B — optional for `type='dm'`. */
+  targetMemberId?: string;
 }
 
 /** Body of `POST /channels/:id/messages`. */
@@ -154,6 +281,19 @@ export interface SendMessageInput {
   clientMessageId?: string;
   /** Pre-uploaded attachment refs; Phase 1 is `{ attachmentId }` shape. */
   attachments?: Array<{ attachmentId: string }>;
+  /**
+   * Phase B (SEALED §3.2) — mention IDs (member or team) referenced
+   * inline in `content`. The FE composer parses chips into this
+   * shape before send; the BE persists as JSON and emits with the
+   * outbound message DTO. Empty array or omitted = no mentions.
+   */
+  mentions?: string[];
+  /**
+   * Phase B (SEALED §3.2) — Slack-style thread reply root. When set,
+   * the new message is a reply within the thread. Omit for top-level
+   * channel messages.
+   */
+  threadId?: string;
 }
 
 /** Principal passed down from auth middleware. */


### PR DESCRIPTION
## Summary

End-to-end backend migration for the Slack-like team-chat surfaces — SEALED design [`slack-like-team-chat-design-2026-04-25.md`](.crewly/knowledge/slack-like-team-chat-design-2026-04-25.md) §3.1 + §3.2 plumbed from SQL → store → service → REST controller. Unblocks Leo's Phase B FE composer (mention chips, thread pane) and the Phase E Cloud Portal acceptance test.

5 commits, all on `feat/slack-like-team-chat-be-migration`:

| Commit | Phase | Scope |
|---|---|---|
| `e8f89837` | A1 | DTO type additions (`ChatChannelType`, `ChatMentionKind`, new fields on row + DTO + input shapes) |
| `0d9bd555` | A2 | SQL migration: chat_channels +`type`/`team_id`/`project_id`/`target_member_id`; chat_messages +`mentions`/`thread_id`; partial-index swap (`uq_channel_agent_active` → `uq_channel_agent_dm_active`); new indexes `ix_channels_team`, `ix_messages_thread`; idempotent legacy-DB upgrade via `applyPhaseAColumnUpgrades` |
| `f6b43a2f` | A2 | Store layer: ChannelStore + MessageStore read/write all new columns; canonical SELECT column constants for single-source-of-truth |
| `c3fbc7bd` | A3 | Service layer + Slack-like validation invariants: type↔teamId↔targetMemberId combos rejected at the service edge; mentions array bounded at 50 entries / 1KB JSON; threadId cross-channel + non-existent guards |
| `94e45124` | A4 | Controller layer: REST body fields (`type`, `teamId`, `projectId`, `targetMemberId`, `mentions`, `threadId`) forwarded end-to-end |

## Design references

- SEALED design: `.crewly/knowledge/slack-like-team-chat-design-2026-04-25.md` §3.1 (ChatConversation deltas) + §3.2 (ChatMessage deltas)
- Tech spec: `.crewly/specs/chat-mvp-phase1-tech-spec-2026-04-24.md` §3.2 (DDL baseline) + §21 (DTO contracts)
- Team norm: `.crewly/knowledge/crewly-product-team-coordination-norm-2026-04-25.md` v0.2 (Rule 2 30-min WIP cadence + test stubs, Rule 7 branch-guard, Rule 4 defensive push — all followed throughout)

## Migration mechanics

**Fresh installs** land on the new schema in one shot — Phase A columns are baked into `CREATE TABLE` bodies in `CHAT_V2_MIGRATION_SQL`.

**Pre-existing DBs** (created under Phase 1 schema) get migrated additively via `applyPhaseAColumnUpgrades`:
1. Base DDL (`CREATE TABLE IF NOT EXISTS`) is no-op on existing tables.
2. `ensureColumn` uses `PRAGMA table_info` to detect missing columns and runs `ALTER TABLE ADD COLUMN` with `NOT NULL DEFAULT 'dm'` so existing rows backfill in one operation — no separate `UPDATE` pass needed.
3. Legacy `uq_channel_agent_active` index is dropped before the new dm-scoped one is created (avoid double-write amplification on dm rows).
4. Phase A indexes (referencing `type` and `thread_id`) are split into `CHAT_V2_PHASE_A_INDEX_SQL` and run AFTER columns are guaranteed to exist — earlier attempt failed with `SqliteError: no such column: type` when DDL was monolithic; tracked in the test harness as a regression guard.

Migration is **idempotent**: `applyPhaseAColumnUpgrades` returns `{channelsAdded:[], messagesAdded:[], legacyIndexDropped:false}` on the second call — verified by `chat-db.test.ts`.

## Test coverage

163 of 163 chat-v2 tests pass across 10 of 10 suites. +49 new tests vs the pre-Phase-A baseline of 114, covering:
- New columns persist on every read path (PRAGMA + round-trip)
- Partial index swap: `uq_channel_agent_dm_active` enforces 1:1 binding for DMs only; multiple `type='channel'` rows can share the empty agent_session sentinel
- Legacy-DB upgrade preserves data + backfills `type='dm'`
- Service-layer validation: `type='channel'` requires `teamId`; `type='dm'` rejects `teamId`; mentions count + JSON-byte caps; threadId cross-channel guard
- REST controller forwards all new fields with correct error shapes

## Test plan

- [ ] `npm run build:backend` — ✅ clean
- [ ] `npx tsc --noEmit -p backend/tsconfig.json` — ✅ clean
- [ ] `npx jest --testPathPattern 'backend/src/(services|controllers)/chat-v2'` — ✅ 163/163 pass
- [ ] Smoke-test: open `~/.crewly/chat.db` from a pre-Phase-A snapshot, verify columns added without data loss (covered by `applyPhaseAColumnUpgrades — pre-Phase-A migration path` test suite)
- [ ] Leo rebases `feat/chat-team-fe-...` (PR #327 follow-on) on top of this branch, verifies composer can emit `mentions` + `threadId`

## Out of Phase A scope (parked)

- WS gateway frame format updates for the `message` event — DTO already carries `mentions` + `threadId`, so likely no code change needed; will verify when Leo wires the FE.
- Dispatcher routing logic for `@mention → agent session` resolution — Phase C/E work; this PR keeps dispatch behavior unchanged.
- Service-layer flat-thread enforcement (i.e., "thread roots cannot themselves be replies") — currently allowed; trivial to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)