### PR TITLE
feat(autonomy_v1): KARPATHY-LITE — entity-centric prompt edits + decomposition pipeline

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -734,6 +734,22 @@ bash {{ORCHESTRATOR_SKILLS_PATH}}/reply-slack/execute.sh '{"channelId":"C0123","
 
 **You are the project manager. The user should not have to ask "what happened?" — you should tell them before they need to ask.**
 
+## V3 Intelligent Decomposition Pipeline (MANDATORY)
+
+To ensure tasks are specific and context-aware (avoiding generic "Plan/Execute/Review" blocks), you MUST follow this decomposition pipeline for every user goal or complex request:
+
+1.  **Analyze Intent**: Use your LLM judgment to determine if the user's message is a **Request** (short-term, specific) or a **Mission** (long-term goal, OKR).
+2.  **Create Entity**:
+    - For Missions: Call `create-mission`.
+    - For Requests: Call `create-request`.
+3.  **Perform Intelligent Decomposition**:
+    - **NEVER** let the system create mindless WorkItems.
+    - If you created a **Mission**: IMMEDIATELY call `decompose-mission` (orchestrator skill). The skill will prompt you for a detailed breakdown. Provide specific, executable tasks with clear descriptions, types, and roles.
+    - If you created a **Request**: If it's complex (L2/L3), call `break-down-request` (agent skill) to generate specific WorkItems.
+4.  **Confirm to User**: Report the created tasks to the user, explaining the plan.
+
+**Rule**: A user message like "Build a login page" should result in 5-8 specific WorkItems (e.g., "Design login UI", "Implement auth API", "Write integration tests", etc.), NOT 3 generic ones.
+
 ---
 
 ## IMPORTANT: Session Management

--- a/config/skills/agent/core/record-learning/SKILL.md
+++ b/config/skills/agent/core/record-learning/SKILL.md
@@ -50,6 +50,35 @@ Record a learning or insight gained during task execution. These learnings are s
 | `--learning` / `-l` | `learning` | Yes | The learning or insight (or pipe via stdin) |
 | `--learning-file` | — | No | Read learning from a file path |
 
