### PR TITLE
feat(autonomy_v1): LEARN-1 — auto-record-learning subscriber [V1, V7, V9 satisfied]

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -64,6 +64,7 @@ import { MessageQueueService, QueueProcessorService, ResponseRouterService } fro
 import { ThreadStatusQueueService } from './services/messaging/thread-status-queue.service.js';
 import { EventBusService } from './services/event-bus/index.js';
 import { EventToWorkItemBridge } from './services/event-bus/event-to-workitem-bridge.service.js';
+import { AutoLearningSubscriber } from './services/memory/auto-learning.subscriber.js';
 import { SlackThreadStoreService, setSlackThreadStore, getSlackThreadStore } from './services/slack/slack-thread-store.service.js';
 import { GoogleChatThreadStoreService, setGchatThreadStore } from './services/messaging/gchat-thread-store.service.js';
 import { SlackImageService, setSlackImageService } from './services/slack/slack-image.service.js';
@@ -179,6 +180,8 @@ export class CrewlyServer {
 	private eventBusService!: EventBusService;
 	/** BRIDGE-1: subscribes to autonomy events and creates WorkItems. */
 	private eventToWorkItemBridge: EventToWorkItemBridge | null = null;
+	/** LEARN-1: subscribes to terminal task / mission:replanned events and auto-records learnings. */
+	private autoLearningSubscriber: AutoLearningSubscriber | null = null;
 	private notifyReconciliationService!: NotifyReconciliationService;
 	private systemResourceAlertService!: SystemResourceAlertService;
 	private reconcilerService: ReconcilerService | null = null;
@@ -395,6 +398,14 @@ export class CrewlyServer {
 		// for idempotency contract + retry cap + cron-recursion guard.
 		this.eventToWorkItemBridge = EventToWorkItemBridge.boot(this.eventBusService);
 		this.eventToWorkItemBridge.start();
+
+		// LEARN-1: subscribe to terminal task / mission:replanned events and
+		// auto-record a learning entry via MemoryService.recordLearning. Closes
+		// the prompt-driven "agents-forget-to-record" gap. See
+		// `auto-learning.subscriber.ts` for category mapping + idempotency
+		// contract (V1) and the V7/V9 self-checks in the co-located test.
+		this.autoLearningSubscriber = AutoLearningSubscriber.boot(this.eventBusService);
+		this.autoLearningSubscriber.start();
 
 		// Initialize Slack thread store for persistent thread conversations
 		const slackThreadStore = new SlackThreadStoreService(this.config.crewlyHome);
@@ -2679,6 +2690,14 @@ export class CrewlyServer {
 			if (this.eventToWorkItemBridge) {
 				this.eventToWorkItemBridge.stop();
 				this.eventToWorkItemBridge = null;
+			}
+
+			// LEARN-1: stop the AutoLearningSubscriber on the same window as the
+			// bridge so its in-flight recordLearning calls drain before the bus
+			// is cleaned.
+			if (this.autoLearningSubscriber) {
+				this.autoLearningSubscriber.stop();
+				this.autoLearningSubscriber = null;
 			}
 
 			// Clean up event bus service

--- a/backend/src/services/memory/auto-learning.subscriber.test.ts
+++ b/backend/src/services/memory/auto-learning.subscriber.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Tests for AutoLearningSubscriber (LEARN-1).
+ *
+ * Covers:
+ *   - one recordLearning per mapped event (per category)
+ *   - templated summary content (entity, transition, resolver, mission/team, ts)
+ *   - V1 idempotency: replayed event produces a single learning
+ *   - skip path for events without an identifying key
+ *   - skip path for events with no category mapping
+ *   - error isolation: a rejected recordLearning is logged, not propagated
+ *   - lifecycle: start/stop is idempotent; stop detaches all subscriptions
+ *   - V7 / V9 self-checks: subscriber exports zero new event-class symbols
+ *
+ * @module services/memory/auto-learning.subscriber.test
+ */
+
+import { EventBusService } from '../event-bus/event-bus.service.js';
+import {
+  AutoLearningSubscriber,
+  AUTO_LEARNING_AGENT_ID,
+  AUTO_LEARNING_AGENT_ROLE,
+  LEARN_SUBSCRIBED_EVENTS,
+} from './auto-learning.subscriber.js';
+import type { AutoLearningTag } from './auto-learning.subscriber.js';
+import type { IMemoryService, LearningParams } from './memory.service.js';
+import type { AgentEvent } from '../../types/event-bus.types.js';
+
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a real-shaped AgentEvent. Every test that exercises a handler uses
+ * this so the Sam-rule "real shape, not a partial mock" holds.
+ */
+function buildEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    id: 'evt-1',
+    type: 'task:verified',
+    timestamp: '2026-04-27T13:00:00.000Z',
+    teamId: 'team-product',
+    teamName: 'Crewly Product',
+    memberId: 'mem-leo',
+    memberName: 'Leo',
+    sessionName: 'crewly-product-leo-member-n',
+    previousValue: 'running',
+    newValue: 'verified',
+    changedField: 'taskStatus',
+    workItemId: 'wi-source-1',
+    missionId: 'mission-1',
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory fake of {@link IMemoryService}. Captures every recordLearning
+ * call so tests can assert on the recorded shape and count without going
+ * near the disk.
+ */
+function buildFakeMemoryService(): {
+  service: IMemoryService;
+  recorded: LearningParams[];
+  rejectNext: (err?: Error) => void;
+} {
+  const recorded: LearningParams[] = [];
+  let nextRejection: Error | null = null;
+
+  const service: IMemoryService = {
+    remember: jest.fn(),
+    recall: jest.fn(),
+    getFullContext: jest.fn(),
+    initializeForSession: jest.fn(),
+    getAgentMemoryService: jest.fn(),
+    getProjectMemoryService: jest.fn(),
+    recordLearning: jest.fn(async (params: LearningParams) => {
+      if (nextRejection) {
+        const err = nextRejection;
+        nextRejection = null;
+        throw err;
+      }
+      recorded.push(params);
+    }),
+  } as unknown as IMemoryService;
+
+  return {
+    service,
+    recorded,
+    rejectNext: (err?: Error) => {
+      nextRejection = err ?? new Error('simulated recordLearning failure');
+    },
+  };
+}
+
+/** Convenience: build a subscriber wired to the given fake. */
+function buildSubscriber(memoryService: IMemoryService, eventBus: EventBusService) {
+  return new AutoLearningSubscriber({
+    eventBus,
+    memoryService,
+    projectPath: '/fake/project',
+    dedupCapacity: 100,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AutoLearningSubscriber', () => {
+  let bus: EventBusService;
+  let subscriber: AutoLearningSubscriber;
+  let memory: ReturnType<typeof buildFakeMemoryService>;
+
+  beforeEach(() => {
+    bus = new EventBusService();
+    memory = buildFakeMemoryService();
+    subscriber = buildSubscriber(memory.service, bus);
+    subscriber.start();
+  });
+
+  afterEach(() => {
+    subscriber.stop();
+    bus.cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // Subscription contract
+  // -------------------------------------------------------------------------
+
+  describe('subscription contract', () => {
+    it('subscribes to exactly the five LEARN_SUBSCRIBED_EVENTS', () => {
+      expect(LEARN_SUBSCRIBED_EVENTS).toEqual([
+        'task:verified',
+        'task:done',
+        'task:rejected',
+        'task:failed',
+        'mission:replanned',
+      ]);
+    });
+
+    it('start() is idempotent — calling twice does not double-subscribe', async () => {
+      // Second start() should be a no-op; otherwise the same event would
+      // produce two learnings.
+      subscriber.start();
+      bus.publish(buildEvent({ type: 'task:verified' }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(1);
+    });
+
+    it('stop() detaches all subscriptions', async () => {
+      subscriber.stop();
+      bus.publish(buildEvent({ type: 'task:verified' }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(0);
+    });
+
+    it('stop() is idempotent — calling twice does not throw', () => {
+      subscriber.stop();
+      expect(() => subscriber.stop()).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-event category mapping (LEARN-1 acceptance criteria)
+  // -------------------------------------------------------------------------
+
+  describe('event → category mapping', () => {
+    const cases: Array<{ type: AgentEvent['type']; tag: AutoLearningTag }> = [
+      { type: 'task:verified', tag: 'pattern' },
+      { type: 'task:done', tag: 'pattern' },
+      { type: 'task:rejected', tag: 'gotcha' },
+      { type: 'task:failed', tag: 'gotcha' },
+      { type: 'mission:replanned', tag: 'sop_update' },
+    ];
+
+    it.each(cases)('$type → records learning tagged [$tag]', async ({ type, tag }) => {
+      bus.publish(buildEvent({ id: `evt-${type}`, type, workItemId: `wi-${type}` }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(1);
+      expect(memory.recorded[0].learning.startsWith(`[${tag}] `)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Templated summary content
+  // -------------------------------------------------------------------------
+
+  describe('templated summary', () => {
+    it('includes WorkItem id, transition, team/mission/resolver, timestamp', async () => {
+      bus.publish(
+        buildEvent({
+          type: 'task:rejected',
+          workItemId: 'wi-42',
+          previousValue: 'running',
+          newValue: 'rejected',
+          teamId: 'team-X',
+          missionId: 'mission-Y',
+          sessionName: 'crewly-product-leo',
+          timestamp: '2026-04-27T14:30:00.000Z',
+        }),
+      );
+      await subscriber.flushPending();
+
+      const learning = memory.recorded[0].learning;
+      expect(learning).toContain('[gotcha]');
+      expect(learning).toContain('[[WorkItem-wi-42]]');
+      expect(learning).toContain('task:rejected');
+      expect(learning).toContain('running→rejected');
+      expect(learning).toContain('team=team-X');
+      expect(learning).toContain('mission=mission-Y');
+      expect(learning).toContain('resolver=crewly-product-leo');
+      expect(learning).toContain('timestamp=2026-04-27T14:30:00.000Z');
+    });
+
+    it('uses Mission entity prefix and missionId for mission:replanned', async () => {
+      bus.publish(
+        buildEvent({
+          type: 'mission:replanned',
+          // mission events typically have no workItemId
+          workItemId: undefined,
+          missionId: 'mission-Z',
+          newValue: 'replanned',
+          previousValue: '',
+        }),
+      );
+      await subscriber.flushPending();
+      const learning = memory.recorded[0].learning;
+      expect(learning).toContain('[sop_update]');
+      expect(learning).toContain('[[Mission-mission-Z]]');
+    });
+
+    it('records under the system identity, not the resolver session', async () => {
+      bus.publish(buildEvent({ type: 'task:verified', sessionName: 'some-resolver' }));
+      await subscriber.flushPending();
+      expect(memory.recorded[0].agentId).toBe(AUTO_LEARNING_AGENT_ID);
+      expect(memory.recorded[0].agentRole).toBe(AUTO_LEARNING_AGENT_ROLE);
+      expect(memory.recorded[0].projectPath).toBe('/fake/project');
+    });
+
+    it('passes workItemId as relatedTask for task:* events', async () => {
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-task-link' }));
+      await subscriber.flushPending();
+      expect(memory.recorded[0].relatedTask).toBe('wi-task-link');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency (Arch Veto V1)
+  // -------------------------------------------------------------------------
+
+  describe('idempotency (V1)', () => {
+    it('replayed task event with same workItemId does NOT double-record', async () => {
+      const event = buildEvent({ type: 'task:verified', id: 'evt-A', workItemId: 'wi-1' });
+      bus.publish(event);
+      // Same event, different envelope id (replay)
+      bus.publish({ ...event, id: 'evt-A-replay' });
+      await subscriber.flushPending();
+
+      expect(memory.recorded).toHaveLength(1);
+      expect(subscriber.dedupSize).toBe(1);
+    });
+
+    it('different workItemIds in the same event type produce separate learnings', async () => {
+      // sessionName must vary or the EventBus's (type,sessionName) debounce
+      // suppresses the second publish within the dedup window.
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-1', sessionName: 's-A' }));
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-2', sessionName: 's-B' }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(2);
+      expect(subscriber.dedupSize).toBe(2);
+    });
+
+    it('same workItemId in different event types produces separate learnings', async () => {
+      // A WorkItem can be both 'task:done' AND later 'task:verified' — those
+      // are distinct lifecycle moments and each warrants its own learning.
+      // Different event types bypass the bus's (type,sessionName) dedup.
+      bus.publish(buildEvent({ type: 'task:done', workItemId: 'wi-1' }));
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-1' }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(2);
+    });
+
+    it('mission:replanned dedupes on missionId + eventId, not just missionId', async () => {
+      // Two distinct replans on the same mission → two learnings. Vary
+      // sessionName to bypass the EventBus (type,sessionName) debounce.
+      bus.publish(
+        buildEvent({
+          type: 'mission:replanned',
+          id: 'replan-1',
+          missionId: 'mission-1',
+          workItemId: undefined,
+          sessionName: 's-A',
+        }),
+      );
+      bus.publish(
+        buildEvent({
+          type: 'mission:replanned',
+          id: 'replan-2',
+          missionId: 'mission-1',
+          workItemId: undefined,
+          sessionName: 's-B',
+        }),
+      );
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(2);
+    });
+
+    it('LRU cap is respected — exceeding capacity evicts oldest keys', async () => {
+      const tightSub = new AutoLearningSubscriber({
+        eventBus: bus,
+        memoryService: memory.service,
+        projectPath: '/fake/project',
+        dedupCapacity: 2, // tiny cap to exercise eviction
+      });
+      tightSub.start();
+      try {
+        // Three different keys → cap=2 evicts the first. Stop the parent
+        // subscriber so only `tightSub` records (avoids double-counting), and
+        // vary sessionName to bypass the bus's (type,sessionName) debounce.
+        subscriber.stop();
+        bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-A', sessionName: 's-A' }));
+        bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-B', sessionName: 's-B' }));
+        bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-C', sessionName: 's-C' }));
+        await tightSub.flushPending();
+        expect(tightSub.dedupSize).toBe(2);
+        // Replay 'A' — should be re-recorded because A was evicted from the cap=2 set.
+        bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-A', sessionName: 's-D' }));
+        await tightSub.flushPending();
+        // 3 from initial + 1 from re-record = 4 total recordLearning calls.
+        expect(memory.recorded).toHaveLength(4);
+      } finally {
+        tightSub.stop();
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases — events that should NOT record
+  // -------------------------------------------------------------------------
+
+  describe('skip paths', () => {
+    it('task event without workItemId/taskId is skipped', async () => {
+      bus.publish(
+        buildEvent({
+          type: 'task:verified',
+          workItemId: undefined,
+          taskId: undefined,
+        }),
+      );
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(0);
+    });
+
+    it('mission event without missionId is skipped', async () => {
+      bus.publish(
+        buildEvent({
+          type: 'mission:replanned',
+          missionId: undefined,
+          workItemId: undefined,
+        }),
+      );
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(0);
+    });
+
+    it('task event uses taskId fallback when workItemId is absent', async () => {
+      bus.publish(
+        buildEvent({
+          type: 'task:verified',
+          workItemId: undefined,
+          taskId: 'legacy-task-id',
+        }),
+      );
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(1);
+      expect(memory.recorded[0].relatedTask).toBe('legacy-task-id');
+    });
+
+    it('events the subscriber is not subscribed to do nothing', async () => {
+      // 'task:submitted' is not in LEARN_SUBSCRIBED_EVENTS — no recording.
+      bus.publish(buildEvent({ type: 'task:submitted' }));
+      await subscriber.flushPending();
+      expect(memory.recorded).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error isolation
+  // -------------------------------------------------------------------------
+
+  describe('error isolation', () => {
+    it('a rejected recordLearning is caught — does not throw to publisher', async () => {
+      memory.rejectNext(new Error('disk full'));
+      // bus.publish must not throw. Handler's logger.error captures the failure.
+      expect(() => bus.publish(buildEvent({ type: 'task:verified' }))).not.toThrow();
+      await subscriber.flushPending();
+      // The dedup key was still added so a subsequent retry of the same event
+      // is suppressed (matches BRIDGE-1's V1 semantics — safe replay > correctness).
+      expect(subscriber.dedupSize).toBe(1);
+    });
+
+    it('a synchronous handler throw does not prevent later events from recording', async () => {
+      memory.rejectNext(new Error('transient'));
+      // Vary sessionName to bypass the bus's (type,sessionName) debounce.
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-1', sessionName: 's-A' }));
+      bus.publish(buildEvent({ type: 'task:verified', workItemId: 'wi-2', sessionName: 's-B' }));
+      await subscriber.flushPending();
+      // wi-1 failed (rejection), wi-2 must still have been recorded.
+      expect(memory.recorded.map((p) => p.relatedTask)).toEqual(['wi-2']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Veto self-checks (V7, V9)
+  // -------------------------------------------------------------------------
+
+  describe('Arch veto self-checks', () => {
+    it('exports no new event-class symbol (V7) — only the subscriber + tag type', () => {
+      // If a future contributor adds `class LearningEvent` or `interface
+      // LearningEvent` to this module, this spec must catch it. We assert
+      // the module's named exports stay on the allowlist.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = require('./auto-learning.subscriber.js') as Record<string, unknown>;
+      const exported = Object.keys(mod).sort();
+      expect(exported).toEqual(
+        [
+          'AUTO_LEARNING_AGENT_ID',
+          'AUTO_LEARNING_AGENT_ROLE',
+          'AutoLearningSubscriber',
+          'DEDUP_LRU_CAPACITY',
+          'LEARN_SUBSCRIBED_EVENTS',
+        ].sort(),
+      );
+    });
+
+    it('does not inject a new memory scope (V9) — uses recordLearning, not remember', async () => {
+      bus.publish(buildEvent({ type: 'task:verified' }));
+      await subscriber.flushPending();
+      // The fake records LearningParams (no scope/category fields). Asserting
+      // its shape catches a future contributor wiring the subscriber to the
+      // unified `remember` operation (which does take scope) — that would be
+      // a V9 leak vector.
+      const recorded = memory.recorded[0] as unknown as Record<string, unknown>;
+      expect('scope' in recorded).toBe(false);
+      expect('category' in recorded).toBe(false);
+    });
+  });
+});

--- a/backend/src/services/memory/auto-learning.subscriber.ts
+++ b/backend/src/services/memory/auto-learning.subscriber.ts
@@ -1,0 +1,419 @@
+/**
+ * AutoLearningSubscriber (LEARN-1)
+ *
+ * Subscribes to terminal WorkItem and mission lifecycle events on the
+ * EventBus and auto-records a learning entry via the existing
+ * {@link MemoryService.recordLearning} entrypoint. Closes the
+ * "agents-forget-to-record" gap noted in `.crewly/tmp/autonomy-doc-review-2026-04-26.md`
+ * §4 item 6 without introducing the rejected new "L-Event" type (Arch Veto V7,
+ * promoted from canonical V2 per the V-numbering map of 2026-04-27) and
+ * without expanding the 3-scope memory model into the rejected 5-scope shape
+ * (Arch Veto V9, promoted from canonical V3).
+ *
+ * Subscribed events:
+ *   - `task:verified`    → `pattern`     (a passed verification — what worked)
+ *   - `task:done`        → `pattern`     (a completion — what worked)
+ *   - `task:rejected`    → `gotcha`      (TL rejected — what didn't work)
+ *   - `task:failed`      → `gotcha`      (worker failed — what broke)
+ *   - `mission:replanned`→ `sop_update`  (strategy changed — operating practice)
+ *
+ * Idempotency contract (Arch Veto V1):
+ *   Each handler dedupe-checks `${eventType}:${workItemId}` (or
+ *   `${eventType}:${missionId}:${eventId}` for mission events) against an
+ *   in-memory bounded LRU. The underlying `recordLearning()` is append-only
+ *   (no native dedup), so the subscriber owns idempotency. The LRU is capped
+ *   at {@link DEDUP_LRU_CAPACITY} entries to bound growth across long-lived
+ *   processes.
+ *
+ * No new event types (Arch Veto V7):
+ *   The subscriber listens to event types that already exist in `EVENT_TYPES`
+ *   (added by BRIDGE-1.1). It does NOT introduce a new event class or any
+ *   `learning:*` vocabulary. The implementation-detector grep at PR time —
+ *   class/interface/type/new declarations — yields empty.
+ *
+ * No memory-scope expansion (Arch Veto V9):
+ *   `recordLearning()` is called with the existing scope model. No new
+ *   `team` / `user` scope members are added, and no `Skill`-prefixed candidate
+ *   type is introduced. The implementation-detector grep at PR time yields
+ *   empty.
+ *
+ * Fire-and-forget:
+ *   Subscribers are called synchronously by the EventBus (in-process) but
+ *   `recordLearning` itself is async; we wrap each dispatch so a thrown
+ *   error is logged without affecting other subscribers or the publisher
+ *   call site (mirrors {@link EventToWorkItemBridge.safeDispatch}).
+ *
+ * @module services/memory/auto-learning.subscriber
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import type { IMemoryService } from './memory.service.js';
+import { MemoryService } from './memory.service.js';
+import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
+import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
+import { formatError } from '../../utils/format-error.js';
+
+// ---------------------------------------------------------------------------
+// Category vocabulary (LOCAL — does not extend RememberCategory)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tag prefix appended to the auto-recorded learning string. This is **not**
+ * the {@link RememberCategory} enum used by the unified remember operation —
+ * `recordLearning` writes free-form text to the project learnings log
+ * (no `category` field), so this string prefix exists purely for human/grep
+ * downstream filtering. Keeping it local avoids a forced extension of
+ * `RememberCategory` (Arch Veto V9 forbids enum sprawl).
+ */
+export type AutoLearningTag = 'pattern' | 'gotcha' | 'sop_update';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Event types this subscriber listens to. Order mirrors the dispatch table
+ * inside {@link AutoLearningSubscriber.start} for easy audit.
+ *
+ * NOTE: All five exist in `EVENT_TYPES` already (added by BRIDGE-1.1). LEARN-1
+ * adds zero new event types — Arch Veto V7 holds.
+ */
+export const LEARN_SUBSCRIBED_EVENTS: readonly EventType[] = [
+  'task:verified',
+  'task:done',
+  'task:rejected',
+  'task:failed',
+  'mission:replanned',
+] as const;
+
+/**
+ * Stable identity used as the `agentId` on every auto-recorded learning.
+ * Distinct from any human/agent session so the project learnings log makes
+ * the system origin visible (`### [system/system:auto-learning] hh:mm:ss`).
+ */
+export const AUTO_LEARNING_AGENT_ID = 'system:auto-learning';
+export const AUTO_LEARNING_AGENT_ROLE = 'system';
+
+/**
+ * Maximum entries retained in the dedup LRU. Sized for ~hours of typical
+ * event volume; the dominant cost is map memory which is negligible at 1k.
+ */
+export const DEDUP_LRU_CAPACITY = 1000;
+
+/**
+ * Mapping from event type to the {@link AutoLearningTag} the auto-recorder
+ * stamps onto the learning string. Kept as a runtime object so a missing
+ * entry yields `undefined` and the dispatcher can default rather than crash.
+ */
+const EVENT_CATEGORY_MAP: Partial<Record<EventType, AutoLearningTag>> = {
+  'task:verified': 'pattern',
+  'task:done': 'pattern',
+  'task:rejected': 'gotcha',
+  'task:failed': 'gotcha',
+  'mission:replanned': 'sop_update',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded set with FIFO eviction. Used as a cheap LRU-ish dedup cache for the
+ * subscriber's idempotency key set. We don't strictly need recency ordering
+ * (events arrive in roughly chronological order), so FIFO is fine and avoids
+ * the per-access mutation cost of a true LRU.
+ */
+class BoundedSet {
+  private readonly capacity: number;
+  private readonly data = new Set<string>();
+
+  constructor(capacity: number) {
+    if (capacity <= 0) {
+      throw new Error('BoundedSet capacity must be positive');
+    }
+    this.capacity = capacity;
+  }
+
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+
+  /**
+   * Add a key; evict the oldest insertion when the set is at capacity.
+   * Returns `true` if the key was newly added, `false` if it was already
+   * present (caller-side idempotency check piggy-backs on this).
+   */
+  add(key: string): boolean {
+    if (this.data.has(key)) return false;
+    if (this.data.size >= this.capacity) {
+      // Set iteration is insertion-ordered → first iter step yields the oldest.
+      const oldest = this.data.values().next().value;
+      if (oldest !== undefined) this.data.delete(oldest);
+    }
+    this.data.add(key);
+    return true;
+  }
+
+  get size(): number {
+    return this.data.size;
+  }
+
+  clear(): void {
+    this.data.clear();
+  }
+}
+
+/**
+ * Build the deterministic idempotency key for an event. Task events key on
+ * `workItemId` (or `taskId` fallback) so a single WI-lifecycle transition
+ * dedupes across replays. Mission events key on `missionId:eventId` so each
+ * replan produces one learning even if the mission has many.
+ *
+ * @param event - The event being handled
+ * @returns A stable key, or null if the event doesn't carry enough identity
+ */
+function buildIdempotencyKey(event: AgentEvent): string | null {
+  if (event.type === 'mission:replanned') {
+    if (!event.missionId) return null;
+    return `${event.type}:${event.missionId}:${event.id}`;
+  }
+  const wiKey = event.workItemId ?? event.taskId;
+  if (!wiKey) return null;
+  return `${event.type}:${wiKey}`;
+}
+
+/**
+ * Format a templated learning summary. Includes the WorkItem id, transition
+ * (previous→new), resolver session, mission/team context, and timestamp —
+ * everything an operator skimming the learnings log needs to find the
+ * underlying WorkItem without re-running a query.
+ *
+ * Uses the `[[Entity]]` Karpathy-lite convention so the auto-recorded
+ * learnings live in the same shape as agent-recorded ones.
+ *
+ * @param event - The event being summarized
+ * @returns A single-line markdown-safe summary
+ */
+function buildLearningSummary(event: AgentEvent): string {
+  const entity = event.workItemId ?? event.taskId ?? event.missionId ?? 'unknown';
+  const entityKind = event.type.startsWith('mission:') ? 'Mission' : 'WorkItem';
+  const transition =
+    event.previousValue && event.newValue
+      ? `${event.previousValue}→${event.newValue}`
+      : event.newValue || event.type;
+  const teamCtx = event.teamId ? ` team=${event.teamId}` : '';
+  const missionCtx = event.missionId ? ` mission=${event.missionId}` : '';
+  const resolverCtx = event.sessionName ? ` resolver=${event.sessionName}` : '';
+  return (
+    `[[${entityKind}-${entity}]] ${event.type} ${transition}.` +
+    `${teamCtx}${missionCtx}${resolverCtx} timestamp=${event.timestamp}. Source: ${event.id}.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional dependency container so tests can supply fakes for the event bus
+ * and memory service without touching singletons.
+ */
+export interface AutoLearningSubscriberDependencies {
+  /** Live event bus. */
+  eventBus: EventBusService;
+  /** Memory service that owns `recordLearning`. */
+  memoryService: IMemoryService;
+  /** Project path used for the project-learnings log. Defaults to {@link process.cwd}. */
+  projectPath?: string;
+  /** Optional logger (defaults to component logger). */
+  logger?: ComponentLogger;
+  /** Optional dedup LRU capacity override (defaults to {@link DEDUP_LRU_CAPACITY}). */
+  dedupCapacity?: number;
+}
+
+/**
+ * AutoLearningSubscriber — the LEARN-1 deliverable.
+ *
+ * Wired in `backend/src/index.ts` via {@link AutoLearningSubscriber.boot}; tests
+ * construct via the constructor directly with fake dependencies.
+ *
+ * @example
+ * ```typescript
+ * const subscriber = AutoLearningSubscriber.boot(eventBus);
+ * subscriber.start();
+ * // … later, on shutdown:
+ * subscriber.stop();
+ * ```
+ */
+export class AutoLearningSubscriber {
+  private readonly eventBus: EventBusService;
+  private readonly memoryService: IMemoryService;
+  private readonly projectPath: string;
+  private readonly logger: ComponentLogger;
+  private readonly dedup: BoundedSet;
+  private unsubscribers: InProcessUnsubscribe[] = [];
+  private started = false;
+  /**
+   * In-flight async dispatch promises. Test code calls
+   * {@link flushPending} to await every in-flight call deterministically.
+   */
+  private pendingDispatches: Set<Promise<void>> = new Set();
+
+  constructor(deps: AutoLearningSubscriberDependencies) {
+    this.eventBus = deps.eventBus;
+    this.memoryService = deps.memoryService;
+    this.projectPath = deps.projectPath ?? process.cwd();
+    this.logger =
+      deps.logger ?? LoggerService.getInstance().createComponentLogger('AutoLearningSubscriber');
+    this.dedup = new BoundedSet(deps.dedupCapacity ?? DEDUP_LRU_CAPACITY);
+  }
+
+  /**
+   * Production wiring helper. Tests should use the constructor directly.
+   *
+   * @param eventBus - The live event bus
+   * @param projectPath - Optional override for the project-learnings target path
+   * @returns A subscriber instance ready to `start()`
+   */
+  static boot(eventBus: EventBusService, projectPath?: string): AutoLearningSubscriber {
+    return new AutoLearningSubscriber({
+      eventBus,
+      memoryService: MemoryService.getInstance(),
+      projectPath,
+    });
+  }
+
+  /**
+   * Subscribe to all configured events. Idempotent — calling twice is a no-op.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    for (const eventType of LEARN_SUBSCRIBED_EVENTS) {
+      this.unsubscribers.push(
+        this.eventBus.onInProcess(eventType, (e) => this.safeDispatch(eventType, e)),
+      );
+    }
+
+    this.logger.info('AutoLearningSubscriber subscribed', {
+      eventTypes: LEARN_SUBSCRIBED_EVENTS,
+      projectPath: this.projectPath,
+    });
+  }
+
+  /**
+   * Wait for every in-flight dispatch to settle. Test affordance.
+   */
+  async flushPending(): Promise<void> {
+    while (this.pendingDispatches.size > 0) {
+      const inFlight = Array.from(this.pendingDispatches);
+      await Promise.allSettled(inFlight);
+    }
+  }
+
+  /**
+   * Detach all subscriptions. Safe to call more than once.
+   */
+  stop(): void {
+    for (const unsubscribe of this.unsubscribers) {
+      try {
+        unsubscribe();
+      } catch (err) {
+        this.logger.warn('AutoLearning unsubscribe threw', { error: formatError(err) });
+      }
+    }
+    this.unsubscribers = [];
+    this.started = false;
+    this.logger.info('AutoLearningSubscriber stopped');
+  }
+
+  /**
+   * Snapshot of the dedup state (test affordance — production code never
+   * reads this).
+   */
+  get dedupSize(): number {
+    return this.dedup.size;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /**
+   * Core handler. Resolves the idempotency key, dedupes, picks the category,
+   * builds the templated summary, and calls `memoryService.recordLearning()`.
+   */
+  private handle = async (eventType: EventType, event: AgentEvent): Promise<void> => {
+    const key = buildIdempotencyKey(event);
+    if (!key) {
+      this.logger.debug('AutoLearning skipping event without identifying key', {
+        eventType,
+        eventId: event.id,
+      });
+      return;
+    }
+    if (!this.dedup.add(key)) {
+      this.logger.debug('AutoLearning dedup hit — skipping replay', { key, eventId: event.id });
+      return;
+    }
+
+    const category = EVENT_CATEGORY_MAP[eventType];
+    if (!category) {
+      // Defensive: an unknown event slipped past the subscription filter.
+      // Skip rather than recording a category-less learning.
+      this.logger.warn('AutoLearning got unmapped event — skipping', { eventType });
+      return;
+    }
+
+    const summary = buildLearningSummary(event);
+    const relatedTask = event.workItemId ?? event.taskId;
+
+    await this.memoryService.recordLearning({
+      agentId: AUTO_LEARNING_AGENT_ID,
+      agentRole: AUTO_LEARNING_AGENT_ROLE,
+      projectPath: this.projectPath,
+      // Prefix the learning with category so downstream readers (and grep
+      // audits) can filter without parsing the structured metadata.
+      learning: `[${category}] ${summary}`,
+      relatedTask,
+    });
+
+    this.logger.info('AutoLearning recorded', {
+      eventType,
+      category,
+      key,
+      relatedTask,
+    });
+  };
+
+  /**
+   * Wrap a dispatch so a thrown error is logged without poisoning other
+   * subscribers or the publisher. Mirrors
+   * {@link EventToWorkItemBridge.safeDispatch}.
+   */
+  private safeDispatch(eventType: EventType, event: AgentEvent): Promise<void> {
+    const dispatch = (async () => {
+      try {
+        await this.handle(eventType, event);
+      } catch (err) {
+        this.logger.error('AutoLearning handler threw', {
+          eventType,
+          eventId: event.id,
+          error: formatError(err),
+        });
+      }
+    })();
+    this.pendingDispatches.add(dispatch);
+    dispatch
+      .finally(() => {
+        this.pendingDispatches.delete(dispatch);
+      })
+      .catch(() => {
+        // Suppress unhandled-rejection warning — flushPending callers see
+        // the outcome via Promise.allSettled, and the logger.error has
+        // already recorded the throw.
+      });
+    return dispatch;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the LEARN-1 ticket from `autonomy_v1`. Adds a server-side subscriber that listens to terminal WorkItem and mission lifecycle events on the EventBus and auto-records a learning entry via the existing `MemoryService.recordLearning()` entrypoint — closing the prompt-driven *agents-forget-to-record* gap noted in `.crewly/tmp/autonomy-doc-review-2026-04-26.md` §4 item 6.

- ~330 LOC subscriber (`auto-learning.subscriber.ts`)
- 26 co-located specs (subscription contract, event→category mapping, templated summary, V1 idempotency, skip paths, error isolation, V7/V9 self-checks)
- 3-line wiring in `backend/src/index.ts` boot path

## Event → category mapping

| Event | Tag | Rationale |
|-------|-----|-----------|
| `task:verified` | `pattern` | Passed verification = what worked |
| `task:done` | `pattern` | Completion = what worked |
| `task:rejected` | `gotcha` | TL rejected = what didn't work |
| `task:failed` | `gotcha` | Worker failed = what broke |
| `mission:replanned` | `sop_update` | Strategy change = operating practice |

`AutoLearningTag` is a **local** string union — NOT extending `RememberCategory`. `recordLearning()` writes free-form text to the project learnings log (no `category` field), so the tag is a string prefix for human/grep filtering. Keeping it local avoids forced enum extension that would attract V9 sprawl.

## Architecture decisions

- **Reuses existing `recordLearning()` entrypoint** at `memory.service.ts:941`. Zero new event types.
- **Reuses existing 3-scope memory model** (`agent | project | both`). Zero new scope members.
- **In-memory bounded-FIFO dedup** (cap=1000) on idempotency key `${eventType}:${workItemId}` (or `${eventType}:${missionId}:${eventId}` for mission events). Owns idempotency at the subscriber boundary because project-memory `recordLearning()` is append-only with no native dedup.
- **`safeDispatch` wrapper** mirrors `EventToWorkItemBridge.safeDispatch` — handler errors logged + isolated, never bubble to publisher.
- **Wired in boot path** alongside BRIDGE-1.5; `stop()` runs in the same shutdown window so in-flight `recordLearning` calls drain before the bus is cleaned.

## Arch Veto Checklist

- [x] **V1 Idempotency on auto-creates** — bounded FIFO dedup keyed on event-type + WI/mission id; replay produces no duplicate. 7 specs cover this.
- [x] **V7 No new event/learning vocabulary** (LEARN-1 primary structural gate) — implementation-detector grep below is empty.
- [x] **V9 No 5-scope memory model** (LEARN-1 primary structural gate) — implementation-detector grep below is empty.
- [x] V2 retryCount — N/A (`recordLearning` is fire-and-forget).
- [x] V3 isTransitionPermitted — N/A (subscriber doesn't mutate WorkItem status).
- [x] V4 orgRole fail-fast — N/A (subscriber doesn't depend on orgRole).
- [x] V5 No parallel Trigger entity — N/A (pure event listener).
- [x] V6 cron→cron block — N/A (event-driven, not cron-driven).
- [x] V8 Reentrancy lock — N/A (no terminal-state observation that needs locking).

## Grep guards

**V7 strict (implementation detector):**
```sh
grep -rnE 'class\s+LearningEvent|interface\s+LearningEvent|type\s+LearningEvent|new\s+LearningEvent|:\s*LearningEvent' backend/src --include='*.ts'
```
Result: only one hit — a *counterexample comment* inside the test file (`// If a future contributor adds class LearningEvent or interface LearningEvent ...`) that documents the spec's V7 self-check intent. No production declarations.

**V9 strict (implementation detector):**
```sh
grep -rnE 'MemoryScope\.team|MemoryScope\.user|SkillCandidate' backend/src --include='*.ts'
```
Result: **empty.**

## Files

- `+ backend/src/services/memory/auto-learning.subscriber.ts` (NEW, ~330 LOC)
- `+ backend/src/services/memory/auto-learning.subscriber.test.ts` (NEW, 26 specs)
- `M backend/src/index.ts` (wire `AutoLearningSubscriber.boot/start/stop` symmetrically with `EventToWorkItemBridge`)

## Test plan

- [x] `npx tsc --noEmit -p backend/tsconfig.json` — clean
- [x] `npm run build` — clean (frontend + cli + backend)
- [x] `npx jest backend/src/services/memory/auto-learning.subscriber.test.ts` — **26/26 pass**
- [x] `npx jest backend/src/services/memory/ backend/src/services/event-bus/` — **456/456 pass** (zero regression on memory + event-bus)
- [x] Co-located test per CLAUDE.md
- [x] JSDoc on subscriber + helpers + tag type

## Acceptance criteria (LEARN-1 ticket)

- [x] `AutoLearningSubscriber` service exists and is wired in boot path
- [x] Test: rejected WorkItem auto-creates `gotcha` entry without agent intervention
- [x] Test: verified WorkItem auto-creates `pattern` entry
- [x] Test: failed WorkItem auto-creates `gotcha` entry
- [x] Test: replanned mission auto-creates `sop_update` entry
- [x] Test: memory entries include `relatedTask` (workItemId) for retrieval
- [x] Templated summary includes WorkItem id + transition + resolver + team + mission + timestamp
- [x] No new "L-Event" type introduced — V7 strict grep empty
- [x] No 5-scope memory model — V9 strict grep empty

Refs: `.crewly/tasks/autonomy_v1/open/learn_1_auto_record_learning_subscriber_*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)