### PR TITLE
fix(onboarding): attribute provisioned teams to authenticated principal (N1b)

### DIFF
--- a/backend/src/controllers/onboarding/onboarding.routes.test.ts
+++ b/backend/src/controllers/onboarding/onboarding.routes.test.ts
@@ -426,5 +426,32 @@ describe('Onboarding Routes', () => {
       expect(ownerRes.status).toBe(200);
       expect(ownerRes.body.data.websiteUrl).toBe('https://owner-update.com');
     });
+
+    // -------------------------------------------------------------------------
+    // /provision team-attribution gate (N1b — Arch's PR #350 follow-up)
+    //
+    // Deep attribution behaviour (`Team.ownerUserId` stamping, body-derived
+    // forgery rejection, distinct owners for distinct callers) is exhaustively
+    // covered in `onboarding-provision.service.test.ts`. Here we only assert
+    // the route-level surface: requireAuth gate + that a request with a
+    // garbage-shaped body still surfaces the same 400 validation pathway
+    // even when authenticated (i.e. the auth gate doesn't change the
+    // existing error contract).
+    // -------------------------------------------------------------------------
+    it('POST /provision returns 401 without a valid token (auth gate)', async () => {
+      const res = await request(app).post('/api/onboarding/provision').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('POST /provision still returns 400 on invalid body when authenticated', async () => {
+      const res = await request(app).post('/api/onboarding/provision')
+        .set('Authorization', `Bearer ${tokenA}`)
+        .send({});
+      // Auth passes; provisionFromOnboarding rejects the empty body via
+      // its own validator and the route surfaces it as 400 (not 500).
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBeDefined();
+    });
   });
 });

