### PR TITLE
feat(autonomy_v1): REVIEW-1 — cadence-driven Mission review WorkItems

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -842,6 +842,23 @@ export class TaskPoolService {
   }
 
   /**
+   * Find a WorkItem by id without mutating it.
+   *
+   * Public read accessor used by callers that need to inspect a
+   * specific item — for example REVIEW-1's reentrancy lock checks the
+   * status of a Mission's `pendingReviewWorkItemId` to decide whether
+   * to clear the lock. Returns `null` (not `undefined`) so callers can
+   * use a uniform null-fallthrough idiom shared with
+   * `getWorkItemSnapshot` and `transitionStatus`.
+   *
+   * @param workItemId - WorkItem id to look up
+   * @returns The WorkItem, or `null` if no item has that id
+   */
+  async findWorkItem(workItemId: string): Promise<WorkItem | null> {
+    return (await this.storage.findWorkItem(workItemId)) ?? null;
+  }
+
+  /**
    * Removes a WorkItem from the pool entirely.
    * Used for purging old completed/cancelled items.
    *

--- a/backend/src/services/v3/mission-reminder.service.test.ts
+++ b/backend/src/services/v3/mission-reminder.service.test.ts
@@ -471,6 +471,39 @@ describe('MissionReminderService', () => {
       expect(persistedMission.pendingReviewWorkItemId).toBe('m-cadence:review:2026-04-28');
     });
 
+    // V8 N1 regression guard (Arch BLOCKING on PR #354):
+    // PENDING_REVIEW_TERMINAL_STATUSES must include every status a review
+    // WorkItem can reach that represents "exited the active queue", otherwise
+    // a single rejection / failure freezes the lock and silently skips all
+    // future cadence ticks for that mission.
+    it.each([
+      ['done',      'done'],
+      ['verified',  'verified'],
+      ['cancelled', 'cancelled'],
+      ['failed',    'failed'],
+      ['rejected',  'rejected'], // ← N1: TL-rejected review WI must clear the lock
+    ])('clears pendingReviewWorkItemId when prior WI status is %s', async (_label, priorStatus) => {
+      pinNow('2026-04-28T10:00:00Z');
+      const mission = makeMissionWithCadence({
+        lastReviewAt: '2026-04-27T09:30:00.000Z',
+        pendingReviewWorkItemId: 'm-cadence:review:2026-04-27',
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+      mockTaskPool.findWorkItem.mockResolvedValue({
+        id: 'm-cadence:review:2026-04-27',
+        status: priorStatus,
+      });
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(1);
+      const lastSaveCall = (atomicWriteJson as any).mock.calls.at(-1);
+      const persistedMission = lastSaveCall[1];
+      expect(persistedMission.pendingReviewWorkItemId).toBe('m-cadence:review:2026-04-28');
+    });
+
     it.each([
       ['CONSERVATIVE', '0 9 * * 1', '2026-04-27T10:00:00Z', '2026-04-27'], // Mon 09:00 UTC
       ['MODERATE',     '0 9 * * 1,4', '2026-04-23T10:00:00Z', '2026-04-23'], // Thu 09:00 UTC

--- a/backend/src/services/v3/mission-reminder.service.test.ts
+++ b/backend/src/services/v3/mission-reminder.service.test.ts
@@ -19,6 +19,7 @@ import { MissionReminderService } from './mission-reminder.service.js';
 import { KRTrackingService } from './kr-tracking.service.js';
 import { StorageService } from '../core/storage.service.js';
 import { getSlackOrchestratorBridge } from '../slack/slack-orchestrator-bridge.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import { atomicWriteJson } from '../../utils/file-io.utils.js';
 import * as fs from 'fs/promises';
 
@@ -26,6 +27,7 @@ import * as fs from 'fs/promises';
 jest.mock('./kr-tracking.service.js');
 jest.mock('../core/storage.service.js');
 jest.mock('../slack/slack-orchestrator-bridge.js');
+jest.mock('../task-pool/task-pool.service.js');
 jest.mock('../../utils/file-io.utils.js');
 jest.mock('fs/promises');
 
@@ -34,6 +36,7 @@ describe('MissionReminderService', () => {
   let mockKRTrackingService: any;
   let mockStorageService: any;
   let mockSlackBridge: any;
+  let mockTaskPool: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -45,7 +48,9 @@ describe('MissionReminderService', () => {
 
     mockStorageService = {
       getMemberById: jest.fn(),
-      getTeams: jest.fn(),
+      // Default to empty list so resolveTeamLeadSession can fall through
+      // to the orchestrator without throwing on `teams.find`.
+      getTeams: jest.fn(() => Promise.resolve([])),
     };
     (StorageService.getInstance as any).mockReturnValue(mockStorageService);
 
@@ -54,7 +59,16 @@ describe('MissionReminderService', () => {
     };
     (getSlackOrchestratorBridge as any).mockReturnValue(mockSlackBridge);
 
+    mockTaskPool = {
+      addToPool: jest.fn(() => Promise.resolve(undefined)),
+      findWorkItem: jest.fn(() => Promise.resolve(null)),
+    };
+    (TaskPoolService.getInstance as any).mockReturnValue(mockTaskPool);
+
     (atomicWriteJson as any).mockResolvedValue(undefined);
+
+    // Default-on for the review WI loop; specific tests can flip this.
+    delete process.env['CREWLY_REVIEW_WI_ENABLED'];
 
     MissionReminderService.resetInstance();
     service = MissionReminderService.getInstance();
@@ -292,5 +306,320 @@ describe('MissionReminderService', () => {
 
     expect(result.skipped).toBe(0);
     expect(result.sent).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // REVIEW-1: cadence-driven review WorkItem creation
+  // ---------------------------------------------------------------------------
+
+  describe('review WorkItem creation (REVIEW-1)', () => {
+    /** Build a mission shaped like the live JSON files, with cadence + member. */
+    function makeMissionWithCadence(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'm-cadence',
+        objective: 'Ship cadence-driven reviews',
+        ownerTeamId: 't-1',
+        successCriteria: [],
+        currentStrategy: '',
+        activeProjectTaskIds: ['pt-1'],
+        cadence: '',
+        status: 'active',
+        createdAt: '2026-04-20T00:00:00.000Z',
+        updatedAt: '2026-04-20T00:00:00.000Z',
+        learnings: [],
+        policy: {
+          missionId: 'm-cadence',
+          executionCadence: {
+            // AUTONOMOUS — daily 09:00 UTC.
+            reviewSchedule: '0 9 * * *',
+            dailyItemLimit: 0,
+            workHours: null,
+            phaseGateApproval: 'none',
+            requireVerificationGate: false,
+          },
+        },
+        ...overrides,
+      };
+    }
+
+    function defaultSummary(overrides: Record<string, number> = {}) {
+      return {
+        missionId: 'm-cadence',
+        total: 1,
+        achieved: 0,
+        onTrack: 1,
+        atRisk: 0,
+        offTrack: 0,
+        progress: 0,
+        status: 'on_track',
+        totalKRs: 1,
+        overallProgress: 0,
+        ...overrides,
+      };
+    }
+
+    /**
+     * Pin `Date.now()` so cron-parser deterministically produces the
+     * same boundary across replays in a single test.
+     */
+    function pinNow(iso: string) {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(iso));
+    }
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('creates a review WorkItem at the cadence boundary with deterministic id', async () => {
+      pinNow('2026-04-27T10:00:00Z'); // after today's 09:00 boundary
+      const mission = makeMissionWithCadence();
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(1);
+      expect(mockTaskPool.addToPool).toHaveBeenCalledTimes(1);
+      const wi = mockTaskPool.addToPool.mock.calls[0][0];
+      // Deterministic id collapses to <missionId>:review:<YYYY-MM-DD>
+      expect(wi.id).toBe('m-cadence:review:2026-04-27');
+      expect(wi.type).toBe('review');
+      expect(wi.owner).toBe('team_lead');
+      expect(wi.missionId).toBe('m-cadence');
+      // F-H: review WIs MUST opt out of TL self-verification.
+      expect(wi.metadata.requiresVerification).toBe(false);
+      // V1: idempotencyKey == id (same dedup surface).
+      expect(wi.metadata.idempotencyKey).toBe(wi.id);
+    });
+
+    it('persists pendingReviewWorkItemId + lastReviewAt on the Mission after creation', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence();
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      await service.runSweep();
+
+      const lastSaveCall = (atomicWriteJson as any).mock.calls.at(-1);
+      const persistedMission = lastSaveCall[1];
+      expect(persistedMission.pendingReviewWorkItemId).toBe('m-cadence:review:2026-04-27');
+      expect(persistedMission.lastReviewAt).toBe('2026-04-27T10:00:00.000Z');
+    });
+
+    it('idempotent replay — second sweep tick within the same cycle creates no duplicate', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence({
+        // First sweep already recorded today's review.
+        lastReviewAt: '2026-04-27T09:30:00.000Z',
+        pendingReviewWorkItemId: undefined, // pretend the prior WI already cleared
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(0);
+      expect(result.reviewsSkipped).toBe(1);
+      expect(mockTaskPool.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('reentrancy lock — pendingReviewWorkItemId in non-terminal state blocks creation', async () => {
+      pinNow('2026-04-28T10:00:00Z'); // next cycle, but the previous WI is still active
+      const mission = makeMissionWithCadence({
+        lastReviewAt: '2026-04-27T09:30:00.000Z',
+        pendingReviewWorkItemId: 'm-cadence:review:2026-04-27',
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+      mockTaskPool.findWorkItem.mockResolvedValue({
+        id: 'm-cadence:review:2026-04-27',
+        status: 'running', // still active — TL hasn't acted on it yet
+      });
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(0);
+      expect(result.reviewsSkipped).toBe(1);
+      expect(mockTaskPool.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('clears pendingReviewWorkItemId when the prior WI has reached terminal status', async () => {
+      pinNow('2026-04-28T10:00:00Z');
+      const mission = makeMissionWithCadence({
+        lastReviewAt: '2026-04-27T09:30:00.000Z',
+        pendingReviewWorkItemId: 'm-cadence:review:2026-04-27',
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+      // Prior WI is verified — lock should clear and a new review fire.
+      mockTaskPool.findWorkItem.mockResolvedValue({
+        id: 'm-cadence:review:2026-04-27',
+        status: 'verified',
+      });
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(1);
+      const lastSaveCall = (atomicWriteJson as any).mock.calls.at(-1);
+      const persistedMission = lastSaveCall[1];
+      expect(persistedMission.pendingReviewWorkItemId).toBe('m-cadence:review:2026-04-28');
+    });
+
+    it.each([
+      ['CONSERVATIVE', '0 9 * * 1', '2026-04-27T10:00:00Z', '2026-04-27'], // Mon 09:00 UTC
+      ['MODERATE',     '0 9 * * 1,4', '2026-04-23T10:00:00Z', '2026-04-23'], // Thu 09:00 UTC
+      ['AUTONOMOUS',   '0 9 * * *', '2026-04-25T10:00:00Z', '2026-04-25'], // any day 09:00 UTC
+    ])('cadence routing: %s → cycleId %s', async (_label, cron, nowIso, expectedCycle) => {
+      pinNow(nowIso);
+      const mission = makeMissionWithCadence({
+        policy: {
+          missionId: 'm-cadence',
+          executionCadence: {
+            reviewSchedule: cron,
+            dailyItemLimit: 0,
+            workHours: null,
+            phaseGateApproval: 'none',
+            requireVerificationGate: false,
+          },
+        },
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      await service.runSweep();
+
+      expect(mockTaskPool.addToPool).toHaveBeenCalledTimes(1);
+      const wi = mockTaskPool.addToPool.mock.calls[0][0];
+      expect(wi.id).toBe(`m-cadence:review:${expectedCycle}`);
+      expect(wi.metadata.reviewCycleId).toBe(expectedCycle);
+      expect(wi.metadata.cadenceSchedule).toBe(cron);
+    });
+
+    it.each([
+      ['off_track_kr',     defaultSummary({ offTrack: 2 }), { activeProjectTaskIds: ['pt-1'] }],
+      ['no_active_work',   defaultSummary(),                { activeProjectTaskIds: [] }],
+      ['scheduled_review', defaultSummary(),                { activeProjectTaskIds: ['pt-1'] }],
+    ])('reviewReason routing → %s', async (expectedReason, summary, missionOverrides) => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence(missionOverrides);
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(summary);
+
+      await service.runSweep();
+
+      const wi = mockTaskPool.addToPool.mock.calls[0][0];
+      expect(wi.metadata.reviewReason).toBe(expectedReason);
+    });
+
+    it('does NOT create a review WorkItem when CREWLY_REVIEW_WI_ENABLED=false (config gate)', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      process.env['CREWLY_REVIEW_WI_ENABLED'] = 'false';
+      const mission = makeMissionWithCadence();
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(0);
+      expect(mockTaskPool.addToPool).not.toHaveBeenCalled();
+      // Slack DM path is independent — must NOT be affected.
+      // (off_track=0 in default summary, so it doesn't fire either way; the
+      // assertion is the absence of pool calls.)
+    });
+
+    it('skips review WI creation when the mission has no executionCadence (legacy mission)', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = {
+        id: 'm-legacy',
+        objective: 'Legacy mission without policy.executionCadence',
+        ownerTeamId: 't-1',
+        successCriteria: [],
+        currentStrategy: '',
+        activeProjectTaskIds: [],
+        cadence: '',
+        status: 'active',
+        createdAt: '2026-04-20T00:00:00.000Z',
+        updatedAt: '2026-04-20T00:00:00.000Z',
+        learnings: [],
+        policy: {
+          missionId: 'm-legacy',
+          // executionCadence intentionally omitted
+        },
+      };
+      (fs.readdir as any).mockResolvedValue(['m-legacy.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(0);
+      expect(result.reviewsSkipped).toBe(0);
+      expect(mockTaskPool.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('targets the team-lead session resolved via pickTeamLead', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence({ ownerId: undefined });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+      mockStorageService.getTeams.mockResolvedValue([
+        {
+          id: 't-1',
+          name: 'Squad',
+          members: [
+            {
+              id: 'm-tl',
+              name: 'Lead Person',
+              sessionName: 'crewly-tl-session',
+              role: 'developer',
+              canDelegate: true,
+              hierarchyLevel: 1,
+            },
+            {
+              id: 'm-w',
+              name: 'Worker',
+              sessionName: 'crewly-worker-session',
+              role: 'developer',
+              canDelegate: false,
+              hierarchyLevel: 2,
+            },
+          ],
+        },
+      ]);
+
+      await service.runSweep();
+
+      const wi = mockTaskPool.addToPool.mock.calls[0][0];
+      expect(wi.target).toBe('crewly-tl-session');
+    });
+
+    it('preserves the Slack DM path even when off_track > 0 (additive, not replacement)', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence();
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(
+        defaultSummary({ offTrack: 1 }),
+      );
+      mockStorageService.getMemberById.mockResolvedValue({ id: 'u1', name: 'Owner' });
+
+      const result = await service.runSweep();
+
+      // Both fire on the same sweep tick.
+      expect(result.sent).toBe(1);
+      expect(result.reviewsCreated).toBe(1);
+      expect(mockSlackBridge.sendNotification).toHaveBeenCalled();
+      expect(mockTaskPool.addToPool).toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/services/v3/mission-reminder.service.ts
+++ b/backend/src/services/v3/mission-reminder.service.ts
@@ -16,12 +16,16 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { CronExpressionParser } from 'cron-parser';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { StorageService } from '../core/storage.service.js';
 import { KRTrackingService } from './kr-tracking.service.js';
 import { getSlackOrchestratorBridge } from '../slack/slack-orchestrator-bridge.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import type { Mission } from '../../types/v2/mission.types.js';
 import type { MissionOKRSummary } from '../../types/v2/key-result.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+import { TERMINAL_WORK_ITEM_STATUSES } from '../../types/v2/work-item.types.js';
 import { atomicWriteJson } from '../../utils/file-io.utils.js';
 import { pickTeamLead } from '../../utils/team.utils.js';
 import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
@@ -33,8 +37,56 @@ import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 /** Minimum interval between reminders for the same mission (24 hours) */
 const REMINDER_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Why this review cycle was scheduled. Surfaces on the review WorkItem's
+ * `metadata.reviewReason` so the TL queue can render context-appropriate
+ * UI (e.g. red badge on `off_track_kr`, neutral badge on
+ * `scheduled_review`).
+ */
+export type ReviewReason =
+  | 'scheduled_review'
+  | 'off_track_kr'
+  | 'no_active_work'
+  | 'phase_complete';
+
+/**
+ * Statuses that *clear* a Mission's `pendingReviewWorkItemId` so the next
+ * sweep tick can fire a new review. The set mirrors
+ * {@link TERMINAL_WORK_ITEM_STATUSES} but adds `failed` because a failed
+ * review WI has also exited the active queue and shouldn't block the
+ * next cadence. The reentrancy lock is sweep-time lazy: we don't subscribe
+ * to TRANS-1 events here, we just observe the WorkItem's current state on
+ * each sweep and clear the lock when it's terminal.
+ */
+const PENDING_REVIEW_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  ...TERMINAL_WORK_ITEM_STATUSES,
+  'failed',
+]);
+
 function getMissionsDir(): string {
   return path.join(process.cwd(), '.crewly', 'missions');
+}
+
+/**
+ * Default timezone used when a mission's `policy.executionCadence.workHours`
+ * does not specify one. UTC keeps the dedup key globally consistent across
+ * deployments — overriding to a local TZ would only matter if we surfaced
+ * the cycleId to humans.
+ */
+const DEFAULT_REVIEW_TIMEZONE = 'UTC';
+
+/**
+ * Whether to create a `type: 'review'` WorkItem on every cadence boundary
+ * in addition to the existing Slack reminder. Controlled by env so ops
+ * can turn the loop off independently of the reminder DM if a downstream
+ * pipeline (BRIDGE-1, LEARN-1) regresses.
+ *
+ * Env:
+ *   `CREWLY_REVIEW_WI_ENABLED=false` — disables review WI creation
+ *   anything else (or unset) — review WI creation enabled (default)
+ */
+function isReviewWorkItemEnabled(): boolean {
+  return process.env['CREWLY_REVIEW_WI_ENABLED'] !== 'false';
 }
 
 // ---------------------------------------------------------------------------
@@ -68,54 +120,290 @@ export class MissionReminderService {
   }
 
   /**
-   * Run a full sweep of all active missions and send reminders where needed.
+   * Run a full sweep of all active missions, sending Slack OKR reminders
+   * AND (per REVIEW-1, Phase E pre-beta) creating cadence-driven review
+   * WorkItems that wake the Team Lead.
    *
-   * @param force - If true, ignores the REMINDER_COOLDOWN_MS
+   * The two outputs are intentionally additive — the Slack DM keeps the
+   * legacy 24h-cooldown path, and the review WorkItem is created when
+   * the mission's `policy.executionCadence.reviewSchedule` cron has
+   * fired since the last `lastReviewAt`. The DM and the WI may both
+   * fire on the same sweep tick — one is a notification, the other is
+   * a queue item the TL can act on. Idempotency is guaranteed by the
+   * deterministic WorkItem id (`<missionId>:review:<cycleId>`) which
+   * the existing `addToPool` dedup-by-id catches; reentrancy is
+   * guaranteed by `mission.pendingReviewWorkItemId` (Arch Veto V8).
+   *
+   * @param force - If true, ignores the REMINDER_COOLDOWN_MS for the
+   *   Slack DM path (does NOT bypass the review-WI cadence/lock — that
+   *   would defeat the deterministic-id contract).
    * @returns Summary of actions taken
    */
-  async runSweep(force: boolean = false): Promise<{ checked: number; sent: number; skipped: number }> {
+  async runSweep(force: boolean = false): Promise<{
+    checked: number;
+    sent: number;
+    skipped: number;
+    reviewsCreated: number;
+    reviewsSkipped: number;
+  }> {
     const now = new Date();
     const missions = await this.loadAllActiveMissions();
-    const result = { checked: 0, sent: 0, skipped: 0 };
+    const result = {
+      checked: 0,
+      sent: 0,
+      skipped: 0,
+      reviewsCreated: 0,
+      reviewsSkipped: 0,
+    };
 
     this.logger.info('Starting Mission OKR reminder sweep', { count: missions.length });
 
     for (const mission of missions) {
       result.checked++;
 
-      // Check cooldown
-      if (!force && mission.lastReminderAt) {
-        const lastSent = new Date(mission.lastReminderAt);
-        if (now.getTime() - lastSent.getTime() < REMINDER_COOLDOWN_MS) {
-          result.skipped++;
-          continue;
-        }
-      }
-
+      let summary: MissionOKRSummary | null = null;
       try {
-        // Get OKR progress summary
-        const summary = await this.krTrackingService.computeMissionOKRProgress(mission.id);
-
-        // If any KRs are off-track or at-risk, send a reminder
-        if (summary.offTrack > 0 || summary.atRisk > 0) {
-          const sent = await this.sendReminder(mission, summary);
-          if (sent) {
-            result.sent++;
-            // Update lastReminderAt
-            mission.lastReminderAt = now.toISOString();
-            await this.saveMission(mission);
-          }
-        }
+        // Get OKR progress summary — needed for both the reminder DM
+        // and the reviewReason inference on the review WorkItem.
+        summary = await this.krTrackingService.computeMissionOKRProgress(mission.id);
       } catch (err) {
-        this.logger.error('Failed to process mission reminder', {
+        this.logger.error('Failed to compute mission OKR progress', {
           missionId: mission.id,
           error: err instanceof Error ? err.message : String(err),
         });
+        // Don't `continue` — the review-WI path doesn't strictly need
+        // the summary (it falls back to `scheduled_review`). Slack
+        // path will be skipped by the off-track/at-risk filter below.
+      }
+
+      // -------------------------------------------------------------------
+      // Slack OKR reminder path (existing — 24h cooldown).
+      // -------------------------------------------------------------------
+      const reminderEligible =
+        force || !mission.lastReminderAt ||
+        now.getTime() - new Date(mission.lastReminderAt).getTime() >= REMINDER_COOLDOWN_MS;
+
+      if (reminderEligible && summary && (summary.offTrack > 0 || summary.atRisk > 0)) {
+        try {
+          const sent = await this.sendReminder(mission, summary);
+          if (sent) {
+            result.sent++;
+            mission.lastReminderAt = now.toISOString();
+            await this.saveMission(mission);
+          }
+        } catch (err) {
+          this.logger.error('Failed to send mission reminder', {
+            missionId: mission.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      } else if (!reminderEligible) {
+        result.skipped++;
+      }
+
+      // -------------------------------------------------------------------
+      // REVIEW-1: cadence-driven review WorkItem creation.
+      //
+      // The DM above is a notification; this is a queue item the TL must
+      // explicitly act on. Both can fire on the same sweep tick.
+      // -------------------------------------------------------------------
+      if (isReviewWorkItemEnabled()) {
+        try {
+          const created = await this.maybeCreateReviewWorkItem(mission, summary, now);
+          if (created === 'created') result.reviewsCreated++;
+          else if (created === 'skipped') result.reviewsSkipped++;
+        } catch (err) {
+          this.logger.error('Failed to create mission review WorkItem', {
+            missionId: mission.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
     }
 
     this.logger.info('Mission OKR reminder sweep complete', result);
     return result;
+  }
+
+  /**
+   * Result of {@link maybeCreateReviewWorkItem} — `'created'` when a new
+   * review WorkItem was added to the pool, `'skipped'` when the
+   * reentrancy lock or cadence boundary blocked creation, `'noop'` when
+   * the mission has no executionCadence configured (legacy missions).
+   */
+  private async maybeCreateReviewWorkItem(
+    mission: Mission,
+    summary: MissionOKRSummary | null,
+    now: Date,
+  ): Promise<'created' | 'skipped' | 'noop'> {
+    const cadence = mission.policy?.executionCadence;
+    if (!cadence?.reviewSchedule) return 'noop';
+
+    const timezone = cadence.workHours?.timezone ?? DEFAULT_REVIEW_TIMEZONE;
+
+    // -----------------------------------------------------------------
+    // Reentrancy lock (Arch Veto V8).
+    // Lazily clear the pending pointer when the previous review WI has
+    // reached terminal status; otherwise short-circuit creation.
+    // -----------------------------------------------------------------
+    if (mission.pendingReviewWorkItemId) {
+      const taskPool = TaskPoolService.getInstance();
+      const pendingWI = await taskPool.findWorkItem(mission.pendingReviewWorkItemId);
+      if (!pendingWI || PENDING_REVIEW_TERMINAL_STATUSES.has(pendingWI.status)) {
+        // Pending WI is gone or terminal — clear and continue.
+        mission.pendingReviewWorkItemId = undefined;
+        await this.saveMission(mission);
+      } else {
+        return 'skipped';
+      }
+    }
+
+    // -----------------------------------------------------------------
+    // Cadence boundary check.
+    // The most recent cron-tick <= now defines the current cycle. If
+    // `lastReviewAt` is at or after that boundary, we already covered
+    // this cycle and the next sweep tick will roll into the next one.
+    // -----------------------------------------------------------------
+    let boundary: Date;
+    try {
+      const interval = CronExpressionParser.parse(cadence.reviewSchedule, {
+        currentDate: now,
+        tz: timezone,
+      });
+      boundary = interval.prev().toDate();
+    } catch (err) {
+      this.logger.warn('Mission has unparseable review cadence cron — skipping review WI', {
+        missionId: mission.id,
+        reviewSchedule: cadence.reviewSchedule,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return 'noop';
+    }
+
+    if (mission.lastReviewAt) {
+      const lastReview = new Date(mission.lastReviewAt);
+      if (lastReview.getTime() >= boundary.getTime()) {
+        // Already reviewed within the current cadence cycle.
+        return 'skipped';
+      }
+    }
+
+    // -----------------------------------------------------------------
+    // Build the deterministic review WorkItem.
+    //
+    // The id collapses to the date-form of the boundary so a sweep
+    // replay within the same cycle hits the existing addToPool
+    // dedup-by-id guard (V1 satisfied without a TaskPoolService change).
+    // -----------------------------------------------------------------
+    const cycleId = boundary.toISOString().slice(0, 10);
+    const reviewWorkItemId = `${mission.id}:review:${cycleId}`;
+    const reviewReason = this.inferReviewReason(mission, summary);
+    const target = await this.resolveTeamLeadSession(mission);
+
+    const reviewWorkItem: WorkItem = {
+      id: reviewWorkItemId,
+      type: 'review',
+      owner: 'team_lead',
+      target,
+      title: `Mission review — ${mission.objective.slice(0, 60)}${mission.objective.length > 60 ? '…' : ''}`,
+      description: `Cadence-driven review for mission ${mission.id}. Reason: ${reviewReason}.`,
+      status: 'queued',
+      createdAt: now.toISOString(),
+      retryCount: 0,
+      maxRetries: 0, // V2 N/A for review WIs — no auto-retry policy
+      missionId: mission.id,
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      metadata: {
+        idempotencyKey: reviewWorkItemId, // V1 — same as id, surfaces in audit logs
+        requiresVerification: false,      // F-H — review WIs do NOT loop back to TL self-verify
+        reviewReason,
+        reviewCycleId: cycleId,
+        cadenceSchedule: cadence.reviewSchedule,
+      },
+    };
+
+    const taskPool = TaskPoolService.getInstance();
+    await taskPool.addToPool(reviewWorkItem);
+
+    // Persist the reentrancy lock + bookkeeping fields.
+    mission.pendingReviewWorkItemId = reviewWorkItemId;
+    mission.lastReviewAt = now.toISOString();
+    await this.saveMission(mission);
+
+    this.logger.info('Mission review WorkItem created', {
+      missionId: mission.id,
+      workItemId: reviewWorkItemId,
+      reviewReason,
+      target,
+      cycleId,
+    });
+
+    return 'created';
+  }
+
+  /**
+   * Pick the {@link ReviewReason} for this sweep tick.
+   *
+   * Precedence (most-actionable-first):
+   *   1. `off_track_kr`     — at least one KR is reported off-track.
+   *   2. `no_active_work`   — the mission has no active project tasks.
+   *   3. `phase_complete`   — the mission has advanced phases since
+   *                            the last review (heuristic — uses
+   *                            `currentPhase` if both this sweep's
+   *                            inferred phase and the previous one are
+   *                            recorded; otherwise skipped).
+   *   4. `scheduled_review` — default; cadence boundary fired.
+   *
+   * Conservative on `phase_complete`: we only emit it when the
+   * previous review (`lastReviewSummary`) and the current `currentPhase`
+   * actually disagree — REVIEW-1 doesn't reach into the phase machine
+   * to invent state.
+   */
+  private inferReviewReason(
+    mission: Mission,
+    summary: MissionOKRSummary | null,
+  ): ReviewReason {
+    if (summary && summary.offTrack > 0) return 'off_track_kr';
+    if (!mission.activeProjectTaskIds || mission.activeProjectTaskIds.length === 0) {
+      return 'no_active_work';
+    }
+    if (
+      typeof mission.currentPhase === 'number' &&
+      mission.lastReviewSummary &&
+      !mission.lastReviewSummary.includes(`phase=${mission.currentPhase}`)
+    ) {
+      return 'phase_complete';
+    }
+    return 'scheduled_review';
+  }
+
+  /**
+   * Resolve the session name to wake when a review WorkItem fires.
+   *
+   * Order:
+   *   1. The mission's explicit owner (`mission.ownerId`)
+   *   2. The team lead resolved via the canonical {@link pickTeamLead}
+   *      cascade (same path as Slack reminder owner resolution)
+   *   3. The orchestrator session as last-resort wake target so a
+   *      review never gets dropped on the floor.
+   *
+   * @param mission - The mission whose review WI is being created
+   * @returns Session name string
+   */
+  private async resolveTeamLeadSession(mission: Mission): Promise<string> {
+    if (mission.ownerId) {
+      const member = await this.storageService.getMemberById(mission.ownerId);
+      if (member?.sessionName) return member.sessionName;
+    }
+    const teams = await this.storageService.getTeams();
+    const team = teams.find((t) => t.id === mission.ownerTeamId);
+    if (team) {
+      const lead = pickTeamLead(team);
+      if (lead?.sessionName) return lead.sessionName;
+    }
+    return ORCHESTRATOR_SESSION_NAME;
   }
 
   /**

--- a/backend/src/services/v3/mission-reminder.service.ts
+++ b/backend/src/services/v3/mission-reminder.service.ts
@@ -52,15 +52,26 @@ export type ReviewReason =
 /**
  * Statuses that *clear* a Mission's `pendingReviewWorkItemId` so the next
  * sweep tick can fire a new review. The set mirrors
- * {@link TERMINAL_WORK_ITEM_STATUSES} but adds `failed` because a failed
- * review WI has also exited the active queue and shouldn't block the
- * next cadence. The reentrancy lock is sweep-time lazy: we don't subscribe
- * to TRANS-1 events here, we just observe the WorkItem's current state on
- * each sweep and clear the lock when it's terminal.
+ * {@link TERMINAL_WORK_ITEM_STATUSES} (`done`, `verified`, `cancelled`) but
+ * adds two statuses that the canonical TERMINAL set excludes for valid
+ * reasons elsewhere — yet which DO represent "exited the active queue" for
+ * the V8 reentrancy-lock perspective:
+ *
+ * - `failed`: a failed review WI has terminated execution; not blocking next cadence.
+ * - `rejected`: a TL-rejected review WI ({@link WorkItemStatus} reachable from
+ *   the review path per work-item.types.ts) has likewise exited the queue.
+ *   Without this, a single TL rejection of a review WI would silently freeze
+ *   that mission's lock forever — exactly the V8 failure mode this lock
+ *   exists to prevent (Arch N1 BLOCKING fix on PR #354).
+ *
+ * The reentrancy lock is sweep-time lazy: we don't subscribe to TRANS-1
+ * events here, we just observe the WorkItem's current state on each sweep
+ * and clear the lock when it's terminal.
  */
 const PENDING_REVIEW_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
   ...TERMINAL_WORK_ITEM_STATUSES,
   'failed',
+  'rejected',
 ]);
 
 function getMissionsDir(): string {

--- a/backend/src/types/v2/mission.types.ts
+++ b/backend/src/types/v2/mission.types.ts
@@ -304,6 +304,18 @@ export interface Mission {
   nextReviewAt?: string;
   /** Last Slack reminder sent for off-track KRs */
   lastReminderAt?: string;
+  /**
+   * WorkItem id of the currently-pending review WorkItem for this Mission
+   * (REVIEW-1 reentrancy lock — Arch Veto V8). Populated by
+   * `MissionReminderService.runSweep()` when a review WorkItem is
+   * created and cleared when that WorkItem reaches a terminal status
+   * (`verified` / `rejected` / `failed` / `cancelled`). When this field
+   * is set on a sweep tick, the sweep short-circuits and skips creation —
+   * preventing double-creation of review WorkItems within the same
+   * cadence boundary even if the sweep is replayed by an external
+   * scheduler glitch or manual TL action.
+   */
+  pendingReviewWorkItemId?: string;
   /** Individual owner ID (optional, defaults to team lead of ownerTeamId) */
   ownerId?: string;
   /** Accumulated learnings from execution */

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "chokidar": "^3.5.3",
         "commander": "^11.0.0",
         "cors": "^2.8.5",
+        "cron-parser": "^5.5.0",
         "dotenv": "^17.2.3",
         "express": "^4.18.2",
         "helmet": "^8.1.0",
@@ -6291,6 +6292,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -11020,6 +11033,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "chokidar": "^3.5.3",
     "commander": "^11.0.0",
     "cors": "^2.8.5",
+    "cron-parser": "^5.5.0",
     "dotenv": "^17.2.3",
     "express": "^4.18.2",
     "helmet": "^8.1.0",


### PR DESCRIPTION
## Summary

Implements **REVIEW-1** of the autonomy_v1 milestone (KR3 — Cloud Portal sub-5-minute onboarding depends on the team self-driving once configured; the Mission heartbeat → review WorkItem → TL wake loop is the day-2 autonomy loop a customer sees).

Extends `MissionReminderService.runSweep()` so every active mission also gets a `type: 'review'` WorkItem when its cadence boundary fires, in **addition** to the existing Slack OKR DM. Idempotent + reentrancy-locked + cadence-aware.

## What changed

| File | Change |
|------|--------|
| `backend/src/types/v2/mission.types.ts` | New optional `Mission.pendingReviewWorkItemId?: string` (V8 reentrancy lock) |
| `backend/src/services/v3/mission-reminder.service.ts` | `runSweep()` extended with `maybeCreateReviewWorkItem()` private method; +reasonRouting + cadence parsing via `cron-parser`; +config gate; +team-lead resolution |
| `backend/src/services/v3/mission-reminder.service.test.ts` | 15 new specs covering deterministic id, idempotent replay, reentrancy, cadence routing matrix, reasonRouting matrix, env gate, legacy back-compat |
| `backend/src/services/task-pool/task-pool.service.ts` | New public `findWorkItem(id): Promise<WorkItem \| null>` so the reentrancy lock can inspect the prior WI without reaching into private storage |
| `package.json` / `package-lock.json` | `cron-parser@^5.5.0` added as runtime dep — Sam approved the choice over a closed-set 3-cadence switch (future-proofing) |

## Veto checklist

| Veto | Status | Reasoning |
|------|--------|-----------|
| V1 Idempotency keys on auto-creates | **✅ primary deliverable** | Deterministic WI id `<missionId>:review:<YYYY-MM-DD>`. Existing `addToPool` dedup-by-id catches replay. `metadata.idempotencyKey === id` for audit log surface. |
| V2 retryCount ≤ 3 | **N/A** | Review WIs aren't auto-retried (BRIDGE-1 owns retry policy). |
| V3 isTransitionPermitted full coverage | **Indirect** | Review WI status mutations (when a TL acts on them) route through TRANS-1's `transitionStatus` helper — already enforced by VERIF-1 #353 facade. |
| V4 missing orgRole fail-fast | **Indirect** | `target` resolves through canonical `pickTeamLead` cascade + orchestrator fallback. Review never dropped on the floor. |
| V5 No parallel Trigger entity | **✅** | Reuses existing `runSweep` invocation path. No new top-level scheduler/trigger primitive. |
| V8 Reentrancy lock | **✅ primary deliverable** | `Mission.pendingReviewWorkItemId` field — set on creation, lazy-cleared on next sweep tick when prior WI is terminal. |

## Idempotency design (Sam-locked)

```
WorkItem.id = `${mission.id}:review:${cycleId}`
cycleId    = boundary.toISOString().slice(0, 10)
boundary   = CronExpressionParser.parse(reviewSchedule, { currentDate: now, tz }).prev().toDate()
```

All three cadences (CONSERVATIVE = weekly Mon, MODERATE = Mon+Thu, AUTONOMOUS = daily) collapse to the same `YYYY-MM-DD` shape — uniform test surface, grep-friendly, replay-safe.

## Reentrancy design

`mission.pendingReviewWorkItemId` is set when a review WI is created. On every subsequent sweep tick:

1. If field is set → look up the WI's current status.
2. If WI is terminal (`verified` / `rejected` / `failed` / `cancelled`) → clear the field, fall through to creation.
3. If WI is still active → short-circuit (skip creation).

Lazy clearing avoids cross-service event-listener coupling — we don't subscribe to TRANS-1 events here, we just observe state on the next sweep.

## reviewReason routing (most-actionable-first)

```ts
1. summary.offTrack > 0           → 'off_track_kr'
2. activeProjectTaskIds.length === 0 → 'no_active_work'
3. lastReviewSummary lacks current phase → 'phase_complete' (heuristic)
4. default                          → 'scheduled_review'
```

Surfaces on `metadata.reviewReason` for TL queue UI rendering.

## Test plan

- [x] **15 new specs** covering creation, persistence, idempotent replay, reentrancy lock + lazy-clear, cadence routing matrix (3 cadences × cycleId assertion), reasonRouting matrix (3 reasons), env gate, legacy back-compat, target resolution, Slack-DM-additive.
- [x] **All 22 mission-reminder tests pass** (7 pre-existing + 15 new).
- [x] **All 73 task-pool tests pass** (after `findWorkItem` addition).
- [x] **Backend build clean**: `npm run build:backend` zero errors.
- [x] Pre-existing `mission-period.service.test.ts` TS error (`createMonthlyPeriod` missing export) verified pre-existing on main via stash bisect — unrelated to this PR.

## Configuration

- `CREWLY_REVIEW_WI_ENABLED=false` — disables review WI creation (default: enabled). Slack DM path unaffected.

## Out of scope

- Real `task:done_by_worker` / `task:verified` event emission — BRIDGE-1 territory.
- KR-tracking-driven `phase_complete` refinement — current heuristic is conservative.
- Read-side filtering of review WIs in TL UI — separate frontend ticket.

## References

- `.crewly/tasks/autonomy_v1/open/review_1_heartbeat_creates_review_workitem_*.md`
- VERIF-1 PR #353 (`e6d2275d`) — provides facade routing for review WI status transitions; F-H opt-out via `metadata.requiresVerification`
- TRANS-1 PR #352 (`4ce5dc9b`) — provides `transitionStatus`
- WIRE-1 PR #349 (`41194481`) + M1 stopgap — actor-role resolution

## Worktree note

Prepared in `/tmp/crewly-review1-c69ce8e6` off `origin/main` (`e6d2275d`, post-VERIF-1). Same recovery pattern as #345 / #348 / #350 / #351 / #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)