### PR TITLE
chore(autonomy_v1): INBOUND-1.f2 — Arch 5 nice-to-haves on PR #357

### DIFF
--- a/backend/src/services/v3/mission-reminder.service.ts
+++ b/backend/src/services/v3/mission-reminder.service.ts
@@ -25,7 +25,7 @@ import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import type { Mission } from '../../types/v2/mission.types.js';
 import type { MissionOKRSummary } from '../../types/v2/key-result.types.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
-import { TERMINAL_WORK_ITEM_STATUSES } from '../../types/v2/work-item.types.js';
+import { SLA_TERMINAL_WORK_ITEM_STATUSES } from '../../types/v2/work-item.types.js';
 import { atomicWriteJson } from '../../utils/file-io.utils.js';
 import { pickTeamLead } from '../../utils/team.utils.js';
 import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
@@ -47,28 +47,29 @@ const REMINDER_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Statuses that *clear* a Mission's `pendingReviewWorkItemId` so the next
- * sweep tick can fire a new review. The set mirrors
- * {@link TERMINAL_WORK_ITEM_STATUSES} (`done`, `verified`, `cancelled`) but
- * adds two statuses that the canonical TERMINAL set excludes for valid
- * reasons elsewhere — yet which DO represent "exited the active queue" for
- * the V8 reentrancy-lock perspective:
+ * sweep tick can fire a new review. Aliases the canonical
+ * {@link SLA_TERMINAL_WORK_ITEM_STATUSES} (work-item.types.ts) per Arch's
+ * N2 hoist on PR #357 — single source of truth for the broader 5-element
+ * "exited active queue" set previously redeclared inline.
  *
- * - `failed`: a failed review WI has terminated execution; not blocking next cadence.
- * - `rejected`: a TL-rejected review WI ({@link WorkItemStatus} reachable from
- *   the review path per work-item.types.ts) has likewise exited the queue.
- *   Without this, a single TL rejection of a review WI would silently freeze
- *   that mission's lock forever — exactly the V8 failure mode this lock
- *   exists to prevent (Arch N1 BLOCKING fix on PR #354).
+ * Members (`done`, `verified`, `cancelled`, `failed`, `rejected`) cover both
+ * the strict-terminal set and the SLA-terminal additions:
+ *
+ * - `done` / `verified` / `cancelled` — strictly terminal in the state
+ *   machine sense.
+ * - `failed`: a failed review WI has terminated execution; not blocking
+ *   next cadence.
+ * - `rejected`: a TL-rejected review WI has likewise exited the queue.
+ *   Without this, a single TL rejection would silently freeze the mission's
+ *   reentrancy lock forever — exactly the V8 failure mode this lock exists
+ *   to prevent (Arch N1 BLOCKING fix on PR #354).
  *
  * The reentrancy lock is sweep-time lazy: we don't subscribe to TRANS-1
  * events here, we just observe the WorkItem's current state on each sweep
- * and clear the lock when it's terminal.
+ * and clear the lock when it's in any of the SLA-terminal states.
  */
-const PENDING_REVIEW_TERMINAL_STATUSES: ReadonlySet<string> = new Set([
-  ...TERMINAL_WORK_ITEM_STATUSES,
-  'failed',
-  'rejected',
-]);
+const PENDING_REVIEW_TERMINAL_STATUSES: ReadonlySet<string> =
+  SLA_TERMINAL_WORK_ITEM_STATUSES;
 
 function getMissionsDir(): string {
   return path.join(process.cwd(), '.crewly', 'missions');

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -57,6 +57,7 @@ import {
   type WorkItem,
   type WorkItemStatus,
   DEFAULT_MAX_RETRIES,
+  SLA_TERMINAL_WORK_ITEM_STATUSES,
 } from '../../types/v2/work-item.types.js';
 import type { Request } from '../../types/v2/request.types.js';
 import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
@@ -147,18 +148,15 @@ export function respondToUserWorkItemId(requestId: string): string {
 
 /**
  * Terminal WorkItem statuses — the SLA timers no-op when the WI has reached
- * any of these by the time the timer fires. Typed as
- * `ReadonlySet<WorkItemStatus>` so a future addition (e.g.
- * `'verified_with_warnings'`) or a typo'd member fails compilation here
- * rather than silently leaking through. Aligns the JSDoc claim with reality.
+ * any of these by the time the timer fires. Aliases
+ * {@link SLA_TERMINAL_WORK_ITEM_STATUSES} (work-item.types.ts) per Arch's
+ * N2 hoist on PR #357 — single source of truth for the broader 5-element
+ * "exited active queue" set, replacing the previously duplicated local
+ * constant. The local alias is retained so the existing call sites in
+ * this file stay terse and the diff stays minimal.
  */
-const TERMINAL_WI_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>([
-  'done',
-  'cancelled',
-  'failed',
-  'verified',
-  'rejected',
-]);
+const TERMINAL_WI_STATUSES: ReadonlySet<WorkItemStatus> =
+  SLA_TERMINAL_WORK_ITEM_STATUSES;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -9,6 +9,7 @@ import {
   WORK_ITEM_OWNERS,
   WORK_ITEM_STATUSES,
   TERMINAL_WORK_ITEM_STATUSES,
+  SLA_TERMINAL_WORK_ITEM_STATUSES,
   WORK_ITEM_TRANSITIONS,
   TRANSITION_PERMISSIONS,
   DEFAULT_MAX_RETRIES,
@@ -61,6 +62,31 @@ describe('WorkItem Types', () => {
     });
     it('should have exactly 3 entries', () => {
       expect(TERMINAL_WORK_ITEM_STATUSES.size).toBe(3);
+    });
+  });
+
+  describe('SLA_TERMINAL_WORK_ITEM_STATUSES (INBOUND-1.f2 N2 hoist)', () => {
+    it('should contain all strict-terminal statuses + failed + rejected', () => {
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('done')).toBe(true);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('verified')).toBe(true);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('cancelled')).toBe(true);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('failed')).toBe(true);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('rejected')).toBe(true);
+    });
+    it('should have exactly 5 entries', () => {
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.size).toBe(5);
+    });
+    it('should be a strict superset of TERMINAL_WORK_ITEM_STATUSES', () => {
+      for (const s of TERMINAL_WORK_ITEM_STATUSES) {
+        expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has(s)).toBe(true);
+      }
+    });
+    it('should NOT include non-terminal active-queue statuses', () => {
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('queued')).toBe(false);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('running')).toBe(false);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('blocked')).toBe(false);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('done_by_worker')).toBe(false);
+      expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('escalated')).toBe(false);
     });
   });
 

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -136,6 +136,37 @@ export const TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus> = new Set(
   'cancelled',
 ]);
 