--- a/backend/src/controllers/onboarding/onboarding.routes.ts
+++ b/backend/src/controllers/onboarding/onboarding.routes.ts
@@ -170,7 +170,11 @@ export function createOnboardingRouter(): Router {
    * Provision a team from the Onboarding Agent's discovery output.
    *
    * Validates the handoff payload, resolves the best-match template,
-   * and creates a fully configured team via TemplateService.
+   * and creates a fully configured team via TemplateService. The team
+   * is attributed to the authenticated principal — `ownerIdFor(req)`
+   * is forwarded to {@link provisionFromOnboarding} so the resulting
+   * `Team.ownerUserId` is bound to `req.user.userId` and never sourced
+   * from the request body (N1b — Arch's PR #350 follow-up).
    *
    * Body: OnboardingProvisionRequest
    * Returns 200 with OnboardingProvisionResponse on success.
@@ -178,7 +182,7 @@ export function createOnboardingRouter(): Router {
    */
   router.post('/provision', requireAuth, async (req: Request, res: Response) => {
     try {
-      const result = await provisionFromOnboarding(req.body);
+      const result = await provisionFromOnboarding(req.body, ownerIdFor(req));
 
       if (!result.success) {
         res.status(400).json(result);

--- a/backend/src/services/onboarding/onboarding-provision.service.test.ts
+++ b/backend/src/services/onboarding/onboarding-provision.service.test.ts
@@ -361,6 +361,76 @@ describe('onboarding-provision.service', () => {
   });
 
   // =========================================================================
+  // Tenant attribution (N1b — Phase E pre-beta)
+  //
+  // The provision flow must stamp the authenticated principal as the team
+  // owner (`Team.ownerUserId`) so cross-tenant attribution is impossible.
+  // The owner is sourced ONLY from the route's `ownerIdFor(req)` call,
+  // never from the request body — even a body that carries an
+  // `ownerUserId` field must NOT influence the saved team.
+  // =========================================================================
+
+  describe('provisionFromOnboarding — tenant attribution (N1b)', () => {
+    it('stamps the authenticated principal onto Team.ownerUserId', async () => {
+      stubTemplateSuccess('growth-marketing-team');
+      const res = await provisionFromOnboarding(makeRequest(), 'user-aaa');
+
+      expect(res.success).toBe(true);
+      expect(mockSaveTeam).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerUserId: 'user-aaa' }),
+      );
+    });
+
+    it('persists distinct owners for distinct callers', async () => {
+      stubTemplateSuccess('growth-marketing-team');
+      await provisionFromOnboarding(makeRequest(), 'user-aaa');
+      stubTemplateSuccess('growth-marketing-team');
+      await provisionFromOnboarding(makeRequest(), 'user-bbb');
+
+      const calls = mockSaveTeam.mock.calls.map((args) => args[0] as { ownerUserId?: string });
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.ownerUserId).toBe('user-aaa');
+      expect(calls[1]?.ownerUserId).toBe('user-bbb');
+    });
+
+    it('leaves Team.ownerUserId undefined when no principal is provided (OSS legacy)', async () => {
+      stubTemplateSuccess('growth-marketing-team');
+      const res = await provisionFromOnboarding(makeRequest());
+
+      expect(res.success).toBe(true);
+      const savedTeam = mockSaveTeam.mock.calls[0]?.[0] as { ownerUserId?: string };
+      expect(savedTeam?.ownerUserId).toBeUndefined();
+    });
+
+    it('IGNORES any ownerUserId field on the request body (no body-derived attribution)', async () => {
+      stubTemplateSuccess('growth-marketing-team');
+      // Body carries a forged owner — defense in depth: the service must
+      // NOT trust it. Only the principal arg can set ownership.
+      const forged = { ...makeRequest(), ownerUserId: 'attacker-id' } as Record<string, unknown>;
+      await provisionFromOnboarding(forged, 'user-aaa');
+
+      const savedTeam = mockSaveTeam.mock.calls[0]?.[0] as { ownerUserId?: string };
+      expect(savedTeam?.ownerUserId).toBe('user-aaa');
+      expect(savedTeam?.ownerUserId).not.toBe('attacker-id');
+    });
+
+    it('does NOT stamp ownerUserId when validation fails (no half-attributed teams)', async () => {
+      const res = await provisionFromOnboarding({} as unknown, 'user-aaa');
+      expect(res.success).toBe(false);
+      expect(mockSaveTeam).not.toHaveBeenCalled();
+    });
+
+    it('does NOT stamp ownerUserId when budget gate trips (starter tier short-circuits)', async () => {
+      const req = makeRequest() as { customer: { strategy: { budget: string } } };
+      req.customer.strategy.budget = 'starter';
+      const res = await provisionFromOnboarding(req, 'user-aaa');
+
+      expect(res.success).toBe(false);
+      expect(mockSaveTeam).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
   // DEFAULT_TEMPLATE_ID constant is exported correctly
   // =========================================================================
 

--- a/backend/src/services/onboarding/onboarding-provision.service.ts
+++ b/backend/src/services/onboarding/onboarding-provision.service.ts
@@ -83,10 +83,20 @@ export function collectIntegrations(
  * Provision a team from an onboarding discovery payload.
  *
  * Validates the request, resolves the matching template, gates on budget tier,
- * creates the team via TemplateService, and returns a structured response with
- * team details, lead agent focus, and pending integrations.
+ * creates the team via TemplateService, attributes the team to the
+ * authenticated principal (`ownerUserId` — N1b, Phase E pre-beta), persists
+ * via StorageService, and returns a structured response with team details,
+ * lead agent focus, and pending integrations.
+ *
+ * The owner attribution is sourced *only* from the authenticated principal
+ * (passed in by the route layer), never from the request body — this closes
+ * the cross-tenant team-attribution leak Arch flagged on PR #350. When
+ * `ownerUserId` is omitted, the team is created without an owner (OSS
+ * single-user / legacy callers); the field stays undefined and read-side
+ * scoping (separate ticket) treats those teams as unscoped.
  *
  * @param request - The onboarding handoff payload from the Onboarding Agent
+ * @param ownerUserId - Authenticated principal id (`req.user.userId`)
  * @returns Structured response indicating success or failure with details
  *
  * @example
@@ -96,13 +106,15 @@ export function collectIntegrations(
  *     identity: { name: 'Acme Corp', vertical: 'Content/Marketing', size: 'small' },
  *     strategy: { goal: 'Scale', budget: 'pro', urgency: 'immediate' },
  *   },
- * });
+ * }, 'user-aaa');
  * // response.success === true
  * // response.data.teamName === 'Acme Corp Growth Team'
+ * // (the persisted team carries ownerUserId === 'user-aaa')
  * ```
  */
 export async function provisionFromOnboarding(
   request: unknown,
+  ownerUserId?: string,
 ): Promise<OnboardingProvisionResponse> {
   // Step a: Validate request
   const validation = validateProvisionRequest(request);
@@ -148,7 +160,19 @@ export async function provisionFromOnboarding(
     };
   }
 
-  // Step e.1: Persist the created team to storage
+  // Step e.1: Attribute the team to the authenticated principal (N1b).
+  //
+  // The owner is sourced ONLY from the route's `ownerIdFor(req)` call,
+  // never from the request body. Even if `request` happened to carry an
+  // `ownerUserId` field, we ignore it — body-derived attribution would
+  // re-open the cross-tenant leak Arch flagged on PR #350. Undefined
+  // `ownerUserId` (OSS single-user mode) leaves the field unset; the team
+  // is treated as legacy/unscoped by consumers.
+  if (ownerUserId !== undefined) {
+    result.team.ownerUserId = ownerUserId;
+  }
+
+  // Step e.2: Persist the created team to storage
   // This ensures the team is visible in the dashboard and to other agents.
   const storage = StorageService.getInstance();
   await storage.saveTeam(result.team);

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -136,6 +136,19 @@ export interface Team {
 
   // === Organization Model fields ===
 
+  /**
+   * Authenticated principal that materialised this team (Cloud Portal
+   * multi-tenant attribution — N1b, Phase E pre-beta). Populated by the
+   * provision route from `req.user.userId` so a team is bound to the user
+   * that triggered its creation. Undefined for OSS single-user teams and
+   * for legacy teams created before this field existed; consumers must
+   * tolerate both shapes.
+   *
+   * Read-side scoping (filter Team list/get by `ownerUserId`) is a
+   * separate ticket — N1b only closes the *attribution* leak so audit
+   * trails and future scoping have a stable field to key on.
+   */
+  ownerUserId?: string;
   /** Team-level ownership scope — what this team is responsible for */
   ownershipScope?: import('./team-template.types.js').OwnershipScope;
   /** Service contract — what the team accepts, avoids, and delivers */


### PR DESCRIPTION
## Summary

Closes the team-attribution gap Arch flagged on PR #350: `/api/onboarding/provision` was correctly auth-gated by N1, but `provisionFromOnboarding(req.body)` discarded the principal so the resulting `Team` had no link back to the caller. In Cloud Portal multi-tenant mode this means an authenticated user A could materialise a team and the persisted record would carry no owner — making cross-tenant audit and a future read-side scoping ticket impossible to key on.

This PR (a) adds `Team.ownerUserId?: string`, (b) threads the route's `ownerIdFor(req)` through `provisionFromOnboarding` to stamp it before `saveTeam`, and (c) explicitly ignores any `ownerUserId` field on the request body so attribution can only flow from the auth principal.

## What changed

| File | Change |
|------|--------|
| `backend/src/types/index.ts` | New optional field `Team.ownerUserId?: string` with JSDoc explaining attribution vs. read-side scoping |
| `backend/src/services/onboarding/onboarding-provision.service.ts` | `provisionFromOnboarding(request, ownerUserId?)` — stamps principal between `createTeamFromTemplate` and `saveTeam`. Body-derived `ownerUserId` is intentionally ignored (defense in depth) |
| `backend/src/services/onboarding/onboarding-provision.service.test.ts` | 6 new service tests covering attribution, body-forgery rejection, distinct-owner-per-caller, no-half-saves on validation/budget failures, OSS legacy passthrough |
| `backend/src/controllers/onboarding/onboarding.routes.ts` | `POST /provision` passes `ownerIdFor(req)` to provisionFromOnboarding |
| `backend/src/controllers/onboarding/onboarding.routes.test.ts` | 2 new route tests in the existing N1 suite: 401 without token, still-400 on invalid body when authenticated |

## Why TemplateService stays generic

`TemplateService.createTeamFromTemplate` is a pure factory. Stamping ownership at that layer would entangle the template engine with auth. Instead, the provision service (which already knows about auth via the route) sets `result.team.ownerUserId` between team creation and persistence. One mutable assignment, zero new entanglement.

## Why we ignore body-derived ownerUserId

Attribution from the body re-opens the cross-tenant leak: an attacker could submit `{ ..., ownerUserId: 'victim' }` and the team would be filed under the victim's account. The service explicitly takes the principal arg only — even if the request body carries an `ownerUserId` field, it's discarded. There's an explicit test for this: `IGNORES any ownerUserId field on the request body (no body-derived attribution)`.

## Test plan

- [x] **6 new service tests** — see file diff. Use `jest.spyOn` on the mocked `StorageService.saveTeam` to assert the persisted Team's `ownerUserId`.
- [x] **2 new route tests** — auth gate (401 without token) + 400 still surfaces on invalid body when authenticated.
- [x] **All 277 onboarding tests pass** across 12 suites.
- [x] **Backend build clean**: `npm run build:backend` zero errors.

## Out of scope

- **Read-side Team scoping** by `ownerUserId` (filter list/get) — separate ticket. Touches `/api/teams` controllers + storage queries; properly designed needs admin-bypass semantics.
- **Back-fill migration** for legacy unscoped teams — Cloud Portal ops checklist concern.
- **`BrandOnboardingService` parity** — separate ticket if marketing flow ever goes multi-tenant.

## References

- Arch's review comment on PR #350 — N1 follow-up "team-attribution gap"
- Stacked on top of PR #350 (`b6c6db65`) which introduced `requireAuth` + `ownerIdFor(req)` pattern. WIRE-1 (#349) and N1 (#350) both already in main.

## Worktree note

Prepared in `/tmp/crewly-n1b-c69ce8e6` off `origin/main` (`41194481`). Same recovery pattern as PRs #345 / #348 / #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)