### PR TITLE
feat(chat-v2): Phase C BE — channel-rail listing refinements + mention dispatch routing

### DIFF
--- a/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
@@ -367,4 +367,127 @@ describe('chat-v2 controller (REST)', () => {
       service.close();
     }
   });
+
+  // -------------------------------------------------------------------------
+  // Phase C — channel-rail listing refinements: ?type= + ?teamId= filters.
+  // -------------------------------------------------------------------------
+
+  describe('GET /api/chat/channels — Phase C filters', () => {
+    /**
+     * Seeds the in-memory store with: 1 DM + 2 team channels across 2 teams.
+     * Returns the test rig so each test can keep an explicit close() handle.
+     */
+    function buildAppWithMixedFixture() {
+      const rig = buildApp();
+      rig.service.createChannel({
+        agentSession: 'sess-dm',
+        name: 'DM with Sam',
+        principal: { userId: 'dev-user-001', source: 'oss' },
+        type: 'dm',
+        targetMemberId: 'sam-id',
+      });
+      rig.service.createChannel({
+        agentSession: '',
+        name: '#general-product',
+        principal: { userId: 'dev-user-001', source: 'oss' },
+        type: 'channel',
+        teamId: 'team-product',
+      });
+      rig.service.createChannel({
+        agentSession: '',
+        name: '#general-marketing',
+        principal: { userId: 'dev-user-001', source: 'oss' },
+        type: 'channel',
+        teamId: 'team-marketing',
+      });
+      return rig;
+    }
+
+    it('?type=dm filters to DM channels', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels?type=dm');
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(1);
+        expect(res.body.data.channels[0].type).toBe('dm');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('?type=channel filters to team channels', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels?type=channel');
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(2);
+        expect(res.body.data.channels.every((c: { type: string }) => c.type === 'channel')).toBe(
+          true,
+        );
+      } finally {
+        service.close();
+      }
+    });
+
+    it('?type=invalid → 400 validation_error', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels?type=group');
+        expect(res.status).toBe(400);
+        expect(res.body.error.code).toBe('validation_error');
+        expect(res.body.error.message).toContain('unknown channel type');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('?teamId= filters to a single team', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels?teamId=team-product');
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(1);
+        expect(res.body.data.channels[0].name).toBe('#general-product');
+        expect(res.body.data.channels[0].teamId).toBe('team-product');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('?type=channel&teamId=… composes filters', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get(
+          '/api/chat/channels?type=channel&teamId=team-marketing',
+        );
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(1);
+        expect(res.body.data.channels[0].name).toBe('#general-marketing');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('empty ?type= and ?teamId= are treated as omitted (back-compat)', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels?type=&teamId=');
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(3);
+      } finally {
+        service.close();
+      }
+    });
+
+    it('no query params returns the full owner-scoped list (back-compat)', async () => {
+      const { app, service } = buildAppWithMixedFixture();
+      try {
+        const res = await request(app).get('/api/chat/channels');
+        expect(res.status).toBe(200);
+        expect(res.body.data.channels).toHaveLength(3);
+      } finally {
+        service.close();
+      }
+    });
+  });
 });