+/**
+ * Broader "exited the active queue" status set used by SLA-style consumers
+ * (e.g. `RequestSlaSubscriber`, `MissionReminderService`) that need to
+ * treat `failed` and `rejected` as terminal for *their* purposes — even
+ * though those statuses are NOT terminal in the strict state-machine sense
+ * (they can transition back to `queued` via the retry path).
+ *
+ * Hoisted to close the canonical-set duplication anti-pattern called out
+ * by Arch on PR #357 (INBOUND-1) N2. Previously each SLA caller redeclared
+ * a 5-element local set; this single source of truth keeps them aligned
+ * if a new "exit-the-queue" status is added in the future.
+ *
+ * Members:
+ * - `done` / `verified` / `cancelled` — strictly terminal (cannot transition).
+ * - `failed` / `rejected` — semantically "exited active queue" for SLA timer
+ *   no-op + reentrancy-lock release purposes, even though the state machine
+ *   permits `rejected → queued` (retry) and `failed` is not formally terminal.
+ *
+ * Use this set when answering "should the SLA timer / reentrancy lock
+ * release based on the current WI state?", and use {@link TERMINAL_WORK_ITEM_STATUSES}
+ * when answering "is the state machine done with this WI?".
+ */
+export const SLA_TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus> =
+  new Set<WorkItemStatus>([
+    'done',
+    'verified',
+    'cancelled',
+    'failed',
+    'rejected',
+  ]);
+
 // ---------------------------------------------------------------------------
 // Core Interface
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the INBOUND-1.f2 follow-up. Status of all 5 nice-to-haves Arch flagged on PR #357:

| # | Item | Status |
|---|---|---|
| N1 | `TERMINAL_WI_STATUSES` typed as `ReadonlySet<WorkItemStatus>` | ✅ shipped in PR #360 (`87bca6e1`) |
| **N2** | **Canonical SLA-terminal set hoist** | ✅ **shipped in this PR** |
| N3 | `handleEscalation` transitions WI to `'failed'` with `slaResolvedReason` | ✅ shipped in PR #360 (`87bca6e1`) |
| N4 | TODO comment for chat-v2 `changedField` revisit | ✅ shipped in PR #360 (`87bca6e1`) |
| N5 | WI `type: 'review'` rename for `respond_to_user` | 🟦 **deferred** — see decision below |

