### PR TITLE
docs(sops): dev-git-workflow v2 — add worktree pattern norm

### DIFF
--- a/config/sops/developer/git-workflow.md
+++ b/config/sops/developer/git-workflow.md
@@ -1,24 +1,27 @@
 ---
 id: dev-git-workflow
-version: 1
+version: 2
 createdAt: 2026-01-29T00:00:00Z
-updatedAt: 2026-01-29T00:00:00Z
+updatedAt: 2026-04-27T23:55:00Z
 createdBy: system
+updatedBy: sam-tl
 role: developer
 category: git
 priority: 10
 title: Git Workflow
-description: Standard git workflow for developers
+description: Standard git workflow for developers — branch naming, commit messages, and worktree-based parallel work
 triggers:
   - commit
   - push
   - branch
   - merge
   - git
+  - worktree
 tags:
   - git
   - workflow
   - version-control
+  - worktree
 ---
 
 # Git Workflow
@@ -50,9 +53,41 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 - Each commit should be atomic (one logical change)
 - Don't commit broken code
 
+## Worktree Pattern (REQUIRED for parallel branch work)
+
+**When to use a worktree:** any time you start work on a branch other than the main repo's current branch, OR when another agent is also working on a parallel branch in the same repo.
+
+**Why required:** working on a feature branch directly in the main repo (`/Users/.../crewly`) means stash / checkout operations across two parallel agents collide. Files modified by one agent appear in the other agent's `git diff`. This produces lost work, accidentally-mixed PRs, and recovery patches like `/tmp/sam-stash-recovery-with-max-inbound2.patch` (incident 2026-04-27 — Sam recovering Max's INBOUND-2 work that mixed into Sam's polish stash).
+
+**Standard worktree flow** (Leo's pattern, model for the team):
+
+```bash
+# 1. Create a worktree for your branch from main (or another base)
+git worktree add /tmp/crewly-{ticket-name}-{owner} main
+
+# 2. cd into the worktree and create your feature branch
+cd /tmp/crewly-{ticket-name}-{owner}
+git checkout -b feat/{ticket-id}-{description}
+
+# 3. Make edits, run tests, commit, push from the worktree
+# (the main repo's working tree is untouched)
+
+# 4. After PR merges, clean up the worktree
+cd /Users/yellowsunhy/Desktop/projects/crewly-projects/crewly
+git worktree remove /tmp/crewly-{ticket-name}-{owner}
+```
+
+**Notes:**
+- `node_modules` is not installed in the worktree by default. For prompt/doc-only PRs that's fine. For backend code PRs that need `npm test` / `npm run build`, run those checks back in the main repo or `npm install` inside the worktree.
+- `.crewly/` directory is gitignored — task spec markdown files written there in a worktree won't appear in the diff. Copy spec files to the main repo's `.crewly/tasks/...` if other agents need to read them.
+- Do NOT use the main repo `crewly/` directory to develop a feature branch when another agent is also active in the team. The main repo is the orchestrator's coordination surface, not a per-agent dev sandbox.
+
+**Solo work exception:** if you are the only developer active in the team and you're not parking work for parallel review, working directly in the main repo is acceptable. The worktree pattern is required only when there is a real risk of branch-state collision.
+
 ## Before Pushing
 
 1. Run `npm run typecheck`
 2. Run `npm test`
 3. Run `npm run lint`
 4. Review your changes: `git diff`
+5. Confirm you're on the correct branch (`git branch --show-current`)


### PR DESCRIPTION
## Summary

Updates the developer git-workflow SOP to v2 with a new "Worktree Pattern (REQUIRED for parallel branch work)" section. Filed in response to a 2026-04-27 incident where Sam recovered Max's INBOUND-2 work from a stash collision (Sam was on `feat/inbound-1-arch-nth`, Max was developing `feat/inbound-2-chatv2-ingress` directly in the main repo, files mixed during a stash op). Recovery patch: `/tmp/sam-stash-recovery-with-max-inbound2.patch`. Per orc directive 2026-04-27 ("worktree pattern is the standard now", Leo's pattern is the model).

## Changes

- New section: "Worktree Pattern (REQUIRED for parallel branch work)"
- The standard 4-step worktree flow (create / cd+checkout / commit+push / cleanup) modeled on Leo's INBOUND-1.f1 working pattern
- Notes on `node_modules` (not installed in fresh worktree — fine for prompt/doc PRs, `npm install` in the worktree if you need to run tests)
- Notes on `.crewly/` being gitignored (spec markdown files written in worktree don't appear in diff — copy to main repo if other agents need to read)
- Solo-work exception: working in main repo is acceptable when there's no real risk of branch-state collision
- New checklist item before pushing: "Confirm you're on the correct branch (`git branch --show-current`)"
- Frontmatter version bump v1 → v2, `updatedBy: sam-tl`, `updatedAt: 2026-04-27T23:55Z`. Triggers list extended with `worktree`.

## Diff stats

```
config/sops/developer/git-workflow.md | +38 -3
1 file changed, 38 insertions(+), 3 deletions(-)
```

## Test plan

- [x] No code changes — SOP markdown only, build unaffected
- [x] No test files touched, no regression possible
- [x] Self-tested the documented worktree flow on `feat/karpathy-lite-entity-prompt-edits` (PR #361) — flow worked exactly as described

## References

- Incident: 2026-04-27 stash collision, recovery patch `/tmp/sam-stash-recovery-with-max-inbound2.patch`
- Model pattern: Leo's INBOUND-1.f1 working flow (worktree at `/tmp/crewly-inbound-f1-leo`)
- Orc directive: 2026-04-27 23:30Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)