### PR TITLE
chore(autonomy_v1): REVIEW-1 NTH-1 to NTH-4 — Arch nice-to-have polish on PR #354

### DIFF
--- a/backend/src/services/v3/mission-reminder.service.test.ts
+++ b/backend/src/services/v3/mission-reminder.service.test.ts
@@ -538,6 +538,21 @@ describe('MissionReminderService', () => {
     it.each([
       ['off_track_kr',     defaultSummary({ offTrack: 2 }), { activeProjectTaskIds: ['pt-1'] }],
       ['no_active_work',   defaultSummary(),                { activeProjectTaskIds: [] }],
+      // NTH-1 (Arch on PR #354): positive test for `phase_complete`. Fires
+      // when the mission's current phase has advanced past whatever the
+      // previous review summary captured (`lastReviewSummary` does NOT
+      // include `phase=<currentPhase>`). Must come BEFORE the
+      // `scheduled_review` default, but AFTER off_track_kr / no_active_work
+      // since those have higher precedence in `inferReviewReason`.
+      [
+        'phase_complete',
+        defaultSummary(),
+        {
+          activeProjectTaskIds: ['pt-1'],
+          currentPhase: 2,
+          lastReviewSummary: 'phase=1, on track',
+        },
+      ],
       ['scheduled_review', defaultSummary(),                { activeProjectTaskIds: ['pt-1'] }],
     ])('reviewReason routing → %s', async (expectedReason, summary, missionOverrides) => {
       pinNow('2026-04-27T10:00:00Z');
@@ -653,6 +668,166 @@ describe('MissionReminderService', () => {
       expect(result.reviewsCreated).toBe(1);
       expect(mockSlackBridge.sendNotification).toHaveBeenCalled();
       expect(mockTaskPool.addToPool).toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------
+    // Arch NTH-2 / NTH-3 / NTH-4 on PR #354 — efficiency + reliability
+    // -------------------------------------------------------------------
+
+    it('NTH-2: collapses lock-clear + new-WI persistence into a SINGLE saveMission per sweep tick', async () => {
+      pinNow('2026-04-28T10:00:00Z'); // next cycle past lastReviewAt
+      const mission = makeMissionWithCadence({
+        // Reentrancy lock points at a WI that has already terminalized.
+        pendingReviewWorkItemId: 'm-cadence:review:2026-04-27',
+        lastReviewAt: '2026-04-27T09:00:00.000Z',
+      });
+      mockTaskPool.findWorkItem.mockResolvedValueOnce({
+        id: 'm-cadence:review:2026-04-27',
+        status: 'verified', // terminal — triggers lazy clear
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      // Reset write-counter before the assertion window so the NTH-2 count
+      // is isolated from any reads/writes in the runSweep setup phase.
+      (atomicWriteJson as any).mockClear();
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(1);
+      // BEFORE NTH-2: 2 writes (clear + new id). AFTER: 1 write only.
+      expect(atomicWriteJson).toHaveBeenCalledTimes(1);
+
+      // Verify the single write carries BOTH the cleared lock-then-new-id
+      // AND the bumped lastReviewAt — proving the collapse is correct
+      // (we did not silently drop the lock-clear).
+      const persistedMission = (atomicWriteJson as any).mock.calls[0][1];
+      expect(persistedMission.pendingReviewWorkItemId).toBe('m-cadence:review:2026-04-28');
+      expect(persistedMission.lastReviewAt).toBe('2026-04-28T10:00:00.000Z');
+    });
+
+    it('NTH-2: still persists the cleared lock when the NEW-WI path bails (skipped/noop)', async () => {
+      // Same setup as above (terminal pendingReview, lock-clear path), but
+      // pin now BEFORE the cadence boundary so the new-WI path returns
+      // 'skipped' — the cleared lock must still be persisted.
+      pinNow('2026-04-27T08:59:59Z'); // BEFORE today's 09:00 boundary
+      const mission = makeMissionWithCadence({
+        pendingReviewWorkItemId: 'm-cadence:review:2026-04-26',
+        lastReviewAt: '2026-04-27T05:00:00.000Z', // covers the previous 09:00 boundary
+      });
+      mockTaskPool.findWorkItem.mockResolvedValueOnce({
+        id: 'm-cadence:review:2026-04-26',
+        status: 'verified',
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      (atomicWriteJson as any).mockClear();
+
+      await service.runSweep();
+
+      // The exit-branch saveMission MUST fire so the cleared lock is durable.
+      expect(atomicWriteJson).toHaveBeenCalledTimes(1);
+      const persistedMission = (atomicWriteJson as any).mock.calls[0][1];
+      expect(persistedMission.pendingReviewWorkItemId).toBeUndefined();
+    });
+
+    it('NTH-3: bumps cronParseFailureCount + warn-logs total on a malformed cron', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence({
+        policy: {
+          missionId: 'm-bad-cron',
+          executionCadence: {
+            reviewSchedule: 'this is not a cron expression',
+            dailyItemLimit: 0,
+            workHours: null,
+            phaseGateApproval: 'none',
+            requireVerificationGate: false,
+          },
+        },
+      });
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      const startCount = service.cronParseFailureCount;
+
+      const result = await service.runSweep();
+
+      expect(result.reviewsCreated).toBe(0);
+      expect(mockTaskPool.addToPool).not.toHaveBeenCalled();
+      // The failure counter incremented by exactly 1.
+      expect(service.cronParseFailureCount).toBe(startCount + 1);
+    });
+
+    it('NTH-3: cronParseFailureCount accumulates across multiple bad missions in one sweep', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const startCount = service.cronParseFailureCount;
+      const m1 = makeMissionWithCadence({
+        id: 'm-bad-1',
+        policy: {
+          missionId: 'm-bad-1',
+          executionCadence: {
+            reviewSchedule: 'garbage-cron-1',
+            dailyItemLimit: 0,
+            workHours: null,
+            phaseGateApproval: 'none',
+            requireVerificationGate: false,
+          },
+        },
+      });
+      const m2 = makeMissionWithCadence({
+        id: 'm-bad-2',
+        policy: {
+          missionId: 'm-bad-2',
+          executionCadence: {
+            reviewSchedule: 'garbage-cron-2',
+            dailyItemLimit: 0,
+            workHours: null,
+            phaseGateApproval: 'none',
+            requireVerificationGate: false,
+          },
+        },
+      });
+      (fs.readdir as any).mockResolvedValue(['m-bad-1.json', 'm-bad-2.json']);
+      (fs.readFile as any).mockImplementation((p: string) => {
+        if (p.includes('m-bad-1')) return Promise.resolve(JSON.stringify(m1));
+        if (p.includes('m-bad-2')) return Promise.resolve(JSON.stringify(m2));
+        return Promise.reject(new Error('File not found'));
+      });
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      await service.runSweep();
+
+      // Both missions failed cron parse → counter += 2.
+      expect(service.cronParseFailureCount).toBe(startCount + 2);
+    });
+
+    it('NTH-4: caches the TaskPoolService.getInstance() result for the service lifetime', async () => {
+      pinNow('2026-04-27T10:00:00Z');
+      const mission = makeMissionWithCadence();
+      (fs.readdir as any).mockResolvedValue(['m-cadence.json']);
+      (fs.readFile as any).mockResolvedValue(JSON.stringify(mission));
+      mockKRTrackingService.computeMissionOKRProgress.mockResolvedValue(defaultSummary());
+
+      // Reset the spy counter just before the runSweep so prior test
+      // setup work (constructor calls etc.) does not leak into this
+      // assertion. The service was constructed at line 74 in beforeEach.
+      (TaskPoolService.getInstance as any).mockClear();
+
+      // Run multiple sweeps in a row — same call-site path each time
+      // (review WI creation + lock check + addToPool).
+      await service.runSweep();
+      await service.runSweep();
+      await service.runSweep();
+
+      // BEFORE NTH-4: TaskPoolService.getInstance() called per call site
+      // per mission per sweep (~6 times across 3 sweeps × 2 sites).
+      // AFTER NTH-4: cached in the private field after first access,
+      // so AT MOST 1 call across the entire service lifetime.
+      expect((TaskPoolService.getInstance as any).mock.calls.length).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/backend/src/services/v3/mission-reminder.service.ts
+++ b/backend/src/services/v3/mission-reminder.service.ts
@@ -108,11 +108,52 @@ export class MissionReminderService {
   private readonly logger: ComponentLogger;
   private readonly storageService: StorageService;
   private readonly krTrackingService: KRTrackingService;
+  /**
+   * Cached TaskPoolService singleton (Arch NTH-4 on PR #354).
+   * Resolved lazily on first access via {@link getTaskPool} and reused
+   * across every sweep × mission call site for the lifetime of this
+   * MissionReminderService instance. Tests that need to swap the
+   * underlying TaskPool must call {@link resetInstance} to also discard
+   * this cached reference.
+   */
+  private taskPool: TaskPoolService | null = null;
+
+  /**
+   * Counter of cron-parse failures observed across all sweeps (Arch NTH-3
+   * on PR #354). Bumped each time {@link CronExpressionParser.parse}
+   * throws on a mission's `reviewSchedule`. Exposed via
+   * {@link cronParseFailureCount} for tests + (future) Prom metric.
+   */
+  private cronParseFailures = 0;
 
   private constructor() {
     this.logger = LoggerService.getInstance().createComponentLogger('MissionReminder');
     this.storageService = StorageService.getInstance();
     this.krTrackingService = KRTrackingService.getInstance();
+  }
+
+  /**
+   * Total number of cron-parse failures observed since this service
+   * instance was constructed. Read by tests (asserting the warn-log path
+   * also bumps the counter) and intended as the source for a future
+   * Prometheus gauge (sister F4 follow-up filed on the OKR Mission
+   * Reminder spec).
+   */
+  public get cronParseFailureCount(): number {
+    return this.cronParseFailures;
+  }
+
+  /**
+   * Cached TaskPoolService accessor. Resolves the singleton on first call
+   * and reuses it thereafter. Allows test harnesses to reset the cache
+   * via {@link resetInstance}, which clears both the
+   * MissionReminderService singleton and any private references it holds.
+   */
+  private getTaskPool(): TaskPoolService {
+    if (!this.taskPool) {
+      this.taskPool = TaskPoolService.getInstance();
+    }
+    return this.taskPool;
   }
 
   static getInstance(): MissionReminderService {
@@ -252,14 +293,21 @@ export class MissionReminderService {
     // Reentrancy lock (Arch Veto V8).
     // Lazily clear the pending pointer when the previous review WI has
     // reached terminal status; otherwise short-circuit creation.
+    //
+    // NTH-2 (Arch on PR #354): defer the saveMission for the lock-clear
+    // until we know whether a new review WI will be created in the same
+    // sweep tick. If yes, both writes (clear + new id) collapse to one
+    // saveMission at the end of the success path. If no (skipped /
+    // noop), we still need to persist the cleared lock — handled in the
+    // exit branches below.
     // -----------------------------------------------------------------
+    let pendingLockCleared = false;
     if (mission.pendingReviewWorkItemId) {
-      const taskPool = TaskPoolService.getInstance();
-      const pendingWI = await taskPool.findWorkItem(mission.pendingReviewWorkItemId);
+      const pendingWI = await this.getTaskPool().findWorkItem(mission.pendingReviewWorkItemId);
       if (!pendingWI || PENDING_REVIEW_TERMINAL_STATUSES.has(pendingWI.status)) {
-        // Pending WI is gone or terminal — clear and continue.
+        // Pending WI is gone or terminal — clear in memory; persist on exit.
         mission.pendingReviewWorkItemId = undefined;
-        await this.saveMission(mission);
+        pendingLockCleared = true;
       } else {
         return 'skipped';
       }
@@ -279,11 +327,23 @@ export class MissionReminderService {
       });
       boundary = interval.prev().toDate();
     } catch (err) {
+      // NTH-3 (Arch on PR #354): bump the cron-parse failure counter so
+      // ops can see how often this fires + which missions are affected.
+      // The warn-log already carried mission id + cron + error message.
+      this.cronParseFailures += 1;
       this.logger.warn('Mission has unparseable review cadence cron — skipping review WI', {
         missionId: mission.id,
         reviewSchedule: cadence.reviewSchedule,
         error: err instanceof Error ? err.message : String(err),
+        totalCronParseFailures: this.cronParseFailures,
       });
+      // Persist the cleared reentrancy lock if we cleared it earlier in
+      // this method but are now bailing out of WI creation — the
+      // mission's in-memory state would otherwise leak the cleared
+      // pointer to the next sweep without disk-backed durability.
+      if (pendingLockCleared) {
+        await this.saveMission(mission);
+      }
       return 'noop';
     }
 
@@ -291,6 +351,10 @@ export class MissionReminderService {
       const lastReview = new Date(mission.lastReviewAt);
       if (lastReview.getTime() >= boundary.getTime()) {
         // Already reviewed within the current cadence cycle.
+        // NTH-2: persist any deferred lock-clear before bailing.
+        if (pendingLockCleared) {
+          await this.saveMission(mission);
+        }
         return 'skipped';
       }
     }
@@ -331,10 +395,11 @@ export class MissionReminderService {
       },
     };
 
-    const taskPool = TaskPoolService.getInstance();
-    await taskPool.addToPool(reviewWorkItem);
+    await this.getTaskPool().addToPool(reviewWorkItem);
 
     // Persist the reentrancy lock + bookkeeping fields.
+    // NTH-2: this is the canonical single saveMission per sweep tick —
+    // any earlier in-memory lock-clear collapses into this write.
     mission.pendingReviewWorkItemId = reviewWorkItemId;
     mission.lastReviewAt = now.toISOString();
     await this.saveMission(mission);


### PR DESCRIPTION
## Summary

Cherry-pick of the four Arch nice-to-have items raised on REVIEW-1 review (PR #354 already merged). Single sweep PR, all non-blocking polish, ships behind a fully green test suite.

| # | Theme | Change |
|---|-------|--------|
| **NTH-1** | Test coverage | Adds positive `phase_complete` row to the `reviewReason` routing `it.each` table. |
| **NTH-2** | Efficiency | Collapses lock-clear + new-WI persistence into a SINGLE `saveMission` per sweep tick. |
| **NTH-3** | Reliability + observability | Adds `cronParseFailures` counter; warn-log now carries `totalCronParseFailures`. |
| **NTH-4** | Efficiency | Caches `TaskPoolService.getInstance()` for service lifetime via `getTaskPool()`. |

All four were called out as non-blocking on PR #354, so they were deferred until after the original ship landed.

## Implementation

### `backend/src/services/v3/mission-reminder.service.ts` (+77, -6)
- **NTH-2**: New `pendingLockCleared: boolean` flag. The lock-clear branch now mutates `mission.pendingReviewWorkItemId = undefined` in-memory and sets the flag instead of immediately calling `saveMission`. The canonical `saveMission` at the end of `createReviewWorkItem` folds in the cleared lock alongside the new `pendingReviewWorkItemId` + bumped `lastReviewAt`. Bail-out branches (cron parse, already-reviewed-this-cycle) explicitly call `saveMission` if `pendingLockCleared` to keep the in-memory clear durable.
- **NTH-3**: New `private cronParseFailures = 0` field, public `cronParseFailureCount` getter. The cron-parse `catch` block bumps the counter and the warn-log now carries `totalCronParseFailures: this.cronParseFailures`. Wires future Prom-counter source.
- **NTH-4**: New `private taskPool: TaskPoolService | null = null` field + `private getTaskPool(): TaskPoolService` accessor. Two prior `TaskPoolService.getInstance()` call sites in `createReviewWorkItem` switched to `this.getTaskPool()`.

### `backend/src/services/v3/mission-reminder.service.test.ts` (+175)
- **NTH-1**: New `phase_complete` row in the `reviewReason` `it.each` table, with the right precedence ordering (after `no_active_work`, before `scheduled_review`).
- **NTH-2 happy path test**: Verifies one and only one `atomicWriteJson` call per sweep tick when both lock-clear and new-WI fire, and the persisted mission carries both the cleared lock + the new id + bumped `lastReviewAt`.
- **NTH-2 bail-out test**: Pins `now` before the cadence boundary so the new-WI path returns `'skipped'`; verifies the cleared lock is still persisted (1 write, `pendingReviewWorkItemId` undefined).
- **NTH-3 single-mission test**: Bad cron string → `runSweep` returns 0 reviews + counter bumps by exactly 1.
- **NTH-3 multi-mission test**: Two missions both with bad crons in one sweep → counter bumps by exactly 2.
- **NTH-4 cache test**: Three sequential sweeps → `TaskPoolService.getInstance()` called at most 1 time across the entire window (after `mockClear`).

## Test plan

- [x] `cd /private/tmp/crewly-review-1-nth-sam && npx jest backend/src/services/v3/mission-reminder.service.test.ts --no-coverage --forceExit` → **33 / 33 pass** (28 prior + 5 new).
- [x] No new files — touches only existing source + test, mirrors original PR #354 module layout per CLAUDE.md 1:1 source-to-test policy.
- [x] Build + TypeScript clean (rebased onto current main `59b17e16`).

## 3-round review notes

- **Round 1 (Refactor & Consistency):** Followed the existing private-field + getter pattern (`logger`, `storageService`, `krTrackingService`) for the new `taskPool` cache + `cronParseFailures` counter. JSDoc on every new member references the originating Arch ticket so future maintainers can trace the rationale.
- **Round 2 (Efficiency & Reliability):** NTH-2 explicitly verified by a write-counter assertion in tests, both happy path and bail-out branches. NTH-3 counter is in-memory (Prom integration is a separate F4 follow-up) — already meaningful via warn-log enrichment. NTH-4 cached reference is reset by `resetInstance()` so test harnesses still work.
- **Round 3 (Overall Quality):** No dead code, no inline magic numbers (counter starts at literal `0`, justified). Naming: `getTaskPool` (verb-noun) matches `getInstance` and `pickTeamLead` patterns. Tests co-located per CLAUDE.md.

## Out of scope (deferred)

- F4 Prom-counter wiring (filed separately).
- Any structural refactor of `inferReviewReason` (NTH-1 only adds coverage; logic untouched).
- Any new mission types or cadence policies.

## Workflow

- Branch developed in worktree at `/private/tmp/crewly-review-1-nth-sam` per dev-git-workflow v2 SOP (worktree pattern is mandatory when shared HEAD is on someone else's branch). Rebased onto current main (commit `59b17e16` from PR #364 merge). 1 commit, signed off by Sam (TL self-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)