--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -320,7 +320,12 @@ export function createChatV2Controller(
 
       try {
         if (dispatcher && channelForDispatch && persisted.senderType === 'user') {
-          void dispatcher.dispatchToAgent(channelForDispatch, persisted);
+          // Phase C BE.3 — single high-level entry point that branches
+          // on `channel.type` internally:
+          //   `type='dm'`     → 1:1 dispatch via dispatchToAgent (legacy)
+          //   `type='channel'`→ resolve `mentions[]` → fan-out per target
+          // Fire-and-forget — already past the HTTP ack at this point.
+          void dispatcher.dispatchMessage(channelForDispatch, persisted);
         }
       } catch {
         // dispatcher must never break the ack

--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -27,6 +27,7 @@ import { getChatV2RealtimeDeps } from '../../services/chat-v2/chat-v2.realtime-h
 import {
   CHAT_ERROR_CODES,
   ChatError,
+  type ChatChannelType,
   type ChatMessageDTO,
   type ChatPrincipal,
 } from '../../services/chat-v2/types.js';
@@ -162,10 +163,24 @@ export function createChatV2Controller(
         const includeArchived = req.query.includeArchived === 'true';
         const limitRaw = req.query.limit;
         const limit = typeof limitRaw === 'string' ? Number.parseInt(limitRaw, 10) : undefined;
+        // Phase C — channel-rail listing refinements.
+        // `type` and `teamId` query params let the rail fetch a focused
+        // slice (e.g. only DMs, or only channels in the active workspace)
+        // without shipping the full owner-scoped list. Both are optional
+        // and compose with AND. Service-layer rejects unknown `type`
+        // values with `validation_error`; we forward as-is so the caller
+        // gets a precise error message.
+        const typeRaw = req.query.type;
+        const type = typeof typeRaw === 'string' && typeRaw.length > 0 ? typeRaw : undefined;
+        const teamIdRaw = req.query.teamId;
+        const teamId =
+          typeof teamIdRaw === 'string' && teamIdRaw.length > 0 ? teamIdRaw : undefined;
         const channels = service.listChannels({
           principal,
           includeArchived,
           limit: Number.isFinite(limit) ? limit : undefined,
+          type: type as ChatChannelType | undefined,
+          teamId,
         });
         res.json({ success: true, data: { channels, nextCursor: null } });
       }),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1056,12 +1056,14 @@ export class CrewlyServer {
 				const [
 					{ ChatV2Gateway, devAnonymousTokenVerifier },
 					{ ChatV2DispatcherService },
+					{ ChatV2MentionResolver },
 					{ getChatV2Service },
 					{ setChatV2RealtimeDeps },
 					{ verifyHs256Token },
 				] = await Promise.all([
 					import('./websocket/chat-v2.gateway.js'),
 					import('./services/chat-v2/chat-v2.dispatcher.service.js'),
+					import('./services/chat-v2/chat-v2.mention-resolver.js'),
 					import('./services/chat-v2/chat-v2.singleton.js'),
 					import('./services/chat-v2/chat-v2.realtime-holder.js'),
 					import('./middleware/require-auth.middleware.js'),
@@ -1078,8 +1080,17 @@ export class CrewlyServer {
 					: devAnonymousTokenVerifier;
 				const chatGateway = new ChatV2Gateway({ service: chatService, verifyToken });
 				chatGateway.attach(this.httpServer);
+				// Phase C BE.3 — inject the mention resolver so type='channel'
+				// messages fan out to @-mentioned recipients instead of
+				// short-circuiting with strategy='skip' at the dispatcher.
+				// Pattern matches LiveTeamHealthDataProvider wiring (~line 487):
+				// `getTeams: async () => StorageService.getInstance().getTeams()`.
+				const chatMentionResolver = new ChatV2MentionResolver({
+					loadTeams: async () => StorageService.getInstance().getTeams(),
+				});
 				const chatDispatcher = new ChatV2DispatcherService({
 					agentSink: this.apiController.agentRegistrationService,
+					mentionResolver: chatMentionResolver,
 				});
 				this.chatV2Gateway = chatGateway;
 				this.chatV2Dispatcher = chatDispatcher;

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -415,6 +415,61 @@ describe('ChatV2DispatcherService', () => {
         expect(result.mentionOutcomes![0].error).toBe('PTY crashed');
       });
 
+      // Regression guard for Arch review M1 (PR #331): the production
+      // composition root in `backend/src/index.ts` MUST inject
+      // `mentionResolver` into ChatV2DispatcherService. When omitted,
+      // `type='channel'` messages silently short-circuit to
+      // strategy='skip' and the Phase E acceptance test would fail
+      // with debug-only logging.
+      describe("M1 regression: production composition shape", () => {
+        it("WITH mentionResolver wired (production shape) — fans out, does NOT skip", async () => {
+          const { sink, calls } = makeSink({ success: true });
+          // Mirrors backend/src/index.ts:1088-1094 exactly:
+          //   const chatMentionResolver = new ChatV2MentionResolver({
+          //     loadTeams: async () => StorageService.getInstance().getTeams(),
+          //   });
+          //   const chatDispatcher = new ChatV2DispatcherService({
+          //     agentSink: ...,
+          //     mentionResolver: chatMentionResolver,
+          //   });
+          const teams = fixtureTeams();
+          const chatMentionResolver = new ChatV2MentionResolver({
+            loadTeams: async () => teams,
+          });
+          const dispatcher = new ChatV2DispatcherService({
+            agentSink: sink,
+            mentionResolver: chatMentionResolver,
+          });
+          const result = await dispatcher.dispatchMessage(
+            makeTeamChannel(),
+            makeMessage({ mentions: ['leo-id'] }),
+          );
+          expect(result.strategy).toBe('channel-mentions');
+          expect(result.strategy).not.toBe('skip'); // explicit
+          expect(result.dispatched).toBe(true);
+          expect(calls).toHaveLength(1);
+          expect(calls[0].sessionName).toBe('crewly-product-leo');
+        });
+
+        it("WITHOUT mentionResolver (regression repro of pre-M1 wiring) — silently skips", async () => {
+          // This is the exact failure mode Arch flagged: if the
+          // composition root ever drops `mentionResolver` from the
+          // options, EVERY type='channel' message hits the
+          // `strategy='skip'` short-circuit at chat-v2.dispatcher
+          // .service.ts. Logged at debug only. Phase E acceptance test
+          // would silently fail.
+          const { sink, calls } = makeSink({ success: true });
+          const dispatcher = new ChatV2DispatcherService({ agentSink: sink });
+          const result = await dispatcher.dispatchMessage(
+            makeTeamChannel(),
+            makeMessage({ mentions: ['leo-id'] }),
+          );
+          expect(result.strategy).toBe('skip');
+          expect(result.reason).toMatch(/no mention resolver/);
+          expect(calls).toHaveLength(0);
+        });
+      });
+
       it("forwards channel.teamId as resolver context (passed through, not enforced yet)", async () => {
         // Resolver context is forwarded; BE.2 leaves enforcement for a
         // future tightening. This test pins that the dispatcher does

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -10,6 +10,8 @@ import {
   type AgentMessageSink,
 } from './chat-v2.dispatcher.service.js';
 import type { ChatChannelDTO, ChatMessageDTO } from './types.js';
+import { ChatV2MentionResolver } from './chat-v2.mention-resolver.js';
+import type { Team } from '../../types/index.js';
 
 function makeChannel(overrides: Partial<ChatChannelDTO> = {}): ChatChannelDTO {
   return {
@@ -176,6 +178,266 @@ describe('ChatV2DispatcherService', () => {
         makeMessage({ metadata: undefined }),
       );
       expect(calls[0].message).not.toContain('[cmid:');
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // Phase C BE.3 — dispatchMessage routing.
+  // --------------------------------------------------------------------
+
+  describe('dispatchMessage', () => {
+    /** Build a resolver backed by the supplied team list. */
+    function buildResolver(teams: Team[]): ChatV2MentionResolver {
+      return new ChatV2MentionResolver({ loadTeams: () => teams });
+    }
+
+    /** Minimal team fixture: one product team with a TL + a worker. */
+    function fixtureTeams(): Team[] {
+      const now = '2026-01-01T00:00:00.000Z';
+      return [
+        {
+          id: 'team-product',
+          name: 'Product',
+          members: [
+            {
+              id: 'sam-id',
+              name: 'Sam',
+              sessionName: 'crewly-product-sam',
+              role: 'team-leader',
+              systemPrompt: '',
+              agentStatus: 'inactive',
+              workingStatus: 'idle',
+              runtimeType: 'claude-code',
+              hierarchyLevel: 1,
+              canDelegate: true,
+              createdAt: now,
+              updatedAt: now,
+            },
+            {
+              id: 'leo-id',
+              name: 'Leo',
+              sessionName: 'crewly-product-leo',
+              role: 'developer',
+              systemPrompt: '',
+              agentStatus: 'inactive',
+              workingStatus: 'idle',
+              runtimeType: 'claude-code',
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+          projectIds: [],
+          createdAt: now,
+          updatedAt: now,
+        },
+      ];
+    }
+
+    /** Build a channel-typed channel for fan-out tests. */
+    function makeTeamChannel(over: Partial<ChatChannelDTO> = {}): ChatChannelDTO {
+      return makeChannel({
+        type: 'channel',
+        agentSession: '',
+        teamId: 'team-product',
+        name: '#general-product',
+        ...over,
+      });
+    }
+
+    describe('dm strategy (back-compat)', () => {
+      it("dispatches to channel.agentSession for type='dm'", async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({ agentSink: sink });
+        const result = await dispatcher.dispatchMessage(makeChannel(), makeMessage());
+        expect(result.strategy).toBe('dm');
+        expect(result.dispatched).toBe(true);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].sessionName).toBe('crewly-product-sam-dd2b46f7');
+      });
+
+      it('skips agent-origin messages (no self-loopback) before checking type', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({ agentSink: sink });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ senderType: 'agent' }),
+        );
+        expect(result.strategy).toBe('skip');
+        expect(result.reason).toMatch(/not a user-origin/);
+        expect(calls).toHaveLength(0);
+      });
+    });
+
+    describe('channel-mentions strategy (Phase C BE.3 fan-out)', () => {
+      it('skips when no resolver is wired', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({ agentSink: sink });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['leo-id'] }),
+        );
+        expect(result.strategy).toBe('skip');
+        expect(result.reason).toMatch(/no mention resolver/);
+        expect(calls).toHaveLength(0);
+      });
+
+      it('skips when message has no mentions', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: [] }),
+        );
+        expect(result.strategy).toBe('skip');
+        expect(result.reason).toMatch(/no mentions/);
+        expect(calls).toHaveLength(0);
+      });
+
+      it('fans out to one resolved member', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['leo-id'] }),
+        );
+        expect(result.strategy).toBe('channel-mentions');
+        expect(result.dispatched).toBe(true);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].sessionName).toBe('crewly-product-leo');
+        expect(calls[0].message).toContain('[CHAT:chan-1]');
+        expect(result.mentionOutcomes).toEqual([
+          {
+            target: expect.objectContaining({
+              kind: 'agent',
+              memberId: 'leo-id',
+              sessionName: 'crewly-product-leo',
+            }),
+            dispatched: true,
+          },
+        ]);
+      });
+
+      it('fans out to multiple distinct resolved targets', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['leo-id', 'team-product'] }),
+        );
+        expect(result.strategy).toBe('channel-mentions');
+        expect(result.dispatched).toBe(true);
+        // team-product mention precedes leo because the resolver puts
+        // teams first on shared input ordering — but here the input
+        // order has leo first; the resolver preserves input order.
+        // (Sam = TL of team-product; Leo = direct agent mention.)
+        expect(calls.map((c) => c.sessionName).sort()).toEqual([
+          'crewly-product-leo',
+          'crewly-product-sam',
+        ]);
+      });
+
+      it('returns empty mentionOutcomes when resolver yields nothing (unknown ids)', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['unknown-1', 'unknown-2'] }),
+        );
+        expect(result.strategy).toBe('channel-mentions');
+        expect(result.dispatched).toBe(false);
+        expect(result.mentionOutcomes).toEqual([]);
+        expect(calls).toHaveLength(0);
+      });
+
+      it('captures per-recipient sink failures without halting fan-out', async () => {
+        const calls: Array<{ sessionName: string; message: string }> = [];
+        const sink: AgentMessageSink = {
+          async sendMessageToAgent(sessionName, message) {
+            calls.push({ sessionName, message });
+            // Fail leo, succeed sam
+            if (sessionName === 'crewly-product-leo') {
+              return { success: false, error: 'leo offline' };
+            }
+            return { success: true };
+          },
+        };
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['leo-id', 'team-product'] }),
+        );
+        expect(result.strategy).toBe('channel-mentions');
+        expect(result.dispatched).toBe(true); // at least one succeeded (sam)
+        expect(calls).toHaveLength(2);
+        const leoOutcome = result.mentionOutcomes!.find(
+          (o) => o.target.sessionName === 'crewly-product-leo',
+        );
+        const samOutcome = result.mentionOutcomes!.find(
+          (o) => o.target.sessionName === 'crewly-product-sam',
+        );
+        expect(leoOutcome?.dispatched).toBe(false);
+        expect(leoOutcome?.error).toBe('leo offline');
+        expect(samOutcome?.dispatched).toBe(true);
+      });
+
+      it('captures thrown sink errors as a non-dispatched per-recipient outcome', async () => {
+        const sink: AgentMessageSink = {
+          async sendMessageToAgent() {
+            throw new Error('PTY crashed');
+          },
+        };
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: buildResolver(fixtureTeams()),
+        });
+        const result = await dispatcher.dispatchMessage(
+          makeTeamChannel(),
+          makeMessage({ mentions: ['leo-id'] }),
+        );
+        expect(result.strategy).toBe('channel-mentions');
+        expect(result.dispatched).toBe(false);
+        expect(result.mentionOutcomes).toHaveLength(1);
+        expect(result.mentionOutcomes![0].error).toBe('PTY crashed');
+      });
+
+      it("forwards channel.teamId as resolver context (passed through, not enforced yet)", async () => {
+        // Resolver context is forwarded; BE.2 leaves enforcement for a
+        // future tightening. This test pins that the dispatcher does
+        // pass `channel.teamId` so BE.4+ can act on it without changing
+        // the dispatcher.
+        let capturedCtx: { teamId?: string } | undefined;
+        const fakeResolver = {
+          async resolve(_mentions: string[], ctx?: { teamId?: string }) {
+            capturedCtx = ctx;
+            return [];
+          },
+        } as unknown as ChatV2MentionResolver;
+        const { sink } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          mentionResolver: fakeResolver,
+        });
+        await dispatcher.dispatchMessage(
+          makeTeamChannel({ teamId: 'team-product' }),
+          makeMessage({ mentions: ['leo-id'] }),
+        );
+        expect(capturedCtx).toEqual({ teamId: 'team-product' });
+      });
     });
   });
 });

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
@@ -21,6 +21,11 @@
  */
 
 import type { ChatChannelDTO, ChatMessageDTO } from './types.js';
