### PR TITLE
feat(onboarding): wire POST /sessions/:id/complete (KR3 magic-moment final step)

### DIFF
--- a/backend/src/controllers/onboarding/onboarding.routes.test.ts
+++ b/backend/src/controllers/onboarding/onboarding.routes.test.ts
@@ -232,6 +232,45 @@ describe('Onboarding Routes', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // POST /sessions/:id/complete (KR3 magic-moment terminal step)
+  // ---------------------------------------------------------------------------
+
+  describe('POST /api/onboarding/sessions/:id/complete', () => {
+    it('marks the session "completed" and stamps completedAt', async () => {
+      const create = await request(app).post('/api/onboarding/sessions').send({});
+      const id = create.body.data.id as string;
+      const res = await request(app)
+        .post(`/api/onboarding/sessions/${id}/complete`)
+        .send({ teamKnowledgeDir: '.crewly/knowledge' });
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.status).toBe('completed');
+      expect(res.body.data.completedAt).toBeDefined();
+      expect(res.body.data.teamKnowledgeDir).toBe('.crewly/knowledge');
+    });
+
+    it('accepts an empty body (teamKnowledgeDir is optional)', async () => {
+      const create = await request(app).post('/api/onboarding/sessions').send({});
+      const id = create.body.data.id as string;
+      const res = await request(app)
+        .post(`/api/onboarding/sessions/${id}/complete`)
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body.data.status).toBe('completed');
+      expect(res.body.data.teamKnowledgeDir).toBeUndefined();
+    });
+
+    it('returns 404 for a missing id (same shape as cross-tenant)', async () => {
+      const res = await request(app)
+        .post('/api/onboarding/sessions/missing/complete')
+        .send({ teamKnowledgeDir: '.crewly/knowledge' });
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.error).toBe('Session not found');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // POST /provision
   // ---------------------------------------------------------------------------
 
@@ -395,6 +434,29 @@ describe('Onboarding Routes', () => {
         .set('Authorization', `Bearer ${tokenA}`);
       expect(verify.body.data.discoveryAnswers).toBeUndefined();
       expect(verify.body.data.status).toBe('created');
+    });
+
+    it('POST /sessions/:id/complete from a foreign tenant returns 404 and does NOT mutate', async () => {
+      const create = await request(app).post('/api/onboarding/sessions')
+        .set('Authorization', `Bearer ${tokenA}`).send({});
+      const id = create.body.data.id as string;
+
+      const foreignRes = await request(app).post(`/api/onboarding/sessions/${id}/complete`)
+        .set('Authorization', `Bearer ${tokenB}`)
+        .send({ teamKnowledgeDir: '.crewly/knowledge' });
+      expect(foreignRes.status).toBe(404);
+      expect(foreignRes.body.error).toBe('Session not found');
+
+      // Owner-side state is unchanged — status still 'created', no completedAt
+      const verify = await request(app).get(`/api/onboarding/sessions/${id}`)
+        .set('Authorization', `Bearer ${tokenA}`);
+      expect(verify.body.data.status).toBe('created');
+      expect(verify.body.data.completedAt).toBeUndefined();
+    });
+
+    it('POST /sessions/:id/complete returns 401 without a valid token (auth gate)', async () => {
+      const res = await request(app).post('/api/onboarding/sessions/anything/complete').send({});
+      expect(res.status).toBe(401);
     });
 
     it('POST /sessions creates sessions stamped with the caller as owner', async () => {

--- a/backend/src/controllers/onboarding/onboarding.routes.ts
+++ b/backend/src/controllers/onboarding/onboarding.routes.ts
@@ -8,6 +8,7 @@
  *   PUT    /api/onboarding/sessions/:id      — Update session (owner-scoped)
  *   POST   /api/onboarding/sessions/:id/prefill   — Store prefill data (owner-scoped)
  *   POST   /api/onboarding/sessions/:id/approve   — Approve profile (owner-scoped)
+ *   POST   /api/onboarding/sessions/:id/complete  — Mark session terminal (owner-scoped, KR3 magic-moment timestamp)
  *   POST   /api/onboarding/provision         — Provision final team (owner-scoped)
  *
  * Every endpoint runs behind `requireAuth` so each request carries
@@ -152,6 +153,39 @@ export function createOnboardingRouter(): Router {
         req.params.id,
         req.body.answers,
         ownerIdFor(req),
+      );
+      if (!session) {
+        res.status(404).json({ success: false, error: 'Session not found' });
+        return;
+      }
+      res.json({ success: true, data: session });
+    } catch (err) {
+      res.status(400).json({
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  /**
+   * Mark an onboarding session terminal and stamp the KR3 magic-moment
+   * telemetry timestamp.
+   *
+   * Called by the frontend wizard's post-provision success screen so we can
+   * measure end-to-end onboarding wall-clock time (createdAt → completedAt).
+   * Body: { teamKnowledgeDir?: string } — opaque metadata stored on the
+   * session for downstream tooling that wants to recover the knowledge dir
+   * the wizard used.
+   *
+   * Cross-tenant calls resolve to 404 (same shape as a missing session) so
+   * cross-tenant id enumeration cannot probe for existence.
+   */
+  router.post('/sessions/:id/complete', requireAuth, (req: Request, res: Response) => {
+    try {
+      const session = service.completeSession(
+        req.params.id,
+        ownerIdFor(req),
+        { teamKnowledgeDir: req.body?.teamKnowledgeDir },
       );
       if (!session) {
         res.status(404).json({ success: false, error: 'Session not found' });

--- a/backend/src/services/onboarding/onboarding.service.test.ts
+++ b/backend/src/services/onboarding/onboarding.service.test.ts
@@ -181,6 +181,63 @@ describe('OnboardingService', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // completeSession (KR3 magic-moment terminal step)
+  // ---------------------------------------------------------------------------
+  describe('completeSession', () => {
+    it('marks the session "completed" and stamps completedAt + updatedAt', () => {
+      const s = svc.createSession();
+      const before = s.updatedAt;
+      // Ensure a non-zero clock delta so the after-stamp is strictly later.
+      const updated = svc.completeSession(s.id);
+      expect(updated).not.toBeNull();
+      expect(updated!.status).toBe('completed');
+      expect(updated!.completedAt).toBeDefined();
+      expect(updated!.completedAt).toBe(updated!.updatedAt);
+      expect(new Date(updated!.updatedAt).getTime())
+        .toBeGreaterThanOrEqual(new Date(before).getTime());
+    });
+
+    it('persists the optional teamKnowledgeDir hint when provided', () => {
+      const s = svc.createSession();
+      const updated = svc.completeSession(s.id, undefined, {
+        teamKnowledgeDir: '.crewly/knowledge',
+      });
+      expect(updated!.teamKnowledgeDir).toBe('.crewly/knowledge');
+    });
+
+    it('omits teamKnowledgeDir when the hint is not provided', () => {
+      const s = svc.createSession();
+      const updated = svc.completeSession(s.id);
+      expect(updated!.teamKnowledgeDir).toBeUndefined();
+    });
+
+    it('returns null for a missing id', () => {
+      expect(svc.completeSession('nope')).toBeNull();
+    });
+
+    it('is idempotent — second call refreshes timestamps but stays terminal', () => {
+      const s = svc.createSession();
+      const first = svc.completeSession(s.id);
+      const second = svc.completeSession(s.id);
+      expect(second!.status).toBe('completed');
+      expect(second!.completedAt).toBeDefined();
+      // Both stamps are valid ISO strings; ordering monotonic.
+      expect(new Date(second!.completedAt!).getTime())
+        .toBeGreaterThanOrEqual(new Date(first!.completedAt!).getTime());
+    });
+
+    it('returns null for cross-tenant calls (no enumeration leak)', () => {
+      const s = svc.createSession('https://a.com', 'user-aaa');
+      // Foreign caller gets the same null shape as a missing id.
+      expect(svc.completeSession(s.id, 'user-bbb')).toBeNull();
+      // Underlying record is untouched — owner can still complete it.
+      const owner = svc.completeSession(s.id, 'user-aaa');
+      expect(owner!.status).toBe('completed');
+      expect(owner!.ownerUserId).toBe('user-aaa');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Tenant scoping (N1 — Phase E pre-beta)
   //
   // Every read and mutation must respect the optional `ownerUserId` scope so

--- a/backend/src/services/onboarding/onboarding.service.ts
+++ b/backend/src/services/onboarding/onboarding.service.ts
@@ -257,4 +257,44 @@ export class OnboardingService {
     this.sessions.set(sessionId, merged);
     return merged;
   }
+
+  /**
+   * Mark an onboarding session terminal and stamp the KR3 magic-moment
+   * telemetry timestamp.
+   *
+   * Called by the frontend wizard's post-provision success screen via
+   * POST /sessions/:id/complete. Stamps `completedAt` (and `updatedAt`)
+   * with a fresh ISO timestamp and advances `status` to `'completed'`.
+   * Idempotent — a second call refreshes both timestamps but keeps the
+   * status terminal.
+   *
+   * Cross-tenant calls return `null` (no enumeration leak — same shape as
+   * a missing session).
+   *
+   * @param sessionId - Session id
+   * @param ownerUserId - Optional owner scope (`req.user.userId` in HTTP)
+   * @param options - Optional metadata forwarded by the frontend; today
+   *   `teamKnowledgeDir` is the only field and is stored opaquely.
+   * @returns The updated session, or `null` if missing or not owned
+   */
+  completeSession(
+    sessionId: string,
+    ownerUserId?: string,
+    options?: { teamKnowledgeDir?: string },
+  ): OnboardingSession | null {
+    const existing = this.resolveOwned(sessionId, ownerUserId);
+    if (!existing) return null;
+    const now = new Date().toISOString();
+    const merged: OnboardingSession = {
+      ...existing,
+      ...(options?.teamKnowledgeDir
+        ? { teamKnowledgeDir: options.teamKnowledgeDir }
+        : {}),
+      status: 'completed',
+      completedAt: now,
+      updatedAt: now,
+    };
+    this.sessions.set(sessionId, merged);
+    return merged;
+  }
 }

--- a/backend/src/services/onboarding/onboarding.types.ts
+++ b/backend/src/services/onboarding/onboarding.types.ts
@@ -27,16 +27,21 @@
  *   prefilled → reviewed   (free-form PUT updates while user reviews)
  *   reviewed  → approved   (after POST /sessions/:id/approve)
  *   approved  → provisioned (after POST /provision succeeds)
+ *   provisioned → completed (after POST /sessions/:id/complete — terminal,
+ *                            stamps the magic-moment KR3 telemetry timestamp)
  *
  * Backwards transitions are allowed via PUT updates so the user can revise
- * answers before approving.
+ * answers before approving. The `completed` state is the terminal flag set
+ * by the frontend wizard once the user reaches the post-provision success
+ * screen — it lets us measure end-to-end onboarding wall-clock time.
  */
 export type OnboardingSessionStatus =
   | 'created'
   | 'prefilled'
   | 'reviewed'
   | 'approved'
-  | 'provisioned';
+  | 'provisioned'
+  | 'completed';
 
 /**
  * Confidence band for an AI-extracted prefill field.
@@ -151,4 +156,19 @@ export interface OnboardingSession {
   createdAt: string;
   /** ISO 8601 timestamp of the last mutation. */
   updatedAt: string;
+  /**
+   * ISO 8601 timestamp of when the onboarding flow was marked terminal via
+   * POST /sessions/:id/complete. Populated only after the user reaches the
+   * post-provision success screen — used as the KR3 magic-moment wall-clock
+   * marker (createdAt → completedAt = end-to-end onboarding duration).
+   */
+  completedAt?: string;
+  /**
+   * Optional knowledge-directory hint forwarded by the frontend's complete
+   * call (`{ teamKnowledgeDir: '.crewly/knowledge' }`). Stored opaquely so
+   * downstream tooling that wants to write team-knowledge artefacts post
+   * onboarding can recover the location the wizard used; not interpreted by
+   * the service itself.
+   */
+  teamKnowledgeDir?: string;
 }


### PR DESCRIPTION
## Summary

- Wires the missing backend route `POST /api/onboarding/sessions/:id/complete` that the frontend wizard's post-provision success screen has been calling (`apiService.completeOnboarding` at `frontend/src/services/api.service.ts:1404`). Previously the request 404'd silently, which broke the KR3 magic-moment telemetry — without a `completedAt` stamp we cannot measure end-to-end onboarding wall-clock time.
- Adds `completed` as the terminal `OnboardingSessionStatus`, plus `completedAt` (ISO 8601 telemetry timestamp) and `teamKnowledgeDir` (opaque hint forwarded by the frontend) on `OnboardingSession`.
- Adds `OnboardingService.completeSession(sessionId, ownerUserId?, options?)` reusing the existing `resolveOwned()` cross-tenant guard from N1 (PR #350) — cross-tenant calls return `null` (route surfaces 404, identical body shape to missing-id) so id enumeration cannot probe for existence. Idempotent: a second call refreshes timestamps, status stays `'completed'`.
- Route uses the existing `ownerIdFor(req)` helper behind `requireAuth`, matching every other tenant-scoped route in the file.

## Files changed (+215 / -2, 5 files — all backend)

- `backend/src/services/onboarding/onboarding.types.ts` — extend status union + add `completedAt` / `teamKnowledgeDir`
- `backend/src/services/onboarding/onboarding.service.ts` — new `completeSession` method
- `backend/src/services/onboarding/onboarding.service.test.ts` — 5 new unit tests
- `backend/src/controllers/onboarding/onboarding.routes.ts` — new route + module docstring update
- `backend/src/controllers/onboarding/onboarding.routes.test.ts` — 4 new route tests + 2 cross-tenant tests

## Test plan

- [x] `npx tsc --noEmit -p backend/tsconfig.json` — clean
- [x] `npm run build:backend` — clean
- [x] `npx jest backend/src/services/onboarding/onboarding.service.test.ts backend/src/controllers/onboarding/onboarding.routes.test.ts` → **2 suites, 66 tests, all passing** (11 new + 55 existing, no regressions)
- [x] Happy path: POST with full body → 200, status='completed', completedAt set, teamKnowledgeDir persisted
- [x] Body optional: empty body → 200, completed stamp still applied
- [x] Negative: missing id → 404 with `error: 'Session not found'` (canonical shape)
- [x] Cross-tenant: foreign tenant attempt → 404 + verifies underlying state unchanged on owner side
- [x] Auth gate: unauthenticated → 401
- [x] Idempotent service-level call covered

## Compliance

- 1:1 source-to-test ratio per CLAUDE.md (every modified source file has its co-located test extended)
- JSDoc on the new service method and route handler, including `@param`, `@returns`, and tenant-scope contract
- No hardcoded values; reuses `ownerIdFor()` and `resolveOwned()` helpers
- Backwards-compatible: existing tests (50+) unchanged; `OnboardingSessionStatus` widening does not narrow any caller (verified via grep)

## OKR linkage

KR3 (sub-5-min onboarding) — closes the wall-clock measurement gap by stamping `completedAt` at the wizard's success screen so we can land the magic-moment metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)