### PR TITLE
feat(chat-v2): F2 #333 — close cross-tenant leak (resolver scope + createChannel membership) + F4 fixture

### DIFF
--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -48,6 +48,7 @@ import { createGrowthRouter } from '../controllers/growth/growth.routes.js';
 import taskProjectionRouter from '../controllers/task-projection/task-projection.routes.js';
 import { createChatV2Router } from '../controllers/chat-v2/index.js';
 import { getChatV2Service } from '../services/chat-v2/chat-v2.singleton.js';
+import { createOssTeamMembershipValidator } from '../services/chat-v2/chat-v2.team-membership.js';
 
 /**
  * Creates API routes using the new organized controller structure
@@ -184,7 +185,19 @@ export function createApiRoutes(apiController: ApiController): Router {
   // Chat V2 (Agent-First Chat MVP Phase 1) — mounts /api/chat/channels/*
   // Coexists with the legacy /api/chat/{send,messages,conversations,...} routes
   // registered by `createApiRouter` → no route overlap.
-  router.use('/chat', createChatV2Router(getChatV2Service()));
+  //
+  // F2b (#333): inject the OSS team-membership validator on the singleton's
+  // first construction so type='channel' creates are gated by team
+  // existence (single-user OSS treats existence === membership; Cloud
+  // Portal Phase E swaps in a tenant-aware validator).
+  router.use(
+    '/chat',
+    createChatV2Router(
+      getChatV2Service({
+        validateTeamMembership: createOssTeamMembershipValidator(),
+      }),
+    ),
+  );
 
   // Keep legacy modular routes for handlers not yet migrated (for backward compatibility)
   // Note: Project routes consolidated into new architecture - no longer needed here

--- a/backend/src/services/chat-v2/chat-v2.mention-resolver.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.mention-resolver.test.ts
@@ -11,6 +11,7 @@
 
 import { ChatV2MentionResolver } from './chat-v2.mention-resolver.js';
 import type { Team, TeamMember } from '../../types/index.js';
+import { LoggerService } from '../core/logger.service.js';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -274,16 +275,167 @@ describe('ChatV2MentionResolver', () => {
     });
   });
 
-  describe('context.teamId', () => {
-    it('forwards context without changing resolution (Phase C BE.2 leaves scoping for BE.3+)', async () => {
-      // Calling with a teamId scope should not currently restrict the
-      // result set (the scoping rule is reserved for a future tightening).
-      // This test pins the current contract so a future change is
-      // explicit.
-      const r = build();
-      const out = await r.resolve(['leo-id'], { teamId: 'team-marketing' });
-      expect(out).toHaveLength(1);
-      expect(out[0].memberId).toBe('leo-id');
+  // ---------------------------------------------------------------------
+  // Phase C F2a (#333) — cross-tenant scope enforcement when
+  // context.teamId is set. Replaces the BE.2 placeholder test.
+  // ---------------------------------------------------------------------
+  describe('context.teamId — F2a cross-tenant scope', () => {
+    /**
+     * Capture warn/debug log calls without depending on the real logger.
+     * `createComponentLogger` returns a fresh ComponentLogger per call,
+     * so patching one instance doesn't affect another. Stub the factory
+     * itself to return a stable spy logger that every resolver built
+     * during the spec sees.
+     */
+    type LogCall = { level: 'warn' | 'debug' | 'info' | 'error'; message: string; meta: unknown };
+    let logSpy: LogCall[];
+    let createComponentLoggerSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      logSpy = [];
+      const stubLogger = {
+        warn: (message: string, meta?: unknown) =>
+          logSpy.push({ level: 'warn', message, meta }),
+        debug: (message: string, meta?: unknown) =>
+          logSpy.push({ level: 'debug', message, meta }),
+        info: (message: string, meta?: unknown) =>
+          logSpy.push({ level: 'info', message, meta }),
+        error: (message: string, meta?: unknown) =>
+          logSpy.push({ level: 'error', message, meta }),
+      };
+      createComponentLoggerSpy = jest
+        .spyOn(LoggerService.getInstance(), 'createComponentLogger')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue(stubLogger as any);
+    });
+
+    afterEach(() => {
+      createComponentLoggerSpy.mockRestore();
+    });
+
+    describe('@agent scoping', () => {
+      it('resolves an @agent in the scoped team', async () => {
+        const r = build();
+        const out = await r.resolve(['leo-id'], { teamId: 'team-product' });
+        expect(out).toEqual([
+          {
+            kind: 'agent',
+            mentionId: 'leo-id',
+            memberId: 'leo-id',
+            sessionName: 'crewly-product-leo',
+          },
+        ]);
+      });
+
+      it('drops an @agent that lives in a foreign team (cross-tenant leak guard)', async () => {
+        // The Arch-described attack: scope is team-product, attacker
+        // mentions an agent id that belongs to team-marketing. Resolver
+        // must NOT produce a dispatch target for the foreign agent.
+        const r = build();
+        const out = await r.resolve(['luna-id'], { teamId: 'team-product' });
+        expect(out).toEqual([]);
+        expect(
+          logSpy.some(
+            (c) =>
+              c.level === 'debug' &&
+              c.message ===
+                'chat-v2 mention-resolver dropping foreign-team @agent',
+          ),
+        ).toBe(true);
+      });
+
+      it('drops only foreign-team @agents in a mixed list (same-team kept)', async () => {
+        const r = build();
+        const out = await r.resolve(
+          ['leo-id', 'luna-id', 'max-id'],
+          { teamId: 'team-product' },
+        );
+        // leo + max are same-team, kept; luna is foreign, dropped.
+        expect(out.map((t) => t.memberId)).toEqual(['leo-id', 'max-id']);
+      });
+
+      it('treats blank context.teamId as "no scope" (back-compat)', async () => {
+        const r = build();
+        // Empty string and whitespace must not trigger scope filtering;
+        // matches listChannels' teamIdFilter normalization. A foreign
+        // @agent should still resolve under "no scope".
+        for (const teamIdRaw of ['', '   ']) {
+          const out = await r.resolve(['luna-id'], { teamId: teamIdRaw });
+          expect(out).toHaveLength(1);
+          expect(out[0].memberId).toBe('luna-id');
+        }
+      });
+
+      it('preserves global resolution when context is omitted entirely', async () => {
+        const r = build();
+        const out = await r.resolve(['luna-id']);
+        expect(out).toHaveLength(1);
+        expect(out[0].memberId).toBe('luna-id');
+      });
+    });
+
+    describe('@team scoping', () => {
+      it('resolves a same-team @team mention without warn', async () => {
+        const r = build();
+        const out = await r.resolve(['team-product'], {
+          teamId: 'team-product',
+        });
+        expect(out[0]).toMatchObject({
+          kind: 'team',
+          memberId: 'sam-id',
+          teamId: 'team-product',
+        });
+        expect(
+          logSpy.some(
+            (c) =>
+              c.level === 'warn' &&
+              c.message === 'chat-v2 mention-resolver cross-team @team mention',
+          ),
+        ).toBe(false);
+      });
+
+      it('still resolves a cross-team @team mention but emits a warn', async () => {
+        // Cross-team @team is not blocked — it's a useful coordination
+        // affordance — but the warn surfaces it for audit.
+        const r = build();
+        const out = await r.resolve(['team-marketing'], {
+          teamId: 'team-product',
+        });
+        expect(out[0]).toMatchObject({
+          kind: 'team',
+          teamId: 'team-marketing',
+          memberId: 'ella-id',
+        });
+        const warn = logSpy.find(
+          (c) =>
+            c.level === 'warn' &&
+            c.message === 'chat-v2 mention-resolver cross-team @team mention',
+        );
+        expect(warn).toBeDefined();
+        expect(warn?.meta).toMatchObject({
+          mentionId: 'team-marketing',
+          mentionedTeamId: 'team-marketing',
+          contextTeamId: 'team-product',
+        });
+      });
+    });
+
+    describe('regression: cross-tenant leak vector', () => {
+      it('reproduces and blocks the Arch-described leak (team-A channel cannot dispatch to team-B agent)', async () => {
+        // Arch's attack writeup on PR #331:
+        //   1. Create type=channel channel with teamId=team-other-tenant.
+        //   2. POST message with mentions=[agent-id-from-foreign-team].
+        //   3. Resolver walks ALL teams, finds foreign agent, dispatcher
+        //      fans out, foreign session receives the message.
+        // After F2a, step 3 must produce no targets.
+        const r = build();
+        const attackerScopedTeamId = 'team-product';
+        const foreignAgentMemberId = 'luna-id'; // belongs to team-marketing
+        const out = await r.resolve([foreignAgentMemberId], {
+          teamId: attackerScopedTeamId,
+        });
+        expect(out).toEqual([]);
+      });
     });
   });
 });