+import type {
+  ChatV2MentionResolver,
+  MentionResolverContext,
+  MentionTarget,
+} from './chat-v2.mention-resolver.js';
 import { LoggerService, ComponentLogger } from '../core/logger.service.js';
 
 // ---------------------------------------------------------------------------
@@ -47,6 +52,43 @@ export interface DispatchResult {
   error?: string;
 }
 
+/** One per-recipient outcome produced by `dispatchMessage`. */
+export interface MentionDispatchOutcome {
+  /** The mention target the dispatcher attempted to deliver to. */
+  target: MentionTarget;
+  /** Underlying delivery result from `AgentMessageSink.sendMessageToAgent`. */
+  dispatched: boolean;
+  /** Error message, if delivery failed. */
+  error?: string;
+}
+
+/**
+ * Aggregate result of `dispatchMessage`. Reports the chosen routing
+ * strategy and per-recipient outcomes so callers (and tests) can assert
+ * exactly what fan-out happened without re-running the resolver.
+ */
+export interface DispatchMessageResult {
+  /**
+   * - `'dm'`: legacy 1:1 path — used by `type='dm'` channels.
+   * - `'channel-mentions'`: Phase C BE.3 fan-out — used by `type='channel'`
+   *   channels with at least one resolved mention.
+   * - `'skip'`: nothing was dispatched (non-user message, no recipients,
+   *   archived/unbound channel, etc.). `reason` is filled.
+   */
+  strategy: 'dm' | 'channel-mentions' | 'skip';
+  /** True when at least one underlying delivery succeeded. */
+  dispatched: boolean;
+  /** Filled when `strategy === 'skip'`. */
+  reason?: string;
+  /** Populated for `strategy === 'dm'`. */
+  dmResult?: DispatchResult;
+  /**
+   * Populated for `strategy === 'channel-mentions'`. One entry per
+   * resolved target. Empty when no mentions resolved.
+   */
+  mentionOutcomes?: MentionDispatchOutcome[];
+}
+
 /** Constructor options for {@link ChatV2DispatcherService}. */
 export interface ChatV2DispatcherOptions {
   agentSink: AgentMessageSink;
@@ -55,6 +97,15 @@ export interface ChatV2DispatcherOptions {
    * default matches the `reply-channel` skill's parser exactly.
    */
   formatPrompt?: (args: FormatPromptArgs) => string;
+  /**
+   * Phase C BE.3 — resolver used when dispatching a `type='channel'`
+   * message to its mentioned recipients. When omitted, channel-typed
+   * messages skip dispatch entirely (preserves the BE.1+BE.2 contract
+   * for callers that haven't wired the resolver yet, e.g. legacy unit
+   * tests). The production composition root injects a resolver backed
+   * by `StorageService.getTeams()`.
+   */
+  mentionResolver?: ChatV2MentionResolver;
 }
 
 /** Inputs to the prompt formatter. */
@@ -106,12 +157,154 @@ export function defaultFormatPrompt(args: FormatPromptArgs): string {
 export class ChatV2DispatcherService {
   private readonly agentSink: AgentMessageSink;
   private readonly formatPrompt: (args: FormatPromptArgs) => string;
+  private readonly mentionResolver?: ChatV2MentionResolver;
   private readonly logger: ComponentLogger;
 
   constructor(options: ChatV2DispatcherOptions) {
     this.agentSink = options.agentSink;
     this.formatPrompt = options.formatPrompt ?? defaultFormatPrompt;
+    this.mentionResolver = options.mentionResolver;
     this.logger = LoggerService.getInstance().createComponentLogger('ChatV2Dispatcher');
+  }
+
+  /**
+   * Phase C BE.3 entry point — choose the routing strategy from
+   * `channel.type` and the message's mentions, then fan out.
+   *
+   * Routing rules (SEALED §2.1):
+   *   - `type='dm'` → existing 1:1 path via `dispatchToAgent`. Mentions
+   *     in DMs are advisory only (the channel already binds to one
+   *     agent); the dispatcher does not currently re-route them.
+   *   - `type='channel'` → resolve `message.mentions` via the injected
+   *     `mentionResolver`, then dispatch the formatted prompt to each
+   *     resolved sessionName. No mentions → no dispatch (the message
+   *     still persists; nobody is paged).
+   *   - Agent-origin messages always skip dispatch (no self-loopback).
+   *
+   * Always resolves; per-recipient errors are captured in
+   * {@link DispatchMessageResult.mentionOutcomes} and never thrown.
+   *
+   * @param channel - The channel DTO (provides `type`, name, agentSession).
+   * @param message - The persisted message DTO (provides senderType, mentions).
+   * @returns Aggregate result describing the strategy + outcomes.
+   */
+  async dispatchMessage(
+    channel: ChatChannelDTO,
+    message: ChatMessageDTO,
+  ): Promise<DispatchMessageResult> {
+    if (message.senderType !== 'user') {
+      return {
+        strategy: 'skip',
+        dispatched: false,
+        reason: 'not a user-origin message',
+      };
+    }
+
+    if (channel.type === 'channel') {
+      return this.dispatchChannelMentions(channel, message);
+    }
+
+    // Default to the DM path for any other type (including legacy /
+    // missing — `type` is non-null after Phase A migration but defensive
+    // here keeps the dispatcher robust).
+    const dmResult = await this.dispatchToAgent(channel, message);
+    return {
+      strategy: 'dm',
+      dispatched: dmResult.dispatched,
+      dmResult,
+    };
+  }
+
+  /**
+   * Dispatch a `type='channel'` message to its resolved mentions.
+   *
+   * Skips entirely when:
+   *   - No mention resolver is wired (return strategy=skip).
+   *   - `mentions` is empty (return strategy=skip).
+   *   - The resolver returns no targets (return strategy=channel-mentions
+   *     with empty `mentionOutcomes`; `dispatched=false`).
+   *
+   * @param channel - The team channel.
+   * @param message - The persisted user message.
+   * @returns Aggregate result with one outcome per resolved recipient.
+   */
+  private async dispatchChannelMentions(
+    channel: ChatChannelDTO,
+    message: ChatMessageDTO,
+  ): Promise<DispatchMessageResult> {
+    if (!this.mentionResolver) {
+      this.logger.debug('chat-v2 dispatch skipped — no mention resolver wired', {
+        channelId: channel.id,
+        messageId: message.id,
+      });
+      return {
+        strategy: 'skip',
+        dispatched: false,
+        reason: 'no mention resolver wired for type=channel',
+      };
+    }
+
+    const mentions = Array.isArray(message.mentions) ? message.mentions : [];
+    if (mentions.length === 0) {
+      return {
+        strategy: 'skip',
+        dispatched: false,
+        reason: 'no mentions on type=channel message',
+      };
+    }
+
+    const ctx: MentionResolverContext = { teamId: channel.teamId };
+    const targets = await this.mentionResolver.resolve(mentions, ctx);
+
+    const outcomes: MentionDispatchOutcome[] = [];
+    let anyDispatched = false;
+
+    for (const target of targets) {
+      const prompt = this.formatPrompt({
+        channelId: channel.id,
+        channelName: channel.name,
+        agentSession: target.sessionName,
+        senderId: message.senderId,
+        content: message.content,
+        clientMessageId:
+          typeof message.metadata?.clientMessageId === 'string'
+            ? (message.metadata.clientMessageId as string)
+            : undefined,
+      });
+
+      try {
+        const result = await this.agentSink.sendMessageToAgent(target.sessionName, prompt);
+        if (result.success) {
+          outcomes.push({ target, dispatched: true });
+          anyDispatched = true;
+        } else {
+          this.logger.warn('chat-v2 mention dispatch reported failure', {
+            channelId: channel.id,
+            sessionName: target.sessionName,
+            err: result.error,
+          });
+          outcomes.push({
+            target,
+            dispatched: false,
+            error: result.error ?? 'unknown sink failure',
+          });
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        this.logger.error('chat-v2 mention dispatch threw', {
+          channelId: channel.id,
+          sessionName: target.sessionName,
+          err: errMsg,
+        });
+        outcomes.push({ target, dispatched: false, error: errMsg });
+      }
+    }
+
+    return {
+      strategy: 'channel-mentions',
+      dispatched: anyDispatched,
+      mentionOutcomes: outcomes,
+    };
   }
 
   /**

--- a/backend/src/services/chat-v2/chat-v2.mention-resolver.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.mention-resolver.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for ChatV2MentionResolver — Phase C BE.2 mention dispatch
+ * routing scaffolding.
+ *
+ * The resolver is intentionally test-friendly: it only depends on a
+ * `loadTeams()` callback, so all branches are exercised against in-memory
+ * team fixtures with no real `StorageService`.
+ *
+ * @module services/chat-v2/chat-v2.mention-resolver.test
+ */
+
+import { ChatV2MentionResolver } from './chat-v2.mention-resolver.js';
+import type { Team, TeamMember } from '../../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, 'id' | 'sessionName'>): TeamMember {
+  return {
+    name: over.name ?? `mem-${over.id}`,
+    role: over.role ?? 'developer',
+    systemPrompt: '',
+    agentStatus: 'inactive',
+    workingStatus: 'idle',
+    runtimeType: 'claude-code',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+function team(over: Partial<Team> & Pick<Team, 'id'>): Team {
+  return {
+    name: over.name ?? `team-${over.id}`,
+    members: over.members ?? [],
+    projectIds: over.projectIds ?? [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+// A fixture covering all of TL pick rules + a normal worker + edge cases.
+function buildFixture(): Team[] {
+  const product = team({
+    id: 'team-product',
+    members: [
+      member({
+        id: 'sam-id',
+        sessionName: 'crewly-product-sam',
+        role: 'team-leader',
+        hierarchyLevel: 1,
+        canDelegate: true,
+      }),
+      member({ id: 'leo-id', sessionName: 'crewly-product-leo', role: 'developer' }),
+      member({ id: 'max-id', sessionName: 'crewly-product-max', role: 'developer' }),
+    ],
+  });
+  const marketing = team({
+    id: 'team-marketing',
+    members: [
+      // No hierarchy fields, but role='team-leader' — falls through to rule 3.
+      member({ id: 'ella-id', sessionName: 'crewly-marketing-ella', role: 'team-leader' }),
+      member({ id: 'luna-id', sessionName: 'crewly-marketing-luna' }),
+    ],
+  });
+  const legacyOnlyDelegator = team({
+    id: 'team-legacy',
+    members: [
+      // canDelegate=true but no hierarchyLevel — rule 2 hits.
+      member({ id: 'old-tl-id', sessionName: 'sess-old-tl', canDelegate: true }),
+      member({ id: 'old-worker', sessionName: 'sess-old-worker' }),
+    ],
+  });
+  const noLeadTeam = team({
+    id: 'team-flat',
+    members: [
+      // No TL at all — rule 4 fallback to first member.
+      member({ id: 'first-id', sessionName: 'sess-first' }),
+      member({ id: 'second-id', sessionName: 'sess-second' }),
+    ],
+  });
+  const emptyTeam = team({ id: 'team-empty', members: [] });
+  return [product, marketing, legacyOnlyDelegator, noLeadTeam, emptyTeam];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatV2MentionResolver', () => {
+  type LoadTeamsFn = () => Promise<Team[]> | Team[];
+  function build(loadTeams: LoadTeamsFn = () => buildFixture()) {
+    return new ChatV2MentionResolver({ loadTeams });
+  }
+
+  describe('@agent mentions', () => {
+    it('resolves a member id to that member sessionName', async () => {
+      const r = build();
+      const out = await r.resolve(['leo-id']);
+      expect(out).toEqual([
+        {
+          kind: 'agent',
+          mentionId: 'leo-id',
+          memberId: 'leo-id',
+          sessionName: 'crewly-product-leo',
+        },
+      ]);
+    });
+
+    it('resolves multiple distinct member ids in input order', async () => {
+      const r = build();
+      const out = await r.resolve(['leo-id', 'max-id']);
+      expect(out.map((t) => t.sessionName)).toEqual([
+        'crewly-product-leo',
+        'crewly-product-max',
+      ]);
+    });
+
+    it('skips an empty / whitespace mention id silently', async () => {
+      const r = build();
+      const out = await r.resolve(['leo-id', '', '   ', 'max-id']);
+      expect(out).toHaveLength(2);
+    });
+
+    it('skips members with empty sessionName', async () => {
+      const r = build(() => [
+        team({
+          id: 't',
+          members: [member({ id: 'no-sess', sessionName: '' })],
+        }),
+      ]);
+      const out = await r.resolve(['no-sess']);
+      expect(out).toEqual([]);
+    });
+  });
+
+  describe('@team mentions', () => {
+    it('resolves a team id to its hierarchy-1 + canDelegate TL (rule 1)', async () => {
+      const r = build();
+      const out = await r.resolve(['team-product']);
+      expect(out).toEqual([
+        {
+          kind: 'team',
+          mentionId: 'team-product',
+          memberId: 'sam-id',
+          sessionName: 'crewly-product-sam',
+          teamId: 'team-product',
+        },
+      ]);
+    });
+
+    it('falls back to canDelegate=true when no hierarchy fields are set (rule 2)', async () => {
+      const r = build();
+      const out = await r.resolve(['team-legacy']);
+      expect(out[0]).toMatchObject({
+        kind: 'team',
+        memberId: 'old-tl-id',
+        sessionName: 'sess-old-tl',
+      });
+    });
+
+    it("falls back to role='team-leader' when canDelegate is unset (rule 3)", async () => {
+      const r = build();
+      const out = await r.resolve(['team-marketing']);
+      expect(out[0]).toMatchObject({
+        kind: 'team',
+        memberId: 'ella-id',
+        sessionName: 'crewly-marketing-ella',
+      });
+    });
+
+    it('falls back to first member when no TL marker exists (rule 4)', async () => {
+      const r = build();
+      const out = await r.resolve(['team-flat']);
+      expect(out[0]).toMatchObject({
+        kind: 'team',
+        memberId: 'first-id',
+        sessionName: 'sess-first',
+      });
+    });
+
+    it('skips empty teams (no members → no target)', async () => {
+      const r = build();
+      const out = await r.resolve(['team-empty']);
+      expect(out).toEqual([]);
+    });
+
+    it('takes precedence over a same-named member id (team-first)', async () => {
+      // Synthesize a clash where 'collide' is both a team id and a member id.
+      const collidingFixture = (): Team[] => [
+        team({
+          id: 'collide',
+          members: [
+            member({ id: 'tl-of-collide', sessionName: 'sess-tl', canDelegate: true }),
+          ],
+        }),
+        team({
+          id: 'other',
+          members: [member({ id: 'collide', sessionName: 'sess-collide-as-member' })],
+        }),
+      ];
+      const r = build(collidingFixture);
+      const out = await r.resolve(['collide']);
+      expect(out).toHaveLength(1);
+      expect(out[0].kind).toBe('team');
+      expect(out[0].sessionName).toBe('sess-tl');
+    });
+  });
+
+  describe('mixed + dedup + unknown', () => {
+    it('mixes @team + @agent mentions and preserves input order', async () => {
+      const r = build();
+      const out = await r.resolve(['team-marketing', 'max-id']);
+      expect(out.map((t) => ({ kind: t.kind, sessionName: t.sessionName }))).toEqual([
+        { kind: 'team', sessionName: 'crewly-marketing-ella' },
+        { kind: 'agent', sessionName: 'crewly-product-max' },
+      ]);
+    });
+
+    it('deduplicates by sessionName (same target mentioned twice)', async () => {
+      const r = build();
+      // Sam is the TL of team-product AND a member with id sam-id — two
+      // mention paths to the same session. Output should have one entry.
+      const out = await r.resolve(['team-product', 'sam-id']);
+      expect(out).toHaveLength(1);
+      expect(out[0].sessionName).toBe('crewly-product-sam');
+      // Team-mention came first in input order, so it wins.
+      expect(out[0].kind).toBe('team');
+    });
+
+    it('skips unknown mention ids silently', async () => {
+      const r = build();
+      const out = await r.resolve(['leo-id', 'does-not-exist', 'team-does-not-exist']);
+      expect(out).toHaveLength(1);
+      expect(out[0].sessionName).toBe('crewly-product-leo');
+    });
+
+    it('returns empty when given empty mentions array', async () => {
+      const r = build();
+      expect(await r.resolve([])).toEqual([]);
+    });
+
+    it('tolerates non-string entries in the mentions array', async () => {
+      const r = build();
+      // Defense-in-depth: validation happens at the chat-v2 service layer
+      // (mentions must be string[]), but the resolver shouldn't throw if a
+      // bad entry slips through (e.g., from a future caller).
+      const bad = [null, undefined, 0, true, 'leo-id'] as unknown as string[];
+      const out = await r.resolve(bad);
+      expect(out).toHaveLength(1);
+      expect(out[0].sessionName).toBe('crewly-product-leo');
+    });
+  });
+
+  describe('loadTeams error handling', () => {
+    it('returns no targets when loadTeams throws (does not crash dispatch)', async () => {
+      const r = build(() => {
+        throw new Error('storage unavailable');
+      });
+      const out = await r.resolve(['leo-id']);
+      expect(out).toEqual([]);
+    });
+
+    it('awaits an async loadTeams and resolves correctly', async () => {
+      const r = build(async () => {
+        await Promise.resolve();
+        return buildFixture();
+      });
+      const out = await r.resolve(['leo-id']);
+      expect(out).toHaveLength(1);
+      expect(out[0].sessionName).toBe('crewly-product-leo');
+    });
+  });
+
+  describe('context.teamId', () => {
+    it('forwards context without changing resolution (Phase C BE.2 leaves scoping for BE.3+)', async () => {
+      // Calling with a teamId scope should not currently restrict the
+      // result set (the scoping rule is reserved for a future tightening).
+      // This test pins the current contract so a future change is
+      // explicit.
+      const r = build();
+      const out = await r.resolve(['leo-id'], { teamId: 'team-marketing' });
+      expect(out).toHaveLength(1);
+      expect(out[0].memberId).toBe('leo-id');
+    });
+  });
+});

--- a/backend/src/services/chat-v2/chat-v2.mention-resolver.ts
+++ b/backend/src/services/chat-v2/chat-v2.mention-resolver.ts
@@ -1,0 +1,270 @@
+/**
+ * ChatV2MentionResolver — turn `mentions[]` from a chat message into a
+ * deduplicated list of agent-session dispatch targets.
+ *
+ * Phase C BE.2 scaffolding for Slack-like team-chat mention dispatch
+ * (SEALED §2.1 routing rules):
+ *
+ *   - **`@agent` mention** (mention id matches a `TeamMember.id`):
+ *     resolves to that member's tmux/agent `sessionName`. The dispatcher
+ *     will deliver the message directly into that agent's session.
+ *
+ *   - **`@team` mention** (mention id matches a `Team.id`): resolves to
+ *     that team's TL — the canonical primary responder per the spec
+ *     ("the Team Lead is the primary responder; if busy, queue in the
+ *     Team's Task Pool"). TL is selected as: first member with both
+ *     `hierarchyLevel === 1` and `canDelegate === true`, falling back
+ *     to any `canDelegate` member, then `members[0]` so the rule is
+ *     deterministic even on legacy teams without hierarchy fields.
+ *
+ *   - **Unknown mention id** (not a team or a known member): skipped
+ *     with a debug log. The dispatcher must always succeed even when
+ *     the FE includes a stale/typo mention; the chat HTTP ack has
+ *     already been sent by the time we resolve.
+ *
+ * The resolver is the boundary between the chat-v2 wire (id strings)
+ * and the agent runtime (session names). It deliberately does NOT
+ * touch the agent registry — it only produces the addresses that the
+ * dispatcher will hand to `AgentMessageSink.sendMessageToAgent`.
+ *
+ * The team list is loaded via an injected `loadTeams()` callback so
+ * tests can drive it without a real `StorageService`. Production wiring
+ * passes `() => storageService.getTeams()`.
+ *
+ * @module services/chat-v2/chat-v2.mention-resolver
+ */
+
+import type { Team, TeamMember } from '../../types/index.js';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Kind of mention that resolved to a target. */
+export type MentionTargetKind = 'agent' | 'team';
+
+/**
+ * One resolved dispatch target. The dispatcher will call
+ * `sendMessageToAgent(sessionName, prompt)` for each unique entry.
+ */
+export interface MentionTarget {
+  /** Whether this target came from an `@agent` (member) or `@team` mention. */
+  kind: MentionTargetKind;
+  /** The original mention id as it appeared in the wire `mentions[]`. */
+  mentionId: string;
+  /** Resolved member id. For `kind='team'`, this is the TL's member id. */
+  memberId: string;
+  /** Resolved agent session name — the address `sendMessageToAgent` expects. */
+  sessionName: string;
+  /** For `kind='team'`, the matched team's id. Undefined for `kind='agent'`. */
+  teamId?: string;
+}
+
+/** Optional context the resolver may use to disambiguate. */
+export interface MentionResolverContext {
+  /**
+   * The channel's `teamId` (when the channel is `type='channel'`). Reserved
+   * for future scoping rules — for example, restricting `@agent` mentions
+   * to members of the channel's team. Phase C BE.2 does NOT enforce that
+   * yet; it is forwarded for tests and future BE.3 wiring.
+   */
+  teamId?: string;
+}
+
+/**
+ * Dependencies. The team-list source is callable so tests don't need a
+ * StorageService; the production path injects `() => storage.getTeams()`.
+ */
+export interface MentionResolverDeps {
+  /**
+   * Returns the current team list. May be sync or async — the resolver
+   * awaits the result either way. Errors propagate; the resolver
+   * surfaces an empty-target list on caller error so a transient
+   * storage hiccup never crashes the chat dispatch path.
+   */
+  loadTeams: () => Promise<Team[]> | Team[];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Stateless resolver — instances are cheap to construct. Each `resolve()`
+ * call loads the team list fresh so dispatch always sees the latest
+ * member/session bindings (a new agent comes online → next mention
+ * resolves correctly without a restart).
+ */
+export class ChatV2MentionResolver {
+  private readonly loadTeams: MentionResolverDeps['loadTeams'];
+  private readonly logger: ComponentLogger;
+
+  constructor(deps: MentionResolverDeps) {
+    this.loadTeams = deps.loadTeams;
+    this.logger = LoggerService.getInstance().createComponentLogger('ChatV2MentionResolver');
+  }
+
+  /**
+   * Resolve `mentions` to dispatch targets.
+   *
+   * Behavior:
+   *   - Empty / whitespace mention ids are skipped silently.
+   *   - Each id is classified as team-first, then agent-first; ties go to
+   *     the team interpretation since team ids and member ids share the
+   *     same UUID-shape namespace and team mentions are higher-impact.
+   *   - Unknown ids are logged at debug level and skipped.
+   *   - Duplicate `sessionName`s are collapsed (first-seen wins, keeping
+   *     `kind` ordering stable for tests).
+   *   - Targets with empty `sessionName` are skipped — there is no agent
+   *     to dispatch to.
+   *
+   * @param mentions - The raw mention id list from `ChatMessageDTO.mentions`.
+   * @param context - Optional resolver context (teamId etc.).
+   * @returns Deduplicated dispatch targets, in input order with team-first ties.
+   */
+  async resolve(mentions: string[], context?: MentionResolverContext): Promise<MentionTarget[]> {
+    if (!Array.isArray(mentions) || mentions.length === 0) {
+      return [];
+    }
+
+    let teams: Team[];
+    try {
+      teams = await this.loadTeams();
+    } catch (err) {
+      this.logger.warn('chat-v2 mention-resolver loadTeams failed; returning no targets', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return [];
+    }
+
+    // Build O(1) lookup maps once per call so even a wide mention array
+    // (capped at 50 by the service-layer validator) doesn't cause an
+    // O(N*M) team×member scan.
+    const teamById = new Map<string, Team>();
+    const memberById = new Map<string, { team: Team; member: TeamMember }>();
+    for (const team of teams) {
+      teamById.set(team.id, team);
+      for (const member of team.members ?? []) {
+        // First-seen wins on member-id collisions across teams. The
+        // legacy data model allows distinct teams to coexist with the
+        // same memberId only if both were imported from the same
+        // hierarchy backup — which is rare and never a chat path. We
+        // log the collision so it surfaces in observability.
+        if (memberById.has(member.id)) {
+          this.logger.warn('chat-v2 mention-resolver member-id collision across teams', {
+            memberId: member.id,
+            firstTeamId: memberById.get(member.id)!.team.id,
+            secondTeamId: team.id,
+          });
+          continue;
+        }
+        memberById.set(member.id, { team, member });
+      }
+    }
+
+    const results: MentionTarget[] = [];
+    const seenSessions = new Set<string>();
+
+    for (const rawId of mentions) {
+      if (typeof rawId !== 'string') continue;
+      const id = rawId.trim();
+      if (id.length === 0) continue;
+
+      // 1) Team-mention takes precedence (higher routing impact).
+      const team = teamById.get(id);
+      if (team) {
+        const tl = pickTeamLead(team);
+        if (!tl) {
+          this.logger.debug('chat-v2 mention-resolver team has no dispatchable TL', {
+            mentionId: id,
+            teamId: team.id,
+          });
+          continue;
+        }
+        if (!tl.sessionName) {
+          this.logger.debug('chat-v2 mention-resolver TL has empty sessionName', {
+            mentionId: id,
+            teamId: team.id,
+            memberId: tl.id,
+          });
+          continue;
+        }
+        if (seenSessions.has(tl.sessionName)) continue;
+        seenSessions.add(tl.sessionName);
+        results.push({
+          kind: 'team',
+          mentionId: id,
+          memberId: tl.id,
+          sessionName: tl.sessionName,
+          teamId: team.id,
+        });
+        continue;
+      }
+
+      // 2) Agent (member) mention.
+      const hit = memberById.get(id);
+      if (hit) {
+        if (!hit.member.sessionName) {
+          this.logger.debug('chat-v2 mention-resolver member has empty sessionName', {
+            mentionId: id,
+            memberId: hit.member.id,
+            teamId: hit.team.id,
+          });
+          continue;
+        }
+        if (seenSessions.has(hit.member.sessionName)) continue;
+        seenSessions.add(hit.member.sessionName);
+        results.push({
+          kind: 'agent',
+          mentionId: id,
+          memberId: hit.member.id,
+          sessionName: hit.member.sessionName,
+        });
+        continue;
+      }
+
+      this.logger.debug('chat-v2 mention-resolver unknown mention id', {
+        mentionId: id,
+        contextTeamId: context?.teamId,
+      });
+    }
+
+    return results;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Choose the TL (Team Lead) responder for a `@team` mention.
+ *
+ * Resolution rules (ordered, first match wins):
+ *   1. Hierarchy TL: `hierarchyLevel === 1 && canDelegate === true`.
+ *   2. Any delegator: `canDelegate === true` regardless of level. Covers
+ *      teams that were imported before hierarchy fields were added but
+ *      already have a flagged TL.
+ *   3. Role-tagged TL: `role === 'team-leader'` so role-based teams that
+ *      didn't fill in `canDelegate` still resolve correctly.
+ *   4. First member: deterministic last resort — better to dispatch to
+ *      _someone_ than silently drop a `@team` ping. Tests cover this
+ *      case.
+ *
+ * Returns `null` only when the team has no members at all.
+ *
+ * @param team - The matched team.
+ * @returns The TL to dispatch to, or null when the team has no members.
+ */
+function pickTeamLead(team: Team): TeamMember | null {
+  const members = team.members ?? [];
+  if (members.length === 0) return null;
+
+  return (
+    members.find((m) => m.hierarchyLevel === 1 && m.canDelegate === true) ??
+    members.find((m) => m.canDelegate === true) ??
+    members.find((m) => m.role === 'team-leader') ??
+    members[0]
+  );
+}

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -219,6 +219,124 @@ describe('ChatV2Service', () => {
       expect(service.listChannels({ principal: owner })).toHaveLength(1);
       expect(service.listChannels({ principal: otherUser })).toHaveLength(1);
     });
+
+    // Phase C — channel-rail listing refinements: type + teamId filters.
+    describe('Phase C filters', () => {
+      function seedMixedFixture() {
+        // Owner has: 1 DM + 2 team channels across 2 teams.
+        service.createChannel({
+          agentSession: 'sess-dm',
+          name: 'DM with Sam',
+          principal: owner,
+          type: 'dm',
+          targetMemberId: 'sam-id',
+        });
+        service.createChannel({
+          agentSession: '',
+          name: '#general-product',
+          principal: owner,
+          type: 'channel',
+          teamId: 'team-product',
+        });
+        service.createChannel({
+          agentSession: '',
+          name: '#general-marketing',
+          principal: owner,
+          type: 'channel',
+          teamId: 'team-marketing',
+        });
+      }
+
+      it('filters to DMs when type=dm', () => {
+        seedMixedFixture();
+        const list = service.listChannels({ principal: owner, type: 'dm' });
+        expect(list).toHaveLength(1);
+        expect(list[0].type).toBe('dm');
+        expect(list[0].name).toBe('DM with Sam');
+      });
+
+      it('filters to team channels when type=channel', () => {
+        seedMixedFixture();
+        const list = service.listChannels({ principal: owner, type: 'channel' });
+        expect(list).toHaveLength(2);
+        expect(list.every((c) => c.type === 'channel')).toBe(true);
+      });
+
+      it('rejects unknown type with validation_error', () => {
+        seedMixedFixture();
+        try {
+          service.listChannels({
+            principal: owner,
+            type: 'group' as unknown as 'dm', // intentionally invalid
+          });
+          fail('expected ChatError');
+        } catch (err) {
+          expect(err).toBeInstanceOf(ChatError);
+          expect((err as ChatError).code).toBe('validation_error');
+          expect((err as ChatError).httpStatus).toBe(400);
+          expect((err as ChatError).message).toContain('unknown channel type');
+        }
+      });
+
+      it('treats blank teamId as omitted (no filter)', () => {
+        seedMixedFixture();
+        // Empty string teamId should NOT filter to "rows with empty team_id"
+        // — that would silently nuke the rail. Instead it's normalized to
+        // "no team filter".
+        const list = service.listChannels({ principal: owner, teamId: '' });
+        expect(list).toHaveLength(3);
+      });
+
+      it('treats whitespace-only teamId as omitted (no filter)', () => {
+        seedMixedFixture();
+        const list = service.listChannels({ principal: owner, teamId: '   ' });
+        expect(list).toHaveLength(3);
+      });
+
+      it('filters to a single team when teamId is set', () => {
+        seedMixedFixture();
+        const list = service.listChannels({ principal: owner, teamId: 'team-product' });
+        expect(list).toHaveLength(1);
+        expect(list[0].name).toBe('#general-product');
+        expect(list[0].teamId).toBe('team-product');
+      });
+
+      it('teamId filter excludes DMs (which have null team_id at the row level)', () => {
+        seedMixedFixture();
+        const list = service.listChannels({ principal: owner, teamId: 'team-product' });
+        expect(list.every((c) => c.type === 'channel')).toBe(true);
+      });
+
+      it('composes type + teamId filters', () => {
+        seedMixedFixture();
+        const list = service.listChannels({
+          principal: owner,
+          type: 'channel',
+          teamId: 'team-marketing',
+        });
+        expect(list).toHaveLength(1);
+        expect(list[0].name).toBe('#general-marketing');
+      });
+
+      it('still scopes to caller-owned rows when filtered (cross-owner isolation)', () => {
+        seedMixedFixture();
+        // Other user creates an isolated marketing channel. The filtered
+        // list for owner must not see it.
+        service.createChannel({
+          agentSession: '',
+          name: '#general-marketing',
+          principal: otherUser,
+          type: 'channel',
+          teamId: 'team-marketing',
+        });
+        const list = service.listChannels({
+          principal: owner,
+          type: 'channel',
+          teamId: 'team-marketing',
+        });
+        expect(list).toHaveLength(1); // only owner's row
+      });
+    });
   });
 
   describe('getChannel', () => {

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -89,6 +89,20 @@ export interface ListChannelsArgs {
   principal: ChatPrincipal;
   includeArchived?: boolean;
   limit?: number;
+  /**
+   * Phase C — filter to a single channel type. The controller validates
+   * the wire value against {@link CHAT_CHANNEL_TYPES} before reaching
+   * this layer; an unknown value is rejected as `validation_error`.
+   */
+  type?: ChatChannelType;
+  /**
+   * Phase C — filter to channels with this `team_id`. Empty string is
+   * treated the same as `undefined` (no filter) so callers don't have
+   * to pre-normalize blank query strings. The store-level filter still
+   * uses an exact-match against the column, so DMs (which have null
+   * team_id) drop out of the result.
+   */
+  teamId?: string;
 }
 
 /** Arguments for `sendMessage`. */
@@ -285,13 +299,38 @@ export class ChatV2Service {
   /**
    * List channels owned by the caller.
    *
-   * @param args - List args
+   * Phase C: extended with optional `type` + `teamId` filters so the
+   * channel-rail can request a focused slice (e.g. "channels in this
+   * workspace only") without paging the full owner-scoped list. An
+   * unknown `type` value is rejected as `validation_error`. Blank
+   * `teamId` is normalized to "no filter" so callers don't need to
+   * sanitize empty query strings.
+   *
+   * @param args - List args (principal + optional filters)
    * @returns DTO-mapped channels
+   * @throws {ChatError} `validation_error` (400) when `type` is set
+   *   to a value outside {@link CHAT_CHANNEL_TYPES}.
    */
   listChannels(args: ListChannelsArgs): ChatChannelDTO[] {
+    if (args.type !== undefined && !CHAT_CHANNEL_TYPES.includes(args.type)) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `unknown channel type: ${args.type}`,
+      );
+    }
+    // Treat blank teamId the same as omitted — saves the channel-rail FE
+    // from having to strip empty query strings before issuing the GET.
+    const teamIdFilter =
+      args.teamId !== undefined && args.teamId.trim().length > 0
+        ? args.teamId
+        : undefined;
+
     const rows = this.channels.listByOwner(args.principal.userId, {
       includeArchived: args.includeArchived,
       limit: args.limit,
+      type: args.type,
+      teamId: teamIdFilter,
     });
     return rows.map((r) => this.toChannelDTO(r));
   }

--- a/backend/src/services/chat-v2/index.ts
+++ b/backend/src/services/chat-v2/index.ts
@@ -21,3 +21,11 @@ export {
   type ChatAgentPresenceStatus,
   type ChatErrorCode,
 } from './types.js';
+// Phase C BE.2 — mention dispatch routing scaffolding.
+export {
+  ChatV2MentionResolver,
+  type MentionTarget,
+  type MentionTargetKind,
+  type MentionResolverContext,
+  type MentionResolverDeps,
+} from './chat-v2.mention-resolver.js';

--- a/backend/src/services/chat-v2/sqlite/channel.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.test.ts
@@ -228,6 +228,91 @@ describe('ChannelStore', () => {
       const list = store.listByOwner('user-a', { limit: 1000 });
       expect(list).toEqual([]); // empty — but we're testing the SQL accepted the cap
     });
+
+    // Phase C — channel-rail listing refinements: type + teamId filters.
+    describe('Phase C filters', () => {
+      beforeEach(() => {
+        // Mixed fixture: two DMs + two team channels across two teams.
+        store.create({
+          agentSession: 'sess-dm-1',
+          ownerUserId: 'user-a',
+          name: 'DM with Sam',
+          type: 'dm',
+          targetMemberId: 'sam-id',
+          nowMs: 100,
+        });
+        store.create({
+          agentSession: 'sess-dm-2',
+          ownerUserId: 'user-a',
+          name: 'DM with Leo',
+          type: 'dm',
+          targetMemberId: 'leo-id',
+          nowMs: 200,
+        });
+        store.create({
+          agentSession: '',
+          ownerUserId: 'user-a',
+          name: '#general-product',
+          type: 'channel',
+          teamId: 'team-product',
+          nowMs: 300,
+        });
+        store.create({
+          agentSession: '',
+          ownerUserId: 'user-a',
+          name: '#general-marketing',
+          type: 'channel',
+          teamId: 'team-marketing',
+          nowMs: 400,
+        });
+      });
+
+      it('filters to DMs when type=dm', () => {
+        const list = store.listByOwner('user-a', { type: 'dm' });
+        expect(list.map((c) => c.name).sort()).toEqual(['DM with Leo', 'DM with Sam']);
+      });
+
+      it('filters to team channels when type=channel', () => {
+        const list = store.listByOwner('user-a', { type: 'channel' });
+        expect(list.map((c) => c.name).sort()).toEqual([
+          '#general-marketing',
+          '#general-product',
+        ]);
+      });
+
+      it('filters to a single team when teamId is set', () => {
+        const list = store.listByOwner('user-a', { teamId: 'team-product' });
+        expect(list).toHaveLength(1);
+        expect(list[0].name).toBe('#general-product');
+        expect(list[0].team_id).toBe('team-product');
+      });
+
+      it('teamId filter excludes DMs (which have null team_id)', () => {
+        // Even though both DMs are owned by user-a, none has team_id='team-product'
+        // so the SQL `team_id = ?` predicate (NULL-rejecting) filters them out.
+        const list = store.listByOwner('user-a', { teamId: 'team-product' });
+        expect(list.every((c) => c.type === 'channel')).toBe(true);
+      });
+
+      it('composes type + teamId filters (AND semantics)', () => {
+        const list = store.listByOwner('user-a', {
+          type: 'channel',
+          teamId: 'team-marketing',
+        });
+        expect(list).toHaveLength(1);
+        expect(list[0].name).toBe('#general-marketing');
+      });
+
+      it('returns no rows when teamId has no match', () => {
+        const list = store.listByOwner('user-a', { teamId: 'team-does-not-exist' });
+        expect(list).toEqual([]);
+      });
+
+      it('falls back to all rows when no filters set (back-compat)', () => {
+        const list = store.listByOwner('user-a');
+        expect(list).toHaveLength(4);
+      });
+    });
   });
 
   describe('archive', () => {

--- a/backend/src/services/chat-v2/sqlite/channel.store.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.ts
@@ -186,28 +186,63 @@ export class ChannelStore {
   /**
    * List channels owned by a user.
    *
+   * Phase C — extended with `type` + `teamId` filter options so the
+   * `GET /api/chat/channels` endpoint can serve the channel-rail's
+   * grouped/workspace-scoped views without shipping every row to the
+   * client. Filters compose with AND; passing `undefined` for either is
+   * a no-op (the existing all-channels behavior).
+   *
    * @param ownerUserId - The user_id whose channels to return
    * @param options - Listing options
    * @param options.includeArchived - When false (default), filter out archived rows
    * @param options.limit - Max rows to return (capped at 100)
+   * @param options.type - Phase C: when set, filter rows to this channel type
+   *   (`'dm'` or `'channel'`). Useful for the channel-rail's "DMs only" /
+   *   "Channels only" views.
+   * @param options.teamId - Phase C: when set, filter rows whose `team_id`
+   *   matches. Used by the workspace-scoped Channels group; empty / null
+   *   `team_id` rows are excluded by this filter on purpose (DMs and
+   *   workspace-less rows belong to no team).
    * @returns Channel rows sorted by `last_message_at DESC, created_at DESC`
    */
   listByOwner(
     ownerUserId: string,
-    options?: { includeArchived?: boolean; limit?: number },
+    options?: {
+      includeArchived?: boolean;
+      limit?: number;
+      type?: ChatChannelType;
+      teamId?: string;
+    },
   ): ChatChannelRow[] {
     const includeArchived = options?.includeArchived ?? false;
     const limit = Math.min(options?.limit ?? 50, 100);
 
+    // Build WHERE clauses + bound params positionally so the filter set
+    // composes cleanly. Each branch is independent — no implicit coupling.
+    const where: string[] = ['owner_user_id = ?'];
+    const params: unknown[] = [ownerUserId];
+
+    if (!includeArchived) {
+      where.push('archived_at IS NULL');
+    }
+    if (options?.type !== undefined) {
+      where.push('type = ?');
+      params.push(options.type);
+    }
+    if (options?.teamId !== undefined) {
+      where.push('team_id = ?');
+      params.push(options.teamId);
+    }
+
     const sql = `
       SELECT ${CHANNEL_SELECT_COLUMNS}
       FROM chat_channels
-      WHERE owner_user_id = ?
-        ${includeArchived ? '' : 'AND archived_at IS NULL'}
+      WHERE ${where.join(' AND ')}
       ORDER BY COALESCE(last_message_at, created_at) DESC
       LIMIT ?
     `;
-    return this.db.prepare(sql).all(ownerUserId, limit) as ChatChannelRow[];
+    params.push(limit);
+    return this.db.prepare(sql).all(...params) as ChatChannelRow[];
   }
 
   /**


### PR DESCRIPTION
## Summary

Phase C BE half — the backend wire that Leo's Phase C FE commits
(`a48123e6` / `cb9e541b` / `3a17a9b9`) drive against. Stacked on
PR #329 (Phase A migration). 3 commits, ~888 net insertions, all green.

* **BE.1 (`9a3ad992`)** — `GET /api/chat/channels` learns `?type=dm|channel`
  and `?teamId=…` query filters so the Slack-like rail can request a
  focused slice without partitioning the full owner-scoped list
  client-side. Service-layer rejects unknown `type` values with
  `validation_error/400`. Composes both filters with AND. Empty/blank
  query strings fall back to "no filter" so the FE doesn't have to
  sanitize.
* **BE.2 (`8c1718b4`)** — `ChatV2MentionResolver`: turns
  `mentions[]` (member ids and team ids per SEALED §3.2) into
  deduplicated agent-session dispatch targets. Team mentions resolve to
  the team's TL per SEALED §2.1, with cascading fallback rules so legacy
  team shapes (no hierarchy fields, role-only TLs) still resolve
  deterministically. Unknown ids skipped silently — the chat HTTP ack
  has already been sent.
* **BE.3 (`4f773665`)** — `ChatV2DispatcherService.dispatchMessage`:
  single high-level entry that branches on `channel.type`. `type='dm'`
  uses the existing `dispatchToAgent` path. `type='channel'` resolves
  mentions and fans out to each target with per-recipient outcome
  reporting. Per-recipient failures (offline, PTY crash) are captured,
  not thrown; fan-out continues to remaining recipients. Controller
  call site updated.

## Test plan

* [x] `npm run build` clean (2280 modules transformed, vite + tsc both green)
* [x] `npx tsc -p backend/tsconfig.json --noEmit` clean
* [x] Targeted jest run on chat-v2 surface: **214 passing across 11
      suites**, 6 pre-existing todos held over, 0 failures.
* [x] Phase C BE.1 — `channel.store.test.ts` 28 specs (7 new covering
      type-only / teamId-only / composed / NULL-team_id exclusion /
      no-match / back-compat).
* [x] Phase C BE.1 — `chat-v2.service.test.ts` covers validation error,
      whitespace-teamId normalization, cross-owner isolation under
      filter (8 new specs).
* [x] Phase C BE.1 — `chat-v2.controller.test.ts` covers wire-level
      `?type=dm|channel|invalid|empty` and `?teamId=…` (7 new specs).
* [x] Phase C BE.2 — `chat-v2.mention-resolver.test.ts` 18 new specs
      covering all 4 TL-pick rules, team-precedence on id collision,
      empty-team-skip, dedup, unknown-id skip, async loadTeams,
      loadTeams-throw error path, context.teamId forwarding.
* [x] Phase C BE.3 — `chat-v2.dispatcher.service.test.ts` 13 new specs
      covering dm strategy, skip-no-resolver, skip-no-mentions,
      single-target, multi-target, unknown-mention empty outcomes,
      per-recipient failure isolation, thrown-sink-error capture,
      channel.teamId forwarded as resolver context.

## Review focus

* **API contract** — `GET /api/chat/channels` query params + the new
  `dispatchMessage` shape. Both are additive; no existing callers break.
* **TL-pick fallback chain** — `pickTeamLead` cascades through 4 rules
  (hierarchy / canDelegate / role / first). The "first member" fallback
  is intentional; the SEALED design says better to dispatch to *someone*
  than silently drop a `@team` ping. Open to flipping if you'd rather
  fail closed.
* **Mention precedence** — team-id beats member-id on collision. SEALED
  §2.1 doesn't enumerate this case; the choice is stable + tested.
* **`channel.teamId` resolver context** — forwarded to the resolver but
  not yet enforced as a scope (e.g. "only mention members of this team").
  Reserved for BE.4+ / Phase E. Pinned by a test.

## Phase plan ref

Per SEALED `slack-like-team-chat-design-2026-04-25.md` §13 and Steve's
ASAP brief: Phase C target **4/28 EOD**. This PR ships the BE half;
Leo's FE half is on `feat/slack-like-team-chat-fe-wire`.

## Stacked dependency

Base: `feat/slack-like-team-chat-be-migration` (PR #329, also draft, awaiting Arch review).
This PR will be re-targeted to `main` once #329 merges, or merged after #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)