### PR TITLE
feat(autonomy_v1): WIRE-1 — prompt autonomy injection + orgRole fail-fast

### DIFF
--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -1406,3 +1406,245 @@ Decompose and delegate.`;
 		});
 	});
 });
+
+// =============================================================================
+// WIRE-1: deriveOrgRole + buildModuleConfigFromTeamMember
+// =============================================================================
+
+import {
+	deriveOrgRole,
+	buildModuleConfigFromTeamMember,
+	type SessionRuntimeContext,
+} from './prompt-builder.service.js';
+import type { Team, TeamMember } from '../../types/index.js';
+
+/**
+ * Build a minimal-valid TeamMember for unit tests. Override fields per case.
+ */
+function makeMember(overrides: Partial<TeamMember> = {}): TeamMember {
+	const base: TeamMember = {
+		id: 'member-1',
+		name: 'Sam',
+		sessionName: 'crewly-product-sam-dd2b46f7',
+		role: 'developer',
+		systemPrompt: '',
+		agentStatus: 'active',
+		workingStatus: 'idle',
+		runtimeType: 'claude-code',
+		createdAt: '2026-04-27T00:00:00Z',
+		updatedAt: '2026-04-27T00:00:00Z',
+	};
+	return { ...base, ...overrides };
+}
+
+/**
+ * Build a minimal-valid Team for unit tests. Override fields per case.
+ */
+function makeTeam(overrides: Partial<Team> = {}): Team {
+	const base: Team = {
+		id: 'team-1',
+		name: 'Crewly Product',
+		members: [],
+		projectIds: [],
+		createdAt: '2026-04-27T00:00:00Z',
+		updatedAt: '2026-04-27T00:00:00Z',
+	};
+	return { ...base, ...overrides };
+}
+
+/**
+ * Standard SessionRuntimeContext for tests — same shape buildModularPrompt
+ * derives at runtime, with predictable string paths.
+ */
+function makeRuntime(overrides: Partial<SessionRuntimeContext> = {}): SessionRuntimeContext {
+	const base: SessionRuntimeContext = {
+		sessionName: 'crewly-product-sam-dd2b46f7',
+		projectPath: '/path/to/project',
+		runtimeType: 'claude-code',
+		agentSkillsPath: '/path/to/project/config/skills/agent',
+		tlSkillsPath: '/path/to/project/config/skills/team-leader',
+		projectRoot: '/path/to/project',
+	};
+	return { ...base, ...overrides };
+}
+
+describe('deriveOrgRole — WIRE-1 cascade', () => {
+	const team = makeTeam();
+
+	it('rule 1: role=orchestrator → orchestrator (highest priority)', () => {
+		const member = makeMember({ role: 'orchestrator', canDelegate: true });
+		expect(deriveOrgRole(member, team)).toBe('orchestrator');
+	});
+
+	it('rule 2: canDelegate=true → team-lead', () => {
+		const member = makeMember({ role: 'developer', canDelegate: true });
+		expect(deriveOrgRole(member, team)).toBe('team-lead');
+	});
+
+	it('rule 3: subordinateIds non-empty → team-lead (legacy team shape)', () => {
+		const member = makeMember({ role: 'developer', canDelegate: false, subordinateIds: ['sub-1'] });
+		expect(deriveOrgRole(member, team)).toBe('team-lead');
+	});
+
+	it('rule 3b: team-side parentMemberId reference → team-lead', () => {
+		const tl = makeMember({ id: 'tl-1', role: 'developer' });
+		const sub = makeMember({ id: 'sub-1', name: 'Leo', parentMemberId: 'tl-1' });
+		const teamWithChild = makeTeam({ members: [tl, sub] });
+		expect(deriveOrgRole(tl, teamWithChild)).toBe('team-lead');
+	});
+
+	it('rule 4: default → executor', () => {
+		const member = makeMember({ role: 'developer', canDelegate: false });
+		expect(deriveOrgRole(member, team)).toBe('executor');
+	});
+
+	it('rule 4: no canDelegate flag and no subordinates → executor', () => {
+		const member = makeMember({ role: 'developer' });
+		expect(deriveOrgRole(member, team)).toBe('executor');
+	});
+
+	it('is total — never throws on any well-formed input', () => {
+		// Verify the function is exhaustive: minimal member + minimal team
+		// must classify (the throws live in RoleBoundaryModule, not here).
+		const minimal = makeMember();
+		expect(() => deriveOrgRole(minimal, team)).not.toThrow();
+	});
+});
+
+describe('buildModuleConfigFromTeamMember — WIRE-1 wiring', () => {
+	it('wires every member-level autonomy and organisation field', () => {
+		const member = makeMember({
+			id: 'member-tl',
+			canDelegate: true,
+			autonomyLevel: 'bounded',
+			capabilities: ['can-decide', 'can-verify'],
+			domainSOP: 'tl-domain.sop',
+			riskPolicy: 'tl-risk.policy',
+			jobTitle: 'Technical Team Lead',
+			jobDescription: 'Owns backend architecture',
+			ownershipScope: { domains: ['backend'], deliverables: ['api'], areas: ['infra'] },
+			expertId: 'tl-expert',
+		});
+		const team = makeTeam();
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+
+		expect(config.canDelegate).toBe(true);
+		expect(config.autonomyLevel).toBe('bounded');
+		expect(config.capabilities).toEqual(['can-decide', 'can-verify']);
+		expect(config.domainSOP).toBe('tl-domain.sop');
+		expect(config.riskPolicy).toBe('tl-risk.policy');
+		expect(config.jobTitle).toBe('Technical Team Lead');
+		expect(config.jobDescription).toBe('Owns backend architecture');
+		expect(config.ownershipScope).toEqual({ domains: ['backend'], deliverables: ['api'], areas: ['infra'] });
+		expect(config.expertId).toBe('tl-expert');
+	});
+
+	it('wires every team-level field (mission, budget, qualityGate, serviceContract, ownershipScope, description)', () => {
+		const member = makeMember();
+		const team = makeTeam({
+			description: 'The Crewly product team',
+			mission: 'Ship the OKR',
+			budget: { maxTokensPerDay: 100000, maxUsdPerMonth: 500, alertThreshold: 80 },
+			qualityGate: { reviewerId: 'arch-1', autoApprove: false, minQualityScore: 70 },
+			serviceContract: { accepts: ['feature requests'], avoids: ['ad-hoc work'], expectedOutput: ['merged PRs'] },
+			ownershipScope: { domains: ['product'], deliverables: ['cli', 'api'], areas: ['platform'] },
+		});
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+
+		expect(config.teamDescription).toBe('The Crewly product team');
+		expect(config.teamMission).toBe('Ship the OKR');
+		expect(config.teamBudget).toEqual({ maxTokensPerDay: 100000, maxUsdPerMonth: 500, alertThreshold: 80 });
+		expect(config.teamQualityGate).toEqual({ reviewerId: 'arch-1', autoApprove: false, minQualityScore: 70 });
+		expect(config.serviceContract).toEqual({ accepts: ['feature requests'], avoids: ['ad-hoc work'], expectedOutput: ['merged PRs'] });
+		expect(config.teamOwnershipScope).toEqual({ domains: ['product'], deliverables: ['cli', 'api'], areas: ['platform'] });
+	});
+
+	it('resolves orgRole=team-lead for canDelegate=true members', () => {
+		const member = makeMember({ canDelegate: true });
+		const team = makeTeam();
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+		expect(config.orgRole).toBe('team-lead');
+	});
+
+	it('resolves orgRole=executor for plain members', () => {
+		const member = makeMember();
+		const team = makeTeam();
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+		expect(config.orgRole).toBe('executor');
+	});
+
+	it('resolves orgRole=orchestrator for role=orchestrator', () => {
+		const member = makeMember({ role: 'orchestrator' });
+		const team = makeTeam();
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+		expect(config.orgRole).toBe('orchestrator');
+	});
+
+	it('resolves subordinates from team.members when not provided in runtime', () => {
+		const tl = makeMember({ id: 'tl-1', canDelegate: true, subordinateIds: ['sub-1', 'sub-2'] });
+		const sub1 = makeMember({ id: 'sub-1', name: 'Leo', sessionName: 'leo-session', role: 'developer' });
+		const sub2 = makeMember({ id: 'sub-2', name: 'Max', sessionName: 'max-session', role: 'developer' });
+		const team = makeTeam({ members: [tl, sub1, sub2] });
+		const config = buildModuleConfigFromTeamMember(tl, team, makeRuntime());
+
+		expect(config.subordinates).toHaveLength(2);
+		expect(config.subordinates?.[0]).toEqual({
+			name: 'Leo',
+			sessionName: 'leo-session',
+			role: 'developer',
+			memberId: 'sub-1',
+		});
+		expect(config.subordinates?.[1]?.name).toBe('Max');
+	});
+
+	it('drops unresolved subordinate ids without throwing', () => {
+		const tl = makeMember({ id: 'tl-1', canDelegate: true, subordinateIds: ['sub-1', 'sub-MISSING'] });
+		const sub1 = makeMember({ id: 'sub-1', name: 'Leo', sessionName: 'leo-session' });
+		const team = makeTeam({ members: [tl, sub1] });
+		const config = buildModuleConfigFromTeamMember(tl, team, makeRuntime());
+
+		expect(config.subordinates).toHaveLength(1);
+		expect(config.subordinates?.[0]?.name).toBe('Leo');
+	});
+
+	it('honours runtime-provided subordinates when present (skipping team-side resolution)', () => {
+		const tl = makeMember({ canDelegate: true, subordinateIds: ['sub-1'] });
+		const team = makeTeam({ members: [tl] }); // no subordinates in team
+		const runtime = makeRuntime({
+			subordinates: [
+				{ name: 'Override', sessionName: 'override-session', role: 'developer', memberId: 'sub-override' },
+			],
+		});
+		const config = buildModuleConfigFromTeamMember(tl, team, runtime);
+
+		expect(config.subordinates).toHaveLength(1);
+		expect(config.subordinates?.[0]?.memberId).toBe('sub-override');
+	});
+
+	it('omits subordinates field entirely when there are none', () => {
+		const member = makeMember();
+		const team = makeTeam();
+		const config = buildModuleConfigFromTeamMember(member, team, makeRuntime());
+		expect(config.subordinates).toBeUndefined();
+	});
+
+	it('passes through runtime-host fields (sessionName, projectPath, paths)', () => {
+		const member = makeMember();
+		const team = makeTeam();
+		const runtime = makeRuntime({
+			sessionName: 'distinct-session-name',
+			projectPath: '/another/project',
+			runtimeType: 'gemini-cli',
+			agentSkillsPath: '/another/agent',
+			tlSkillsPath: '/another/tl',
+			projectRoot: '/another/root',
+		});
+		const config = buildModuleConfigFromTeamMember(member, team, runtime);
+		expect(config.sessionName).toBe('distinct-session-name');
+		expect(config.projectPath).toBe('/another/project');
+		expect(config.runtimeType).toBe('gemini-cli');
+		expect(config.agentSkillsPath).toBe('/another/agent');
+		expect(config.tlSkillsPath).toBe('/another/tl');
+		expect(config.projectRoot).toBe('/another/root');
+	});
+});

--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -1404,6 +1404,74 @@ Decompose and delegate.`;
 			expect(typeof result).toBe('string');
 			expect(result.length).toBeGreaterThan(0);
 		});