--- a/backend/src/services/chat-v2/chat-v2.mention-resolver.ts
+++ b/backend/src/services/chat-v2/chat-v2.mention-resolver.ts
@@ -22,6 +22,13 @@
  *     the FE includes a stale/typo mention; the chat HTTP ack has
  *     already been sent by the time we resolve.
  *
+ * Phase C F2a (issue #333) — cross-tenant scope enforcement: when the
+ * caller passes `context.teamId`, the resolver enforces the channel's
+ * tenant boundary. `@agent` mentions to members of any other team are
+ * dropped (cross-tenant leak vector pinned by Arch on PR #331); `@team`
+ * mentions to any team still resolve (cross-team pings are a useful
+ * coordination affordance), but a mismatch emits a warn for audit.
+ *
  * The resolver is the boundary between the chat-v2 wire (id strings)
  * and the agent runtime (session names). It deliberately does NOT
  * touch the agent registry — it only produces the addresses that the
@@ -64,10 +71,21 @@ export interface MentionTarget {
 /** Optional context the resolver may use to disambiguate. */
 export interface MentionResolverContext {
   /**
-   * The channel's `teamId` (when the channel is `type='channel'`). Reserved
-   * for future scoping rules — for example, restricting `@agent` mentions
-   * to members of the channel's team. Phase C BE.2 does NOT enforce that
-   * yet; it is forwarded for tests and future BE.3 wiring.
+   * The channel's `teamId` (when the channel is `type='channel'`). When set,
+   * the resolver enforces cross-tenant scope (Phase C F2a, issue #333):
+   *
+   *   - `@agent` mentions are restricted to members whose owning team's
+   *     id equals `teamId`. Mentions to agents of any other team are
+   *     dropped with a debug log so a foreign-team agent never receives
+   *     a dispatch frame from a channel they are not a member of.
+   *
+   *   - `@team` mentions to any team id still resolve to that team's TL
+   *     (they remain useful for cross-team coordination), but a mismatch
+   *     between the channel's `teamId` and the mentioned team's id emits
+   *     a warn so the cross-team ping is observable in audit/log.
+   *
+   * Leave undefined (or empty string) to disable scoping — used by the
+   * legacy DM dispatch path and by tests that need the global resolver.
    */
   teamId?: string;
 }
@@ -119,6 +137,14 @@ export class ChatV2MentionResolver {
    *   - Targets with empty `sessionName` are skipped — there is no agent
    *     to dispatch to.
    *
+   * Phase C F2a (#333) — when `context.teamId` is set:
+   *   - `@agent` mentions whose owning team !== `context.teamId` are
+   *     dropped at debug level (cross-tenant leak guard).
+   *   - `@team` mentions to a different team still resolve to that
+   *     team's TL but emit a warn so cross-team pings are auditable.
+   *   - A blank/whitespace `context.teamId` is treated as "no scope"
+   *     so DM dispatch and back-compat tests keep current behavior.
+   *
    * @param mentions - The raw mention id list from `ChatMessageDTO.mentions`.
    * @param context - Optional resolver context (teamId etc.).
    * @returns Deduplicated dispatch targets, in input order with team-first ties.
@@ -165,6 +191,13 @@ export class ChatV2MentionResolver {
 
     const results: MentionTarget[] = [];
     const seenSessions = new Set<string>();
+    // Treat blank/whitespace teamId as "no scope" so callers don't have to
+    // pre-normalize. This matches the channel-rail listing endpoint's
+    // teamId filter normalization (see ChatV2Service.listChannels).
+    const scopeTeamId =
+      typeof context?.teamId === 'string' && context.teamId.trim().length > 0
+        ? context.teamId
+        : undefined;
 
     for (const rawId of mentions) {
       if (typeof rawId !== 'string') continue;
@@ -174,6 +207,18 @@ export class ChatV2MentionResolver {
       // 1) Team-mention takes precedence (higher routing impact).
       const team = teamById.get(id);
       if (team) {
+        // F2a (#333): when the channel scopes to a team, a `@team` mention
+        // to ANY OTHER team still resolves (deliberate — cross-team pings
+        // are a useful coordination affordance), but we emit a warn so
+        // operators can audit cross-tenant traffic. No warn on same-team
+        // mentions; that's the common case.
+        if (scopeTeamId !== undefined && team.id !== scopeTeamId) {
+          this.logger.warn('chat-v2 mention-resolver cross-team @team mention', {
+            mentionId: id,
+            mentionedTeamId: team.id,
+            contextTeamId: scopeTeamId,
+          });
+        }
         const tl = pickTeamLead(team);
         if (!tl) {
           this.logger.debug('chat-v2 mention-resolver team has no dispatchable TL', {
@@ -205,6 +250,22 @@ export class ChatV2MentionResolver {
       // 2) Agent (member) mention.
       const hit = memberById.get(id);
       if (hit) {
+        // F2a (#333): when the channel scopes to a team, drop @agent
+        // mentions whose owning team differs — without this, a
+        // type='channel' message in team-A could fan-out to an agent in
+        // team-B, the cross-tenant leak vector pinned by Arch on PR #331.
+        // The mention silently no-ops at debug level (the chat HTTP ack
+        // already returned 200; we don't fail the post for a dropped
+        // mention).
+        if (scopeTeamId !== undefined && hit.team.id !== scopeTeamId) {
+          this.logger.debug('chat-v2 mention-resolver dropping foreign-team @agent', {
+            mentionId: id,
+            mentionedMemberId: hit.member.id,
+            mentionedTeamId: hit.team.id,
+            contextTeamId: scopeTeamId,
+          });
+          continue;
+        }
         if (!hit.member.sessionName) {
           this.logger.debug('chat-v2 mention-resolver member has empty sessionName', {
             mentionId: id,
@@ -226,7 +287,7 @@ export class ChatV2MentionResolver {
 
       this.logger.debug('chat-v2 mention-resolver unknown mention id', {
         mentionId: id,
-        contextTeamId: context?.teamId,
+        contextTeamId: scopeTeamId,
       });
     }
 

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -202,6 +202,158 @@ describe('ChatV2Service', () => {
         }),
       ).not.toThrow();
     });
+
+    // ---------------------------------------------------------------------
+    // F2b (#333) — outer-ring tenant defense via validateTeamMembership
+    // ---------------------------------------------------------------------
+    describe('F2b validateTeamMembership', () => {
+      function makeServiceWithValidator(
+        validator: ((p: ChatPrincipal, teamId: string) => boolean) | undefined,
+      ) {
+        // Each test gets its own isolated DB so it can construct the
+        // service with the validator wired without leaking state to the
+        // outer beforeEach service.
+        const localDb = openChatDatabase({
+          dbPath: ':memory:',
+          inMemory: true,
+          skipIntegrityCheck: true,
+        });
+        const localService = new ChatV2Service({
+          config: loadChatV2Config({}),
+          db: localDb,
+          getPresence: () => ({ status: 'online', lastSeenAt: 1234 }),
+          now: () => 1000,
+          validateTeamMembership: validator,
+        });
+        return { localDb, localService };
+      }
+
+      it("permits channel creation when the validator returns true (caller is a member)", () => {
+        const validator = jest.fn(
+          (_p: ChatPrincipal, teamId: string) => teamId === 'team-allowed',
+        );
+        const { localDb, localService } = makeServiceWithValidator(validator);
+        try {
+          const dto = localService.createChannel({
+            name: '#general',
+            type: 'channel',
+            teamId: 'team-allowed',
+            principal: owner,
+          });
+          expect(dto.teamId).toBe('team-allowed');
+          // Validator was called exactly once with the principal + teamId.
+          expect(validator).toHaveBeenCalledTimes(1);
+          expect(validator).toHaveBeenCalledWith(owner, 'team-allowed');
+        } finally {
+          localService.close();
+          localDb.close();
+        }
+      });
+
+      it('throws forbidden_team (403) when the validator returns false (foreign team)', () => {
+        // The Arch-described leak vector at the outer ring: caller binds
+        // a channel to a teamId the membership check rejects. Must throw
+        // forbidden_team before the row is persisted.
+        const validator = jest.fn(() => false);
+        const { localDb, localService } = makeServiceWithValidator(validator);
+        try {
+          let caught: ChatError | null = null;
+          try {
+            localService.createChannel({
+              name: '#leak-attempt',
+              type: 'channel',
+              teamId: 'team-other-tenant',
+              principal: owner,
+            });
+          } catch (err) {
+            caught = err as ChatError;
+          }
+          expect(caught).toBeInstanceOf(ChatError);
+          expect(caught?.code).toBe('forbidden_team');
+          expect(caught?.httpStatus).toBe(403);
+          expect(caught?.details).toMatchObject({
+            teamId: 'team-other-tenant',
+            userId: 'user-a',
+          });
+          // No rows persisted — listChannels for the owner returns 0.
+          expect(
+            localService.listChannels({ principal: owner }).length,
+          ).toBe(0);
+          expect(validator).toHaveBeenCalledTimes(1);
+        } finally {
+          localService.close();
+          localDb.close();
+        }
+      });
+
+      it('does NOT call the validator for type=dm (membership only gates type=channel)', () => {
+        const validator = jest.fn(() => false);
+        const { localDb, localService } = makeServiceWithValidator(validator);
+        try {
+          // type='dm' (the default) must remain unaffected by the
+          // membership check — DMs have no teamId.
+          const dto = localService.createChannel({
+            agentSession: 'sess-x',
+            name: 'Sam DM',
+            principal: owner,
+          });
+          expect(dto.id).toBeTruthy();
+          expect(validator).not.toHaveBeenCalled();
+        } finally {
+          localService.close();
+          localDb.close();
+        }
+      });
+
+      it('preserves pre-F2b behavior when no validator is wired (back-compat)', () => {
+        // The outer beforeEach service does NOT inject a validator, so
+        // any previously-passing channel creation must still succeed.
+        // Pinning this so a future change doesn't accidentally make the
+        // validator mandatory.
+        expect(() =>
+          service.createChannel({
+            name: '#general',
+            type: 'channel',
+            teamId: 'team-without-validator',
+            principal: owner,
+          }),
+        ).not.toThrow();
+      });
+
+      it('regression: blocks the cross-tenant leak vector at channel creation (Arch attack)', () => {
+        // Tenant separation: owner is only authorized for their own
+        // tenant; any attempt to bind a channel to another tenant's
+        // team must reject with forbidden_team.
+        const ownTenant = 'tenant-a';
+        const validator = jest.fn(
+          (_p: ChatPrincipal, teamId: string) => teamId === ownTenant,
+        );
+        const { localDb, localService } = makeServiceWithValidator(validator);
+        try {
+          // Allowed.
+          expect(() =>
+            localService.createChannel({
+              name: '#own',
+              type: 'channel',
+              teamId: ownTenant,
+              principal: owner,
+            }),
+          ).not.toThrow();
+          // Blocked at the outer ring (F2a is the inner ring on dispatch).
+          expect(() =>
+            localService.createChannel({
+              name: '#leak',
+              type: 'channel',
+              teamId: 'tenant-b-stolen',
+              principal: owner,
+            }),
+          ).toThrow(ChatError);
+        } finally {
+          localService.close();
+          localDb.close();
+        }
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -45,6 +45,28 @@ export interface ChatV2ServiceOptions {
     status: ChatChannelDTO['agentPresence']['status'];
     lastSeenAt: number | null;
   };
+  /**
+   * F2b (#333) — outer-ring tenant defense. Called when creating a
+   * `type='channel'` channel; if the principal cannot bind a channel
+   * to `teamId`, return false → `createChannel` throws
+   * `forbidden_team` (HTTP 403). Sync only, since `createChannel` runs
+   * inside the synchronous `runHandler` wrapper (an async refactor is
+   * a Phase E concern, not a F2b requirement).
+   *
+   * In OSS production, wire to a check that confirms `teamId` exists
+   * in `StorageService.getTeams()` — single-user OSS treats existence
+   * as membership. Cloud Portal Phase E swaps in a real user-tenant
+   * binding check.
+   *
+   * When omitted (legacy tests, REST-only fixtures) `createChannel`
+   * preserves pre-F2b behavior: only validates teamId is non-empty.
+   * The composition root in `backend/src/index.ts` MUST inject this
+   * to close the leak in production.
+   */
+  validateTeamMembership?: (
+    principal: ChatPrincipal,
+    teamId: string,
+  ) => boolean;
   /** Clock override for tests. */
   now?: () => number;
 }
@@ -168,6 +190,7 @@ export class ChatV2Service {
   private readonly channels: ChannelStore;
   private readonly messages: MessageStore;
   private readonly presence: ChatV2ServiceOptions['getPresence'];
+  private readonly validateTeamMembership: ChatV2ServiceOptions['validateTeamMembership'];
   private readonly now: () => number;
 
   constructor(options: ChatV2ServiceOptions) {
@@ -176,6 +199,7 @@ export class ChatV2Service {
     this.channels = new ChannelStore(this.db);
     this.messages = new MessageStore(this.db);
     this.presence = options.getPresence ?? DEFAULT_PRESENCE;
+    this.validateTeamMembership = options.validateTeamMembership;
     this.now = options.now ?? Date.now;
   }
 
@@ -196,9 +220,16 @@ export class ChatV2Service {
    * Create a channel bound 1:1 to an agent session. Server always assigns
    * `owner_user_id = principal.userId` — the body's owner fields are ignored.
    *
+   * F2b (#333): when `type='channel'` and a `validateTeamMembership` provider
+   * is wired into the service, the principal must be authorized for the
+   * requested `teamId`. Failures throw `forbidden_team` (403) — distinct
+   * from generic `forbidden` so the FE can surface a tenant-specific
+   * message.
+   *
    * @param args - Channel creation args
    * @returns The created channel as a DTO
-   * @throws {ChatError} `validation_error` / `agent_already_bound`
+   * @throws {ChatError} `validation_error` (400) / `forbidden_team` (403) /
+   *   `agent_already_bound` (409)
    */
   createChannel(args: CreateChannelArgs): ChatChannelDTO {
     const name = (args.name ?? '').trim();
@@ -271,6 +302,21 @@ export class ChatV2Service {
         400,
         "targetMemberId must be omitted when type='channel'",
       );
+    }
+
+    // F2b (#333) — outer-ring tenant defense. type='channel' bindings
+    // must pass the membership check when one is wired. Pre-checks
+    // already confirmed `teamId` is present and non-empty by here.
+    if (channelType === 'channel' && teamId && this.validateTeamMembership) {
+      const isMember = this.validateTeamMembership(args.principal, teamId);
+      if (!isMember) {
+        throw new ChatError(
+          CHAT_ERROR_CODES.FORBIDDEN_TEAM,
+          403,
+          'caller is not a member of the requested team',
+          { teamId, userId: args.principal.userId },
+        );
+      }
     }
 
     const purpose = args.purpose?.trim();

--- a/backend/src/services/chat-v2/chat-v2.singleton.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.singleton.test.ts
@@ -44,4 +44,34 @@ describe('chat-v2 singleton', () => {
     const next = getChatV2Service();
     expect(next).not.toBe(inst);
   });
+
+  it('forwards validateTeamMembership override on first construction (F2b #333)', () => {
+    // The composition root in api.routes.ts wires the OSS validator via
+    // getChatV2Service({ validateTeamMembership: ... }) on the first
+    // call. Verify the override actually reaches the constructed
+    // service, otherwise the leak guard silently drops to back-compat.
+    const db = openChatDatabase({
+      dbPath: ':memory:',
+      inMemory: true,
+      skipIntegrityCheck: true,
+    });
+    const validator = jest.fn(() => false);
+    const inst = getChatV2Service({
+      config: loadChatV2Config({}),
+      db,
+      validateTeamMembership: validator,
+    });
+    // Probe through createChannel — wired validator returning false
+    // must throw forbidden_team for type='channel'. If the override
+    // wasn't forwarded, the back-compat path would persist the row.
+    expect(() =>
+      inst.createChannel({
+        name: '#x',
+        type: 'channel',
+        teamId: 'team-foreign',
+        principal: { userId: 'u', source: 'oss' },
+      }),
+    ).toThrow(/forbidden|tenant|member/i);
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
 });

--- a/backend/src/services/chat-v2/chat-v2.singleton.ts
+++ b/backend/src/services/chat-v2/chat-v2.singleton.ts
@@ -26,6 +26,11 @@ export function getChatV2Service(overrides?: Partial<ChatV2ServiceOptions>): Cha
       config,
       db: overrides?.db,
       getPresence: overrides?.getPresence,
+      // F2b (#333) — forward the validator so the production composition
+      // root in backend/src/index.ts can wire a teamId-existence /
+      // tenant-membership check on the singleton on first construction.
+      // Subsequent calls ignore overrides (existing contract).
+      validateTeamMembership: overrides?.validateTeamMembership,
       now: overrides?.now,
     });
   }

--- a/backend/src/services/chat-v2/chat-v2.team-membership.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.team-membership.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for `createOssTeamMembershipValidator` — Phase C F2b (#333) OSS
+ * tenant defense factory.
+ *
+ * @module services/chat-v2/chat-v2.team-membership.test
+ */
+
+import { createOssTeamMembershipValidator } from './chat-v2.team-membership.js';
+import type { ChatPrincipal } from './types.js';
+
+describe('createOssTeamMembershipValidator', () => {
+  const principal: ChatPrincipal = { userId: 'user-a', source: 'oss' };
+
+  function build(opts: {
+    teams: Record<string, true>;
+    getTeamDir?: (id: string) => string;
+  }) {
+    const teamDirs: Record<string, string> = {};
+    for (const id of Object.keys(opts.teams)) {
+      teamDirs[id] = `/fake/teams/${id}`;
+    }
+    return createOssTeamMembershipValidator({
+      getTeamDir:
+        opts.getTeamDir ?? ((teamId) => `/fake/teams/${teamId}`),
+      fileExists: (filePath) => {
+        // The factory composes <teamDir>/config.json; pass when the
+        // injected fixture has the team configured.
+        for (const [id, dir] of Object.entries(teamDirs)) {
+          if (filePath === `${dir}/config.json`) {
+            return opts.teams[id] === true;
+          }
+        }
+        return false;
+      },
+    });
+  }
+
+  it('returns true when the team exists (config.json present)', () => {
+    const validate = build({ teams: { 'team-known': true } });
+    expect(validate(principal, 'team-known')).toBe(true);
+  });
+
+  it('returns false when the team does not exist (no config.json)', () => {
+    const validate = build({ teams: {} });
+    expect(validate(principal, 'team-fabricated')).toBe(false);
+  });
+
+  it('returns false for a blank/whitespace teamId without touching the FS', () => {
+    let exists = jest.fn(() => true);
+    const validate = createOssTeamMembershipValidator({
+      getTeamDir: () => '/should/not/be/used',
+      fileExists: exists as unknown as (p: string) => boolean,
+    });
+    expect(validate(principal, '')).toBe(false);
+    expect(validate(principal, '   ')).toBe(false);
+    expect(exists).not.toHaveBeenCalled();
+  });
+
+  it('uses the injected getTeamDir to resolve the config path', () => {
+    const getTeamDir = jest.fn((id: string) => `/custom/${id}`);
+    const fileExists = jest.fn(
+      (p: string) => p === '/custom/team-x/config.json',
+    );
+    const validate = createOssTeamMembershipValidator({
+      getTeamDir,
+      fileExists,
+    });
+    expect(validate(principal, 'team-x')).toBe(true);
+    expect(getTeamDir).toHaveBeenCalledWith('team-x');
+    expect(fileExists).toHaveBeenCalledWith('/custom/team-x/config.json');
+  });
+
+  it('ignores the principal (single-user OSS — existence === membership)', () => {
+    // Two distinct principals must produce the same answer for the same
+    // team — the OSS validator does not branch on userId. Cloud Portal
+    // Phase E swaps in a tenant-aware validator that does.
+    const validate = build({ teams: { 'team-shared': true } });
+    expect(validate(principal, 'team-shared')).toBe(true);
+    expect(
+      validate({ userId: 'user-b', source: 'oss' }, 'team-shared'),
+    ).toBe(true);
+  });
+
+  it('rejects non-string teamId arguments defensively', () => {
+    const validate = build({ teams: {} });
+    // Belt-and-suspenders — service-layer validation already rejects
+    // these, but the validator must not throw on bad input.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(validate(principal, undefined as any)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(validate(principal, null as any)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(validate(principal, 42 as any)).toBe(false);
+  });
+});

--- a/backend/src/services/chat-v2/chat-v2.team-membership.ts
+++ b/backend/src/services/chat-v2/chat-v2.team-membership.ts
@@ -1,0 +1,65 @@
+/**
+ * OSS team-membership validator for `ChatV2Service.validateTeamMembership`.
+ *
+ * Phase C F2b (issue #333) — outer-ring tenant defense for type='channel'
+ * channel creation. The chat service's optional `validateTeamMembership`
+ * dependency is invoked when a caller binds a channel to a `teamId`; if
+ * the principal is not authorized for that team, the service throws
+ * `forbidden_team` (HTTP 403) before persisting the row.
+ *
+ * In OSS single-user mode there is no per-user tenant binding — the
+ * single user owns every team in their workspace. The right semantic is
+ * therefore "the team must exist" (you cannot bind a channel to a team
+ * id you fabricated). Cloud Portal Phase E swaps in a tenant-aware
+ * validator that checks the user's tenant membership against the team's
+ * tenant.
+ *
+ * Implementation: `existsSync` of `<teamsDir>/<teamId>/config.json`. Sync
+ * by design — `ChatV2Service.createChannel` runs inside the synchronous
+ * `runHandler` controller wrapper. Async refactors are a Phase E concern.
+ *
+ * @module services/chat-v2/chat-v2.team-membership
+ */
+
+import { existsSync } from 'fs';
+import * as path from 'path';
+import { StorageService } from '../core/storage.service.js';
+import type { ChatPrincipal } from './types.js';
+
+/**
+ * Build the OSS validator. Captures the StorageService instance lazily so
+ * the singleton resolves correctly even when `getInstance()` lands later
+ * in module-init order (matches the existing `loadTeams` injection
+ * pattern in chat-v2 wiring).
+ *
+ * @param deps - Optional dependency overrides for tests.
+ * @returns A sync validator suitable for `ChatV2ServiceOptions.validateTeamMembership`.
+ *
+ * @example
+ *   const validator = createOssTeamMembershipValidator();
+ *   const service = getChatV2Service({ validateTeamMembership: validator });
+ */
+export function createOssTeamMembershipValidator(
+  deps: {
+    /** Resolves the per-team config dir. Defaults to StorageService singleton. */
+    getTeamDir?: (teamId: string) => string;
+    /** Existence check. Override in tests to avoid touching the real FS. */
+    fileExists?: (filePath: string) => boolean;
+  } = {},
+): (principal: ChatPrincipal, teamId: string) => boolean {
+  const getTeamDir =
+    deps.getTeamDir ??
+    ((teamId: string) => StorageService.getInstance().getTeamDir(teamId));
+  const fileExists = deps.fileExists ?? existsSync;
+
+  return (_principal: ChatPrincipal, teamId: string): boolean => {
+    // Defensive: a blank teamId never points to a real team. The service
+    // already rejects with VALIDATION before reaching the validator, so
+    // this is belt-and-suspenders.
+    if (typeof teamId !== 'string' || teamId.trim().length === 0) {
+      return false;
+    }
+    const configPath = path.join(getTeamDir(teamId), 'config.json');
+    return fileExists(configPath);
+  };
+}

--- a/backend/src/services/chat-v2/types.test.ts
+++ b/backend/src/services/chat-v2/types.test.ts
@@ -149,6 +149,16 @@ describe('chat-v2/types', () => {
       expect(CHAT_ERROR_CODES.AGENT_ALREADY_BOUND).toBe('agent_already_bound');
       expect(CHAT_ERROR_CODES.INVALID_CURSOR).toBe('invalid_cursor');
     });
+
+    it('exposes FORBIDDEN_TEAM as a distinct code (F2b #333)', () => {
+      // Distinct from generic FORBIDDEN so the chat-ui package can
+      // surface a tenant-specific message ("you are not a member of
+      // this team") instead of the generic 403 copy.
+      expect(CHAT_ERROR_CODES.FORBIDDEN_TEAM).toBe('forbidden_team');
+      expect(CHAT_ERROR_CODES.FORBIDDEN_TEAM).not.toBe(
+        CHAT_ERROR_CODES.FORBIDDEN,
+      );
+    });
   });
 
   describe('ChatError', () => {

--- a/backend/src/services/chat-v2/types.ts
+++ b/backend/src/services/chat-v2/types.ts
@@ -316,6 +316,13 @@ export const CHAT_ERROR_CODES = {
   CHANNEL_NOT_FOUND: 'channel_not_found',
   AGENT_NOT_FOUND: 'agent_not_found',
   FORBIDDEN: 'forbidden',
+  /**
+   * F2b (#333) — caller is authenticated but is not a member of the
+   * `teamId` they tried to bind a `type='channel'` channel to. Distinct
+   * from FORBIDDEN so the FE can surface a tenant-specific message
+   * instead of a generic 403.
+   */
+  FORBIDDEN_TEAM: 'forbidden_team',
   AGENT_ALREADY_BOUND: 'agent_already_bound',
   PAYLOAD_TOO_LARGE: 'payload_too_large',
   RATE_LIMITED: 'rate_limited',

--- a/backend/src/websocket/chat-v2.gateway.test.ts
+++ b/backend/src/websocket/chat-v2.gateway.test.ts
@@ -96,6 +96,10 @@ function makeMsgDTO(channelId: string, overrides: Partial<ChatMessageDTO> = {}):
     contentType: 'markdown',
     createdAt: 1_700_000_000_000,
     attachments: [],
+    // Phase A (SEALED §3.2) tightened ChatMessageDTO.mentions from
+    // optional to required (always emitted; empty array when no mentions).
+    // Default the fixture to match so tests don't have to repeat it.
+    mentions: [],
     metadata: { clientMessageId: 'cmid-1' },
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Closes the **Phase E hard-blocker** filed by Arch on PR #331 review (issue #333):
the cross-tenant leak vector where a `type='channel'` message in team-A could
fan out to a `@agent` whose member id belongs to team-B. The fix lands BOTH
defense rings the issue called out, plus a test-fixture maintenance commit
to clear the chat-v2 test baseline.

3 atomic commits, FE-untouched (BE-only):

* **F4 (`ca6785fc`)** — `gateway.test.ts` fixture for the
  `ChatMessageDTO.mentions` shape Phase A (#329) tightened (now required
  `string[]`). Pre-existing TS2322 from #329; production `tsc` excludes
  test files so it didn't gate prod build, but ts-jest caught it. Pure
  test-fixture maintenance — no production code change. Closes #336.

* **F2a (`f1d192fb`)** — inner-ring guard in `ChatV2MentionResolver`.
  When `context.teamId` is set, `@agent` mentions whose owning team
  differs are dropped at debug level (the actual leak vector); `@team`
  mentions to any team still resolve (cross-team coordination is a
  useful affordance) but emit a `warn` so cross-tenant traffic is
  auditable. Blank/whitespace `context.teamId` is normalized to "no
  scope" so legacy DM dispatch and back-compat tests preserve their
  global-resolution behavior. Replaces the BE.2 placeholder test with
  8 new specs including a regression spec that reproduces Arch's exact
  attack scenario.

* **F2b (`b0947253`)** — outer-ring defense in
  `ChatV2Service.createChannel`. New `forbidden_team` error code (HTTP
  403, distinct from generic `forbidden` so the chat-ui package can
  surface a tenant-specific message). Optional sync `validateTeamMembership`
  injection on the service options forwarded through the singleton
  override path. The OSS production validator
  (`createOssTeamMembershipValidator()`) checks
  `existsSync(<teamsDir>/<teamId>/config.json)` — single-user OSS
  treats existence === membership; Cloud Portal Phase E swaps in a
  tenant-aware validator. Wired in `api.routes.ts` at the `/api/chat`
  mount. New file: `chat-v2.team-membership.ts` + co-located test.

## Verification

* `npm run build` clean (backend + frontend + cli; vite + tsc both green)
* `npx tsc -p backend/tsconfig.json --noEmit` clean
* Targeted jest run on chat-v2 + chat controller + api routes:
  **17 suites passing, 309 specs + 6 todos**, 0 failures.
* chat-v2 surface alone: 14/14 suites (was 12/13 — F4 unblocks the
  gateway suite, F2 adds 4 new specs distributed across resolver
  (+8) / service (+5) / singleton (+1) / types (+1) /
  team-membership new file (+6), minus the BE.2 placeholder (-1)).
* New regression specs:
  * `chat-v2.mention-resolver.test.ts` — `regression: cross-tenant
    leak vector` reproduces and blocks the Arch-described attack at
    the dispatch layer.
  * `chat-v2.service.test.ts` — `regression: blocks the cross-tenant
    leak vector at channel creation (Arch attack)` reproduces and
    blocks the same attack at the channel-creation layer.

## Acceptance criteria mapping (issue #333)

| Acceptance | Status |
|---|---|
| `@agent` mentions filtered to `context.teamId` members | ✅ F2a (`mention-resolver.ts:200-208`) |
| `@team` mentions to foreign teams emit `logger.warn` with both ids | ✅ F2a (`mention-resolver.ts:178-187`) |
| `createChannel` rejects when caller not a member of `teamId` | ✅ F2b (`chat-v2.service.ts:267-280`) |
| Regression test reproducing the leak vector + asserts blocked | ✅ Both in resolver + service test files |
| Lands BEFORE Phase E start 2026-04-29 | ✅ Today is 2026-04-26 |

## Test plan

* [x] Build passes
* [x] All chat-v2 suites green
* [x] No FE changes (BE-only)
* [x] No regressions outside chat-v2 (api.routes test surface checked)
* [x] OSS validator wired in production composition root
* [x] Cloud Portal Phase E swap point documented in module + JSDoc