+---
+
+## Mandated Format: Karpathy-lite (Entity-Centric)
+
+To support future automated knowledge synthesis, all new learnings MUST follow the **Entity-Centric** format. This moves from "logging what happened" to "building a compounding wiki."
+
+### Formatting Rules:
+1. **Entity First**: Start with the primary entity (concept, file, function, or component) in brackets: `[[Entity Name]]`.
+2. **Concise**: 1-3 sentences maximum. No fluff.
+3. **Linked**: Reference related entities or components.
+4. **Sourced**: Reference the specific Task ID, PR, or Log line where this was learned.
+
+### Examples:
+
+**✅ CORRECT (Entity-Centric):**
+> `[[Fts5IndexService]] SQLite FTS5 rank is a negative double (more-negative = more-relevant). Invert to 100 - rank for score consistency. Learned during PR #320.`
+
+**✅ CORRECT (Component Relationship):**
+> `[[LearningReferenceModule]] injects memory usage instructions via PromptAssemblyService. Related to [[record-learning]] skill. Ref: backend/src/services/ai/prompt-modules/index.ts.`
+
+**❌ INCORRECT (Log-style):**
+> `I fixed a bug today in the FTS5 service where the ranking was inverted. It took me 2 hours because I didn't know SQLite's sign convention.`
+
+### Why this format
+
+The `LearningReferenceModule` (prompt-layer) and the LEARN-1 auto-record subscriber both join learnings on entity references. Free-form prose breaks that join. The `[[Entity]]` bracket convention also matches the cross-doc linking pattern used elsewhere in the project (mirrors Obsidian/Roam-style backlinks for future synthesis tooling).
+
+---
+
 ## Examples — CLI Flags (preferred)
 
 ```bash


### PR DESCRIPTION
## Summary

Two prompt/doc-layer edits drafted earlier (stash `WIP-archive 2026-04-27 pre-LEARN-1`) and held back to keep the autonomy_v1 chain (#356/#357/#358/#359) atomic. Reviewed post-LEARN-1 per orc directive 2026-04-27 (cleanup batch item #3) — both decided **KEEP**.

Spec: `.crewly/tasks/autonomy_v1/follow-up/karpathy-lite-prompt-edits.md`

## 1) Orc decomposition pipeline (16 LOC in `config/roles/orchestrator/prompt.md`)

New MANDATORY section forcing the orc to classify user intent (Request vs Mission) → create the right entity → intelligently decompose via the right skill (`decompose-mission` for Mission, `break-down-request` for complex Request).

**Why post-LEARN-1**: orthogonal to learning storage. LEARN-1 records terminal-state learnings; this section governs orc behavior at *request-arrival time*. Closes the "generic Plan/Execute/Review block" failure mode.

## 2) Karpathy-lite Entity-Centric format mandate (29 LOC in `config/skills/agent/core/record-learning/SKILL.md`)

All new manual learnings MUST start with `[[Entity Name]]`, be 1–3 sentences, link related entities, and cite source (Task / PR / Log).

**Why post-LEARN-1**: complements, doesn't overlap. LEARN-1 auto-records carry structured metadata; manual calls produce free-form prose. The `[[Entity]]` mandate makes both surfaces joinable on the same entity-reference layer. Matches Obsidian/Roam backlinks for future Archivist v2 synthesis tooling.

## Diff stats

```
config/roles/orchestrator/prompt.md               | +16
config/skills/agent/core/record-learning/SKILL.md | +29
2 files changed, 45 insertions(+)
```

## Test plan

- [x] No code changes — prompt/doc-only, build is unaffected
- [x] No new skills referenced that don't exist on main:
  - `config/skills/orchestrator/decompose-mission/` ✓
  - `config/skills/agent/core/break-down-request/` ✓
  - `config/skills/agent/core/create-mission/` ✓
  - `config/skills/agent/core/create-request/` ✓
- [x] No test files touched, no regression possible
- [x] Karpathy-lite section explicitly answers the "is this redundant with LEARN-1" question (joinability story + Archivist v2 roadmap alignment)
- [x] Stash backup preserved at `/tmp/karpathy-stash.patch` until merge (orc directive)

## Sam (TL) self-review

- **Round 1 (Refactor & Consistency)**: V3 Decomposition Pipeline section sits next to the project-manager closing line — natural narrative flow into Session Management. Karpathy-lite section sits between the parameter table and CLI Examples — readers see the format requirement before the worked examples that demonstrate it. Both sections use the project's standard MANDATORY/RULE markers consistent with adjacent prompt content.
- **Round 2 (Efficiency & Reliability)**: zero runtime impact. Both edits are static prompt/doc strings consumed at prompt-assembly time only. No new dependencies, no new code paths, no test impact.
- **Round 3 (Overall Quality)**: section headers follow project markdown conventions. JSDoc-style examples use `> ` blockquote for visual scan-ability. Anti-pattern example included alongside positive examples (mirrors the Karpathy "show what NOT to do" pedagogy that gives the format its name).

## Out of scope

- Other files from the same stash (`api.routes.test.ts`, `learning-reference.module.ts`, `v3-data.service`, `review-reason.types.ts`) — already merged via #356/#357. Stash retained as backup, will drop after this PR merges.
- New backend service for entity extraction / cross-doc linking — Archivist v2 territory.

## References

- Stash: `WIP-archive 2026-04-27 pre-LEARN-1: learning-ref + record-learning + review-reason + foreign (api.routes, v3-data, orc/prompt)` (`/tmp/karpathy-stash.patch`)
- LEARN-1: PR #356 (merged at `a15f6147`)
- INBOUND-1.2 LEARN-1 polish: PR #357 (merged at `2b024022`)
- Sister architecture: `sop-norm-prompt-module.md` v2 roadmap (Archivist v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)