### PR TITLE
fix(v3): remove RequestTracker time-window fallback (P2-2)

### DIFF
--- a/backend/src/controllers/chat/chat.controller.test.ts
+++ b/backend/src/controllers/chat/chat.controller.test.ts
@@ -755,4 +755,25 @@ describe('Chat Controller', () => {
       setMessageQueueService(null as any);
     });
   });
+
+  // ---------------------------------------------------------------------
+  // P2-2 regression: chat.controller no longer writes to RequestTracker.
+  // The companion read in v3-data.service was removed in this PR; the
+  // write path here is now dead code and was deleted to prevent dead-code
+  // rot. This test pins that no-write contract by inspecting the source
+  // text — a static guard that fires the moment someone re-introduces
+  // setActiveRequest in this controller.
+  // ---------------------------------------------------------------------
+  describe('P2-2: RequestTracker write removal', () => {
+    it('chat.controller source must not call RequestTracker.setActiveRequest', () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const fs = require('fs');
+      const path = require('path');
+      const src = fs.readFileSync(
+        path.join(__dirname, 'chat.controller.ts'),
+        'utf-8',
+      );
+      expect(src).not.toMatch(/RequestTracker\.getInstance\(\)\.setActiveRequest/);
+    });
+  });
 });

--- a/backend/src/controllers/chat/chat.controller.ts
+++ b/backend/src/controllers/chat/chat.controller.ts
@@ -114,9 +114,9 @@ export async function sendMessage(
             priority: 'normal',
             tags: ['chat-ui'],
           });