This PR therefore lands the one remaining 1-5 LOC item not picked up by PR #360 (N2) and records the deferral decision for N5.

## N2 — Canonical SLA-terminal set hoist

Two SLA-style consumers were redeclaring the same 5-element terminal status set inline, exactly the canonical-set-duplication anti-pattern Arch flagged on PR #354 N1, now surfacing at a different module:

- `request-sla.subscriber.ts:155-161` — local `TERMINAL_WI_STATUSES` (5 elements)
- `mission-reminder.service.ts:67-71` — local `PENDING_REVIEW_TERMINAL_STATUSES` (`TERMINAL_WORK_ITEM_STATUSES` ∪ `{failed, rejected}`)

Both end up with the same set: `{ done, verified, cancelled, failed, rejected }`.

### Hoist
Adds `SLA_TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus>` to `backend/src/types/v2/work-item.types.ts`, alongside (NOT replacing) the strict-terminal `TERMINAL_WORK_ITEM_STATUSES`. JSDoc explains the semantic difference:

- `TERMINAL_WORK_ITEM_STATUSES` answers _"is the state machine done with this WI?"_ (3 members)
- `SLA_TERMINAL_WORK_ITEM_STATUSES` answers _"should the SLA timer / reentrancy lock release based on the current WI state?"_ (5 members — adds `failed` and `rejected`, which the state machine does NOT consider strictly terminal because they can transition back to `queued` via the retry path)

Both consumers now alias the canonical export instead of redeclaring locally.

## N5 — WorkItem type rename: DEFERRED (decision recorded)

Spec proposed two paths:
- **(a) `type: 'execute'` (~1 LOC change)** — verified NOT viable on origin/main: `'execute'` is not a member of `WORK_ITEM_TYPES` (valid set: `{ delegate, project_task, check, notify, cron_run, review, confirm, reconcile }`). Spec's "1 LOC" estimate was based on a type that does not exist.
- **(b) New `'respond'` type (heavier)** — requires modifying `WORK_ITEM_TYPES`, possibly `WORK_ITEM_TRANSITIONS` / `TRANSITION_PERMISSIONS`, plus any frontend type-filter UI that keys on `'review'`. Firmly outside the f2 envelope of "1-5 LOC each".

Spec itself recommends _"Defer until orc terminal grows a per-type filter UI"_. Decision: **defer per spec** — will be picked up when the orc terminal grows per-type filter affordances that make the semantic distinction observable.

## Files changed (+85 / -29, 4 files — all backend)

- `backend/src/types/v2/work-item.types.ts` — new export
- `backend/src/types/v2/work-item.types.test.ts` — 4 new specs on the new constant
- `backend/src/services/v3/request-sla.subscriber.ts` — alias to imported constant
- `backend/src/services/v3/mission-reminder.service.ts` — alias to imported constant + drop unused `TERMINAL_WORK_ITEM_STATUSES` import

## Test plan

- [x] `npx tsc --noEmit -p backend/tsconfig.json` — clean
- [x] `npm run build:backend` — clean
- [x] `npx jest backend/src/types/v2/work-item.types.test.ts backend/src/services/v3/request-sla.subscriber.test.ts backend/src/services/v3/mission-reminder.service.test.ts` → **3 suites, 173 tests passing** (4 new + 169 existing, no regressions)
- [x] New constant: 5-member content + exact size + strict-superset of `TERMINAL_WORK_ITEM_STATUSES` + exclusion of active-queue statuses (`queued`, `running`, `blocked`, `done_by_worker`, `escalated`)
- [x] Existing consumer specs all green against the aliased binding (no behavioural change — identical 5-member content)

## Compliance

- 1:1 source-to-test ratio per CLAUDE.md (every modified source file with observable behaviour has its co-located test extended; the two consumer files are pure aliases with identical runtime semantics)
- JSDoc on the new export including a "when to use this vs the strict TERMINAL set" usage note
- No hardcoded magic; single source of truth for the 5-element set

## OKR linkage

KR3 polish — orc terminal hygiene + state-machine canonicalization. Closes the canonical-set duplication anti-pattern called out by Arch on PR #357.

## References

- Spec: `.crewly/tasks/autonomy_v1/follow-up/inbound_1_arch_nice_to_haves.md`
- Sister PR: #360 (`87bca6e1`) — N1+N3+N4
- Related anti-pattern: PR #354 N1 (canonical-set duplication, hoisted earlier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)