### PR TITLE
feat(autonomy_v1): INBOUND-1.f2 — Arch N1+N3+N4 polish on PR #357

### DIFF
--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -444,6 +444,107 @@ describe('RequestSlaSubscriber', () => {
       // No callback wired → no crash, escalateCalls empty.
       expect(escalateCalls).toHaveLength(0);
     });
+
+    // ---------------------------------------------------------------------
+    // Arch N3 on PR #357 — orphan respond_to_user WI close on escalation
+    // ---------------------------------------------------------------------
+    it('transitions the orphan respond_to_user WI to "failed" with slaResolvedReason="escalation_timeout" after a 10min escalation (DM success path)', async () => {
+      const r = buildRequest();
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+
+      jest.advanceTimersByTime(10_000);
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+      // The respond_to_user WI must be transitioned to 'failed' after the DM.
+      const wiId = `request:${r.id}:respond_to_user`;
+      const failTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
+      expect(failTransitions).toHaveLength(1);
+      expect(failTransitions[0].status).toBe('failed');
+      expect(failTransitions[0].actor).toBe('system');
+
+      // Mutator must stamp slaResolvedReason for ops visibility.
+      const wi = await pool.taskPool.findWorkItem(wiId);
+      expect(wi?.status).toBe('failed');
+      expect(wi?.metadata?.slaResolvedReason).toBe('escalation_timeout');
+      expect(typeof wi?.metadata?.slaResolvedAt).toBe('string');
+    });
+
+    it('still transitions the orphan WI to "failed" when no Slack DM hook is wired', async () => {
+      sub.stop();
+      sub = new RequestSlaSubscriber({
+        eventBus: bus,
+        taskPool: pool.taskPool,
+        requestService: svc.service,
+        // sendEscalationDm intentionally omitted — exercises the no-hook return path.
+        slaMs: 5_000,
+        escalationMs: 10_000,
+      });
+      sub.start();
+
+      const r = buildRequest();
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+
+      jest.advanceTimersByTime(10_000);
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+      const wiId = `request:${r.id}:respond_to_user`;
+      const failTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
+      expect(failTransitions).toHaveLength(1);
+      expect(failTransitions[0].status).toBe('failed');
+    });
+
+    it('still transitions the orphan WI to "failed" when the Slack DM callback throws', async () => {
+      sub.stop();
+      const throwingEscalate: EscalationSlackCallback = jest.fn(async () => {
+        throw new Error('slack 503');
+      });
+      sub = new RequestSlaSubscriber({
+        eventBus: bus,
+        taskPool: pool.taskPool,
+        requestService: svc.service,
+        sendEscalationDm: throwingEscalate,
+        slaMs: 5_000,
+        escalationMs: 10_000,
+      });
+      sub.start();
+
+      const r = buildRequest();
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+
+      jest.advanceTimersByTime(10_000);
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+      const wiId = `request:${r.id}:respond_to_user`;
+      const failTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
+      expect(failTransitions).toHaveLength(1);
+      expect(failTransitions[0].status).toBe('failed');
+    });
+
+    it('does NOT transition the WI when it is already terminal at escalation time', async () => {
+      const r = buildRequest();
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+
+      // Out-of-band cleanup: WI manually closed before the 10min mark.
+      const wiId = `request:${r.id}:respond_to_user`;
+      pool.setStatus(wiId, 'cancelled');
+
+      jest.advanceTimersByTime(10_000);
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+      // No transition to 'failed' because the WI is already terminal.
+      const failTransitions = pool.transitionCalls.filter(
+        (c) => c.id === wiId && c.status === 'failed',
+      );
+      expect(failTransitions).toHaveLength(0);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -47,6 +47,7 @@ import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 import { formatError } from '../../utils/format-error.js';
 import {
   type WorkItem,
+  type WorkItemStatus,
   DEFAULT_MAX_RETRIES,
 } from '../../types/v2/work-item.types.js';
 import type { Request } from '../../types/v2/request.types.js';
@@ -118,12 +119,12 @@ export const REQUEST_SLA_SUBSCRIBED_EVENTS: readonly EventType[] = [
 
 /**
  * Terminal WorkItem statuses — the SLA timers no-op when the WI has reached
- * any of these by the time the timer fires. Imports the
- * {@link WorkItemStatus} enum members directly so a future addition (e.g.
- * `'verified_with_warnings'`) forces an explicit decision here rather than
- * silently leaking through.
+ * any of these by the time the timer fires. Typed as
+ * `ReadonlySet<WorkItemStatus>` so a future addition (e.g.
+ * `'verified_with_warnings'`) or a typo'd member fails compilation here
+ * rather than silently leaking through. Aligns the JSDoc claim with reality.
  */
-const TERMINAL_WI_STATUSES = new Set([
+const TERMINAL_WI_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>([
   'done',
   'cancelled',
   'failed',
@@ -556,7 +557,10 @@ export class RequestSlaSubscriber {
   /**
    * 10-minute escalation handler. Emits the level-10 breach event and —
    * if a Slack DM callback is wired — sends the user a "still working on
-   * it" nudge so they're never blind to the miss.
+   * it" nudge so they're never blind to the miss. After the DM (or DM-skip),
+   * transitions the orphaned respond_to_user WI to `'failed'` with
+   * `slaResolvedReason: 'escalation_timeout'` so the orc queue does not keep
+   * a stale `queued` WI forever (Arch N3 on PR #357).
    */
   private async handleEscalation(requestId: string): Promise<void> {
     const tracked = this.trackedByRequest.get(requestId);
@@ -570,11 +574,16 @@ export class RequestSlaSubscriber {
     const stillTracked = this.trackedByRequest.get(requestId);
     if (!stillTracked) return;
 
+    // Capture the WI id BEFORE cleanupTracked() drops the record so we can
+    // still transition the orphan WI to 'failed' afterwards.
+    const wiId = stillTracked.workItemId;
+
     if (!this.sendEscalationDm) {
       this.logger.warn('SLA escalation reached 10min — no Slack DM hook wired', {
         requestId,
       });
       this.cleanupTracked(requestId);
+      await this.failOrphanRespondWi(wiId, requestId);
       return;
     }
 
@@ -583,6 +592,7 @@ export class RequestSlaSubscriber {
         requestId,
       });
       this.cleanupTracked(requestId);
+      await this.failOrphanRespondWi(wiId, requestId);
       return;
     }
 
@@ -608,8 +618,55 @@ export class RequestSlaSubscriber {
         error: formatError(err),
       });
     } finally {
-      // Escalation is the terminal hook in v1 — drop tracking either way.
+      // Escalation is the terminal hook in v1 — drop tracking + close the
+      // orphan WI either way (DM success or failure).
       this.cleanupTracked(requestId);
+      await this.failOrphanRespondWi(wiId, requestId);
+    }
+  }
+
+  /**
+   * Transition an escalated respond_to_user WI to `'failed'` with
+   * `slaResolvedReason: 'escalation_timeout'` so the orc queue does not
+   * keep a stale `queued` WI forever after a 10-min escalation. No-op if
+   * the WI is already terminal (e.g. user gave up + an out-of-band cleanup
+   * already closed it).
+   *
+   * Mirrors {@link markResolved}'s terminal-status guard. Errors are
+   * logged but never propagated — the SLA chain is already terminal at
+   * this point and we do not want to mask the original DM-path outcome.
+   *
+   * @param workItemId - The respond_to_user WI id to close.
+   * @param requestId  - The originating Request id (logging context only).
+   */
+  private async failOrphanRespondWi(
+    workItemId: string,
+    requestId: string,
+  ): Promise<void> {
+    try {
+      const wi = await this.taskPool.findWorkItem(workItemId);
+      if (!wi) return;
+      if (TERMINAL_WI_STATUSES.has(wi.status)) {
+        // Already terminal — nothing to do.
+        return;
+      }
+      await this.taskPool.transitionStatus(workItemId, 'failed', 'system', (item) => {
+        item.metadata = {
+          ...(item.metadata ?? {}),
+          slaResolvedReason: 'escalation_timeout',
+          slaResolvedAt: new Date().toISOString(),
+        };
+      });
+      this.logger.info('SLA escalation orphan WI auto-failed', {
+        workItemId,
+        requestId,
+      });
+    } catch (err) {
+      this.logger.warn('SLA escalation orphan-fail threw', {
+        workItemId,
+        requestId,
+        error: formatError(err),
+      });
     }
   }
 

--- a/backend/src/services/v3/request.service.ts
+++ b/backend/src/services/v3/request.service.ts
@@ -193,6 +193,9 @@ export class RequestService {
         // 'taskStatus' is the closest existing ChangedField for a Request
         // lifecycle signal. Adding 'requestStatus' would touch 23 unrelated
         // call sites; the request:created event itself is the canonical hook.
+        // TODO(autonomy_v2): add 'requestStatus' to ChangedField when chat-v2
+        // ingress (INBOUND-2) lands and we revisit the enum-narrowing decision.
+        // Filed as Arch N4 on PR #357.
         changedField: 'taskStatus',
         requestId: request.id,
         missionId: request.missionId,


### PR DESCRIPTION
## Summary

Cherry-pick of three Arch nice-to-haves from PR #357 review. All three touch `request-sla.subscriber.ts` / `request.service.ts` and are individually 1–5 LOC, so bundling them into one polish PR. Spec: `.crewly/tasks/autonomy_v1/follow-up/inbound_1_arch_nice_to_haves.md`.

- **N1**: Type `TERMINAL_WI_STATUSES` as `ReadonlySet<WorkItemStatus>` so the JSDoc claim of compile-time safety actually holds.
- **N3**: After 10-min escalation, transition the orphan `respond_to_user` WI to `'failed'` with `slaResolvedReason: 'escalation_timeout'` so the orc queue does not keep a stale `queued` WI forever. New private `failOrphanRespondWi()` helper mirrors `markResolved()`'s terminal-status guard.
- **N4**: TODO(autonomy_v2) marker on the `changedField: 'taskStatus'` decision in `request.service.ts:196` so it surfaces during INBOUND-2 (chat-v2 ingress) work.

Skipped per spec recommendation:
- **N2** (canonical 5-element terminal-set hoist) — Arch said spin a separate `terminal-set-canonicalization` ticket.
- **N5** (`type: 'review'` → `'execute'` for respond_to_user) — defer until orc terminal grows a per-type filter UI.

## Diff stats

```
backend/src/services/v3/request-sla.subscriber.ts       | +71 -7
backend/src/services/v3/request-sla.subscriber.test.ts  | +101
backend/src/services/v3/request.service.ts              | +3
3 files changed, 168 insertions(+), 7 deletions(-)
```

## Test plan

- [x] `npm run build` passes
- [x] `npm run build:backend` (tsc) clean
- [x] `npx jest backend/src/services/v3/request-sla.subscriber.test.ts` — **29/29 pass** (was 25, +4 new N3 specs)
- [x] `npx jest backend/src/services/v3/` — 298 pass / 1 fail (identical to main baseline before this PR: 294 pass / 1 fail; +4 new passing specs, **zero new failures**)
- [x] JSDoc on the new `failOrphanRespondWi` private method per project standard
- [x] N3 specs cover all 4 escalation outcomes: DM-success / no-DM-hook / DM-throws / already-terminal-no-op

## Review rounds (per Code Commit SOP)

This PR is small (3 files, 168 lines) and the changes are all isolated polish per Arch's review. Sam (TL) self-review:

- **Round 1 (Refactor & Consistency)**: `failOrphanRespondWi` mirrors the existing `markResolved` shape (terminal-status guard + try/catch + log-but-don't-throw). The wiId capture before `cleanupTracked()` is the only ordering subtlety — flagged in code comment. No duplication.
- **Round 2 (Efficiency & Reliability)**: `failOrphanRespondWi` is awaited in `finally` after `cleanupTracked`, so a slow `transitionStatus` call extends the escalation handler tail by one DB roundtrip — acceptable since this is the terminal hook in v1. Errors logged at warn level (consistent with `markResolved`'s error handling). The 4 new specs cover the 3 paths into `failOrphanRespondWi` (DM success / no hook / DM throws) plus the terminal-status no-op guard.
- **Round 3 (Overall Quality)**: New helper has full JSDoc with `@param` tags. Code comment explains the wiId-before-cleanup ordering. Inline TODO uses `TODO(autonomy_v2)` convention so the chat-v2 work picks it up. No console.log, no commented-out code, no stray TODOs.

## References

- PR #357 (INBOUND-1) — merged at `2b024022`. This PR's spec is the f2 follow-up filed at the same time as #357 landed.
- Spec: `.crewly/tasks/autonomy_v1/follow-up/inbound_1_arch_nice_to_haves.md`
- Sister follow-up in flight: INBOUND-1.f1 (auto-close on Request decompose) — Leo on `feat/inbound-1-f1-decompose-autoclose`
- Sister sprint work in flight: INBOUND-2 (chat-v2 ingress) — Max on `feat/inbound-2-chatv2-ingress`

## Out of scope

- N2 hoist (separate ticket)
- N5 type rename (deferred)
- Any chat-v2 surface (INBOUND-2 owns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)