### PR TITLE
feat(autonomy_v1): TRANS-1 — wire isTransitionPermitted + close re-queue gates (V3 + F-F)

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -584,4 +584,178 @@ describe('TaskPoolService', () => {
       expect(claims[0].status).toBe('expiring');
     });
   });
+
+  // =========================================================================
+  // TRANS-1: transitionStatus + role-based permission enforcement (V3)
+  // =========================================================================
+
+  describe('transitionStatus — TRANS-1 V3 enforcement', () => {
+    /**
+     * Helper: add a WorkItem to the pool and claim it so it reaches 'running'
+     * status, mirroring the steady-state of an in-flight task. Used by the
+     * verification gate tests.
+     */
+    async function makeRunning(): Promise<{ id: string; agent: string }> {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      const result = await service.claimFromPool('agent-test');
+      expect(result).not.toBeNull();
+      return { id: result!.workItem.id, agent: 'agent-test' };
+    }
+
+    it('throws when WorkItem does not exist', async () => {
+      await expect(
+        service.transitionStatus('does-not-exist', 'done', 'system'),
+      ).rejects.toThrow(/WorkItem not found/);
+    });
+
+    it('throws on illegal state-machine transition (e.g. done → running)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-test');
+      // Drive to terminal 'done' first via the legitimate path.
+      await service.transitionStatus(wi.id, 'done', 'system');
+      // Now attempt to revert — disallowed by WORK_ITEM_TRANSITIONS.
+      await expect(
+        service.transitionStatus(wi.id, 'running', 'system'),
+      ).rejects.toThrow(/Invalid status transition/);
+    });
+
+    it('agent CANNOT verify their own work (running → verified blocked for agent)', async () => {
+      const { id } = await makeRunning();
+      // Move to done_by_worker via agent — this is allowed.
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      // Attempt agent self-verification — must throw.
+      await expect(
+        service.transitionStatus(id, 'verified', 'agent'),
+      ).rejects.toThrow(/Forbidden transition.*actor='agent'/);
+    });
+
+    it('team_lead CAN verify worker output (done_by_worker → verified)', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      const verified = await service.transitionStatus(id, 'verified', 'team_lead');
+      expect(verified).not.toBeNull();
+      expect(verified!.status).toBe('verified');
+    });
+
+    it('team_lead CAN reject worker output with custom mutator carrying the error', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      const rejected = await service.transitionStatus(id, 'rejected', 'team_lead', (wi) => {
+        wi.error = 'Did not meet acceptance criteria';
+      });
+      expect(rejected!.status).toBe('rejected');
+      expect(rejected!.error).toBe('Did not meet acceptance criteria');
+    });
+
+    // -----------------------------------------------------------------------
+    // F-F: rejected → queued is gated to TL/orchestrator/system only
+    // -----------------------------------------------------------------------
+
+    it('F-F: agent CANNOT self-revive a rejected WorkItem (rejected → queued)', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      await service.transitionStatus(id, 'rejected', 'team_lead');
+      // Attempt agent self-revival — must throw per F-F.
+      await expect(
+        service.transitionStatus(id, 'queued', 'agent'),
+      ).rejects.toThrow(/Forbidden transition.*actor='agent'/);
+    });
+
+    it('F-F: team_lead CAN re-queue a rejected WorkItem', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      await service.transitionStatus(id, 'rejected', 'team_lead');
+      const requeued = await service.transitionStatus(id, 'queued', 'team_lead');
+      expect(requeued!.status).toBe('queued');
+    });
+
+    it('F-F: orchestrator CAN re-queue a rejected WorkItem', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      await service.transitionStatus(id, 'rejected', 'team_lead');
+      const requeued = await service.transitionStatus(id, 'queued', 'orchestrator');
+      expect(requeued!.status).toBe('queued');
+    });
+
+    it('F-F: system actor (Reconciler) CAN re-queue a rejected WorkItem', async () => {
+      const { id } = await makeRunning();
+      await service.transitionStatus(id, 'done_by_worker', 'agent');
+      await service.transitionStatus(id, 'rejected', 'team_lead');
+      const requeued = await service.transitionStatus(id, 'queued', 'system');
+      expect(requeued!.status).toBe('queued');
+    });
+
+    it('F-F: agent CANNOT self-revive a failed WorkItem (failed → queued)', async () => {
+      const { id } = await makeRunning();
+      // Move to failed via the existing failItem path.
+      await service.failItem(id, 'simulated failure');
+      // Attempt agent self-revival — must throw per F-F.
+      await expect(
+        service.transitionStatus(id, 'queued', 'agent'),
+      ).rejects.toThrow(/Forbidden transition.*actor='agent'/);
+    });
+
+    it('system actor passes through any legal transition (Reconciler exemption)', async () => {
+      const { id } = await makeRunning();
+      // Reconciler stuck-running corrective: running → blocked.
+      const blocked = await service.transitionStatus(id, 'blocked', 'system');
+      expect(blocked!.status).toBe('blocked');
+    });
+
+    // -----------------------------------------------------------------------
+    // mutator atomicity
+    // -----------------------------------------------------------------------
+
+    it('mutator runs atomically with the status update', async () => {
+      const { id } = await makeRunning();
+      const updated = await service.transitionStatus(id, 'done', 'system', (wi) => {
+        wi.result = { reportPath: '/tmp/done.md' };
+        wi.cost = 0.42;
+      });
+      expect(updated!.status).toBe('done');
+      expect(updated!.result).toEqual({ reportPath: '/tmp/done.md' });
+      expect(updated!.cost).toBe(0.42);
+      expect(updated!.completedAt).toBeDefined();
+    });
+
+    it('refreshes startedAt on transition into running', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      const before = new Date().toISOString();
+      const updated = await service.transitionStatus(wi.id, 'running', 'system');
+      expect(updated!.status).toBe('running');
+      expect(updated!.startedAt).toBeDefined();
+      expect(updated!.startedAt! >= before).toBe(true);
+    });
+  });
+
+  // =========================================================================
+  // TRANS-1: updateItemStatus actor-role gate (Reconciler legacy entry)
+  // =========================================================================
+
+  describe('updateItemStatus — TRANS-1 V3 actor gate', () => {
+    it('defaults actorRole to "system" when omitted (Reconciler default)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      // No third arg — defaults to system per backwards compat.
+      await service.updateItemStatus(wi.id, 'running');
+      const items = await service.getAvailableItems();
+      // Legacy callers continue to work unchanged.
+      expect(items.find((x) => x.id === wi.id)).toBeUndefined(); // no longer queued
+    });
+
+    it('rejects an agent attempting an unauthorised transition via updateItemStatus', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-test');
+      // agent moves to done_by_worker (allowed).
+      await service.updateItemStatus(wi.id, 'done_by_worker', 'agent');
+      // agent now attempts to verify themselves — must throw.
+      await expect(
+        service.updateItemStatus(wi.id, 'verified', 'agent'),
+      ).rejects.toThrow(/Forbidden transition.*actor='agent'/);
+    });
+  });
 });

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -18,7 +18,7 @@ import type {
   WorkItemType,
   WorkItemOwner,
 } from '../../types/v2/work-item.types.js';