+
+		// ---------------------------------------------------------------------
+		// WIRE-1 Arch M1 — merge-time safety regression for the legacy path
+		// ---------------------------------------------------------------------
+
+		/**
+		 * Arch M1 (P0 production regression) protection: the V4 throw added in
+		 * RoleBoundaryModule.build() must NOT fire on the legacy
+		 * `buildSystemPromptWithMemory` path. Pre-WIRE-1 the legacy
+		 * `buildModularPrompt` set `canDelegate` from session config but never
+		 * `orgRole`, which combined with the new throw would break every
+		 * existing TL agent on next prompt assembly the moment WIRE-1 merged.
+		 *
+		 * The stopgap is a SessionConfig-only orgRole cascade inside
+		 * `buildModularPrompt` that mirrors `deriveOrgRole`'s rules with the
+		 * fields available at that layer (role + canDelegate). This test
+		 * pins it.
+		 */
+		it('does not throw on the legacy path for a TL session config (canDelegate=true)', async () => {
+			delete process.env.CREWLY_USE_MODULAR_PROMPTS; // default: modular path
+			const tlConfig: TeamMemberSessionConfig = {
+				name: 'crewly-product-sam-dd2b46f7',
+				role: 'developer',
+				projectPath: '/test/project',
+				memberId: 'tl-member-id',
+				systemPrompt: '',
+				canDelegate: true,
+				teamId: 'tl-team-id',
+			};
+			await expect(service.buildSystemPromptWithMemory(tlConfig)).resolves.not.toThrow();
+		});
+
+		/**
+		 * Companion to the M1 regression test — orchestrator role on the legacy
+		 * path also resolves cleanly (orgRole='orchestrator' set inline).
+		 */
+		it('does not throw on the legacy path for an orchestrator session config', async () => {
+			delete process.env.CREWLY_USE_MODULAR_PROMPTS;
+			const orcConfig: TeamMemberSessionConfig = {
+				name: 'crewly-orc',
+				role: 'orchestrator',
+				projectPath: '/test/project',
+				memberId: 'orc-member-id',
+				systemPrompt: '',
+				teamId: 'orc-team-id',
+			};
+			await expect(service.buildSystemPromptWithMemory(orcConfig)).resolves.not.toThrow();
+		});
+
+		/**
+		 * Companion to the M1 regression test — plain executor on the legacy
+		 * path also resolves cleanly (orgRole left undefined; module falls
+		 * back to executor without firing the V4 throw because canDelegate
+		 * is not true).
+		 */
+		it('does not throw on the legacy path for a plain executor session config', async () => {
+			delete process.env.CREWLY_USE_MODULAR_PROMPTS;
+			const execConfig: TeamMemberSessionConfig = {
+				name: 'crewly-product-leo-62440736',
+				role: 'developer',
+				projectPath: '/test/project',
+				memberId: 'leo-member-id',
+				systemPrompt: '',
+				teamId: 'leo-team-id',
+				// canDelegate omitted (undefined) — V4 throw must NOT fire
+			};
+			await expect(service.buildSystemPromptWithMemory(execConfig)).resolves.not.toThrow();
+		});
 	});
 });
 

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -1,12 +1,188 @@
 import { readFile, access } from 'fs/promises';
 import * as path from 'path';
 import { LoggerService, ComponentLogger } from '../core/logger.service.js';
