### PR TITLE
feat(autonomy_v1): F1-BRIDGE-1 — wire task:done_by_worker + task:rejected publishers

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -561,6 +561,90 @@ describe('TaskPoolService', () => {
       await expect(service.submitForVerification(wi.id, 'agent'))
         .rejects.toThrow(/Invalid status transition/);
     });
+
+    // ---------------------------------------------------------------------
+    // F1-BRIDGE-1: task:done_by_worker publish hook
+    // ---------------------------------------------------------------------
+
+    describe('task:done_by_worker publish (F1-BRIDGE-1)', () => {
+      it('publishes task:done_by_worker exactly once per successful submit, with workItemId + correlation fields', async () => {
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        service.setEventBusService(fakeBus);
+
+        const wi = makeWorkItem({ type: 'delegate', requestId: 'req-42', missionId: 'm-9' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+
+        await service.submitForVerification(wi.id, 'agent', { output: 'draft' });
+
+        // 1 workitem:queued (from addToPool) + 1 task:done_by_worker
+        const doneEvents = publishCalls.filter((e) => e.type === 'task:done_by_worker');
+        expect(doneEvents).toHaveLength(1);
+        expect(doneEvents[0].workItemId).toBe(wi.id);
+        expect(doneEvents[0].requestId).toBe('req-42');
+        expect(doneEvents[0].missionId).toBe('m-9');
+        expect(doneEvents[0].previousValue).toBe('running');
+        expect(doneEvents[0].newValue).toBe('done_by_worker');
+        // Deterministic event id keyed on the WI id (dedup contract — mirrors workitem:queued)
+        expect(doneEvents[0].id).toBe(`task:done_by_worker:${wi.id}`);
+      });
+
+      it('does NOT publish task:done_by_worker when the transition throws (state-machine gate)', async () => {
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        service.setEventBusService(fakeBus);
+
+        const wi = makeWorkItem({ type: 'delegate' });
+        await service.addToPool(wi);
+        // Skip claimFromPool so the WI stays in `queued`, not `running` —
+        // submitForVerification must throw on the invalid transition, and
+        // the publisher must NEVER fire on a rolled-back transition.
+        await expect(service.submitForVerification(wi.id, 'agent'))
+          .rejects.toThrow(/Invalid status transition/);
+
+        const doneEvents = publishCalls.filter((e) => e.type === 'task:done_by_worker');
+        expect(doneEvents).toHaveLength(0);
+      });
+
+      it('does NOT publish task:done_by_worker when no EventBus is wired (legacy/test path)', async () => {
+        const wi = makeWorkItem({ type: 'delegate' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+
+        // No setEventBusService — eventBus stays null, submitForVerification must not throw.
+        await expect(
+          service.submitForVerification(wi.id, 'agent', { output: 'draft' }),
+        ).resolves.not.toBeNull();
+      });
+
+      it('isolates EventBus.publish errors from the verification transition (state commit wins)', async () => {
+        const fakeBus = {
+          publish: jest.fn((event: any) => {
+            // Only blow up on task:done_by_worker so the addToPool publish
+            // (workitem:queued) does not throw and dirty the setup phase.
+            if (event.type === 'task:done_by_worker') {
+              throw new Error('bus blew up');
+            }
+          }),
+        } as any;
+        service.setEventBusService(fakeBus);
+
+        const wi = makeWorkItem({ type: 'delegate' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+
+        const updated = await service.submitForVerification(wi.id, 'agent', { output: 'draft' });
+
+        // Transition committed even though the bus threw.
+        expect(updated).not.toBeNull();
+        expect(updated!.status).toBe('done_by_worker');
+      });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -681,6 +765,97 @@ describe('TaskPoolService', () => {
 
       await expect(service.verifyItem(wi.id, 'team_lead', 'verified'))
         .rejects.toThrow(/Invalid status transition/);
+    });
+
+    // ---------------------------------------------------------------------
+    // F1-BRIDGE-1: task:rejected publish hook
+    // ---------------------------------------------------------------------
+
+    describe('task:rejected publish (F1-BRIDGE-1)', () => {
+      it('publishes task:rejected exactly once on a rejected verdict, with workItemId + correlation fields', async () => {
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        // Wire the bus AFTER the setup helper so we don't capture the
+        // workitem:queued + task:done_by_worker events from the seeding
+        // submitForVerification call. We're isolating the verifyItem
+        // publish here.
+        const wi = await makeAwaitingVerification();
+        service.setEventBusService(fakeBus);
+
+        await service.verifyItem(wi.id, 'team_lead', 'rejected', 'Output incomplete');
+
+        const rejectEvents = publishCalls.filter((e) => e.type === 'task:rejected');
+        expect(rejectEvents).toHaveLength(1);
+        expect(rejectEvents[0].workItemId).toBe(wi.id);
+        expect(rejectEvents[0].previousValue).toBe('done_by_worker');
+        expect(rejectEvents[0].newValue).toBe('rejected');
+        // Deterministic event id (dedup contract).
+        expect(rejectEvents[0].id).toBe(`task:rejected:${wi.id}`);
+      });
+
+      it('does NOT publish task:rejected on the verified branch (success path is bridge-silent)', async () => {
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        const wi = await makeAwaitingVerification();
+        service.setEventBusService(fakeBus);
+
+        await service.verifyItem(wi.id, 'team_lead', 'verified');
+
+        const rejectEvents = publishCalls.filter((e) => e.type === 'task:rejected');
+        expect(rejectEvents).toHaveLength(0);
+      });
+
+      it('does NOT publish task:rejected when the transition throws (state-machine gate)', async () => {
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        service.setEventBusService(fakeBus);
+
+        const wi = makeWorkItem({ type: 'delegate' });
+        await service.addToPool(wi);
+        // Never claimed / submitted — verifyItem on a queued item must throw.
+        await expect(service.verifyItem(wi.id, 'team_lead', 'rejected'))
+          .rejects.toThrow(/Invalid status transition/);
+
+        const rejectEvents = publishCalls.filter((e) => e.type === 'task:rejected');
+        expect(rejectEvents).toHaveLength(0);
+      });
+
+      it('does NOT publish task:rejected when no EventBus is wired (legacy/test path)', async () => {
+        const wi = await makeAwaitingVerification();
+        // No setEventBusService — eventBus stays null, verifyItem must not throw.
+        await expect(
+          service.verifyItem(wi.id, 'team_lead', 'rejected', 'no-bus-test'),
+        ).resolves.not.toBeNull();
+      });
+
+      it('isolates EventBus.publish errors from the rejection transition (state commit wins)', async () => {
+        const fakeBus = {
+          publish: jest.fn((event: any) => {
+            if (event.type === 'task:rejected') {
+              throw new Error('bus blew up');
+            }
+          }),
+        } as any;
+        const wi = await makeAwaitingVerification();
+        service.setEventBusService(fakeBus);
+
+        const updated = await service.verifyItem(
+          wi.id,
+          'team_lead',
+          'rejected',
+          'reviewer comment',
+        );
+
+        // Transition committed even though the bus threw.
+        expect(updated).not.toBeNull();
+        expect(updated!.status).toBe('rejected');
+      });
     });
   });
 

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -282,6 +282,114 @@ export class TaskPoolService {
   }
 
   /**
+   * F1-BRIDGE-1 helper: publish `task:done_by_worker` after a successful
+   * `submitForVerification` transition. The {@link EventToWorkItemBridge}
+   * subscribes to this event and creates a verification WorkItem for the
+   * resolved team-lead session.
+   *
+   * Stays a separate method (mirrors {@link publishWorkItemQueued}) so:
+   *   1. The dependency on EventBus stays explicit and grep-able — Arch's
+   *      grep guard checks both the type declaration AND a publish call
+   *      site for `task:done_by_worker`.
+   *   2. Error handling is uniform with the other publishers — a thrown
+   *      bus must NOT back out the verified state transition; the storage
+   *      flush has already committed.
+   *   3. A future caller adding an alternate verification-submission path
+   *      (e.g. an admin endpoint or a CLI) routes through the same publisher.
+   *
+   * The deterministic event id (`task:done_by_worker:${workItemId}`) keys
+   * dedup so a redelivered submitForVerification (theoretical) collapses
+   * through the bus without firing the bridge handler twice.
+   */
+  private publishTaskDoneByWorker(workItem: WorkItem): void {
+    if (!this.eventBus) {
+      this.logger.debug('No EventBus wired — skipping task:done_by_worker publish', {
+        workItemId: workItem.id,
+      });
+      return;
+    }
+    try {
+      this.eventBus.publish({
+        id: `task:done_by_worker:${workItem.id}`,
+        type: 'task:done_by_worker',
+        timestamp: new Date().toISOString(),
+        teamId: '',
+        teamName: '',
+        memberId: '',
+        memberName: '',
+        // sessionName is empty — `task:done_by_worker` is published from the
+        // pool layer which doesn't carry the worker's PTY session. The bridge
+        // uses `workItemId` (and falls back to `taskId`) to resolve the
+        // source WI; sessionName is informational. Empty matches the
+        // workitem:queued publish convention.
+        sessionName: '',
+        // The state machine just landed at done_by_worker. Carry both ends
+        // so any subscriber filtering on (previousValue, newValue) sees
+        // the canonical transition.
+        previousValue: 'running',
+        newValue: 'done_by_worker',
+        changedField: 'taskStatus',
+        // BRIDGE-1.1 hybrid extension. `workItemId` is mandatory for the
+        // bridge handler; the `taskId` fallback path is unused here because
+        // WorkItem itself does not carry a taskId (the bridge resolves the
+        // source WI by id alone via taskPool.findWorkItem).
+        workItemId: workItem.id,
+        missionId: workItem.missionId,
+        requestId: workItem.requestId,
+      });
+    } catch (err) {
+      this.logger.warn('task:done_by_worker publish threw', {
+        workItemId: workItem.id,
+        error: formatError(err),
+      });
+    }
+  }
+
+  /**
+   * F1-BRIDGE-1 helper: publish `task:rejected` after a successful
+   * `verifyItem` transition with verdict='rejected'. The
+   * {@link EventToWorkItemBridge} subscribes and either creates a retry
+   * WI (`retryCount < maxRetries`) or escalates to a TL review WI with
+   * `reviewReason='max_retries_exceeded'` at the cap.
+   *
+   * Mirrors {@link publishTaskDoneByWorker} for symmetry. Only the
+   * verdict='rejected' branch reaches this publisher — `verdict='verified'`
+   * does NOT publish (terminal-success path goes through
+   * {@link resolveBlockedDependents}, which is not a bridge trigger).
+   */
+  private publishTaskRejected(workItem: WorkItem): void {
+    if (!this.eventBus) {
+      this.logger.debug('No EventBus wired — skipping task:rejected publish', {
+        workItemId: workItem.id,
+      });
+      return;
+    }
+    try {
+      this.eventBus.publish({
+        id: `task:rejected:${workItem.id}`,
+        type: 'task:rejected',
+        timestamp: new Date().toISOString(),
+        teamId: '',
+        teamName: '',
+        memberId: '',
+        memberName: '',
+        sessionName: '',
+        previousValue: 'done_by_worker',
+        newValue: 'rejected',
+        changedField: 'taskStatus',
+        workItemId: workItem.id,
+        missionId: workItem.missionId,
+        requestId: workItem.requestId,
+      });
+    } catch (err) {
+      this.logger.warn('task:rejected publish threw', {
+        workItemId: workItem.id,
+        error: formatError(err),
+      });
+    }
+  }
+
+  /**
    * Claims the next available WorkItem from the pool for an agent.
    *
    * Selection strategy: FIFO among matching unclaimed 'queued' items.
@@ -561,11 +669,18 @@ export class TaskPoolService {
     this.logger.info('WorkItem submitted for verification', {
       workItemId,
       actorRole,
-      // BRIDGE-1 will turn this into a real `task:done_by_worker` event
-      // that wakes the TL session. For now the log line is the wake
-      // signal — a TL-watching subscriber can grep on it.
+      // BRIDGE-1 turns this into a real `task:done_by_worker` event below
+      // (F1-BRIDGE-1). The log line is preserved as a wake signal for any
+      // tail-based TL-watching subscriber that still greps it.
       tlWakeRequested: true,
     });
+    // F1-BRIDGE-1: publish AFTER the storage flush so any subscriber that
+    // re-reads via taskPool.findWorkItem sees the committed `done_by_worker`
+    // status. `updated` is null only on race-window deletion — skip the
+    // publish in that case (no source WI for the bridge to resolve).
+    if (updated) {
+      this.publishTaskDoneByWorker(updated);
+    }
     return updated;
   }
 
@@ -656,6 +771,13 @@ export class TaskPoolService {
     }
     await this.storage.flush();
     this.logger.info('WorkItem verdict recorded', { workItemId, verdict, actorRole });
+    // F1-BRIDGE-1: only the `rejected` branch publishes. The bridge's
+    // task:rejected handler creates the retry-or-escalate WI; the `verified`
+    // branch is terminal-success and unblocks dependents above without any
+    // bridge involvement. Skip the publish on race-window deletion.
+    if (verdict === 'rejected' && updated) {
+      this.publishTaskRejected(updated);
+    }
     return updated;
   }
 


### PR DESCRIPTION
## Summary

Closes the publisher gap identified in BRIDGE-1 PR #355: the bridge handlers for `task:done_by_worker` and `task:rejected` shipped on main with **zero publishers**, leaving them dormant in production. Without these publishers the autonomy chain (worker submit → TL verify → retry/escalate) silently never advances through the bridge — falls back to log-grep only.

Picked up post-#366 merge per orc directive ("cherry-pick anything you think is worth it from follow-up/").

## Implementation

### `backend/src/services/task-pool/task-pool.service.ts` (+114, -3)

Two new private publishers mirror the existing `publishWorkItemQueued` shape (INBOUND-1.f1):

- **`publishTaskDoneByWorker(workItem)`** — invoked from `submitForVerification` AFTER the storage flush. Carries `workItemId` (mandatory for the bridge), `requestId`, `missionId`. Deterministic event id `task:done_by_worker:${id}` for the bus's per-(type,session) dedup window.
- **`publishTaskRejected(workItem)`** — invoked from `verifyItem` ONLY when `verdict === 'rejected'` AND the transition succeeded. The verified branch stays bridge-silent (terminal-success path goes through `resolveBlockedDependents`, not the bridge).

Both publishers:
1. No-op cleanly when EventBus is not wired (test/CLI path) — log at debug.
2. Catch-and-warn on `bus.publish()` throw — the storage commit is the source of truth, the event is informational. Mirrors the existing `workitem:queued` isolation pattern.
3. Skip publish on race-window deletion (`updated === null`) — the bridge has no source WI to resolve.

### `backend/src/services/task-pool/task-pool.service.test.ts` (+186)

9 new tests co-located per CLAUDE.md, dropped into the existing `submitForVerification` and `verifyItem` describe blocks:

**`task:done_by_worker publish (F1-BRIDGE-1)` — 4 tests:**
- Publishes exactly once per successful submit, with `workItemId` + `requestId` + `missionId` + `previousValue/newValue` + deterministic event id.
- Does NOT publish when the transition throws (state-machine gate).
- Does NOT publish when no EventBus is wired (legacy/test path).
- Isolates EventBus.publish errors from the verification transition (state commit wins).

**`task:rejected publish (F1-BRIDGE-1)` — 5 tests:**
- Publishes exactly once on a rejected verdict, with `workItemId` + `previousValue/newValue` + deterministic event id.
- Does NOT publish on the verified branch (success path is bridge-silent).
- Does NOT publish when the transition throws.
- Does NOT publish when no EventBus is wired.
- Isolates EventBus.publish errors from the rejection transition.

## Test plan

- [x] `npx jest backend/src/services/task-pool/task-pool.service.test.ts --no-coverage --forceExit` → **93/93 pass** (84 prior + 9 new).
- [x] `npx jest backend/src/services/event-bus --no-coverage --forceExit` → **77/77 pass** (no bridge regression — handlers still resolve correctly with the new publishers).
- [x] `npx tsc --noEmit -p backend/tsconfig.json` → clean.

## Arch grep guard (PR-time)

```
grep -nE "task:done_by_worker|task:rejected" backend/src --include='*.ts' | grep -E "publish|type:"
  → backend/src/services/task-pool/task-pool.service.ts: type: 'task:done_by_worker' (PUBLISH SITE)
  → backend/src/services/task-pool/task-pool.service.ts: type: 'task:rejected' (PUBLISH SITE)
  → backend/src/types/event-bus.types.ts: 'task:done_by_worker' (TYPE DECL)
  → backend/src/types/event-bus.types.ts: 'task:rejected' (TYPE DECL)
  → backend/src/services/event-bus/event-to-workitem-bridge.service.ts: onInProcess('task:done_by_worker', …) (HANDLER)
  → backend/src/services/event-bus/event-to-workitem-bridge.service.ts: onInProcess('task:rejected', …) (HANDLER)
```

Both events now have a complete declaration → publish → handler chain. Bridge handlers are no longer dormant in production.

## 3-round review notes

- **Round 1 (Refactor & Consistency):** Both publishers extracted into private methods following the `publishWorkItemQueued` pattern. JSDoc cites the F1-BRIDGE-1 origin so future maintainers can trace the rationale. Deterministic event id format keys on the WI id for symmetric dedup with the existing `workitem:queued` publish.
- **Round 2 (Efficiency & Reliability):** Publish happens AFTER `storage.flush()` so any subscriber that re-reads via `taskPool.findWorkItem` sees the committed state. Race-window null check before publish (no source WI = no point firing). Bus errors are isolated via try/catch + warn-log — never back out a committed state transition.
- **Round 3 (Overall Quality):** Naming follows the existing publish pattern (`publishX`). All new public-shaped private methods carry JSDoc with cross-references to the consumer (bridge handler). Tests cover the full happy/throw/no-bus/bus-throws matrix per Arch's review template.

## Out of scope

- `agentSession` field on the new publishes — task-pool layer doesn't carry the worker's PTY session. Bridge resolves via `workItemId` alone, sufficient.
- `task:done_by_worker` for the `completeSimpleItem` path — that path bypasses verification by design (cron_run/notify/reconcile/check/confirm/review types). No bridge involvement intended there.
- F1.A/F1.B's prescribed `verification.service.ts` location — the actual code lives in `task-pool.service.ts`. Same logical layer, identical test coverage.

## Workflow

- Branch developed in worktree at `/tmp/crewly-f1-publishers-sam` per dev-git-workflow v2 SOP. 1 commit, signed off by Sam (TL self-review). Rebased onto current main `b5e3d8df` (PR #366 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)