-          // Set active request for RequestTracker time-window correlation
-          const { RequestTracker } = await import('../../services/v3/request-tracker.service.js');
-          RequestTracker.getInstance().setActiveRequest(request.id);
+          // P2-2: RequestTracker.setActiveRequest write removed. The
+          // companion read in v3-data.service.ts no longer falls back to
+          // time-window correlation, so writing here would be dead code.
           logger.debug('V3 Request created from chat message', { messageId: result.message.id, requestId: request.id });
         }
       } catch (err) {

--- a/backend/src/controllers/request/request.controller.test.ts
+++ b/backend/src/controllers/request/request.controller.test.ts
@@ -1,6 +1,16 @@
 /**
  * Tests for Request Controller — HTTP handlers for V3 Request API.
  *
+ * NOTE (P2-2 PR): this file is currently authored against `vitest` while
+ * the project's test runner is `jest`. The whole suite currently fails
+ * to load because of the missing `vitest` dependency. The migration to
+ * jest-globals is tracked as a separate cleanup follow-up — this PR
+ * leaves the file untouched apart from this header note so that the
+ * RequestTracker write removal does not get conflated with the runner
+ * migration. The behavioral guard for the P2-2 write removal lives in
+ * v3-data.service.test.ts (P2-2 explicit test) and the static-source
+ * guards in chat.controller.test.ts and slack-orchestrator-bridge.test.ts.
+ *
  * @module controllers/request/request.controller.test
  */
 

--- a/backend/src/controllers/request/request.controller.ts
+++ b/backend/src/controllers/request/request.controller.ts
@@ -13,7 +13,6 @@
 
 import type { Request as ExpressRequest, Response } from 'express';
 import { RequestService } from '../../services/v3/request.service.js';
-import { RequestTracker } from '../../services/v3/request-tracker.service.js';
 import type { CreateRequestInput, UpdateRequestInput } from '../../types/v2/index.js';
 
 /**
@@ -97,11 +96,10 @@ export async function createRequestHandler(req: ExpressRequest, res: Response): 
 
     const request = await getService().create(body);
 
-    // @deprecated — Time-window correlation via RequestTracker is a legacy
-    // fallback. All delegation paths should pass requestId explicitly via
-    // the --request-id flag on delegate-task skills. The RequestTracker
-    // will be removed once all callers are confirmed to pass requestId.
-    RequestTracker.getInstance().setActiveRequest(request.id);
+    // P2-2: RequestTracker.setActiveRequest write removed. The companion
+    // read in v3-data.service.ts no longer falls back to time-window
+    // correlation, so writing here would be dead code. All delegations
+    // must now pass requestId explicitly via --request-id.
 
     res.status(201).json({ success: true, data: request });
   } catch (error) {

--- a/backend/src/services/slack/slack-orchestrator-bridge.test.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.test.ts
@@ -1778,4 +1778,23 @@ describe('SlackOrchestratorBridge', () => {
       expect(persistedContent).not.toMatch(/Thread context file/);
     });
   });
+
+  // ---------------------------------------------------------------------
+  // P2-2 regression: slack-orchestrator-bridge no longer writes to
+  // RequestTracker on the V3-Request-from-Slack path. Static source guard
+  // mirrors the chat.controller test to fire the moment someone
+  // re-introduces setActiveRequest here.
+  // ---------------------------------------------------------------------
+  describe('P2-2: RequestTracker write removal', () => {
+    it('slack-orchestrator-bridge source must not call RequestTracker.setActiveRequest', () => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const fs = require('fs');
+      const path = require('path');
+      const src = fs.readFileSync(
+        path.join(__dirname, 'slack-orchestrator-bridge.ts'),
+        'utf-8',
+      );
+      expect(src).not.toMatch(/RequestTracker\.getInstance\(\)\.setActiveRequest/);
+    });
+  });
 });

--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -381,10 +381,10 @@ export class SlackOrchestratorBridge extends EventEmitter {
                   priority: 'normal',
                   tags: ['slack'],
                 });
-                // Set active request for RequestTracker time-window correlation
-                // so downstream delegate-task calls can link WorkItems to this Request
-                const { RequestTracker } = await import('../v3/request-tracker.service.js');
-                RequestTracker.getInstance().setActiveRequest(request.id);
+                // P2-2: RequestTracker.setActiveRequest write removed. The
+                // companion read in v3-data.service.ts no longer falls back
+                // to time-window correlation; downstream delegate-task
+                // skills must now pass requestId explicitly.
                 this.logger.debug('V3 Request created from Slack message', { msgId, requestId: request.id });
               }
             } catch (err) {

--- a/backend/src/services/v3/v3-data.service.test.ts
+++ b/backend/src/services/v3/v3-data.service.test.ts
@@ -234,10 +234,11 @@ describe('V3DataService', () => {
     });
 
     it('should NOT resolve requestId from RequestTracker — explicit only (P2-2 fix)', async () => {
-      // Simulate: RequestTracker has an active request, but event has no requestId.
-      // After P2-2 fix, onTaskDelegated should NOT fall back to RequestTracker.
-      // RequestTracker resolution now happens at the emission site (controller),
-      // not at the consumption site (V3DataService).
+      // P2-2 fix verified by this commit: onTaskDelegated must not consult
+      // RequestTracker even when getActiveRequestId() would return a value.
+      // The time-window correlation was a global-singleton race vector that
+      // produced cross-conversation mislinks; all delegation paths now must
+      // pass requestId explicitly via TaskDelegatedEvent.requestId.
       RequestTracker.getInstance().setActiveRequest('req-from-tracker');
 
       const event: TaskDelegatedEvent = {
@@ -257,6 +258,33 @@ describe('V3DataService', () => {
       // requestId should be undefined — no fallback to RequestTracker
       expect(addedItem.requestId).toBeUndefined();
       expect(mockRequestLinkWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('P2-2: explicit event.requestId still resolves (no fallback regression)', async () => {
+      // Regression guard: removing the RequestTracker fallback must not
+      // also break the explicit-requestId path. event.requestId must still
+      // flow through to the resulting WorkItem.
+      const event: TaskDelegatedEvent = {
+        taskId: 'task-explicit-req',
+        title: 'Task with explicit requestId',
+        assignedTo: 'agent-leo',
+        projectPath: '/tmp/test',
+        requestId: 'req-explicit-123',
+        timestamp: new Date().toISOString(),
+      };
+
+      mockRequestGetById.mockResolvedValueOnce({
+        id: 'req-explicit-123',
+        status: 'open',
+        workItemIds: [],
+      });
+
+      eventBus.emit('v3:task_delegated', event);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockAddToPool).toHaveBeenCalledTimes(1);
+      const addedItem = mockAddToPool.mock.calls[0][0];
+      expect(addedItem.requestId).toBe('req-explicit-123');
     });
 
     it('should NOT use greedy fallback — no cross-conversation mislinks (Bug 2 fix)', async () => {

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -258,12 +258,14 @@ export class V3DataService {
         return;
       }
 
-      // Resolve requestId: prefer explicit value from the event payload,
-      // fall back to RequestTracker time-window correlation for orchestrator
-      // skill-based delegations that don't pass requestId explicitly.
-      const resolvedRequestId = event.requestId
-        || RequestTracker.getInstance().getActiveRequestId()
-        || undefined;
+      // Resolve requestId: explicit value from the event payload only.
+      // Removed (P2-2): RequestTracker time-window correlation. Orchestrator
+      // skills that need to associate a delegation with a Request must pass
+      // requestId explicitly via --request-id; the time-window fallback was
+      // a global-singleton race vector that produced cross-conversation
+      // mislinks (see v3-data.service.test.ts "should NOT use greedy
+      // fallback" + "should NOT resolve requestId from RequestTracker").
+      const resolvedRequestId = event.requestId || undefined;
 
       const workItem = createWorkItem({
         type: 'delegate',


### PR DESCRIPTION
## Summary

Removes the global-singleton `RequestTracker` time-window correlation that linked WorkItems to a Request via wall-clock proximity. This was a known cross-conversation mislink vector — a Request created in conversation A could be silently linked to a delegation that fired seconds later from conversation B, polluting both Requests' workItemIds.

The OKR Mission Reminder PR (#342) intentionally split this behavioral change out of the OKR-types refactor; this PR lands it on its own merits.

## Changes

- `v3-data.service.onTaskDelegated`: drop the `RequestTracker.getInstance().getActiveRequestId()` fallback. `requestId` is now the explicit value from the event payload only.
- `request.controller.create()`: remove the `setActiveRequest` write — companion read is gone, so write is dead code.
- `chat.controller.chat-message-create`: same removal on the V3-Request-from-chat path.
- `slack-orchestrator-bridge` V3-Request-from-Slack path: same removal.

## Behavioral contract going forward

All delegation paths must pass `requestId` explicitly via `--request-id` on `delegate-task` skills (or via `TaskDelegatedEvent.requestId` on the wire). The pre-existing test specs `"should NOT use greedy fallback — no cross-conversation mislinks (Bug 2 fix)"` and `"should NOT resolve requestId from RequestTracker — explicit only (P2-2 fix)"` were already in `v3-data.service.test.ts` expecting this behavior; this PR makes the production code match. **The previously-failing P2-2 test on main now passes.**

## Tests

- `v3-data.service.test`: P2-2 explicit-removal test passes; new regression guard verifies that explicit `event.requestId` still flows through (no fallback regression).
- `chat.controller.test`, `slack-orchestrator-bridge.test`: static source guards that fire the moment someone re-introduces `setActiveRequest` in either site.
- `request.controller.test`: header note added — the suite is currently broken on main (uses `vitest` in a `jest` project); the runner migration is tracked as a separate follow-up. The P2-2 guard is covered by the static source guards above.

## Test plan

- [x] `npx tsc -p backend/tsconfig.json --noEmit` — clean
- [x] `npx jest backend/src/services/v3/v3-data.service.test.ts` — 76/76 ✅ (was 75/76 with P2-2 failing on main)
- [x] `npx jest backend/src/controllers/chat/chat.controller.test.ts` — pass with new static guard
- [x] `npx jest backend/src/services/slack/slack-orchestrator-bridge.test.ts` — pass with new static guard
- [ ] Manual smoke (post-merge): create a Request via the chat HTTP path, confirm WorkItems delegated subsequently DO carry the explicit requestId from the orchestrator skill (not from the now-removed tracker)

## Compatibility / what stays

- `RequestTracker` class itself is retained (deprecated). The `clearOnNewMessage()` defensive-clear in `onUserWorkMessage` is kept because the existing `"should clear RequestTracker on new message"` test still pins the contract; it is a no-op in practice now that no callsite writes to the singleton, but removing it requires deleting the test and is left for a follow-up cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)