-import { TeamMemberSessionConfig, SubordinateInfo, SOPRole } from '../../types/index.js';
+import { TeamMemberSessionConfig, SubordinateInfo, SOPRole, TeamMember, Team } from '../../types/index.js';
 import { MemoryService } from '../memory/memory.service.js';
 import { SOPService } from '../sop/sop.service.js';
 import { getRoleService } from '../settings/role.service.js';
 import { PromptAssemblyService } from './prompt-modules/prompt-assembly.service.js';
-import type { ModuleConfig } from './prompt-modules/prompt-module.interface.js';
+import type { ModuleConfig, OrgRole } from './prompt-modules/prompt-module.interface.js';
+
+// =============================================================================
+// WIRE-1: Autonomy field injection helpers
+// =============================================================================
+
+/**
+ * Derive the organisational role for a member from team-hierarchy facts.
+ *
+ * Resolution cascade (first match wins):
+ *   1. `role === 'orchestrator'`        → `'orchestrator'`
+ *   2. `canDelegate === true`           → `'team-lead'`
+ *   3. has subordinates in the team     → `'team-lead'`
+ *   4. otherwise                        → `'executor'`
+ *
+ * This function is total — every member resolves to one of the three roles —
+ * so it never throws. Fail-fast on misconfiguration is enforced downstream
+ * by {@link RoleBoundaryModule} (a member with `canDelegate=true` whose
+ * `orgRole` is undefined when the boundary is rendered indicates the
+ * caller bypassed `buildModuleConfigFromTeamMember` — that boundary throws).
+ *
+ * @param member - Full TeamMember record
+ * @param team - Full Team record (used to detect implicit subordination)
+ * @returns The resolved organisational role
+ */
+export function deriveOrgRole(member: TeamMember, team: Team): OrgRole {
+	if (member.role === 'orchestrator') return 'orchestrator';
+	if (member.canDelegate === true) return 'team-lead';
+	if (Array.isArray(member.subordinateIds) && member.subordinateIds.length > 0) return 'team-lead';
+	// Some legacy team shapes record the relationship on the team side only —
+	// catch members who appear as a parent of any other member.
+	if (team.members?.some((m) => m.parentMemberId === member.id)) return 'team-lead';
+	return 'executor';
+}
+
+/**
+ * Snapshot of the SessionConfig fields the helper needs that are NOT
+ * carried on TeamMember/Team (runtime-host concerns: session name, project
+ * path, runtime type, and the precomputed subordinate list).
+ *
+ * Splitting these out keeps {@link buildModuleConfigFromTeamMember} pure —
+ * it can be invoked anywhere TeamMember + Team are available without
+ * coupling to the legacy `TeamMemberSessionConfig` shape.
+ */
+export interface SessionRuntimeContext {
+	/** Agent's session name (e.g. 'crewly-product-sam-dd2b46f7'). */
+	sessionName: string;
+	/** Absolute path to the project directory. */
+	projectPath?: string;
+	/** Runtime host (claude-code, gemini-cli, codex, crewly-agent). */
+	runtimeType?: ModuleConfig['runtimeType'];
+	/** Optional precomputed subordinate list. When omitted, the helper
+	 * resolves it from `team.members` and `member.subordinateIds`. */
+	subordinates?: SubordinateInfo[];
+	/** Absolute path to agent skill scripts (e.g. `<projectRoot>/config/skills/agent`). */
+	agentSkillsPath: string;
+	/** Absolute path to team-leader skill scripts. */
+	tlSkillsPath: string;
+	/** Absolute path to the project root (where config/ lives). */
+	projectRoot: string;
+}
+
+/**
+ * Build a complete {@link ModuleConfig} from a TeamMember + Team pair.
+ *
+ * Wires every autonomy / organisation / team-context field declared on
+ * `TeamMember` and `Team` into the prompt assembler — the gap that caused
+ * every TL agent in production to silently render with the executor
+ * boundary (because `orgRole` was never injected, and
+ * `RoleBoundaryModule.build()` previously fell back to `'executor'`).
+ *
+ * Fields wired from `member`:
+ *   - `autonomyLevel`, `domainSOP`, `riskPolicy`, `capabilities`
+ *   - `jobTitle`, `jobDescription`, `ownershipScope`, `expertId`
+ *
+ * Fields wired from `team`:
+ *   - `team.mission` → `teamMission`
+ *   - `team.budget` → `teamBudget`
+ *   - `team.qualityGate` → `teamQualityGate`
+ *   - `team.serviceContract` → `serviceContract`
+ *   - `team.ownershipScope` → `teamOwnershipScope`
+ *   - `team.description` → `teamDescription`
+ *
+ * `orgRole` is resolved via {@link deriveOrgRole}. `canDelegate` is mirrored
+ * from the member record. The subordinate list is taken from
+ * `runtime.subordinates` when supplied, otherwise resolved from `team.members`.
+ *
+ * @param member - Full TeamMember record
+ * @param team - Full Team record
+ * @param runtime - Runtime-host context (session name, project paths, etc.)
+ * @returns A fully populated ModuleConfig
+ *
+ * @example
+ * ```typescript
+ * const config = buildModuleConfigFromTeamMember(member, team, {
+ *   sessionName: 'crewly-product-sam-dd2b46f7',
+ *   projectPath: '/Users/.../crewly',
+ *   runtimeType: 'claude-code',
+ *   agentSkillsPath: path.join(projectRoot, 'config/skills/agent'),
+ *   tlSkillsPath: path.join(projectRoot, 'config/skills/team-leader'),
+ *   projectRoot,
+ * });
+ * const { prompt } = await new PromptAssemblyService().assemble(config);
+ * ```
+ */
+export function buildModuleConfigFromTeamMember(
+	member: TeamMember,
+	team: Team,
+	runtime: SessionRuntimeContext,
+): ModuleConfig {
+	const orgRole = deriveOrgRole(member, team);
+	const subordinates = runtime.subordinates ?? resolveSubordinatesFromTeam(member, team);
+
+	return {
+		// Identity / runtime
+		sessionName: runtime.sessionName,
+		memberId: member.id ?? '',
+		role: member.role,
+		teamId: team.id,
+		projectPath: runtime.projectPath,
+		runtimeType: runtime.runtimeType,
+
+		// Hierarchy
+		canDelegate: member.canDelegate,
+		subordinates,
+
+		// Skill paths
+		agentSkillsPath: runtime.agentSkillsPath,
+		tlSkillsPath: runtime.tlSkillsPath,
+		projectRoot: runtime.projectRoot,
+
+		// === Autonomy + capability overlay (member-level) ===
+		orgRole,
+		autonomyLevel: member.autonomyLevel,
+		capabilities: member.capabilities,
+		domainSOP: member.domainSOP,
+		riskPolicy: member.riskPolicy,
+
+		// === Organisation model (member-level) ===
+		jobTitle: member.jobTitle,
+		jobDescription: member.jobDescription,
+		ownershipScope: member.ownershipScope,
+		expertId: member.expertId,
+
+		// === Team-level injection ===
+		teamDescription: team.description,
+		teamMission: team.mission,
+		teamBudget: team.budget,
+		teamQualityGate: team.qualityGate,
+		serviceContract: team.serviceContract,
+		teamOwnershipScope: team.ownershipScope,
+	};
+}
+
+/**
+ * Resolve a member's subordinate roster from the team record.
+ *
+ * Used when {@link buildModuleConfigFromTeamMember} is called without a
+ * pre-computed `runtime.subordinates`. Maps `member.subordinateIds` to the
+ * matching `team.members` entries, dropping any unresolved ids.
+ */
+function resolveSubordinatesFromTeam(member: TeamMember, team: Team): SubordinateInfo[] | undefined {
+	if (!Array.isArray(member.subordinateIds) || member.subordinateIds.length === 0) return undefined;
+	const byId = new Map(team.members?.map((m) => [m.id, m]) ?? []);
+	const subs: SubordinateInfo[] = [];
+	for (const subId of member.subordinateIds) {
+		const sub = byId.get(subId);
+		if (!sub) continue;
+		subs.push({
+			name: sub.name,
+			sessionName: sub.sessionName ?? '',
+			role: sub.role ?? 'developer',
+			memberId: sub.id ?? subId,
+		});
+	}
+	return subs.length > 0 ? subs : undefined;
+}
 
 /**
  * Options for building system prompts

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -489,6 +489,22 @@ Start all teams on Phase 1 simultaneously.`.trim();
 		const agentSkillsPath = path.join(this.projectRoot, 'config', 'skills', 'agent');
 		const tlSkillsPath = path.join(this.projectRoot, 'config', 'skills', 'team-leader');
 
+		// WIRE-1 stopgap (Arch M1 — merge-time safety): RoleBoundaryModule now
+		// throws when canDelegate=true && orgRole undefined. Without setting
+		// orgRole here, every existing TL agent (Sam/Mia/Ella/Remi) would throw
+		// on next prompt assembly. The proper fix is wiring this path to call
+		// `buildModuleConfigFromTeamMember(member, team, runtime)` — tracked
+		// as the WIRE-2 follow-up. Until then, a SessionConfig-only cascade
+		// (role + canDelegate) actively resolves orgRole for the two cases
+		// that matter: orchestrator and TL. Non-TL members keep `undefined`
+		// so the executor fallback renders correctly.
+		const orgRole: ModuleConfig['orgRole'] =
+			config.role === 'orchestrator'
+				? 'orchestrator'
+				: config.canDelegate === true
+					? 'team-lead'
+					: undefined;
+
 		const moduleConfig: ModuleConfig = {
 			sessionName: config.name,
 			memberId: config.memberId ?? '',
@@ -497,6 +513,7 @@ Start all teams on Phase 1 simultaneously.`.trim();
 			projectPath: config.projectPath,
 			runtimeType: config.runtimeType as ModuleConfig['runtimeType'],
 			canDelegate: config.canDelegate,
+			orgRole,
 			subordinates: config.subordinates?.map(s => ({
 				name: s.name,
 				sessionName: s.sessionName,

--- a/backend/src/services/ai/prompt-modules/role-boundary.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/role-boundary.module.test.ts
@@ -247,4 +247,92 @@ describe('RoleBoundaryModule', () => {
 		expect(result).toContain('identified_risks');
 		expect(result).toContain('pre_classified');
 	});
+
+	// =========================================================================
+	// WIRE-1 fail-fast misconfiguration guards (V4 + F-G)
+	// =========================================================================
+
+	/**
+	 * V4 (Arch Veto #7): canDelegate=true && orgRole undefined → throw.
+	 *
+	 * The bug WIRE-1 fixes: pre-WIRE-1, the module silently fell back to the
+	 * executor boundary when `orgRole` was undefined, so every TL agent in
+	 * production rendered with the wrong boundary text. The throw forces
+	 * callers to resolve `orgRole` via `deriveOrgRole(member, team)` before
+	 * assembly.
+	 */
+	it('throws when canDelegate=true and orgRole is undefined (V4 — silent fallback bug)', async () => {
+		const misconfig: ModuleConfig = {
+			...baseConfig,
+			canDelegate: true,
+			// orgRole intentionally undefined
+		};
+		await expect(module.build(misconfig)).rejects.toThrow(
+			/canDelegate=true but orgRole is undefined/,
+		);
+	});
+
+	/**
+	 * V4 detail: error message must mention the session for log correlation.
+	 */
+	it('error message includes the session name for log correlation', async () => {
+		const misconfig: ModuleConfig = {
+			...baseConfig,
+			sessionName: 'crewly-product-sam-dd2b46f7',
+			canDelegate: true,
+		};
+		await expect(module.build(misconfig)).rejects.toThrow(
+			/session=crewly-product-sam-dd2b46f7/,
+		);
+	});
+
+	/**
+	 * F-G symmetric misconfig: canDelegate=false && orgRole='team-lead' → throw.
+	 *
+	 * Refuse to render TL authority for a member that explicitly cannot
+	 * delegate. Either the caller mis-resolved orgRole or the member record
+	 * itself contradicts the team-side hierarchy — fail loudly either way.
+	 */
+	it('throws when canDelegate=false and orgRole=team-lead (F-G symmetric misconfig)', async () => {
+		const misconfig: ModuleConfig = {
+			...baseConfig,
+			canDelegate: false,
+			orgRole: 'team-lead',
+		};
+		await expect(module.build(misconfig)).rejects.toThrow(
+			/canDelegate=false but orgRole='team-lead'/,
+		);
+	});
+
+	/**
+	 * Negative — the V4 throw must NOT fire when canDelegate is undefined
+	 * (the legacy path for non-TL agents whose record predates canDelegate
+	 * being set). These render as executor and that is correct behaviour.
+	 */
+	it('does not throw when canDelegate is undefined and orgRole is undefined', async () => {
+		const config: ModuleConfig = {
+			...baseConfig,
+			// canDelegate intentionally omitted; orgRole intentionally undefined
+		};
+		const result = await module.build(config);
+		expect(result).toContain('## Role Boundaries');
+		// Should render executor boundary (the correct fallback for non-TL members)
+		expect(result).toContain('Scoped implementer');
+	});
+
+	/**
+	 * Negative — the V4 throw must NOT fire on a properly configured TL
+	 * (canDelegate=true AND orgRole resolved). This is the happy path.
+	 */
+	it('renders TL boundary when canDelegate=true and orgRole=team-lead', async () => {
+		const config: ModuleConfig = {
+			...baseConfig,
+			canDelegate: true,
+			orgRole: 'team-lead',
+		};
+		const result = await module.build(config);
+		expect(result).toContain('Objective owner');
+		expect(result).toContain('Delegator');
+		expect(result).toContain('Quality verifier');
+	});
 });

