### PR TITLE
feat(autonomy_v1): TRANS-2 — route 5 internal pool methods through transitionStatus (V3)

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -988,4 +988,168 @@ describe('TaskPoolService', () => {
       ).rejects.toThrow(/Forbidden transition.*actor='agent'/);
     });
   });
+
+  // =========================================================================
+  // TRANS-2: internal call sites route through transitionStatus(actor='system')
+  //
+  // Each test wraps `transitionStatus` on the prototype (so calls dispatched
+  // via `this.transitionStatus` from sibling methods like
+  // `completeSimpleItem` → `resolveBlockedDependents` are also captured) and
+  // asserts the expected (workItemId, newStatus, actorRole) tuple appears.
+  // This is the compile-time guard against a future contributor silently
+  // restoring a direct `storage.updateWorkItem` mutation that would bypass
+  // the V3 actor gate.
+  // =========================================================================
+
+  describe('TRANS-2: internal sites route through transitionStatus(actor="system")', () => {
+    /**
+     * Patch `transitionStatus` on the TaskPoolService prototype so every
+     * invocation is captured as a tuple of [workItemId, newStatus, actorRole].
+     * Patching the prototype (rather than a single instance own-property) is
+     * required because some internal callers (e.g. `resolveBlockedDependents`)
+     * dispatch through `this.transitionStatus` from sibling methods, and
+     * Jest's `spyOn(instance, 'method')` mock with `mockImplementation` does
+     * not always intercept those dispatches. The original implementation is
+     * still invoked unchanged so tests assert the call shape AND end-to-end
+     * behaviour together.
+     */
+    function spyTransitionStatus(): {
+      calls: Array<[string, string, string]>;
+      restore: () => void;
+    } {
+      const calls: Array<[string, string, string]> = [];
+      const proto = TaskPoolService.prototype as TaskPoolService;
+      const original = proto.transitionStatus;
+      proto.transitionStatus = async function (
+        this: TaskPoolService,
+        workItemId: string,
+        newStatus: Parameters<TaskPoolService['transitionStatus']>[1],
+        actorRole: Parameters<TaskPoolService['transitionStatus']>[2],
+        mutator?: Parameters<TaskPoolService['transitionStatus']>[3],
+      ) {
+        calls.push([workItemId, newStatus, actorRole]);
+        return original.call(this, workItemId, newStatus, actorRole, mutator);
+      };
+      return {
+        calls,
+        restore: () => {
+          proto.transitionStatus = original;
+        },
+      };
+    }
+
+    it('claimFromPool calls transitionStatus(queued→running, system)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        const result = await service.claimFromPool('agent-leo');
+        expect(result).not.toBeNull();
+        expect(calls).toContainEqual([wi.id, 'running', 'system']);
+      } finally {
+        restore();
+      }
+    });
+
+    it('claimSpecificItem calls transitionStatus(queued→running, system)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        const result = await service.claimSpecificItem('agent-leo', wi.id);
+        expect(result).not.toBeNull();
+        expect(calls).toContainEqual([wi.id, 'running', 'system']);
+      } finally {
+        restore();
+      }
+    });
+
+    it('releaseBack from running calls transitionStatus(running→queued, system) with retryCount bump', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-leo');
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        await service.releaseBack(wi.id, 'agent busy');
+        expect(calls).toContainEqual([wi.id, 'queued', 'system']);
+
+        // Verify side-effect mutator ran atomically with the status flip.
+        const items = await service.getAllItems();
+        const released = items.find((i) => i.id === wi.id)!;
+        expect(released.status).toBe('queued');
+        expect(released.retryCount).toBe(1);
+        expect(released.startedAt).toBeUndefined();
+      } finally {
+        restore();
+      }
+    });
+
+    it('releaseBack from blocked preserves target via mutator', async () => {
+      const wi = makeWorkItem({ target: 'agent-leo' });
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-leo');
+      // Force the running item to blocked so releaseBack hits the
+      // blocked → queued branch (which already had a TRANS-1 permission
+      // entry; this test confirms the same path now flows through the
+      // shared transitionStatus helper).
+      await service.updateItemStatus(wi.id, 'blocked');
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        await service.releaseBack(wi.id, 'dependency stalled');
+        expect(calls).toContainEqual([wi.id, 'queued', 'system']);
+
+        const items = await service.getAllItems();
+        const released = items.find((i) => i.id === wi.id)!;
+        expect(released.status).toBe('queued');
+        // Target preserved for the previously-blocked path so the same
+        // agent can re-claim via target filter.
+        expect(released.target).toBe('agent-leo');
+      } finally {
+        restore();
+      }
+    });
+
+    it('resolveBlockedDependents calls transitionStatus(blocked→queued, system)', async () => {
+      const upstream = makeWorkItem({ type: 'cron_run', title: 'upstream' });
+      await service.addToPool(upstream);
+      const downstream = makeWorkItem({
+        type: 'cron_run',
+        title: 'downstream',
+        dependsOn: [upstream.id],
+      });
+      await service.addToPool(downstream);
+      // Drive the upstream to running so it can complete.
+      await service.claimFromPool('agent-a');
+
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        await service.completeItem(upstream.id);
+        // The resolver fires inside completeSimpleItem after the
+        // upstream completes; we expect a blocked→queued promotion for
+        // the downstream item with system actor.
+        expect(calls).toContainEqual([downstream.id, 'queued', 'system']);
+      } finally {
+        restore();
+      }
+    });
+
+    it('failItem calls transitionStatus(running→failed, system) with error in mutator', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-leo');
+      const { calls, restore } = spyTransitionStatus();
+      try {
+        await service.failItem(wi.id, 'agent crashed');
+        expect(calls).toContainEqual([wi.id, 'failed', 'system']);
+
+        const items = await service.getAllItems();
+        const failed = items.find((i) => i.id === wi.id)!;
+        expect(failed.status).toBe('failed');
+        expect(failed.error).toBe('agent crashed');
+        expect(failed.completedAt).toBeDefined();
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -245,14 +245,21 @@ export class TaskPoolService {
 
       const selected = candidates[0];
 
-      // Transition item to 'running'
-      const updated = await this.storage.updateWorkItem(selected.id, (wi) => {
-        wi.status = 'running';
-        wi.startedAt = new Date().toISOString();
-        wi.target = agentId;
-      });
+      // TRANS-2: route the queued → running flip through the guarded
+      // transitionStatus helper so internal callers are subject to the
+      // same V3 actor-role + state-machine gates as external callers.
+      // `startedAt` is set automatically by transitionStatus when
+      // newStatus === 'running'; the mutator carries the agent target.
+      const claimedItem = await this.transitionStatus(
+        selected.id,
+        'running',
+        'system',
+        (wi) => {
+          wi.target = agentId;
+        },
+      );
 
-      if (!updated) {
+      if (!claimedItem) {
         this.logger.warn('Failed to update WorkItem during claim', { workItemId: selected.id });
         return null;
       }
@@ -273,10 +280,8 @@ export class TaskPoolService {
         title: selected.title,
       });
 
-      // Return the updated item
-      const claimedItem = await this.storage.findWorkItem(selected.id);
       return {
-        workItem: claimedItem!,
+        workItem: claimedItem,
         claim,
       };
     });
@@ -306,12 +311,17 @@ export class TaskPoolService {
       const claims = await this.storage.getClaims();
       if (claims.some((c) => c.workItemId === workItemId && c.status === 'active')) return null;
 
-      const updated = await this.storage.updateWorkItem(workItemId, (wi) => {
-        wi.status = 'running';
-        wi.startedAt = new Date().toISOString();
-        wi.target = agentId;
-      });
-      if (!updated) return null;
+      // TRANS-2: route the queued → running flip through transitionStatus
+      // (mirrors claimFromPool — same V3 + state-machine gates).
+      const claimedItem = await this.transitionStatus(
+        workItemId,
+        'running',
+        'system',
+        (wi) => {
+          wi.target = agentId;
+        },
+      );
+      if (!claimedItem) return null;
 
       const claimInput: CreateClaimInput = { workItemId, agentId };
       const claim = createTaskClaim(claimInput);
@@ -320,8 +330,7 @@ export class TaskPoolService {
 
       this.logger.info('WorkItem claimed (specific)', { workItemId, agentId, claimId: claim.id });
 
-      const claimedItem = await this.storage.findWorkItem(workItemId);
-      return claimedItem ? { workItem: claimedItem, claim } : null;
+      return { workItem: claimedItem, claim };
     });
   }
 