-import { isWorkItem, isValidWorkItemTransition } from '../../types/v2/work-item.types.js';
+import { isWorkItem, isValidWorkItemTransition, isTransitionPermitted } from '../../types/v2/work-item.types.js';
 import {
   createTaskClaim,
   type TaskClaim,
@@ -700,11 +700,23 @@ export class TaskPoolService {
    * Updates a work item's status directly.
    * Used by the Reconciler for corrections (e.g., stuck → blocked).
    *
+   * Reconciler invocations pass through `actorRole='system'` (default) which
+   * bypasses the per-role gate at {@link isTransitionPermitted} but still
+   * enforces the state-machine via {@link isValidWorkItemTransition}. Other
+   * callers MUST supply the actor's role so TRANS-1 V3 enforcement applies.
+   *
    * @param workItemId - The work item ID
    * @param newStatus - The target status
-   * @throws Error if work item not found or transition is invalid
+   * @param actorRole - Role of the caller (defaults to `'system'` for Reconciler)
+   * @throws Error if work item not found
+   * @throws Error if transition is invalid (state machine — see WORK_ITEM_TRANSITIONS)
+   * @throws Error if actor is not permitted (role check — see TRANSITION_PERMISSIONS)
    */
-  async updateItemStatus(workItemId: string, newStatus: WorkItemStatus): Promise<void> {
+  async updateItemStatus(
+    workItemId: string,
+    newStatus: WorkItemStatus,
+    actorRole: WorkItemOwner = 'system',
+  ): Promise<void> {
     const items = await this.storage.getWorkItems();
     const item = items.find((wi) => wi.id === workItemId);
 
@@ -715,6 +727,14 @@ export class TaskPoolService {
     if (!isValidWorkItemTransition(item.status, newStatus)) {
       throw new Error(
         `Invalid status transition for WorkItem ${workItemId}: ${item.status} → ${newStatus}`,
+      );
+    }
+
+    // TRANS-1 V3: enforce per-role permissions. system role always passes.
+    if (!isTransitionPermitted(item.status, newStatus, actorRole)) {
+      throw new Error(
+        `Forbidden transition for WorkItem ${workItemId}: actor='${actorRole}' ` +
+          `not permitted to perform ${item.status} → ${newStatus}.`,
       );
     }
 
@@ -732,7 +752,113 @@ export class TaskPoolService {
       workItemId,
       from: item.status,
       to: newStatus,
+      actorRole,
     });
+  }
+
+  /**
+   * Public guarded transition helper — TRANS-1's canonical entrypoint.
+   *
+   * Routes any externally-initiated WorkItem status change through the
+   * combined state-machine + actor-role gates. Designed as the public API
+   * VERIF-1 will call from `submitForVerification` / `verifyItem`, and as
+   * the recommended path for any future caller that previously reached
+   * for `storage.updateWorkItem` to flip status.
+   *
+   * Differences vs {@link updateItemStatus}:
+   *   - Requires `actorRole` explicitly (no default) — forces the caller to
+   *     decide the trust posture rather than silently inheriting `'system'`.
+   *   - Accepts an optional `mutator` so callers can carry additional field
+   *     updates (e.g. `result`, `error`, `completedAt`) atomically with the
+   *     status flip — preventing races between status update and metadata
+   *     attachment that direct `storage.updateWorkItem` callers risked.
+   *
+   * @param workItemId - The work item ID
+   * @param newStatus - The target status
+   * @param actorRole - Role of the caller (REQUIRED; pass `'system'` for trusted server-internal paths)
+   * @param mutator - Optional additional WorkItem field updates applied atomically with the status change
+   * @returns The updated WorkItem after the transition
+   * @throws Error if work item not found
+   * @throws Error if transition is invalid (state machine)
+   * @throws Error if actor is not permitted (role check)
+   *
+   * @example
+   * ```typescript
+   * // VERIF-1 worker submitting for verification
+   * await pool.transitionStatus(wiId, 'done_by_worker', 'agent', (wi) => {
+   *   wi.result = output;
+   * });
+   *
+   * // VERIF-1 TL verifying
+   * await pool.transitionStatus(wiId, 'verified', 'team_lead');
+   *
+   * // VERIF-1 TL rejecting (allowed for TL only)
+   * await pool.transitionStatus(wiId, 'rejected', 'team_lead', (wi) => {
+   *   wi.error = 'Did not meet acceptance criteria';
+   * });
+   * ```
+   */
+  async transitionStatus(
+    workItemId: string,
+    newStatus: WorkItemStatus,
+    actorRole: WorkItemOwner,
+    mutator?: (wi: WorkItem) => void,
+  ): Promise<WorkItem | null> {
+    const item = await this.storage.findWorkItem(workItemId);
+    if (!item) {
+      throw new Error(`WorkItem not found: ${workItemId}`);
+    }
+
+    if (!isValidWorkItemTransition(item.status, newStatus)) {
+      throw new Error(
+        `Invalid status transition for WorkItem ${workItemId}: ${item.status} → ${newStatus}`,
+      );
+    }
+
+    if (!isTransitionPermitted(item.status, newStatus, actorRole)) {
+      throw new Error(
+        `Forbidden transition for WorkItem ${workItemId}: actor='${actorRole}' ` +
+          `not permitted to perform ${item.status} → ${newStatus}.`,
+      );
+    }
+
+    const ok = await this.storage.updateWorkItem(workItemId, (wi) => {
+      wi.status = newStatus;
+      // Standard timestamp side-effects mirror updateItemStatus so callers
+      // get consistent metadata regardless of which API they used.
+      if (newStatus === 'running') {
+        wi.startedAt = new Date().toISOString();
+      } else if (
+        newStatus === 'done' ||
+        newStatus === 'failed' ||
+        newStatus === 'verified' ||
+        newStatus === 'done_by_worker' ||
+        newStatus === 'rejected'
+      ) {
+        wi.completedAt = new Date().toISOString();
+      }
+      if (mutator) mutator(wi);
+    });
+
+    if (!ok) {
+      // Race window: someone else removed the WorkItem between findWorkItem
+      // and updateWorkItem. Surface as null so callers can distinguish from
+      // a thrown invalid-transition / forbidden-transition error.
+      return null;
+    }
+
+    this.logger.info('WorkItem transitioned', {
+      workItemId,
+      from: item.status,
+      to: newStatus,
+      actorRole,
+    });
+
+    // Return the post-update WorkItem snapshot so callers can chain on the
+    // resolved value rather than re-fetching. Coerce `undefined` (item
+    // removed during the race window) to `null` to match the declared
+    // return type.
+    return (await this.storage.findWorkItem(workItemId)) ?? null;
   }
 
   /**

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -234,6 +234,45 @@ describe('WorkItem Types', () => {
       expect(isTransitionPermitted('queued', 'proposed', 'orchestrator')).toBe(true);
       expect(isTransitionPermitted('queued', 'proposed', 'agent')).toBe(false);
     });
+
+    // -------------------------------------------------------------------
+    // TRANS-1 F-F: rejected→queued / failed→queued / blocked→queued are
+    // restricted to TL/orchestrator/system. Agent self-revival is blocked.
+    // -------------------------------------------------------------------
+
+    describe('F-F: re-queue gates (rejected/failed/blocked → queued)', () => {
+      it('blocks agent from re-queueing a rejected WorkItem (self-revival hazard)', () => {
+        expect(isTransitionPermitted('rejected', 'queued', 'agent')).toBe(false);
+      });
+
+      it('allows team_lead to re-queue a rejected WorkItem', () => {
+        expect(isTransitionPermitted('rejected', 'queued', 'team_lead')).toBe(true);
+      });
+
+      it('allows orchestrator to re-queue a rejected WorkItem', () => {
+        expect(isTransitionPermitted('rejected', 'queued', 'orchestrator')).toBe(true);
+      });
+
+      it('allows system actor (Reconciler) to re-queue a rejected WorkItem', () => {
+        expect(isTransitionPermitted('rejected', 'queued', 'system')).toBe(true);
+      });
+
+      it('blocks agent from re-queueing a failed WorkItem (BRIDGE-1 retry path is canonical)', () => {
+        expect(isTransitionPermitted('failed', 'queued', 'agent')).toBe(false);
+      });
+
+      it('allows team_lead to re-queue a failed WorkItem', () => {
+        expect(isTransitionPermitted('failed', 'queued', 'team_lead')).toBe(true);
+      });
+
+      it('blocks agent from re-queueing a blocked WorkItem', () => {
+        expect(isTransitionPermitted('blocked', 'queued', 'agent')).toBe(false);
+      });
+
+      it('allows system actor for the dependency-resolution path (blocked → queued)', () => {
+        expect(isTransitionPermitted('blocked', 'queued', 'system')).toBe(true);
+      });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -293,6 +293,20 @@ export const TRANSITION_PERMISSIONS: Record<string, ReadonlySet<WorkItemOwner>> 
   'done_by_worker→rejected':  new Set(['team_lead']),
   // Simple done — allowed for agents (simple tasks) and system (reconciler)
   'running→done':             new Set(['agent', 'system', 'orchestrator']),
+  // TRANS-1 F-F: only TL / orchestrator / system may re-queue a rejected
+  // WorkItem. Without this entry, the backward-compat default-allow at
+  // isTransitionPermitted line ~322 lets any actor (including the agent
+  // whose work was rejected) re-queue itself — a self-revival hazard.
+  // BRIDGE-1 retry policy is the canonical re-queueing path; manual
+  // TL action (or system reconciler) is the only other legal path.
+  'rejected→queued':          new Set(['team_lead', 'orchestrator', 'system']),
+  // failed→queued (BRIDGE-1 retry path) — same gate as rejected→queued.
+  // Agent cannot self-resurrect a failed WorkItem.
+  'failed→queued':            new Set(['team_lead', 'orchestrator', 'system']),
+  // blocked→queued (dependency-resolution path) — system-only by
+  // default. The TaskPoolService.resolveBlockedDependents() helper
+  // is the canonical caller and runs as system.
+  'blocked→queued':           new Set(['team_lead', 'orchestrator', 'system']),
 };
 
 /**


### PR DESCRIPTION
## Summary

- New `TaskPoolService.transitionStatus(workItemId, toStatus, actorRole, mutator?)` — public guarded API that combines state-machine + actor-role gates + atomic mutator. The canonical path VERIF-1 will use.
- `TaskPoolService.updateItemStatus` (Reconciler legacy entry) now also calls `isTransitionPermitted`. Default `actorRole='system'` preserves backwards compat.
- Three new entries in `TRANSITION_PERMISSIONS` per Arch's F-F: `rejected→queued`, `failed→queued`, `blocked→queued` are now restricted to TL/orchestrator/system. Closes the agent self-revival hazard.
- 22 new specs (12 transitionStatus + 8 F-F at type layer + 2 updateItemStatus actor gate).

## Veto checklist

- V1 N/A
- V2 N/A
- **V3 ✅ APPLIES — primary deliverable.** Audit included below.
- V4 dependency met: WIRE-1 (#349, M1 stopgap included) merged at `41194481`.
- V5 N/A
- V6 N/A

`[V3 satisfied — full audit attached]`
`[V4 dependency on WIRE-1 — confirmed merged]`

## Audit (per ticket §1)

`grep -rn 'workItem\.status\s*=' backend/src --include='*.ts' | grep -v test`
- 1 mutating site at `mission-executor.service.ts:136` — initial-state assignment on a to-be-stored WorkItem object before persistence; not a status transition.

`grep -rn 'updateWorkItem' backend/src --include='*.ts' | grep -v test`
- 9 sites in `task-pool.service.ts`: `claim @ 249`, `claimSpecificItem @ 309`, `releaseBack @ 361`, `completeItem @ 410`, `resolveBlockedDependents @ 454`, `failItem @ 494`, `updateItemStatus @ 721 (now guarded)`, `updateTokenUsage @ 757 (no status mutation)`. All 9 sites are inside trusted server-internal service code (implicit `actor='system'`). V3 is satisfied for ALL EXTERNAL mutation paths via the two public APIs guarded above.

`grep -rn 'isTransitionPermitted' backend/src --include='*.ts' | grep -v test`
- BEFORE: only the type-file definition. Zero production callers.
- AFTER this PR: 2 production callers — `updateItemStatus` and `transitionStatus`.

## Tests

- 12 new specs in `task-pool.service.test.ts` (transitionStatus): agent-cannot-self-verify, TL-can-verify, TL-can-reject-with-mutator, F-F: agent-cannot-re-queue {rejected, failed}, F-F: TL/orchestrator/system can re-queue rejected, system can do any legal transition, mutator runs atomically, startedAt refreshes on running.
- 8 new specs in `work-item.types.test.ts` (F-F at type layer): rejected/failed/blocked → queued for each role.
- 2 new specs in `task-pool.service.test.ts` (`updateItemStatus` actor gate).

**189 tests pass across 4 suites.** Backend typecheck clean (1 unrelated pre-existing `whatsapp.service.ts` missing optional dep, on main). Pre-commit Quality Gates: passed.

## Sub-sequence

Pairs with VERIF-1 (Max owns). Max coordinated to land VERIF-1 on top of TRANS-1 — `transitionStatus` signature is locked: `(workItemId: string, toStatus: WorkItemStatus, actorRole: WorkItemOwner, mutator?: (wi: WorkItem) => void) => Promise<WorkItem | null>`.

## Out of scope

- Refactoring the 9 internal task-pool sites — trusted server-internal (implicit `actor='system'`). Tracked as TRANS-2 follow-up if explicit actor-role distinction needed inside pool service itself.
- Mission-executor initial-state assignment — not a transition.
- BRIDGE-1's retry path policy (uses `failed→queued`, now TL/orc/system-gated).

## Phase E

This PR does not touch any Phase E acceptance path (Cloud Portal onboarding, provisioning, OnboardingService).

🤖 Generated with [Claude Code](https://claude.com/claude-code)