--- a/backend/src/services/ai/prompt-modules/role-boundary.module.ts
+++ b/backend/src/services/ai/prompt-modules/role-boundary.module.ts
@@ -40,13 +40,43 @@ export class RoleBoundaryModule implements PromptModule {
 	 * @returns Formatted markdown role boundary section
 	 */
 	async build(config: ModuleConfig): Promise<string> {
+		// === Fail-fast misconfiguration guards (WIRE-1 V4 + F-G) ===========
+		// (1) canDelegate=true && orgRole undefined → throw.
+		// A member who can delegate but whose orgRole was never resolved
+		// indicates the caller bypassed `buildModuleConfigFromTeamMember`.
+		// The previous silent `?? 'executor'` fallback caused every TL
+		// agent in production to render with the executor boundary —
+		// the bug this ticket fixes (Arch Veto #7).
+		if (config.canDelegate === true && config.orgRole === undefined) {
+			throw new Error(
+				`RoleBoundaryModule: canDelegate=true but orgRole is undefined for ` +
+					`session=${config.sessionName ?? '<unknown>'}. ` +
+					`Resolve orgRole via deriveOrgRole(member, team) before assembly — ` +
+					`silent executor fallback is the bug WIRE-1 fixes (Arch Veto #7).`,
+			);
+		}
+		// (2) Symmetric misconfig (F-G): canDelegate=false && orgRole='team-lead'.
+		// Refuse to render TL authority for a member that cannot delegate.
+		if (config.canDelegate === false && config.orgRole === 'team-lead') {
+			throw new Error(
+				`RoleBoundaryModule: canDelegate=false but orgRole='team-lead' for ` +
+					`session=${config.sessionName ?? '<unknown>'}. ` +
+					`Symmetric misconfiguration — refuse to render TL authority for a ` +
+					`member that cannot delegate (WIRE-1 F-G).`,
+			);
+		}
+
 		// Try loading a custom role fragment first
 		const fragment = loadRoleFragment(config.projectRoot, config.role, 'role-boundary');
 		if (fragment) {
 			return fragment + this.buildOrganizationContext(config);
 		}
 
-		// Fall back to inline content based on orgRole (default: executor)
+		// Fall back to inline content based on orgRole. Default to 'executor'
+		// for non-TL members whose orgRole was not resolved — that path is
+		// correct (executor is the right boundary for plain workers) and not
+		// the bug we are fixing. The canDelegate=true case is gated above
+		// so it cannot reach this fallback silently.
 		const orgRole = config.orgRole ?? 'executor';
 
 		let boundary: string;


### PR DESCRIPTION
## Summary

- New helpers `deriveOrgRole(member, team)` + `buildModuleConfigFromTeamMember(member, team, runtime)` in `prompt-builder.service.ts` that wire every autonomy / organisation / team-context field declared on `TeamMember` and `Team` into `ModuleConfig`.
- Fail-fast guards in `RoleBoundaryModule.build()`: throws on `canDelegate=true && orgRole undefined` (V4 — the silent fallback bug WIRE-1 fixes) and on `canDelegate=false && orgRole='team-lead'` (F-G symmetric misconfig).
- 22 new specs (5 in role-boundary.module.test.ts + 17 in prompt-builder.service.test.ts).

## Arch Veto Checklist (PR-time)

- [x] **V1 Idempotency keys on auto-creates**: N/A — this PR doesn't create WorkItems. Inherits from REVIEW-1/BRIDGE-1.
- [x] **V2 retryCount ≤ 3**: N/A — this PR doesn't auto-retry. Inherits from BRIDGE-1.
- [x] **V3 isTransitionPermitted full coverage**: N/A — this PR doesn't mutate WorkItem status. Inherits from TRANS-1.
- [x] **V4 Missing orgRole fail-fast**: ✅ **PRIMARY DELIVERABLE.** Throw, not silent fallback. Tested with explicit `expect(...).rejects.toThrow(...)`.
- [x] **V5 No parallel Trigger entity**: N/A — this PR doesn't touch SchedulerService. Inherits from BRIDGE-1.
- [x] **V6 cron→cron block**: N/A — this PR doesn't touch cron. Inherits from BRIDGE-1.

`[V4 satisfied]` `[F-G bonus]`

V-numbering follows the ticket-side numbering map (canonical V7 = ticket V4; see `.crewly/tmp/autonomy-doc-review-2026-04-26.md` §V-numbering map).

## Verification (TL pre-PR)

- `npx tsc --noEmit -p backend/tsconfig.json` — **0 new errors.** One unrelated pre-existing error (`whatsapp.service.ts` → missing optional `@whiskeysockets/baileys` dep), out of scope and present on main.
- `npx jest prompt-builder.service.test prompt-modules/role-boundary` — **117 passed / 1 pre-existing failure unrelated to WIRE-1** (recovery-protocol step-name drift in test at line 1317; identical failure verified on origin/main via `git show`).
- Pre-commit Quality Gates: passed.

## Test plan

- [ ] Verify deriveOrgRole cascade tests (rules 1-4) cover the orgRole resolution rules per ticket §2.
- [ ] Verify buildModuleConfigFromTeamMember tests cover every field listed in ticket §1 (member-level autonomy + team-level injection).
- [ ] Verify V4 throw is structurally enforced (not just logged) — see role-boundary.module.test.ts.
- [ ] Verify F-G symmetric throw added per Arch's nice-to-have.
- [ ] Manual smoke after merge: re-run an existing TL agent (e.g. `crewly-product-sam-dd2b46f7`) once consumer wiring lands and confirm the boundary text contains `## Role Boundaries — TL`-equivalent block.

## Out of scope (per ticket)

- Module-side consumer changes (capability-overlay / domain-sop / risk-policy already consume the wired fields).
- TeamMember type changes (already has the fields).
- ModuleConfig interface changes (already declares them).
- Updating all callers of `buildModularPrompt` to pass `TeamMember + Team` — separate wiring pass. The helper is exported and ready for `agent-registration.service.ts:1538-1585` to switch to.

## Phase E

This PR does not touch any Phase E acceptance path (Cloud Portal onboarding, provisionFromOnboarding, OnboardingService). Build-side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)