@@ -355,11 +364,14 @@ export class TaskPoolService {
       });
     }
 
-    // Revert item to queued. Preserve target when unblocking so the
-    // same agent can re-claim via target filter.
+    // TRANS-2: route the (running|blocked) → queued flip through the
+    // guarded transitionStatus helper. The state-machine entry for
+    // `running → queued` is a TRANS-2 addition, gated to system/TL/orc;
+    // `blocked → queued` was already TL/orc/system-gated by TRANS-1.
+    // Side-effect mutations (startedAt clear, target preservation when
+    // unblocking, retryCount bump) move into the atomic mutator.
     const wasBlocked = workItem.status === 'blocked';
-    await this.storage.updateWorkItem(workItemId, (wi) => {
-      wi.status = 'queued';
+    await this.transitionStatus(workItemId, 'queued', 'system', (wi) => {
       wi.startedAt = undefined;
       if (!wasBlocked) {
         wi.target = undefined;
@@ -624,9 +636,12 @@ export class TaskPoolService {
         );
         if (!allSatisfied) continue;
 
-        await this.storage.updateWorkItem(candidate.id, (wi) => {
-          wi.status = 'queued';
-        });
+        // TRANS-2: route the blocked → queued promotion through
+        // transitionStatus. The 'system' actor matches both the V3
+        // permission gate (blocked→queued requires TL/orc/system) and
+        // the existing intent — dependency resolution is server-side
+        // bookkeeping, not a user-initiated action.
+        await this.transitionStatus(candidate.id, 'queued', 'system');
         this.logger.info('WorkItem unblocked — all deps satisfied', {
           workItemId: candidate.id,
           via: completedId,
@@ -663,10 +678,10 @@ export class TaskPoolService {
       });
     }
 
-    // Mark item failed
-    await this.storage.updateWorkItem(workItemId, (wi) => {
-      wi.status = 'failed';
-      wi.completedAt = new Date().toISOString();
+    // TRANS-2: route the running → failed flip through transitionStatus.
+    // `completedAt` is set automatically when newStatus === 'failed'; the
+    // mutator only needs to attach the error description.
+    await this.transitionStatus(workItemId, 'failed', 'system', (wi) => {
       wi.error = error;
     });
 

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -132,6 +132,11 @@ describe('WorkItem Types', () => {
     it('should allow running → blocked', () => {
       expect(isValidWorkItemTransition('running', 'blocked')).toBe(true);
     });
+    // TRANS-2: legalised for TaskPoolService.releaseBack (Reconciler abandon
+    // and TL-initiated busy-release). Permission-gated in TRANSITION_PERMISSIONS.
+    it('should allow running → queued (TRANS-2 releaseBack)', () => {
+      expect(isValidWorkItemTransition('running', 'queued')).toBe(true);
+    });
     it('should allow blocked → queued', () => {
       expect(isValidWorkItemTransition('blocked', 'queued')).toBe(true);
     });
@@ -271,6 +276,24 @@ describe('WorkItem Types', () => {
 
       it('allows system actor for the dependency-resolution path (blocked → queued)', () => {
         expect(isTransitionPermitted('blocked', 'queued', 'system')).toBe(true);
+      });
+
+      // TRANS-2: running → queued is gated to the same set as the other
+      // re-queue transitions. Agents cannot self-revive a claim they hold.
+      it('blocks agent from re-queueing a running WorkItem (claim self-revival hazard)', () => {
+        expect(isTransitionPermitted('running', 'queued', 'agent')).toBe(false);
+      });
+
+      it('allows team_lead to release a running WorkItem back to queued', () => {
+        expect(isTransitionPermitted('running', 'queued', 'team_lead')).toBe(true);
+      });
+
+      it('allows orchestrator to release a running WorkItem back to queued', () => {
+        expect(isTransitionPermitted('running', 'queued', 'orchestrator')).toBe(true);
+      });
+
+      it('allows system actor (Reconciler abandon path) to release running → queued', () => {
+        expect(isTransitionPermitted('running', 'queued', 'system')).toBe(true);
       });
     });
   });

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -256,7 +256,12 @@ export const WORK_ITEM_TRANSITIONS: Record<WorkItemStatus, ReadonlySet<WorkItemS
   scheduled:      new Set(['queued', 'cancelled']),
   proposed:       new Set(['accepted', 'rejected', 'cancelled']),
   accepted:       new Set(['running', 'cancelled']),
-  running:        new Set(['done', 'done_by_worker', 'failed', 'blocked', 'escalated', 'cancelled']),
+  // TRANS-2: `running → queued` legalised so TaskPoolService.releaseBack
+  // (Reconciler abandon path, controller-initiated agent-busy releases)
+  // can route through the guarded {@link transitionStatus} helper. Gated
+  // in TRANSITION_PERMISSIONS to TL/orchestrator/system — agents cannot
+  // self-revive a running claim.
+  running:        new Set(['done', 'done_by_worker', 'failed', 'blocked', 'escalated', 'cancelled', 'queued']),
   blocked:        new Set(['queued', 'cancelled']),
   escalated:      new Set(['queued', 'cancelled']),
   done_by_worker: new Set(['verified', 'rejected']),
@@ -307,6 +312,11 @@ export const TRANSITION_PERMISSIONS: Record<string, ReadonlySet<WorkItemOwner>> 
   // default. The TaskPoolService.resolveBlockedDependents() helper
   // is the canonical caller and runs as system.
   'blocked→queued':           new Set(['team_lead', 'orchestrator', 'system']),
+  // TRANS-2: running→queued (releaseBack abandon path). Same gate as
+  // the other re-queue transitions — Reconciler revoke and TL manual
+  // release are the legitimate callers; agents cannot self-revive a
+  // running claim by re-queueing it.
+  'running→queued':           new Set(['team_lead', 'orchestrator', 'system']),
 };
 
 /**


### PR DESCRIPTION
## Summary

V3 hardening — TRANS-1 follow-up. Refactors the 5 status-mutating internal sites in `TaskPoolService` that previously bypassed the V3 actor-role gate by reaching for `storage.updateWorkItem` directly. After this PR, the only remaining `storage.updateWorkItem` callsites in `task-pool.service.ts` are the three legitimate internal helpers:

| Site | Purpose |
|------|---------|
| `updateItemStatus` (line 946) | Reconciler legacy facade — already V3-gated by TRANS-1 |
| `transitionStatus` (line 1030) | The canonical guarded wrapper itself |
| `updateTokenUsage` (line 1088) | Non-status mutation — out of scope |

`[V3 hardening — TRANS-1 follow-up]`

## What changed

### 5 internal sites refactored (`backend/src/services/task-pool/task-pool.service.ts`)

| # | Method | Transition | Mutator carries |
|---|--------|-----------|-----------------|
| 1 | `claimFromPool` | `queued → running` | `target` |
| 2 | `claimSpecificItem` | `queued → running` | `target` |
| 3 | `releaseBack` | `(running\|blocked) → queued` | `startedAt` clear, target preservation when blocked, `retryCount++` |
| 4 | `resolveBlockedDependents` | `blocked → queued` | (none) |
| 5 | `failItem` | `running → failed` | `error` |

Each site now calls `this.transitionStatus(workItemId, newStatus, 'system', mutator)`. Standard timestamp side-effects (`startedAt` on running, `completedAt` on failed/done/verified/done_by_worker/rejected) are owned by `transitionStatus`, so each mutator only carries non-timestamp fields.

### Supporting type-level change (`backend/src/types/v2/work-item.types.ts`)

- Added `running → queued` to `WORK_ITEM_TRANSITIONS` so `releaseBack` (from running, the Reconciler abandon path) routes through `transitionStatus` without the state-machine check rejecting it.
- Added `'running→queued'` permission entry: `[team_lead, orchestrator, system]`. Same gate as the other re-queue transitions — agents cannot self-revive a claim they hold.

## Veto checklist

- [x] V1 N/A (no auto-create)
- [x] V2 N/A (no retry policy)
- [x] **V3 ✅ APPLIES — primary deliverable.** All 5 refactored sites now flow through the guarded `transitionStatus` helper.
- [x] V4 N/A (orgRole is upstream)
- [x] V5 N/A (no Trigger entity)
- [x] V6 N/A (no cron)

## Audit (per ticket §"grep guard test")

```
$ grep -n 'storage\.updateWorkItem' backend/src/services/task-pool/task-pool.service.ts
946:    await this.storage.updateWorkItem(workItemId, (wi) => {     # updateItemStatus internal
1030:   const ok = await this.storage.updateWorkItem(workItemId, (wi) => {  # transitionStatus internal
1088:   await this.storage.updateWorkItem(workItemId, (wi) => {     # updateTokenUsage non-status
```

Lines 971 / 979 of the original grep are JSDoc references, not callsites.

The state-machine + actor gate now fires for every status mutation in TaskPoolService.

## Tests

### `work-item.types.test.ts` — 5 new specs
- `running → queued` is a valid state-machine transition.
- Permission matrix: agent BLOCKED; team_lead/orchestrator/system ALLOWED for `running → queued` (consistent with the other re-queue transitions).

### `task-pool.service.test.ts` — 6 new specs (\"TRANS-2: internal sites route through transitionStatus(actor='system')\")
- `claimFromPool` → `(queued, running, system)`
- `claimSpecificItem` → `(queued, running, system)`
- `releaseBack from running` → `(queued, system)` + `retryCount++` via mutator
- `releaseBack from blocked` → preserves target via mutator
- `resolveBlockedDependents` → `(blocked → queued, system)`
- `failItem` → `(running → failed, system)` + error via mutator

The new tests wrap `transitionStatus` on the prototype (rather than via `jest.spyOn(instance, ...)`) because `resolveBlockedDependents` is dispatched via `this.transitionStatus` from inside `completeSimpleItem` — instance-level spies do not always intercept those nested dispatches. They are the compile-time guard against a future contributor silently restoring a direct `storage.updateWorkItem` mutation that bypasses the V3 actor gate.

### Test results
- All 162 tests in the changed test files pass.
- Full task-pool + work-item.types + reconciler test surface (674 tests across 16 suites) is green.
- The unrelated `task-pool.routes.test.ts` failure (`Cannot find module 'vitest'`) is pre-existing on main and out of scope.

## Sequence

- ✅ TRANS-1 (#352) merged — `transitionStatus` and the V3 actor gate exist.
- ✅ VERIF-1 (#353) merged — `completeItem` is now a thin facade calling `submitForVerification` / `completeSimpleItem`, both of which already use `transitionStatus`. TRANS-2 picks up the remaining 5 sites without double-touching `completeItem`.

## Out of scope

- `mission-executor.service.ts:136` — initial-state assignment, not a transition.
- `updateTokenUsage` — non-status mutation, kept on storage.
- Reconciler/agent-claim refactors to expose actor-role API — separate ticket if/when Cloud Portal exposes a direct claim endpoint.

## Test plan

- [x] `npm run build:backend` — clean
- [x] `npx jest backend/src/services/task-pool backend/src/types/v2/work-item.types.test.ts` — 162/162 pass
- [x] `npx jest backend/src/controllers/task-pool backend/src/services/task-pool backend/src/types/v2 backend/src/services/reconciler` — 674 pass (1 unrelated vitest-import failure pre-existing on main)
- [x] grep audit confirms only 3 legitimate `storage.updateWorkItem` sites remain in `task-pool.service.ts`

## Recovery note

Mid-PR, the shared working tree swapped to a sibling branch (Type-B contamination) and wiped the in-progress work. Recovered cleanly via the documented worktree pattern (`git worktree add /tmp/crewly-trans-2-c69ce8e6 -b feat/trans-2-route-internal-pool-via-transitionStatus origin/main` + node_modules symlink). No data loss after recovery; all changes here were re-applied and re-validated in the isolated tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)