### PR TITLE
feat(autonomy_v1): cross-machine event triggers (f1) — OSS-side

### DIFF
--- a/backend/src/controllers/cloud/cloud.controller.ts
+++ b/backend/src/controllers/cloud/cloud.controller.ts
@@ -200,6 +200,16 @@ export async function connectToCloud(req: Request, res: Response, next: NextFunc
       } catch {
         logger.debug('MessageRouterService start deferred (non-fatal)');
       }
+
+      // autonomy_v1.f1 — start the cross-machine event bridges so paired
+      // devices can fire local triggers (inbound) and so allow-listed
+      // local events broadcast to peers (outbound). Non-blocking.
+      try {
+        const { startCrossMachineEventBridges } = await import('../../services/cloud/cloud-initializer.js');
+        startCrossMachineEventBridges(process.cwd());
+      } catch {
+        logger.debug('CrossMachineEventBridges start deferred (non-fatal)');
+      }
     } catch (syncErr) {
       logger.warn('CloudSyncService start failed (non-fatal)', {
         error: syncErr instanceof Error ? syncErr.message : String(syncErr),

--- a/backend/src/controllers/event-bus/event-bus.controller.ts
+++ b/backend/src/controllers/event-bus/event-bus.controller.ts
@@ -24,6 +24,19 @@ export function setEventBusService(service: EventBusService): void {
 }
 
 /**
+ * Get the module-level EventBusService instance, or null when boot hasn't
+ * wired it yet. Used by services that initialise lazily (e.g. the
+ * autonomy_v1.f1 cross-machine event bridges started after Cloud
+ * connects). Mirrors `getEventBusServiceForTaskCleanup` in
+ * task-management.controller.
+ *
+ * @returns The configured EventBusService or null when not yet set.
+ */
+export function getEventBusService(): EventBusService | null {
+  return eventBusService;
+}
+
+/**
  * POST /api/events/subscribe
  *
  * Create a new event subscription.

--- a/backend/src/services/cloud/cloud-event-bridge.service.test.ts
+++ b/backend/src/services/cloud/cloud-event-bridge.service.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for CloudEventInboundBridge (autonomy_v1.f1, Arch N1 file separation).
+ *
+ * Verifies that inbound `'event'` MessageType messages on the cloud transport
+ * are translated into local AgentEvents stamped with `source: 'remote'` +
+ * `originDeviceId` and re-published onto the EventBus, while:
+ *   - non-`event` MessageTypes are ignored,
+ *   - malformed `EventMessagePayload` is dropped with a warn log,
+ *   - unknown-to-local peer event types are accepted via the
+ *     `RemoteEventType = string` boundary cast (Arch Q4) without widening
+ *     the closed `EVENT_TYPES` enum,
+ *   - start/stop is idempotent and detaches the cloud listener cleanly.
+ *
+ * @module services/cloud/cloud-event-bridge.service.test
+ */
+
+import { EventEmitter } from 'events';
+import {
+	CloudEventInboundBridge,
+	type CloudMessageEmitter,
+} from './cloud-event-bridge.service.js';
+import type { IncomingMessage } from './cloud-sync.types.js';
+import type { AgentEvent } from '../../types/event-bus.types.js';
+import type { EventBusService } from '../event-bus/event-bus.service.js';
+
+// Mock the logger module so the bridge constructor can fall back to its
+// default logger without booting the full LoggerService singleton.
+jest.mock('../core/logger.service.js', () => ({
+	LoggerService: {
+		getInstance: () => ({
+			createComponentLogger: () => ({
+				debug: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+			}),
+		}),
+	},
+}));
+
+/**
+ * Build a minimum IncomingMessage with an EventMessagePayload body.
+ */
+function makeEventMessage(overrides?: {
+	id?: string;
+	from?: string;
+	event?: Partial<AgentEvent>;
+	originDeviceId?: string;
+	originDeviceName?: string;
+}): IncomingMessage {
+	const event = {
+		id: 'evt-uuid-1',
+		type: 'xhs:scrape:done',
+		sessionName: 'iriss-air-marketing',
+		timestamp: '2026-04-28T01:44:12.345Z',
+		teamId: 'team-marketing',
+		teamName: 'Marketing',
+		memberId: 'member-1',
+		memberName: 'Iriss',
+		previousValue: '',
+		newValue: 'done',
+		changedField: 'workingStatus',
+		...(overrides?.event ?? {}),
+	};
+
+	return {
+		id: overrides?.id ?? 'cloud-msg-1',
+		from: overrides?.from ?? 'device-A',
+		fromDeviceName: overrides?.originDeviceName ?? 'iriss-air',
+		type: 'event',
+		payload: {
+			event,
+			originDeviceId: overrides?.originDeviceId ?? 'device-A',
+			originDeviceName: overrides?.originDeviceName ?? 'iriss-air',
+		},
+		encrypted: false,
+		sentAt: '2026-04-28T01:44:12.345Z',
+	};
+}
+
+describe('CloudEventInboundBridge', () => {
+	let cloudSync: EventEmitter;
+	let eventBus: { publish: jest.Mock };
+	let bridge: CloudEventInboundBridge;
+
+	beforeEach(() => {
+		cloudSync = new EventEmitter();
+		eventBus = { publish: jest.fn() };
+		bridge = new CloudEventInboundBridge({
+			cloudSync: cloudSync as unknown as CloudMessageEmitter,
+			eventBus: eventBus as unknown as EventBusService,
+		});
+	});
+
+	afterEach(() => {
+		bridge.stop();
+		cloudSync.removeAllListeners();
+	});
+
+	describe('start / stop lifecycle', () => {
+		it('subscribes to the cloud transport on start', () => {
+			expect(cloudSync.listenerCount('message')).toBe(0);
+			bridge.start();
+			expect(cloudSync.listenerCount('message')).toBe(1);
+		});
+
+		it('start() is idempotent (no listener leak)', () => {
+			bridge.start();
+			bridge.start();
+			bridge.start();
+			expect(cloudSync.listenerCount('message')).toBe(1);
+		});
+
+		it('stop() detaches the listener', () => {
+			bridge.start();
+			bridge.stop();
+			expect(cloudSync.listenerCount('message')).toBe(0);
+		});
+
+		it('stop() before start() is a no-op', () => {
+			expect(() => bridge.stop()).not.toThrow();
+		});
+	});
+
+	describe('inbound event re-publishing', () => {
+		beforeEach(() => bridge.start());
+
+		it("re-publishes an 'event' MessageType onto EventBus with source='remote' + originDeviceId", () => {
+			cloudSync.emit('message', makeEventMessage());
+
+			expect(eventBus.publish).toHaveBeenCalledTimes(1);
+			const published = eventBus.publish.mock.calls[0][0] as AgentEvent;
+			expect(published.id).toBe('evt-uuid-1');
+			expect(published.type).toBe('xhs:scrape:done');
+			expect(published.sessionName).toBe('iriss-air-marketing');
+			expect(published.source).toBe('remote');
+			expect(published.originDeviceId).toBe('device-A');
+		});
+
+		it('passes through extra event fields the origin device set (e.g. workItemId, missionId)', () => {
+			cloudSync.emit(
+				'message',
+				makeEventMessage({
+					event: {
+						workItemId: 'wi-123',
+						missionId: 'mission-A',
+						requestId: 'req-77',
+					},
+				}),
+			);
+
+			const published = eventBus.publish.mock.calls[0][0] as AgentEvent;
+			expect(published.workItemId).toBe('wi-123');
+			expect(published.missionId).toBe('mission-A');
+			expect(published.requestId).toBe('req-77');
+		});
+
+		it('preserves origin sessionName (does NOT prepend deviceId per Arch Q3)', () => {
+			cloudSync.emit(
+				'message',
+				makeEventMessage({
+					originDeviceId: 'device-A',
+					event: { sessionName: 'pristine-session-name' },
+				}),
+			);
+
+			const published = eventBus.publish.mock.calls[0][0] as AgentEvent;
+			// sessionName is the bare origin value — disambiguation by origin
+			// device is via EventFilter.originDeviceId, not by mutating
+			// sessionName.
+			expect(published.sessionName).toBe('pristine-session-name');
+			expect(published.originDeviceId).toBe('device-A');
+		});
+
+		it('accepts unknown-to-local event types via RemoteEventType boundary cast (Arch Q4)', () => {
+			cloudSync.emit(
+				'message',
+				makeEventMessage({
+					event: { type: 'peer:future:event:type' as unknown as AgentEvent['type'] },
+				}),
+			);
+
+			expect(eventBus.publish).toHaveBeenCalledTimes(1);
+			const published = eventBus.publish.mock.calls[0][0] as AgentEvent;
+			expect(published.type).toBe('peer:future:event:type');
+		});
+
+		it('ignores non-event MessageTypes (no publish)', () => {
+			const otherMsg: IncomingMessage = {
+				id: 'cloud-msg-2',
+				from: 'device-B',
+				fromDeviceName: 'other',
+				type: 'agent_message',
+				payload: { targetSession: 'agent-x', message: 'hi', fromDevice: 'device-B', fromDeviceName: 'other' },
+				encrypted: false,
+				sentAt: '2026-04-28T01:44:12.345Z',
+			};
+			cloudSync.emit('message', otherMsg);
+
+			expect(eventBus.publish).not.toHaveBeenCalled();
+		});
+
+		it('drops malformed EventMessagePayload without throwing or publishing', () => {
+			const badMsg: IncomingMessage = {
+				id: 'cloud-msg-3',
+				from: 'device-A',
+				fromDeviceName: 'iriss-air',
+				type: 'event',
+				payload: {
+					// missing originDeviceId
+					event: { id: 'evt-9', type: 't', sessionName: 's', timestamp: 'now' },
+				},
+				encrypted: false,
+				sentAt: 'now',
+			};
+			expect(() => cloudSync.emit('message', badMsg)).not.toThrow();
+			expect(eventBus.publish).not.toHaveBeenCalled();
+		});
+
+		it('drops payload whose event lacks a non-empty id', () => {
+			const badMsg: IncomingMessage = {
+				id: 'cloud-msg-4',
+				from: 'device-A',
+				fromDeviceName: 'iriss-air',
+				type: 'event',
+				payload: {
+					event: { id: '', type: 'xhs:scrape:done', sessionName: 's', timestamp: 'now' },
+					originDeviceId: 'device-A',
+				},
+				encrypted: false,
+				sentAt: 'now',
+			};
+			cloudSync.emit('message', badMsg);
+			expect(eventBus.publish).not.toHaveBeenCalled();
+		});
+
+		it('isolates a thrown publish error from the cloud listener (does not leak)', () => {
+			eventBus.publish.mockImplementationOnce(() => {
+				throw new Error('publish blew up');
+			});
+			expect(() => cloudSync.emit('message', makeEventMessage())).not.toThrow();
+		});
+
+		it('is idempotent across start cycles — second start re-uses the same single listener', () => {
+			bridge.stop();
+			bridge.start();
+			bridge.start();
+			cloudSync.emit('message', makeEventMessage({ id: 'cloud-msg-cycle' }));
+			// Exactly one publish — listener didn't double-up.
+			expect(eventBus.publish).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/backend/src/services/cloud/cloud-event-bridge.service.ts
+++ b/backend/src/services/cloud/cloud-event-bridge.service.ts
@@ -1,0 +1,226 @@
+/**
+ * Cloud Event Inbound Bridge — autonomy_v1.f1
+ *
+ * Receives `'event'` MessageType inbound from the Cloud Relay (via the
+ * existing CloudSyncService poll → `'message'` event-emitter hop) and
+ * re-publishes the carried AgentEvent onto the local EventBusService with
+ * `source = 'remote'` and `originDeviceId` stamped from the wire envelope.
+ *
+ * Compose-at-boundary discipline (per Arch verdict 2026-04-28 N1):
+ *   - CloudSyncService stays a transport — it polls Cloud, dedupes by
+ *     `processedMessageIds`, emits an in-process `'message'` event.
+ *   - This service is the AgentEvent translator. It owns the bridge between
+ *     the cloud message vocabulary (`MessageType` + `EventMessagePayload`)
+ *     and the local event-bus vocabulary (`AgentEvent`). It does NOT touch
+ *     the poll loop or the cloud transport.
+ *
+ * Mirrors the BRIDGE-1 ↔ EventBus separation pattern: CloudSync EMITS,
+ * downstream LISTENS. Same shape as PR #347 (BrandOnboarding ⊥
+ * OnboardingService) and PR #348 (StatusBadge ⊥ RequestStatusPill) where
+ * two parallel modules share a single narrow artifact.
+ *
+ * Idempotency:
+ *   The local LRU at CloudSyncService blocks at-least-once cloud-message-id
+ *   re-delivery upstream. The recent-publish suppression in EventBusService
+ *   (post-M2 fix: `${type}:${sessionName}:${event.id}`) catches any
+ *   duplicate that slips through to the publish boundary. The TriggerEngine
+ *   per-trigger dedup `${triggerId}:${event.id}` (Slice 3) is the third
+ *   layer at the trigger fire boundary.
+ *
+ * Unknown peer event types (Arch Q4):
+ *   The closed `EVENT_TYPES` enum stays closed. Bridge accepts any string
+ *   at the wire boundary via `RemoteEventType = string` and casts to
+ *   `EventType` at the local re-publish boundary so the rest of the
+ *   pipeline sees a stable type. A debug log names any unrecognised type
+ *   so ops can audit drift.
+ *
+ * @module services/cloud/cloud-event-bridge.service
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { formatError } from '../../utils/format-error.js';
+import type { EventBusService } from '../event-bus/event-bus.service.js';
+import type {
+	AgentEvent,
+	EventType,
+	RemoteEventType,
+} from '../../types/event-bus.types.js';
+import { EVENT_TYPES } from '../../types/event-bus.types.js';
+import {
+	isEventMessagePayload,
+	type IncomingMessage,
+} from './cloud-sync.types.js';
+
+/**
+ * Minimum shape this bridge needs from the upstream cloud transport.
+ * Defined locally rather than importing the full {@link CloudSyncService}
+ * type so the bridge is unit-testable with a tiny mock and isn't coupled
+ * to the whole transport surface.
+ */
+export interface CloudMessageEmitter {
+	on(eventName: 'message', listener: (msg: IncomingMessage) => void): this;
+	off(eventName: 'message', listener: (msg: IncomingMessage) => void): this;
+}
+
+/**
+ * Constructor dependencies for the inbound bridge.
+ */
+export interface CloudEventInboundBridgeDeps {
+	/** Cloud transport that emits 'message' events (CloudSyncService in prod). */
+	cloudSync: CloudMessageEmitter;
+	/** Local event bus the bridge publishes onto. */
+	eventBus: EventBusService;
+	/** Optional logger override (test isolation). */
+	logger?: ComponentLogger;
+}
+
+/**
+ * Bridges inbound cross-machine events from Cloud Relay → local EventBus.
+ *
+ * @example
+ * ```typescript
+ * const bridge = new CloudEventInboundBridge({
+ *   cloudSync: CloudSyncService.getInstance(),
+ *   eventBus: EventBusService.getInstance(),
+ * });
+ * bridge.start();
+ * // ... later
+ * bridge.stop();
+ * ```
+ */
+export class CloudEventInboundBridge {
+	private readonly logger: ComponentLogger;
+	private readonly cloudSync: CloudMessageEmitter;
+	private readonly eventBus: EventBusService;
+
+	/**
+	 * Bound listener kept so {@link stop} can detach it cleanly. Without
+	 * this, repeated start/stop cycles (dev reloads, tests) would leak
+	 * additional listeners.
+	 */
+	private listener: ((msg: IncomingMessage) => void) | null = null;
+
+	/** Whether the bridge is currently subscribed. */
+	private running = false;
+
+	/**
+	 * Construct the bridge. Subscription does NOT start until
+	 * {@link start} is called explicitly so callers control lifecycle.
+	 */
+	constructor(deps: CloudEventInboundBridgeDeps) {
+		this.cloudSync = deps.cloudSync;
+		this.eventBus = deps.eventBus;
+		this.logger =
+			deps.logger ??
+			LoggerService.getInstance().createComponentLogger('CloudEventInboundBridge');
+	}
+
+	/**
+	 * Subscribe to the cloud transport's `'message'` event. Idempotent — a
+	 * second `start()` call is a no-op.
+	 */
+	start(): void {
+		if (this.running) return;
+		this.listener = (msg: IncomingMessage) => {
+			try {
+				this.handle(msg);
+			} catch (err) {
+				// Defensive — handle() already swallows known failure modes,
+				// but a thrown error here MUST NOT poison other 'message'
+				// listeners on the cloud transport.
+				this.logger.error('CloudEventInboundBridge handler threw', {
+					error: formatError(err),
+					messageId: msg?.id,
+				});
+			}
+		};
+		this.cloudSync.on('message', this.listener);
+		this.running = true;
+		this.logger.info('CloudEventInboundBridge started — listening for `event` MessageType');
+	}
+
+	/**
+	 * Detach the cloud transport listener. Safe to call when not running.
+	 */
+	stop(): void {
+		if (this.listener) {
+			this.cloudSync.off('message', this.listener);
+			this.listener = null;
+		}
+		this.running = false;
+	}
+
+	/**
+	 * Process a single inbound cloud message. Filters on `type === 'event'`,
+	 * validates the payload shape, then re-publishes the carried AgentEvent
+	 * onto the local EventBus with `source = 'remote'` + `originDeviceId`.
+	 *
+	 * Public for unit tests only; production code should drive the bridge
+	 * via the cloud transport's `'message'` event.
+	 */
+	public handle(msg: IncomingMessage): void {
+		// Wrong type — leave it for the consumer that actually owns it
+		// (CrossMachineMessageRouter, browser command handler, etc).
+		if (msg.type !== 'event') {
+			return;
+		}
+
+		if (!isEventMessagePayload(msg.payload)) {
+			this.logger.warn('Dropping malformed cross-machine event payload', {
+				messageId: msg.id,
+				from: msg.from,
+			});
+			return;
+		}
+
+		const { event: wireEvent, originDeviceId, originDeviceName } = msg.payload;
+		const remoteType: RemoteEventType = wireEvent.type;
+
+		// Per Arch Q4: log when a peer ships a type we don't know locally.
+		// We still re-publish — closed-enum sync would create a deployment-
+		// ordering constraint we explicitly rejected.
+		if (!isKnownEventType(remoteType)) {
+			this.logger.debug(
+				'Cross-machine event with unknown-to-local event type — accepting via RemoteEventType boundary',
+				{
+					messageId: msg.id,
+					eventId: wireEvent.id,
+					unknownType: remoteType,
+					originDeviceId,
+				},
+			);
+		}
+
+		// Build the AgentEvent. Wire payload may carry extra fields the
+		// origin device knew about (e.g. workItemId, missionId, requestId)
+		// — pass them through unchanged. Our bridge only stamps the two
+		// origin-tag fields.
+		const agentEvent: AgentEvent = {
+			...(wireEvent as unknown as AgentEvent),
+			// Cast at the boundary per Arch Q4. Closed `EVENT_TYPES` enum
+			// stays closed; downstream consumers see a stable EventType.
+			type: remoteType as EventType,
+			source: 'remote',
+			originDeviceId,
+		};
+
+		this.logger.info('Re-publishing cross-machine event onto local EventBus', {
+			messageId: msg.id,
+			eventId: agentEvent.id,
+			eventType: agentEvent.type,
+			originDeviceId,
+			originDeviceName,
+		});
+
+		this.eventBus.publish(agentEvent);
+	}
+}
+
+/**
+ * Internal helper — true when the wire event-type matches the closed
+ * `EVENT_TYPES` enum. Used only for the debug-log breadcrumb; does NOT
+ * gate re-publish (per Arch Q4).
+ */
+function isKnownEventType(value: string): boolean {
+	return (EVENT_TYPES as readonly string[]).includes(value);
+}

--- a/backend/src/services/cloud/cloud-event-forwarder.service.test.ts
+++ b/backend/src/services/cloud/cloud-event-forwarder.service.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for CloudEventForwarder (autonomy_v1.f1, Slice 5).
+ *
+ * Coverage:
+ *   - Allow-list gating (Q1 LOCKED — opt-in via crewly.json).
+ *   - Q5 LOCKED — dedicated forwarder-loop-prevention `it()` test (PR
+ *     #354 N1 fence-at-test-surface pattern). Forwarder MUST short-
+ *     circuit on `event.source === 'remote'`.
+ *   - Fail-safe behaviour on malformed / missing config.
+ *   - Stripping of cross-machine origin fields from the wire payload so
+ *     the receiving bridge stamps them from the envelope.
+ *   - Forward-on-broadcast happy path with allow-list override.
+ *   - Lifecycle (idempotent start, clean stop).
+ *
+ * @module services/cloud/cloud-event-forwarder.service.test
+ */
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { EventBusService } from '../event-bus/event-bus.service.js';
+import {
+	CloudEventForwarder,
+	type CloudEventSender,
+} from './cloud-event-forwarder.service.js';
+import type { AgentEvent } from '../../types/event-bus.types.js';
+
+// Match the project pattern for logger isolation.
+jest.mock('../core/logger.service.js', () => ({
+	LoggerService: {
+		getInstance: () => ({
+			createComponentLogger: () => ({
+				debug: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+			}),
+		}),
+	},
+}));
+
+/**
+ * Build a minimum AgentEvent carrying enough fields for the forwarder to
+ * publish + serialise. Tests override only what the assertion needs.
+ */
+function makeEvent(overrides?: Partial<AgentEvent>): AgentEvent {
+	return {
+		id: 'evt-1',
+		type: 'xhs:scrape:done' as AgentEvent['type'],
+		timestamp: '2026-04-28T01:44:12.345Z',
+		teamId: 'team-marketing',
+		teamName: 'Marketing',
+		memberId: 'member-1',
+		memberName: 'Iriss',
+		sessionName: 'iriss-air-marketing',
+		previousValue: '',
+		newValue: 'done',
+		changedField: 'workingStatus',
+		...overrides,
+	};
+}
+
+describe('CloudEventForwarder', () => {
+	let eventBus: EventBusService;
+	let cloudSync: CloudEventSender & { sendMessage: jest.Mock };
+	let forwarder: CloudEventForwarder;
+
+	beforeEach(() => {
+		eventBus = new EventBusService();
+		cloudSync = {
+			sendMessage: jest.fn().mockResolvedValue(undefined),
+		};
+	});
+
+	afterEach(() => {
+		forwarder?.stop();
+		eventBus.cleanup();
+	});
+
+	// -------------------------------------------------------------------------
+	// Q5 LOCKED — dedicated forwarder-loop-prevention test
+	// -------------------------------------------------------------------------
+
+	it('Q5 LOCKED — does NOT forward events with source="remote" (loop-prevention fence)', async () => {
+		// This is the dedicated `it()` per Arch verdict 2026-04-28 Q5 +
+		// PR #354 N1 fence-at-test-surface pattern. Without the
+		// `if (event.source === 'remote') return` short-circuit in
+		// CloudEventForwarder.handle, the inbound bridge → forwarder pair
+		// forms an infinite ping-pong loop. If anyone removes the fence,
+		// THIS test fails immediately.
+		forwarder = new CloudEventForwarder({
+			cloudSync,
+			eventBus,
+			originDeviceId: 'device-A',
+			projectPath: '/tmp/test-project-q5',
+			allowListOverride: ['xhs:scrape:done'], // explicitly listed
+		});
+		await forwarder.start();
+
+		// Simulate the inbound bridge re-publishing a remote event onto
+		// the local bus. Even though its type is on the allow-list, the
+		// forwarder MUST NOT re-broadcast it.
+		eventBus.publish(makeEvent({
+			source: 'remote',
+			originDeviceId: 'device-B',
+		}));
+
+		// Allow microtasks to flush.
+		await Promise.resolve();
+
+		expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+	});
+
+	// -------------------------------------------------------------------------
+	// Allow-list gating (Q1)
+	// -------------------------------------------------------------------------
+
+	describe('allow-list gating (Q1)', () => {
+		it('forwards LOCAL events whose type is on the allow-list', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				originDeviceName: 'iriss-air',
+				projectPath: '/tmp/test-project-allowed',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).toHaveBeenCalledTimes(1);
+			const [target, type, payload] = cloudSync.sendMessage.mock.calls[0];
+			expect(target).toBe('*broadcast');
+			expect(type).toBe('event');
+			expect(payload.event.id).toBe('evt-1');
+			expect(payload.event.type).toBe('xhs:scrape:done');
+			expect(payload.originDeviceId).toBe('device-A');
+			expect(payload.originDeviceName).toBe('iriss-air');
+		});
+
+		it('does NOT forward LOCAL events whose type is off the allow-list', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-project-blocked',
+				allowListOverride: ['xhs:scrape:done'], // not agent:idle
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent({ type: 'agent:idle' as AgentEvent['type'] }));
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('empty allow-list = no-op forwarder (no listeners attached)', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-project-empty',
+				allowListOverride: [],
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Wire payload contract
+	// -------------------------------------------------------------------------
+
+	describe('wire payload', () => {
+		it('strips source + originDeviceId off event before serialising (envelope owns those)', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-project-strip',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+
+			// Local publish — defaults source='local' at publish.
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			const payload = cloudSync.sendMessage.mock.calls[0][2];
+			expect(payload.event.source).toBeUndefined();
+			expect(payload.event.originDeviceId).toBeUndefined();
+			// Per-event metadata is preserved.
+			expect(payload.event.timestamp).toBe('2026-04-28T01:44:12.345Z');
+			expect(payload.event.sessionName).toBe('iriss-air-marketing');
+		});
+
+		it('passes through extra event fields the publisher sets (workItemId / missionId / requestId)', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-project-passthrough',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+
+			eventBus.publish(
+				makeEvent({
+					workItemId: 'wi-77',
+					missionId: 'mission-X',
+					requestId: 'req-42',
+				}),
+			);
+			await Promise.resolve();
+
+			const payload = cloudSync.sendMessage.mock.calls[0][2];
+			expect(payload.event.workItemId).toBe('wi-77');
+			expect(payload.event.missionId).toBe('mission-X');
+			expect(payload.event.requestId).toBe('req-42');
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Allow-list resolution from crewly.json
+	// -------------------------------------------------------------------------
+
+	describe('crewly.json allow-list resolution', () => {
+		let tmpDir: string;
+
+		beforeEach(async () => {
+			tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'forwarder-cfg-'));
+		});
+
+		afterEach(async () => {
+			try {
+				await fs.rm(tmpDir, { recursive: true, force: true });
+			} catch {
+				/* best-effort cleanup */
+			}
+		});
+
+		it('reads `crossMachineEvents` array from crewly.json', async () => {
+			await fs.writeFile(
+				path.join(tmpDir, 'crewly.json'),
+				JSON.stringify({ crossMachineEvents: ['xhs:scrape:done', 'agent:idle'] }),
+			);
+
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: tmpDir,
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent({ type: 'xhs:scrape:done' as AgentEvent['type'] }));
+			eventBus.publish(makeEvent({
+				id: 'evt-2',
+				sessionName: 'agent-other', // avoid recent-publish suppression
+				type: 'agent:idle' as AgentEvent['type'],
+			}));
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).toHaveBeenCalledTimes(2);
+		});
+
+		it('missing crewly.json → empty allow-list → no-op', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: tmpDir, // no crewly.json written
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('malformed crewly.json (non-JSON) → empty allow-list → no-op (fail-safe)', async () => {
+			await fs.writeFile(path.join(tmpDir, 'crewly.json'), 'not json {');
+
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: tmpDir,
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('crossMachineEvents present but not an array → empty allow-list → no-op (fail-safe)', async () => {
+			await fs.writeFile(
+				path.join(tmpDir, 'crewly.json'),
+				JSON.stringify({ crossMachineEvents: 'xhs:scrape:done' }), // string not array
+			);
+
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: tmpDir,
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('drops non-string entries from crossMachineEvents (forwarder still works for valid entries)', async () => {
+			await fs.writeFile(
+				path.join(tmpDir, 'crewly.json'),
+				JSON.stringify({ crossMachineEvents: ['xhs:scrape:done', 42, null, ''] }),
+			);
+
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: tmpDir,
+			});
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Lifecycle
+	// -------------------------------------------------------------------------
+
+	describe('lifecycle', () => {
+		it('start() is idempotent — no double subscription', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-idempotent',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+			await forwarder.start();
+			await forwarder.start();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			// Single subscription means single forward.
+			expect(cloudSync.sendMessage).toHaveBeenCalledTimes(1);
+		});
+
+		it('stop() detaches all listeners — subsequent publishes do not forward', async () => {
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-stop',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+			forwarder.stop();
+
+			eventBus.publish(makeEvent());
+			await Promise.resolve();
+
+			expect(cloudSync.sendMessage).not.toHaveBeenCalled();
+		});
+
+		it('isolates a sendMessage rejection — does not throw out of the event-bus dispatch', async () => {
+			cloudSync.sendMessage.mockRejectedValueOnce(new Error('cloud outage'));
+			forwarder = new CloudEventForwarder({
+				cloudSync,
+				eventBus,
+				originDeviceId: 'device-A',
+				projectPath: '/tmp/test-rejection',
+				allowListOverride: ['xhs:scrape:done'],
+			});
+			await forwarder.start();
+
+			expect(() => eventBus.publish(makeEvent())).not.toThrow();
+			await Promise.resolve();
+			await Promise.resolve(); // flush microtask for the awaited reject
+		});
+	});
+});

--- a/backend/src/services/cloud/cloud-event-forwarder.service.ts
+++ b/backend/src/services/cloud/cloud-event-forwarder.service.ts
@@ -1,0 +1,302 @@
+/**
+ * Cloud Event Outbound Forwarder — autonomy_v1.f1
+ *
+ * Closes the bidirectional cross-machine event loop. Subscribes to the
+ * local EventBusService for events whose type is on an OPT-IN allow-list
+ * (read from `crewly.json` at project root, key `crossMachineEvents`) and
+ * forwards each via `cloudSync.sendMessage(broadcast, 'event', payload)`
+ * so paired devices receive them at their inbound bridge.
+ *
+ * Forwarder discipline (per Arch verdict 2026-04-28):
+ *   - **Q1 LOCKED — OPT-IN allow-list.** v1 forwards ONLY events whose
+ *     type is explicitly listed in `crewly.json` `crossMachineEvents`.
+ *     Reasons: privacy (avoid leaking internal events to peers), payload
+ *     bloat, per-paired-device DoS-source containment. Empty allow-list
+ *     → forwarder is a no-op.
+ *   - **Q5 LOCKED — Loop-prevention fence.** The forwarder MUST short-
+ *     circuit on `event.source === 'remote'`. Otherwise the inbound
+ *     bridge re-publishes a remote event onto the local EventBus, the
+ *     forwarder picks it up, ships it back to cloud, cloud fans it out
+ *     again, etc. The fence is locked at the test surface via a
+ *     dedicated `it()` (PR #354 N1 fence-at-test-surface pattern).
+ *   - **Fail-safe on config.** Malformed `crewly.json`, missing file, or
+ *     non-array `crossMachineEvents` → forwarder defaults to no-op (NOT
+ *     "forward everything"). Surfaces an error log so ops can spot the
+ *     misconfiguration without leaking events accidentally.
+ *
+ * Compose-at-boundary discipline (Arch N1, mirrors the inbound bridge):
+ *   - CloudSyncService stays a transport — the forwarder calls
+ *     `sendMessage` and that's the only coupling point.
+ *   - This forwarder is a NEW file at the same boundary level as
+ *     `cloud-event-bridge.service.ts`. Inbound and outbound bridges are
+ *     symmetric.
+ *
+ * @module services/cloud/cloud-event-forwarder.service
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { formatError } from '../../utils/format-error.js';
+import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
+import type {
+	AgentEvent,
+	EventType,
+} from '../../types/event-bus.types.js';
+import type { EventMessagePayload } from './cloud-sync.types.js';
+
+/**
+ * Minimum cloud transport surface needed for outbound. Defined locally
+ * (mirrors `CloudMessageEmitter` in the inbound bridge) so the test mock
+ * is tiny and the forwarder is not coupled to the entire CloudSyncService.
+ */
+export interface CloudEventSender {
+	/**
+	 * Broadcast an `'event'` MessageType to all paired devices in the same
+	 * tenant. Cloud Relay handles the fan-out (web/ ticket).
+	 *
+	 * For v1 we use a sentinel deviceId `'*broadcast'` per the cloud
+	 * contract spec §(c). Future v2 may add per-event subscription
+	 * routing, in which case the call site here changes; the contract
+	 * field shape is forward-compatible.
+	 */
+	sendMessage(toDeviceId: string, type: 'event', payload: EventMessagePayload): Promise<void>;
+}
+
+/**
+ * Constructor dependencies for the outbound forwarder.
+ */
+export interface CloudEventForwarderDeps {
+	/** Cloud transport for `sendMessage` (CloudSyncService in prod). */
+	cloudSync: CloudEventSender;
+	/** Local event bus the forwarder subscribes to. */
+	eventBus: EventBusService;
+	/** Origin device identity stamped onto every outbound payload. */
+	originDeviceId: string;
+	/** Optional human-readable origin device name (for log lines on the peer). */
+	originDeviceName?: string;
+	/** Project root used to resolve `crewly.json`. */
+	projectPath: string;
+	/**
+	 * Optional override for the allow-list. When provided, the forwarder
+	 * uses this instead of reading `crewly.json`. Test injection only.
+	 */
+	allowListOverride?: ReadonlyArray<string>;
+	/** Optional logger override (test isolation). */
+	logger?: ComponentLogger;
+}
+
+/** Sentinel for "fan out to every paired device in the tenant". */
+const BROADCAST_TARGET = '*broadcast';
+
+/**
+ * Forwards local AgentEvents to paired devices via Cloud Relay when their
+ * type is on the configured allow-list.
+ */
+export class CloudEventForwarder {
+	private readonly logger: ComponentLogger;
+	private readonly cloudSync: CloudEventSender;
+	private readonly eventBus: EventBusService;
+	private readonly originDeviceId: string;
+	private readonly originDeviceName?: string;
+	private readonly projectPath: string;
+	private readonly allowListOverride?: ReadonlyArray<string>;
+
+	/** Resolved allow-list of event types. Empty = forwarder is a no-op. */
+	private allowList: ReadonlySet<string> = new Set();
+
+	/** Detach functions returned by EventBusService.onInProcess(). */
+	private unsubscribers: InProcessUnsubscribe[] = [];
+
+	/** Whether the forwarder is currently subscribed. */
+	private running = false;
+
+	constructor(deps: CloudEventForwarderDeps) {
+		this.cloudSync = deps.cloudSync;
+		this.eventBus = deps.eventBus;
+		this.originDeviceId = deps.originDeviceId;
+		this.originDeviceName = deps.originDeviceName;
+		this.projectPath = deps.projectPath;
+		this.allowListOverride = deps.allowListOverride;
+		this.logger =
+			deps.logger ??
+			LoggerService.getInstance().createComponentLogger('CloudEventForwarder');
+	}
+
+	/**
+	 * Load the allow-list and subscribe to the event bus. Idempotent.
+	 *
+	 * The forwarder uses {@link EventBusService.onInProcess} per
+	 * registered allow-list type so it receives FULL `AgentEvent` payloads
+	 * (including the `source` field needed for the loop-prevention fence).
+	 * The widened `'event_published'` emit payload would also work but is
+	 * stripped of optional fields the wire payload needs (e.g. workItemId,
+	 * missionId).
+	 */
+	async start(): Promise<void> {
+		if (this.running) return;
+
+		this.allowList = await this.resolveAllowList();
+		if (this.allowList.size === 0) {
+			this.logger.info(
+				'CloudEventForwarder allow-list is empty — forwarder will be a no-op until configured',
+				{ projectPath: this.projectPath },
+			);
+			this.running = true;
+			return;
+		}
+
+		for (const eventType of this.allowList) {
+			const unsub = this.eventBus.onInProcess(
+				[eventType as EventType],
+				(event) => this.handle(event),
+			);
+			this.unsubscribers.push(unsub);
+		}
+
+		this.running = true;
+		this.logger.info('CloudEventForwarder started', {
+			allowList: Array.from(this.allowList),
+			originDeviceId: this.originDeviceId,
+		});
+	}
+
+	/**
+	 * Detach all event-bus listeners. Safe to call when not running.
+	 */
+	stop(): void {
+		for (const unsub of this.unsubscribers) {
+			try {
+				unsub();
+			} catch (err) {
+				this.logger.warn('CloudEventForwarder unsubscribe threw', { error: formatError(err) });
+			}
+		}
+		this.unsubscribers = [];
+		this.running = false;
+	}
+
+	/**
+	 * Process a single local event — forward to cloud if eligible.
+	 *
+	 * Public for unit tests only; production drives this via the
+	 * EventBusService.onInProcess subscription installed in {@link start}.
+	 */
+	public async handle(event: AgentEvent): Promise<void> {
+		// Q5 LOCKED — loop-prevention fence. NEVER forward an event that
+		// itself arrived from cloud. Without this, the inbound bridge ↔
+		// forwarder pair would form an infinite ping-pong loop.
+		if (event.source === 'remote') {
+			return;
+		}
+
+		// Allow-list gate (Q1 LOCKED).
+		if (!this.allowList.has(event.type)) {
+			return;
+		}
+
+		const payload: EventMessagePayload = {
+			event: {
+				id: event.id,
+				type: event.type,
+				sessionName: event.sessionName,
+				timestamp: event.timestamp,
+				// Pass through the rest of the AgentEvent so the inbound
+				// bridge on the peer device sees the full picture (workItemId,
+				// missionId, requestId, etc.). `source` and `originDeviceId`
+				// are NOT included — the receiving bridge stamps those from
+				// the message envelope so the contract stays symmetric.
+				...stripCrossMachineFields(event),
+			},
+			originDeviceId: this.originDeviceId,
+			originDeviceName: this.originDeviceName,
+		};
+
+		try {
+			await this.cloudSync.sendMessage(BROADCAST_TARGET, 'event', payload);
+			this.logger.debug('CloudEventForwarder broadcast', {
+				eventId: event.id,
+				eventType: event.type,
+			});
+		} catch (err) {
+			// Failure is non-fatal — local processing already happened. We
+			// log + drop. A future enhancement could buffer + retry, but v1
+			// trusts the cloud queue's TTL semantics (see decomp §(c)
+			// errors table).
+			this.logger.warn('CloudEventForwarder broadcast failed', {
+				eventId: event.id,
+				eventType: event.type,
+				error: formatError(err),
+			});
+		}
+	}
+
+	/**
+	 * Resolve the allow-list. Order:
+	 *   1. `allowListOverride` (test injection).
+	 *   2. `<projectPath>/crewly.json` `crossMachineEvents` array.
+	 *   3. Empty (no-op forwarder) — fail-safe default.
+	 *
+	 * Malformed JSON or non-array `crossMachineEvents` → empty + error log.
+	 * NEVER defaults to "forward everything" — privacy + DoS containment.
+	 */
+	private async resolveAllowList(): Promise<ReadonlySet<string>> {
+		if (this.allowListOverride) {
+			return new Set(this.allowListOverride);
+		}
+
+		const configPath = path.join(this.projectPath, 'crewly.json');
+		try {
+			const raw = await fs.readFile(configPath, 'utf-8');
+			const parsed = JSON.parse(raw) as { crossMachineEvents?: unknown };
+			const value = parsed.crossMachineEvents;
+			if (value === undefined || value === null) return new Set();
+			if (!Array.isArray(value)) {
+				this.logger.error(
+					'crewly.json `crossMachineEvents` must be an array — falling back to empty allow-list (no events will forward)',
+					{ configPath, actualType: typeof value },
+				);
+				return new Set();
+			}
+			const cleaned = value.filter((v): v is string => typeof v === 'string' && v.length > 0);
+			if (cleaned.length !== value.length) {
+				this.logger.warn(
+					'crewly.json `crossMachineEvents` contains non-string entries — dropped',
+					{ configPath, kept: cleaned, droppedCount: value.length - cleaned.length },
+				);
+			}
+			return new Set(cleaned);
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === 'ENOENT') {
+				// File simply doesn't exist — silent default to empty.
+				return new Set();
+			}
+			this.logger.error(
+				'Failed to read crewly.json — falling back to empty allow-list (no events will forward)',
+				{ configPath, error: formatError(err) },
+			);
+			return new Set();
+		}
+	}
+}
+
+/**
+ * Strip the cross-machine origin fields off an event before serialising
+ * onto the wire. The receiving bridge stamps `source` + `originDeviceId`
+ * from the message envelope — including them in the payload would let
+ * the wire mutate them mid-flight.
+ */
+function stripCrossMachineFields(event: AgentEvent): Record<string, unknown> {
+	// Shallow copy + drop the two fields. `id`, `type`, `sessionName`,
+	// `timestamp` are added back explicitly by the caller (above) so we
+	// don't double-spread them.
+	const out: Record<string, unknown> = { ...(event as unknown as Record<string, unknown>) };
+	delete out.source;
+	delete out.originDeviceId;
+	delete out.id;
+	delete out.type;
+	delete out.sessionName;
+	delete out.timestamp;
+	return out;
+}

--- a/backend/src/services/cloud/cloud-initializer.ts
+++ b/backend/src/services/cloud/cloud-initializer.ts
@@ -105,6 +105,74 @@ export function startMessageRouter(): void {
 }
 
 /**
+ * Start the cross-machine event bridges (autonomy_v1.f1).
+ *
+ * Wires up both halves of the bidirectional cross-machine event loop:
+ *   - Inbound: `CloudEventInboundBridge` listens for `'event'` MessageType
+ *     from CloudSyncService and re-publishes onto the local EventBus,
+ *     stamped with `source = 'remote'` + `originDeviceId`.
+ *   - Outbound: `CloudEventForwarder` subscribes to local EventBus events
+ *     whose type is on the `crewly.json` allow-list and forwards them via
+ *     `cloudSync.sendMessage(broadcast, 'event', payload)`. Loop-prevention
+ *     fence: the forwarder skips events with `source === 'remote'` (Q5).
+ *
+ * Non-blocking: failures are logged but do not affect Cloud connectivity.
+ *
+ * @param projectPath - Project root used for `crewly.json` allow-list lookup.
+ */
+export function startCrossMachineEventBridges(projectPath: string): void {
+	try {
+		// Dynamic imports to avoid circular dependency at module-load time.
+		Promise.all([
+			import('./cloud-event-bridge.service.js'),
+			import('./cloud-event-forwarder.service.js'),
+			import('../../controllers/event-bus/event-bus.controller.js'),
+			import('./device-identity.service.js'),
+		])
+			.then(async ([bridgeMod, forwarderMod, eventBusController, identityMod]) => {
+				const cloudSync = CloudSyncService.getInstance();
+				const eventBus = eventBusController.getEventBusService();
+				if (!eventBus) {
+					logger.warn(
+						'CrossMachineEventBridges deferred — EventBusService not yet wired by boot',
+					);
+					return;
+				}
+				const identity = await identityMod.DeviceIdentityService.getInstance().getOrCreateIdentity();
+
+				// Inbound first so any in-flight `'event'` messages already in
+				// the cloud queue are translated before the forwarder starts
+				// echoing local events back.
+				const inboundBridge = new bridgeMod.CloudEventInboundBridge({
+					cloudSync,
+					eventBus,
+				});
+				inboundBridge.start();
+				logger.info('CloudEventInboundBridge started', { deviceId: identity.deviceId });
+
+				const forwarder = new forwarderMod.CloudEventForwarder({
+					cloudSync,
+					eventBus,
+					originDeviceId: identity.deviceId,
+					originDeviceName: identity.deviceName,
+					projectPath,
+				});
+				await forwarder.start();
+				logger.info('CloudEventForwarder started', { deviceId: identity.deviceId });
+			})
+			.catch((err) => {
+				logger.warn('Failed to start cross-machine event bridges (non-fatal)', {
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
+	} catch (err) {
+		logger.warn('Failed to start cross-machine event bridges (non-fatal)', {
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
+
+/**
  * Start the BrowserRelayAdapter auto-discovery to listen for Chrome Extension
  * devices coming online via CloudSync. When a device with role 'browser' is
  * detected, the adapter automatically sets its device ID as the relay target.
@@ -229,6 +297,12 @@ export async function initializeCloudIfConfigured(): Promise<CloudInitResult> {
 
 			// Start browser extension auto-discovery via CloudSync device events
 			startBrowserRelayAutoDiscovery();
+
+			// autonomy_v1.f1 — start cross-machine event inbound bridge +
+			// outbound forwarder. Inbound translates remote events onto
+			// the local EventBus; outbound forwards allow-listed local
+			// events to paired devices via Cloud Relay broadcast.
+			startCrossMachineEventBridges(process.cwd());
 		} catch (syncError) {
 			logger.warn('CloudSyncService start failed during initialization (non-fatal)', {
 				error: syncError instanceof Error ? syncError.message : String(syncError),

--- a/backend/src/services/cloud/cloud-sync.types.test.ts
+++ b/backend/src/services/cloud/cloud-sync.types.test.ts
@@ -11,6 +11,7 @@ import {
   isIncomingMessage,
   isCloudSyncConfig,
   isAgentMessagePayload,
+  isEventMessagePayload,
   CLOUD_SYNC_STATES,
   MESSAGE_TYPES,
 } from './cloud-sync.types.js';
@@ -48,11 +49,91 @@ describe('cloud-sync.types', () => {
       expect(isMessageType('task_update')).toBe(true);
     });
 
+    // autonomy_v1.f1 — new 'event' MessageType for cross-machine event fan-out
+    it("should include the new 'event' MessageType (autonomy_v1.f1)", () => {
+      expect(isMessageType('event')).toBe(true);
+      expect(MESSAGE_TYPES).toContain('event');
+    });
+
+    it("preserves the prior-art 'cross-machine' MessageType (M1 parallel-types regression guard)", () => {
+      // Per Arch verdict 2026-04-28 M1: 'cross-machine' (free-text orchestrator
+      // messages) and 'event' (typed AgentEvent objects) are kept parallel.
+      // If anyone later collapses one into the other, this assertion fails.
+      expect(isMessageType('cross-machine')).toBe(true);
+      expect(isMessageType('event')).toBe(true);
+      expect(MESSAGE_TYPES).toContain('cross-machine');
+      expect(MESSAGE_TYPES).toContain('event');
+    });
+
     it('should return false for invalid values', () => {
       expect(isMessageType('chat')).toBe(false);
       expect(isMessageType('')).toBe(false);
       expect(isMessageType(null)).toBe(false);
       expect(isMessageType(123)).toBe(false);
+    });
+  });
+
+  // autonomy_v1.f1 — EventMessagePayload guard
+  describe('isEventMessagePayload', () => {
+    const validPayload = {
+      event: {
+        id: 'evt-uuid-1',
+        type: 'xhs:scrape:done',
+        sessionName: 'iriss-air-marketing',
+        timestamp: '2026-04-28T01:44:12.345Z',
+      },
+      originDeviceId: 'device-A',
+      originDeviceName: 'iriss-air',
+    };
+
+    it('accepts a well-formed payload', () => {
+      expect(isEventMessagePayload(validPayload)).toBe(true);
+    });
+
+    it('accepts payload with extra event fields (forward-compatible)', () => {
+      expect(isEventMessagePayload({
+        ...validPayload,
+        event: { ...validPayload.event, payload: { items: 42 } },
+      })).toBe(true);
+    });
+
+    it('rejects null / non-object', () => {
+      expect(isEventMessagePayload(null)).toBe(false);
+      expect(isEventMessagePayload(undefined)).toBe(false);
+      expect(isEventMessagePayload('string')).toBe(false);
+      expect(isEventMessagePayload(42)).toBe(false);
+    });
+
+    it('rejects missing originDeviceId', () => {
+      const { originDeviceId: _drop, ...bad } = validPayload;
+      expect(isEventMessagePayload(bad)).toBe(false);
+    });
+
+    it('rejects empty originDeviceId', () => {
+      expect(isEventMessagePayload({ ...validPayload, originDeviceId: '' })).toBe(false);
+    });
+
+    it('rejects missing event', () => {
+      expect(isEventMessagePayload({ originDeviceId: 'device-A' })).toBe(false);
+    });
+
+    it('rejects event without id / type / sessionName / timestamp', () => {
+      expect(isEventMessagePayload({
+        ...validPayload,
+        event: { ...validPayload.event, id: '' },
+      })).toBe(false);
+      expect(isEventMessagePayload({
+        ...validPayload,
+        event: { ...validPayload.event, type: '' },
+      })).toBe(false);
+      expect(isEventMessagePayload({
+        ...validPayload,
+        event: { ...validPayload.event, sessionName: 42 as unknown as string },
+      })).toBe(false);
+      expect(isEventMessagePayload({
+        ...validPayload,
+        event: { ...validPayload.event, timestamp: undefined as unknown as string },
+      })).toBe(false);
     });
   });
 

--- a/backend/src/services/cloud/cloud-sync.types.ts
+++ b/backend/src/services/cloud/cloud-sync.types.ts
@@ -138,7 +138,8 @@ export type MessageType =
   | 'agent_message'
   | 'cross-machine'
   | 'browser_command'
-  | 'browser_response';
+  | 'browser_response'
+  | 'event';
 
 /** Valid message type values for runtime validation. */
 export const MESSAGE_TYPES: readonly MessageType[] = [
@@ -153,6 +154,7 @@ export const MESSAGE_TYPES: readonly MessageType[] = [
   'cross-machine',
   'browser_command',
   'browser_response',
+  'event',
 ] as const;
 
 /**
@@ -254,6 +256,71 @@ export function isAgentMessagePayload(value: unknown): value is AgentMessagePayl
     typeof obj.message === 'string' &&
     typeof obj.fromDevice === 'string' &&
     typeof obj.fromDeviceName === 'string'
+  );
+}
+
+/**
+ * Cross-machine AgentEvent payload — the wire format for the `'event'`
+ * MessageType (autonomy_v1.f1).
+ *
+ * Distinct from `AgentMessagePayload` and `'cross-machine'` MessageType:
+ *   - `'cross-machine'` routes free-text orchestrator MESSAGES (slack-style).
+ *   - `'event'` broadcasts typed AgentEvent OBJECTS (schema-stable).
+ *
+ * Different shape, different consumer (router vs CloudEventInboundBridge),
+ * different validation paths. Kept parallel by Arch verdict 2026-04-28 (M1).
+ *
+ * The Cloud Relay fan-out (web/) duplicates this payload into N device
+ * queues; each queue assigns its own message id, so the local
+ * `processedMessageIds` LRU dedupes at-least-once delivery transparently.
+ */
+export interface EventMessagePayload {
+  /**
+   * The serialised AgentEvent the origin device published locally.
+   * Carries `event.id` (origin-assigned uuid, stable across fan-out),
+   * `event.type`, `event.sessionName`, `event.timestamp`, and the
+   * event-specific payload fields. The receiving CloudEventInboundBridge
+   * stamps `source: 'remote'` + `originDeviceId` before re-publishing on
+   * the local EventBus; those two fields are NOT shipped on the wire to
+   * keep the contract symmetric (any device, on any side, computes the
+   * tag from the message envelope).
+   */
+  event: {
+    id: string;
+    type: string;
+    sessionName: string;
+    timestamp: string;
+    [extra: string]: unknown;
+  };
+
+  /** Origin device id — echoes the sender so the receiver can stamp `originDeviceId` on the re-published event. */
+  originDeviceId: string;
+
+  /** Human-readable origin device name for log lines + ops audit. */
+  originDeviceName?: string;
+}
+
+/**
+ * Check if an object satisfies the EventMessagePayload interface shape.
+ *
+ * Validates the minimum schema needed for the inbound bridge to safely
+ * re-publish: a non-empty `event.id`, `event.type`, `event.sessionName`,
+ * `event.timestamp`, and a non-empty `originDeviceId`.
+ *
+ * @param value - Value to check
+ * @returns True if the value has the required EventMessagePayload fields
+ */
+export function isEventMessagePayload(value: unknown): value is EventMessagePayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.originDeviceId !== 'string' || obj.originDeviceId.length === 0) return false;
+  if (typeof obj.event !== 'object' || obj.event === null) return false;
+  const evt = obj.event as Record<string, unknown>;
+  return (
+    typeof evt.id === 'string' && evt.id.length > 0 &&
+    typeof evt.type === 'string' && evt.type.length > 0 &&
+    typeof evt.sessionName === 'string' &&
+    typeof evt.timestamp === 'string'
   );
 }
 

--- a/backend/src/services/event-bus/event-bus.service.test.ts
+++ b/backend/src/services/event-bus/event-bus.service.test.ts
@@ -593,17 +593,39 @@ describe('EventBusService', () => {
   });
 
   describe('publish dedup and flush', () => {
-    it('should suppress duplicate publish events within debounce window', () => {
+    it('should suppress TRUE-duplicate publish events (same id) within debounce window', () => {
+      // M2 fix (autonomy_v1.f1): the recent-publish dedup key is now
+      // `${type}:${sessionName}:${event.id}`. Two events with the same id
+      // are still TRUE duplicates and the second is suppressed; legitimate
+      // distinct events with different ids both publish (see next test).
       eventBus.subscribe(createTestSubscriptionInput({ oneShot: false }));
 
-      // Publish same event (same type + sessionName) twice within 5s
-      eventBus.publish(createTestEvent({ type: 'agent:busy', sessionName: 'agent-joe' }));
-      eventBus.publish(createTestEvent({ type: 'agent:busy', sessionName: 'agent-joe' }));
+      const sharedId = 'evt-true-dup-1';
+      eventBus.publish(createTestEvent({ id: sharedId, type: 'agent:busy', sessionName: 'agent-joe' }));
+      eventBus.publish(createTestEvent({ id: sharedId, type: 'agent:busy', sessionName: 'agent-joe' }));
 
       jest.advanceTimersByTime(5000);
 
-      // Second publish was silently ignored by the recentPublishMap dedup guard
+      // Second publish suppressed — same event id within window.
       expect(mockQueueService.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('M2 fix: BOTH publishes pass when (type, sessionName) match but ids differ within window', () => {
+      // The M2 fix sits at the recent-publish suppression layer (post-M2
+      // key includes event.id). Asserting via `'event_published'` emit count
+      // directly tests THAT layer, isolated from the per-subscriber buffer
+      // dedup at line 523 (which is a separate, intentional layer that
+      // keeps only the latest notification per (subscriber, sessionName) —
+      // outside the scope of this fix).
+      const published: string[] = [];
+      eventBus.on('event_published', (data) => published.push(data.eventId));
+
+      eventBus.publish(createTestEvent({ id: 'evt-m2-A', type: 'agent:busy', sessionName: 'agent-joe' }));
+      eventBus.publish(createTestEvent({ id: 'evt-m2-B', type: 'agent:busy', sessionName: 'agent-joe' }));
+
+      // Pre-M2 the second publish would have been silently suppressed.
+      // Post-M2 both pass.
+      expect(published).toEqual(['evt-m2-A', 'evt-m2-B']);
     });
 
     it('should allow same event after debounce window expires', () => {
@@ -721,6 +743,113 @@ describe('EventBusService', () => {
       );
       expect(targets).toContain('crewly-orc');
       expect(targets).toContain('crewly-assistant');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // autonomy_v1.f1 — cross-machine event source + emit payload widening
+  // -------------------------------------------------------------------------
+
+  describe('publish — autonomy_v1.f1 cross-machine semantics', () => {
+    it("defaults event.source to 'local' when publisher leaves it unset", () => {
+      const evt = createTestEvent({ id: 'evt-default-source' });
+      delete evt.source;
+      eventBus.publish(evt);
+      expect(evt.source).toBe('local');
+    });
+
+    it("preserves event.source = 'remote' set by the inbound bridge", () => {
+      const evt = createTestEvent({ id: 'evt-remote-source', source: 'remote', originDeviceId: 'device-A' });
+      eventBus.publish(evt);
+      expect(evt.source).toBe('remote');
+      expect(evt.originDeviceId).toBe('device-A');
+    });
+
+    it("widened 'event_published' emit payload carries source + originDeviceId for remote events", () => {
+      const captured: any[] = [];
+      eventBus.on('event_published', (data) => captured.push(data));
+
+      eventBus.publish(createTestEvent({
+        id: 'evt-emit-remote',
+        source: 'remote',
+        originDeviceId: 'device-B',
+      }));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]).toMatchObject({
+        eventId: 'evt-emit-remote',
+        eventType: 'agent:busy',
+        source: 'remote',
+        originDeviceId: 'device-B',
+      });
+    });
+
+    it("widened emit payload carries source = 'local' (no originDeviceId) for local events", () => {
+      const captured: any[] = [];
+      eventBus.on('event_published', (data) => captured.push(data));
+
+      eventBus.publish(createTestEvent({ id: 'evt-emit-local' }));
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].source).toBe('local');
+      expect(captured[0].originDeviceId).toBeUndefined();
+    });
+
+    it("EventFilter.originDeviceId disambiguates remote events by origin", () => {
+      // Subscriber wants only events originated on device-A.
+      eventBus.subscribe(createTestSubscriptionInput({
+        oneShot: false,
+        filter: { originDeviceId: 'device-A' },
+      }));
+
+      // Remote event from device-A — should match.
+      eventBus.publish(createTestEvent({
+        id: 'evt-orig-a',
+        source: 'remote',
+        originDeviceId: 'device-A',
+      }));
+      // Remote event from device-B — should be rejected by the filter.
+      eventBus.publish(createTestEvent({
+        id: 'evt-orig-b',
+        sessionName: 'agent-other', // avoid the per-subscriber notify dedup
+        source: 'remote',
+        originDeviceId: 'device-B',
+      }));
+
+      jest.advanceTimersByTime(5000);
+
+      expect(mockQueueService.enqueue).toHaveBeenCalledTimes(1);
+      const enqueued = mockQueueService.enqueue.mock.calls[0][0];
+      expect(enqueued.targetSession).toBeDefined();
+      // The single delivered notification corresponds to the device-A event.
+    });
+
+    it("EventFilter without originDeviceId accepts events from any origin", () => {
+      // Asserting via the publish-level dispatch (event_published) avoids
+      // entanglement with the per-subscriber buffer dedup. The semantic
+      // claim is "an absent originDeviceId filter does not exclude any
+      // origin" — which is verified by both events passing publish.
+      const published: string[] = [];
+      eventBus.on('event_published', (data) => published.push(data.eventId));
+
+      eventBus.subscribe(createTestSubscriptionInput({
+        oneShot: false,
+        filter: {}, // no origin filter
+      }));
+
+      eventBus.publish(createTestEvent({
+        id: 'evt-any-1',
+        sessionName: 'agent-1',
+        source: 'remote',
+        originDeviceId: 'device-A',
+      }));
+      eventBus.publish(createTestEvent({
+        id: 'evt-any-2',
+        sessionName: 'agent-2',
+        // no source / originDeviceId — defaults to local
+      }));
+
+      expect(published).toEqual(['evt-any-1', 'evt-any-2']);
     });
   });
 

--- a/backend/src/services/event-bus/event-bus.service.ts
+++ b/backend/src/services/event-bus/event-bus.service.ts
@@ -218,16 +218,36 @@ export class EventBusService extends EventEmitter {
    * @param event - The agent lifecycle event to publish
    */
   publish(event: AgentEvent): void {
-    // Dedup: ignore duplicate events for the same (type, sessionName) within
-    // the debounce window. This prevents redundant notifications when both
-    // the file watcher and ActivityMonitor detect the same status transition.
-    const dedupKey = `${event.type}:${event.sessionName}`;
+    // autonomy_v1.f1: default `source` to 'local' when absent so the rest of
+    // the pipeline (TriggerEngine source filter, EventFilter consumers) sees
+    // a stable invariant. Local publishers leave it unset; the
+    // CloudEventInboundBridge sets it to 'remote' before calling publish.
+    if (event.source === undefined) {
+      event.source = 'local';
+    }
+
+    // Dedup: ignore TRUE-duplicate events (same id) for the same
+    // (type, sessionName) within the debounce window. Prevents redundant
+    // notifications when both the file watcher and ActivityMonitor detect
+    // the same status transition.
+    //
+    // M2 fix (autonomy_v1.f1, Arch verdict 2026-04-28): the previous key
+    // `${type}:${sessionName}` over-merged — two LEGITIMATE distinct events
+    // from the same session within the 5 s window were silently dropped
+    // (e.g. iriss-air emits `xhs:scrape:done` for session-A twice in 4 s
+    // due to two parallel scrape jobs). Cross-machine surfaces this more
+    // because remote events arrive in dense bursts. Widening to include
+    // `event.id` is strictly more permissive — true duplicates (same id
+    // re-arriving) are still suppressed; legitimate distinct events both
+    // publish.
+    const dedupKey = `${event.type}:${event.sessionName}:${event.id}`;
     const nowMs = Date.now();
     const lastPublished = this.recentPublishMap.get(dedupKey);
     if (lastPublished && nowMs - lastPublished < EVENT_BUS_CONSTANTS.EVENT_DEBOUNCE_WINDOW_MS) {
       this.logger.debug('Duplicate event suppressed within debounce window', {
         type: event.type,
         sessionName: event.sessionName,
+        eventId: event.id,
         msSinceLast: nowMs - lastPublished,
       });
       return;
@@ -253,11 +273,20 @@ export class EventBusService extends EventEmitter {
     });
 
     // Emit event_published for any listener that needs to react to ALL events
-    // regardless of subscriptions (e.g., auditor monitoring agent:inactive)
+    // regardless of subscriptions (e.g., auditor monitoring agent:inactive,
+    // TriggerEngine signal triggers).
+    //
+    // autonomy_v1.f1: payload widened to carry `source` + `originDeviceId`
+    // so the TriggerEngine source filter (read inside `signalMatches`) can
+    // honour `'local' | 'remote' | 'any'` without a separate per-event
+    // lookup. Existing listeners that only read the original three fields
+    // are unaffected — TS structural extension, no behaviour change.
     this.emit('event_published', {
       eventId: event.id,
       eventType: event.type,
       sessionName: event.sessionName,
+      source: event.source,
+      originDeviceId: event.originDeviceId,
     });
 
     // Dispatch to in-process handlers (BRIDGE-1, LEARN-1, …). Errors are
@@ -656,6 +685,16 @@ export class EventBusService extends EventEmitter {
       return false;
     }
     if (filter.parentMemberId && filter.parentMemberId !== event.parentMemberId) {
+      return false;
+    }
+
+    // autonomy_v1.f1 (Arch Q3): cross-device origin disambiguation. When
+    // the consumer sets `originDeviceId` it wants to match ONLY events that
+    // originated on a specific paired device (or, when the event is local,
+    // local events have no originDeviceId so the filter always rejects).
+    // Filters that don't set this field accept events from any origin
+    // (subject to higher-layer source filtering in TriggerEngine).
+    if (filter.originDeviceId && filter.originDeviceId !== event.originDeviceId) {
       return false;
     }
 

--- a/backend/src/services/v3/trigger-engine.cross-machine.service.test.ts
+++ b/backend/src/services/v3/trigger-engine.cross-machine.service.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for TriggerEngine cross-machine surface (autonomy_v1.f1, Slice 3).
+ *
+ * Co-located alongside the existing `trigger-engine.service.test.ts` (which
+ * uses vitest and does not run in jest CI — pre-existing infrastructure
+ * decision, out of scope for this PR). This file is jest-compatible and
+ * runs as part of `npm run test:unit`.
+ *
+ * Coverage:
+ *   - SignalTriggerConfig.source filter (`'local'` / `'remote'` / `'any'`,
+ *     unset defaults to `'local'`).
+ *   - Per-trigger `${triggerId}:${eventId}` dedup against at-least-once
+ *     cloud delivery.
+ *   - Source-filter check sits in `signalMatches` (the predicate) — locked
+ *     by drift addendum.
+ *   - LRU eviction kicks in at capacity.
+ *
+ * @module services/v3/trigger-engine.cross-machine.service.test
+ */
+
+import { EventEmitter } from 'events';
+import { TriggerEngine, type TriggerActionHandler } from './trigger-engine.service.js';
+import type { EventBusService } from '../event-bus/event-bus.service.js';
+import type { CreateTriggerInput, Trigger } from '../../types/v2/trigger.types.js';
+
+// Logger mock — match the project pattern (memory.controller.test.ts uses
+// the same shape).
+jest.mock('../core/logger.service.js', () => ({
+	LoggerService: {
+		getInstance: () => ({
+			createComponentLogger: () => ({
+				debug: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+			}),
+		}),
+	},
+}));
+
+// File-io mock — TriggerEngine persists triggers to disk, but we don't want
+// real disk writes in unit tests. The engine uses safeReadJson which
+// returns null on miss; ensureDir + atomicWriteJson are no-ops here.
+jest.mock('../../utils/file-io.utils.js', () => ({
+	ensureDir: jest.fn().mockResolvedValue(undefined),
+	atomicWriteJson: jest.fn().mockResolvedValue(undefined),
+	safeReadJson: jest.fn().mockResolvedValue(null),
+}));
+
+/**
+ * Build a SignalEventData payload (the widened `'event_published'` emit
+ * shape consumed by TriggerEngine). Mirrors the autonomy_v1.f1 widening.
+ */
+function makeEventData(overrides?: {
+	eventId?: string;
+	eventType?: string;
+	sessionName?: string;
+	source?: 'local' | 'remote';
+	originDeviceId?: string;
+}) {
+	return {
+		eventId: overrides?.eventId ?? 'evt-1',
+		eventType: overrides?.eventType ?? 'xhs:scrape:done',
+		sessionName: overrides?.sessionName ?? 'iriss-air-marketing',
+		source: overrides?.source,
+		originDeviceId: overrides?.originDeviceId,
+	};
+}
+
+/**
+ * Build a CreateTriggerInput for a signal trigger with a delegate-style
+ * action handler. Used by every test below.
+ */
+function makeSignalInput(overrides?: {
+	eventType?: string;
+	source?: 'local' | 'remote' | 'any';
+	filter?: Record<string, unknown>;
+	name?: string;
+}): CreateTriggerInput {
+	return {
+		type: 'signal',
+		config: {
+			type: 'signal',
+			eventType: overrides?.eventType ?? 'xhs:scrape:done',
+			source: overrides?.source,
+			filter: overrides?.filter,
+		},
+		action: {
+			createWorkItem: { id: 'wi-stub' as never },
+		},
+		createdBy: 'system',
+		name: overrides?.name,
+	};
+}
+
+describe('TriggerEngine — autonomy_v1.f1 cross-machine surface', () => {
+	let engine: TriggerEngine;
+	let eventBus: EventEmitter;
+	let actionHandler: jest.Mock;
+
+	beforeEach(() => {
+		TriggerEngine.resetInstance();
+		engine = TriggerEngine.getInstance('/tmp/test-trigger-engine-f1');
+		eventBus = new EventEmitter();
+		engine.setEventBus(eventBus as unknown as EventBusService);
+		actionHandler = jest.fn().mockResolvedValue(undefined);
+		engine.setActionHandler(actionHandler as unknown as TriggerActionHandler);
+	});
+
+	afterEach(() => {
+		TriggerEngine.resetInstance();
+	});
+
+	// -------------------------------------------------------------------------
+	// Source filter — locked by Arch Q2 (default 'local')
+	// -------------------------------------------------------------------------
+
+	describe('signalMatches source filter', () => {
+		it("default (unset) source matches LOCAL events", async () => {
+			const t = await engine.create(makeSignalInput({ name: 'sig-default' }));
+
+			await engine.handleSignalEvent(makeEventData({ source: 'local' }));
+			expect(actionHandler).toHaveBeenCalledTimes(1);
+			expectFiredFor(actionHandler, t.id);
+		});
+
+		it("default (unset) source REJECTS remote events (Arch Q2 LOCKED)", async () => {
+			await engine.create(makeSignalInput({ name: 'sig-default-rejects-remote' }));
+
+			await engine.handleSignalEvent(
+				makeEventData({ source: 'remote', originDeviceId: 'device-A' }),
+			);
+			expect(actionHandler).not.toHaveBeenCalled();
+		});
+
+		it("source='local' matches LOCAL events only", async () => {
+			await engine.create(makeSignalInput({ source: 'local', name: 'sig-local' }));
+
+			await engine.handleSignalEvent(makeEventData({ source: 'local' }));
+			await engine.handleSignalEvent(
+				makeEventData({ eventId: 'evt-2', source: 'remote', originDeviceId: 'device-A' }),
+			);
+
+			expect(actionHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it("source='remote' matches REMOTE events only", async () => {
+			await engine.create(makeSignalInput({ source: 'remote', name: 'sig-remote' }));
+
+			await engine.handleSignalEvent(makeEventData({ source: 'local' }));
+			await engine.handleSignalEvent(
+				makeEventData({ eventId: 'evt-2', source: 'remote', originDeviceId: 'device-A' }),
+			);
+
+			expect(actionHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it("source='any' matches BOTH local and remote events", async () => {
+			await engine.create(makeSignalInput({ source: 'any', name: 'sig-any' }));
+
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-1', source: 'local' }));
+			await engine.handleSignalEvent(
+				makeEventData({ eventId: 'evt-2', source: 'remote', originDeviceId: 'device-A' }),
+			);
+
+			expect(actionHandler).toHaveBeenCalledTimes(2);
+		});
+
+		it("event with absent source defaults to 'local' for filter purposes", async () => {
+			// A legacy publisher might emit without setting source on the wire
+			// payload. The default of 'local' must apply at signal-match time too.
+			await engine.create(makeSignalInput({ source: 'remote', name: 'sig-remote-2' }));
+
+			await engine.handleSignalEvent({
+				eventId: 'evt-legacy',
+				eventType: 'xhs:scrape:done',
+				sessionName: 'session-x',
+				// source intentionally undefined
+			});
+
+			expect(actionHandler).not.toHaveBeenCalled();
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Per-trigger ${triggerId}:${eventId} dedup — Arch decomp memo §(d) Layer 3
+	// -------------------------------------------------------------------------
+
+	describe('per-trigger eventId dedup', () => {
+		it('does NOT fire twice for the same (triggerId, eventId) pair', async () => {
+			await engine.create(makeSignalInput({ source: 'any', name: 'sig-dedup' }));
+
+			// At-least-once cloud delivery — same event.id arrives twice.
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-dup' }));
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-dup' }));
+
+			expect(actionHandler).toHaveBeenCalledTimes(1);
+		});
+
+		it('FIRES TWICE when (type, sessionName) match but eventIds differ', async () => {
+			await engine.create(makeSignalInput({ source: 'any', name: 'sig-distinct' }));
+
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-A' }));
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-B' }));
+
+			expect(actionHandler).toHaveBeenCalledTimes(2);
+		});
+
+		it('two triggers on the same event each fire once (per-trigger keying)', async () => {
+			await engine.create(makeSignalInput({ source: 'any', name: 'sig-A' }));
+			await engine.create(makeSignalInput({ source: 'any', name: 'sig-B' }));
+
+			await engine.handleSignalEvent(makeEventData({ eventId: 'evt-shared' }));
+
+			expect(actionHandler).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	// -------------------------------------------------------------------------
+	// Source filter sits in signalMatches predicate — drift-addendum lock
+	// -------------------------------------------------------------------------
+
+	describe('source filter placement (drift-addendum lock)', () => {
+		it('signalMatches considers BOTH eventType and source as gating predicates', async () => {
+			// Trigger A: matches type=xhs:scrape:done, source=remote
+			// Trigger B: matches type=xhs:scrape:done, source=local
+			// One inbound event with type=xhs:scrape:done, source=local must
+			// fire B but NOT A. Gates the placement-in-predicate lock — if
+			// the source filter were misplaced (e.g. into signalListener
+			// pre-iteration), one or both would mis-fire.
+			const a = await engine.create(makeSignalInput({ source: 'remote', name: 'sig-A-remote' }));
+			const b = await engine.create(makeSignalInput({ source: 'local', name: 'sig-B-local' }));
+
+			await engine.handleSignalEvent(makeEventData({ source: 'local' }));
+
+			expect(actionHandler).toHaveBeenCalledTimes(1);
+			expectFiredFor(actionHandler, b.id);
+			expectNotFiredFor(actionHandler, a.id);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function expectFiredFor(handler: jest.Mock, triggerId: string): void {
+	const matchedCalls = handler.mock.calls.filter(
+		(call) => (call[0] as Trigger).id === triggerId,
+	);
+	expect(matchedCalls.length).toBeGreaterThanOrEqual(1);
+}
+
+function expectNotFiredFor(handler: jest.Mock, triggerId: string): void {
+	const matchedCalls = handler.mock.calls.filter(
+		(call) => (call[0] as Trigger).id === triggerId,
+	);
+	expect(matchedCalls.length).toBe(0);
+}

--- a/backend/src/services/v3/trigger-engine.service.ts
+++ b/backend/src/services/v3/trigger-engine.service.ts
@@ -43,6 +43,36 @@ const TRIGGERS_DIR = 'triggers';
 /** File name for persisted trigger store. */
 const TRIGGERS_FILE = 'triggers.json';
 
+/**
+ * Bounded LRU capacity for the per-trigger fired-event dedup. Sized for
+ * 24 h × N triggers worth of events under typical load. Memory cost is
+ * negligible (~80 bytes/key × 2000 = ~160 KB).
+ *
+ * Per Arch Q6: this LRU is in-memory only. After process restart it starts
+ * empty, so a re-delivered cross-machine event in the restart window
+ * COULD double-fire. Symmetric with cloud-side `processedMessageIds`
+ * which is also in-memory. The startup warn-log breadcrumb in `start()`
+ * makes this trade-off observable to ops without leaking it as a silent
+ * gotcha.
+ */
+const TRIGGER_FIRE_DEDUP_CAPACITY = 2000;
+
+/**
+ * Wider event-bus emit payload consumed by `signalListener`. Mirrors the
+ * `'event_published'` shape after the autonomy_v1.f1 widening (see
+ * `event-bus.service.ts` near the `this.emit('event_published', ...)`
+ * call). The `source` and `originDeviceId` fields are optional only
+ * because legacy publishers leave them unset (defaulted to `'local'` at
+ * publish time).
+ */
+interface SignalEventData {
+  eventId: string;
+  eventType: string;
+  sessionName: string;
+  source?: 'local' | 'remote';
+  originDeviceId?: string;
+}
+
 /** How often to check time-based triggers (60 seconds). */
 const TIME_CHECK_INTERVAL_MS = 60_000;
 
@@ -106,8 +136,28 @@ export class TriggerEngine {
    * don't accumulate a new copy on every `start()`. Without this, repeated
    * start/stop cycles (dev reloads, tests, escalation restarts) would
    * register additional listeners that each fire independently.
+   *
+   * Payload widened (autonomy_v1.f1): the EventBus now emits
+   * `{ eventId, eventType, sessionName, source?, originDeviceId? }` so the
+   * source filter on `SignalTriggerConfig` can read both fields without an
+   * event-id lookup. Listeners that only read the original three fields
+   * are unaffected (TS structural extension).
    */
-  private signalListener: ((eventData: { eventId: string; eventType: string; sessionName: string }) => void) | null = null;
+  private signalListener: ((eventData: SignalEventData) => void) | null = null;
+
+  /**
+   * Per-trigger dedup LRU keyed on `${triggerId}:${eventId}`. Bounds growth
+   * across long-lived processes (autonomy_v1.f1). Catches at-least-once
+   * cloud delivery that slipped past CloudSync's `processedMessageIds`
+   * (different cloud-message-ids wrapping the same `event.id`) AND past
+   * the EventBus recent-publish suppression (different (type, sessionName)
+   * but same event.id arriving outside the 5s window).
+   *
+   * Key shape is INTENTIONALLY DISJOINT from BRIDGE-1's per-handler keys
+   * (workItemId / missionId / verifyId / retryId / blockedId / escalationId)
+   * so the two layers compose without collision (see decomp memo §(d)).
+   */
+  private firedDedup: Set<string> = new Set();
 
   /** Callback for executing trigger actions. */
   private actionHandler: TriggerActionHandler | null = null;
@@ -197,6 +247,18 @@ export class TriggerEngine {
     this.setupSignalListeners();
     this.setupOneShotTimers();
     this.running = true;
+
+    // Q6 breadcrumb (autonomy_v1.f1): the per-trigger dedup LRU is
+    // in-memory only. After process restart it starts empty, so any
+    // cross-machine event re-delivered by Cloud Relay during the restart
+    // window could double-fire its trigger. Symmetric with cloud-side
+    // `processedMessageIds`. Surfacing this at startup gives ops a
+    // breadcrumb to correlate any double-fire reports with restarts.
+    this.logger.warn(
+      'TriggerEngine dedup LRU is in-memory; cross-machine events delivered during the restart window may double-fire',
+      { dedupCapacity: TRIGGER_FIRE_DEDUP_CAPACITY },
+    );
+
     this.logger.info('TriggerEngine started', { triggerCount: this.triggers.size });
   }
 
@@ -659,32 +721,67 @@ export class TriggerEngine {
   /**
    * Handles an EventBus event by checking all active signal triggers.
    *
-   * @param eventData - The event data from EventBus
+   * autonomy_v1.f1: applies the per-trigger `${triggerId}:${eventId}` dedup
+   * BEFORE firing so duplicate cloud deliveries (e.g. CloudSync
+   * `processedMessageIds` LRU evicted before a retry) cannot double-fire
+   * a trigger. Dedup key is intentionally disjoint from BRIDGE-1's
+   * per-handler `idempotencyKey` shapes (workItemId / missionId /
+   * verifyId / etc.) — see decomp memo §(d) for the layered proof.
+   *
+   * @param eventData - The widened event data from EventBus
+   *   (`{ eventId, eventType, sessionName, source?, originDeviceId? }`)
    */
-  public async handleSignalEvent(eventData: {
-    eventId: string;
-    eventType: string;
-    sessionName: string;
-  }): Promise<TriggerFireResult[]> {
+  public async handleSignalEvent(eventData: SignalEventData): Promise<TriggerFireResult[]> {
     const results: TriggerFireResult[] = [];
 
     for (const trigger of this.triggers.values()) {
       if (trigger.status !== 'active') continue;
 
+      let matched = false;
       if (trigger.config.type === 'signal') {
-        if (this.signalMatches(trigger.config, eventData)) {
-          const result = await this.fire(trigger);
-          results.push(result);
-        }
+        matched = this.signalMatches(trigger.config, eventData);
       } else if (trigger.config.type === 'compound') {
-        if (this.compoundSignalMatches(trigger.config, eventData)) {
-          const result = await this.fire(trigger);
-          results.push(result);
-        }
+        matched = this.compoundSignalMatches(trigger.config, eventData);
       }
+
+      if (!matched) continue;
+
+      // Per-trigger dedup. We dedup AFTER signal-match so we don't pollute
+      // the LRU with non-matching events (which would shorten the
+      // effective window the LRU covers).
+      const dedupKey = `${trigger.id}:${eventData.eventId}`;
+      if (this.firedDedup.has(dedupKey)) {
+        this.logger.debug('TriggerEngine dedup: skipping already-fired (trigger, eventId)', {
+          triggerId: trigger.id,
+          eventId: eventData.eventId,
+        });
+        continue;
+      }
+      this.firedDedup.add(dedupKey);
+      this.evictDedupIfFull();
+
+      const result = await this.fire(trigger);
+      results.push(result);
     }
 
     return results;
+  }
+
+  /**
+   * Bound the dedup LRU. When at capacity, drop the oldest entries
+   * (insertion-order via Set). Capacity is tuned for 24h × N triggers
+   * (see {@link TRIGGER_FIRE_DEDUP_CAPACITY}); memory cost is negligible.
+   */
+  private evictDedupIfFull(): void {
+    if (this.firedDedup.size <= TRIGGER_FIRE_DEDUP_CAPACITY) return;
+    // Drop the oldest 10% to amortise eviction cost.
+    const dropCount = Math.max(1, Math.floor(TRIGGER_FIRE_DEDUP_CAPACITY * 0.1));
+    const iter = this.firedDedup.values();
+    for (let i = 0; i < dropCount; i++) {
+      const next = iter.next();
+      if (next.done) break;
+      this.firedDedup.delete(next.value);
+    }
   }
 
   /**
@@ -696,16 +793,27 @@ export class TriggerEngine {
    */
   private signalMatches(
     config: SignalTriggerConfig,
-    eventData: { eventType: string; sessionName: string },
+    eventData: SignalEventData,
   ): boolean {
     if (config.eventType !== eventData.eventType) {
       return false;
     }
 
+    // autonomy_v1.f1 source filter (Arch Q2 LOCKED).
+    // Default at evaluation = 'local' for backward compat — every existing
+    // trigger registered before f1 had no `source` field; defaulting to
+    // 'any' would silently flip their scope (the WIRE-1 V4 veto scenario).
+    const triggerSource = config.source ?? 'local';
+    const eventSource = eventData.source ?? 'local';
+    if (triggerSource !== 'any' && triggerSource !== eventSource) {
+      return false;
+    }
+
     // Apply filter if present
     if (config.filter) {
+      const fields = eventData as unknown as Record<string, unknown>;
       for (const [key, value] of Object.entries(config.filter)) {
-        if ((eventData as Record<string, unknown>)[key] !== value) {
+        if (fields[key] !== value) {
           return false;
         }
       }
@@ -724,7 +832,7 @@ export class TriggerEngine {
    */
   private compoundSignalMatches(
     config: CompoundTriggerConfig,
-    eventData: { eventType: string; sessionName: string },
+    eventData: SignalEventData,
   ): boolean {
     const signalConditions = config.conditions.filter(
       (c): c is SignalTriggerConfig => c.type === 'signal',

--- a/backend/src/types/event-bus.types.ts
+++ b/backend/src/types/event-bus.types.ts
@@ -89,6 +89,36 @@ export const EVENT_TYPES = [
 export type EventType = (typeof EVENT_TYPES)[number];
 
 /**
+ * Runtime-only event-type alias used at the cross-machine inbound bridge
+ * boundary (autonomy_v1.f1, Arch Q4).
+ *
+ * The closed `EVENT_TYPES` enum stays closed — paired devices may roll out
+ * new event types one at a time without forcing a deployment-ordering
+ * constraint across the fleet. The inbound bridge accepts unknown peer
+ * types as `string`, then casts to `EventType` at the local re-publish
+ * boundary so the rest of the local pipeline (TriggerEngine, EventBus
+ * subscribers) sees the type as if it were native. A debug log inside the
+ * bridge names any unrecognised type so ops can audit drift.
+ *
+ * Do NOT use this alias outside the inbound-bridge boundary — local
+ * publishers must use the closed `EventType` union.
+ */
+export type RemoteEventType = string;
+
+/**
+ * Source of an event — local origin or relayed from a paired device.
+ *
+ * - `'local'` (default): emitted by an in-process publisher on this device.
+ * - `'remote'`: re-published by the CloudEventInboundBridge after arriving
+ *   from a paired device via Cloud Relay.
+ *
+ * `EventBusService.publish` defaults missing `source` to `'local'`.
+ * `SignalTriggerConfig.source` filters on this value to scope which
+ * triggers fire on which origins (default `'local'` for backwards compat).
+ */
+export type EventSource = 'local' | 'remote';
+
+/**
  * Event priority levels used for subscriber filtering.
  * Critical events are delivered immediately; info events may be suppressed
  * or debounced for subscribers that opt into critical-only mode.
@@ -257,6 +287,29 @@ export interface AgentEvent {
    * other event types — never read outside the request handlers.
    */
   requestId?: string;
+
+  // === Cross-machine fields (autonomy_v1.f1) ===
+  // The CloudEventInboundBridge stamps these when re-publishing an event
+  // received from a paired device. Local publishers leave both unset; the
+  // bus treats absent `source` as `'local'`. SignalTriggerConfig `source`
+  // filter and EventFilter.originDeviceId disambiguate cross-device
+  // consumers.
+
+  /**
+   * Origin of this event. `'local'` for in-process publishers, `'remote'`
+   * for events relayed via Cloud Relay from a paired device. Defaults to
+   * `'local'` at publish time when unset.
+   */
+  source?: EventSource;
+
+  /**
+   * Device id of the origin paired device. Set ONLY when `source === 'remote'`;
+   * the inbound bridge stamps this from the cloud message envelope. Triggers
+   * needing cross-device disambiguation filter on this field via
+   * {@link EventFilter.originDeviceId}; `sessionName` is left origin-pristine
+   * so existing filter consumers continue to key on it unchanged.
+   */
+  originDeviceId?: string;
 }
 
 // =============================================================================
@@ -284,6 +337,20 @@ export interface EventFilter {
 
   /** Match events from subordinates of a specific parent member */
   parentMemberId?: string;
+
+  /**
+   * Match events that originated from a specific paired device
+   * (autonomy_v1.f1, Arch Q3). Set ONLY when the consumer wants to
+   * disambiguate by origin device — e.g. when two paired devices both
+   * have a session of the same `sessionName`. When unset, the filter
+   * matches events from any origin (local + remote alike, subject to
+   * the trigger's `source` filter).
+   *
+   * `sessionName` is intentionally left origin-pristine — adding this
+   * field instead avoids mutating a public field that every existing
+   * filter consumer keys on.
+   */
+  originDeviceId?: string;
 }
 
 /**

--- a/backend/src/types/v2/trigger.types.test.ts
+++ b/backend/src/types/v2/trigger.types.test.ts
@@ -106,6 +106,30 @@ describe('Trigger Types', () => {
       expect(isValidTriggerConfig(config)).toBe(false);
     });
 
+    // autonomy_v1.f1 — source filter validation
+    it("should accept signal config with source = 'local'", () => {
+      const config: SignalTriggerConfig = { type: 'signal', eventType: 'agent:idle', source: 'local' };
+      expect(isValidTriggerConfig(config)).toBe(true);
+    });
+    it("should accept signal config with source = 'remote'", () => {
+      const config: SignalTriggerConfig = { type: 'signal', eventType: 'agent:idle', source: 'remote' };
+      expect(isValidTriggerConfig(config)).toBe(true);
+    });
+    it("should accept signal config with source = 'any'", () => {
+      const config: SignalTriggerConfig = { type: 'signal', eventType: 'agent:idle', source: 'any' };
+      expect(isValidTriggerConfig(config)).toBe(true);
+    });
+    it('should accept signal config with source unset (defaults at evaluation)', () => {
+      const config: SignalTriggerConfig = { type: 'signal', eventType: 'agent:idle' };
+      expect(isValidTriggerConfig(config)).toBe(true);
+    });
+    it('should reject signal config with malformed source value', () => {
+      // Reject typos / unknown values at registration so they surface
+      // immediately rather than silently coercing to default.
+      const config = { type: 'signal', eventType: 'agent:idle', source: 'global' } as unknown as SignalTriggerConfig;
+      expect(isValidTriggerConfig(config)).toBe(false);
+    });
+
     it('should validate compound config', () => {
       const config: CompoundTriggerConfig = {
         type: 'compound',

--- a/backend/src/types/v2/trigger.types.ts
+++ b/backend/src/types/v2/trigger.types.ts
@@ -72,6 +72,19 @@ export interface SignalTriggerConfig {
   eventType: string;
   /** Optional filter — only fire if event payload matches */
   filter?: Record<string, unknown>;
+  /**
+   * Origin filter for cross-machine event triggers (autonomy_v1.f1).
+   * - `'local'` (default): only fire on events emitted on this device.
+   * - `'remote'`: only fire on events relayed from a paired device via
+   *   Cloud Relay.
+   * - `'any'`: fire on both local and remote events.
+   *
+   * Defaults to `'local'` at evaluation when unset — backward compatible
+   * for every existing trigger. Defaulting to `'any'` would silently flip
+   * every trigger's scope, the exact regression the WIRE-1 V4 veto was
+   * designed to prevent (Arch verdict 2026-04-28 Q2 LOCKED).
+   */
+  source?: 'local' | 'remote' | 'any';
 }
 
 /**
@@ -219,8 +232,16 @@ export function isValidTriggerConfig(config: TriggerConfig): boolean {
   switch (config.type) {
     case 'time':
       return !!(config.cronExpression || config.delayMs || config.fireAt);
-    case 'signal':
-      return typeof config.eventType === 'string' && config.eventType.length > 0;
+    case 'signal': {
+      if (typeof config.eventType !== 'string' || config.eventType.length === 0) return false;
+      // autonomy_v1.f1: source filter is optional but, when present, must be
+      // one of the three accepted values. Reject malformed values instead of
+      // silently coercing to default (which would mask typos at registration).
+      if (config.source !== undefined && config.source !== 'local' && config.source !== 'remote' && config.source !== 'any') {
+        return false;
+      }
+      return true;
+    }
     case 'compound':
       return (
         (config.operator === 'and' || config.operator === 'or') &&

--- a/config/skills/agent/core/watch-for-event/SKILL.md
+++ b/config/skills/agent/core/watch-for-event/SKILL.md
@@ -44,6 +44,34 @@ bash execute.sh --event-type task:completed \
   --title "Q2 mission task landed"
 ```
 
+## Cross-machine triggers — `--source` (autonomy_v1.f1)
+
+When Cloud Relay is paired with another device, events emitted on a peer
+device can fire local triggers via the inbound event bridge. Use `--source`
+to scope which origins this watcher reacts to.
+
+| Value | Fires on |
+|-------|----------|
+| `local` (default) | Events emitted on this device only — same scope as every pre-f1 trigger. |
+| `remote` | Events relayed via Cloud Relay from a paired device only. |
+| `any` | Both local and remote events. |
+
+```bash
+# Wake the local Marketing team when iriss-air finishes a scrape (XHS pipeline).
+bash execute.sh --event-type xhs:scrape:done \
+  --source remote \
+  --target crewly-marketing-orc \
+  --title "Remote scrape landed — kick off analysis pipeline"
+```
+
+The default is `local` to preserve the scope of every existing trigger
+(Arch Q2 backward-compat lock). Defaulting to `any` would silently broaden
+trigger scope — opt in explicitly.
+
+For the loop close (forwarding LOCAL events to peer devices), the
+`CloudEventForwarder` reads an opt-in allow-list from `crewly.json`
+(`crossMachineEvents: [...]`) — separate from the watcher.
+
 ## Key invariants
 
 - Every watcher is **team-scoped**, listed under `list-my-followups`,

--- a/config/skills/agent/core/watch-for-event/execute.sh
+++ b/config/skills/agent/core/watch-for-event/execute.sh
@@ -39,6 +39,10 @@ Options:
   --name            Stable name for cancel/dedup. Auto-generated if absent.
   --max-fires       Stop after N fires (default: unlimited — use --max-idle-fires as safety)
   --max-idle-fires  Auto-cancel after N consecutive unproductive fires (default: 3)
+  --source          Origin filter (autonomy_v1.f1): "local" (default), "remote", or "any".
+                    "remote" fires only on cross-machine events relayed via Cloud Relay;
+                    "any" fires on both local and remote. Default "local" preserves the
+                    backward-compat scope of every existing trigger (Arch Q2).
   --json      | -j  Raw JSON payload (legacy)
   --help      | -h  Show this help
 EOF_USAGE
@@ -54,6 +58,7 @@ DESCRIPTION=""
 NAME=""
 MAX_FIRES=""
 MAX_IDLE_FIRES="3"
+SOURCE=""
 
 if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
   INPUT_JSON="$1"
@@ -71,6 +76,7 @@ while [[ $# -gt 0 ]]; do
     --name)               NAME="$2"; shift 2 ;;
     --max-fires)          MAX_FIRES="$2"; shift 2 ;;
     --max-idle-fires)     MAX_IDLE_FIRES="$2"; shift 2 ;;
+    --source)             SOURCE="$2"; shift 2 ;;
     --json|-j)            INPUT_JSON="$2"; shift 2 ;;
     --help|-h)            print_usage; exit 0 ;;
     --)                   shift; break ;;
@@ -95,6 +101,15 @@ if [ -n "$INPUT_JSON" ]; then
   NAME=$(printf '%s' "$INPUT_JSON" | jq -r '.name // empty')
   MAX_FIRES=$(printf '%s' "$INPUT_JSON" | jq -r '.maxFires // empty')
   MAX_IDLE_FIRES=$(printf '%s' "$INPUT_JSON" | jq -r '.maxIdleFires // "3"')
+  [ -z "$SOURCE" ] && SOURCE=$(printf '%s' "$INPUT_JSON" | jq -r '.source // empty')
+fi
+
+# autonomy_v1.f1 — validate --source value at the skill boundary so typos
+# surface immediately rather than coercing silently to default at the
+# server. Accepted values mirror SignalTriggerConfig.source.
+if [ -n "$SOURCE" ] && [ "$SOURCE" != "local" ] && [ "$SOURCE" != "remote" ] && [ "$SOURCE" != "any" ]; then
+  echo "{\"error\":\"--source must be one of: local | remote | any (got: $SOURCE)\"}" >&2
+  exit 1
 fi
 
 [ -z "$EVENT_TYPE" ] && { echo '{"error":"--event-type is required"}' >&2; exit 1; }
@@ -127,6 +142,13 @@ if [ -n "$FILTER_OBJ" ]; then
   CONFIG_JSON=$(jq -n --arg et "$EVENT_TYPE" --argjson f "$FILTER_OBJ" '{type:"signal", eventType:$et, filter:$f}')
 else
   CONFIG_JSON=$(jq -n --arg et "$EVENT_TYPE" '{type:"signal", eventType:$et}')
+fi
+
+# autonomy_v1.f1 — propagate origin filter into SignalTriggerConfig.source.
+# Omitted at the skill layer when unset so the server-side default
+# ('local' per Arch Q2) governs without an explicit override on the wire.
+if [ -n "$SOURCE" ]; then
+  CONFIG_JSON=$(printf '%s' "$CONFIG_JSON" | jq --arg s "$SOURCE" '. + {source:$s}')
 fi
 
 WI_JSON=$(jq -n \

--- a/config/skills/agent/core/watch-for-event/execute.test.sh
+++ b/config/skills/agent/core/watch-for-event/execute.test.sh
@@ -37,6 +37,16 @@ OUTPUT=$(bash "$SCRIPT_DIR/execute.sh" --help 2>&1) || true
 assert_contains "Help lists --event-type" -- "--event-type" "$OUTPUT"
 assert_contains "Help lists --filter-session" -- "--filter-session" "$OUTPUT"
 assert_contains "Help mentions agent:idle example" "agent:idle" "$OUTPUT"
+# autonomy_v1.f1 — --source flag exposed in help
+assert_contains "Help lists --source" -- "--source" "$OUTPUT"
+
+echo ""
+echo "--- --source flag (autonomy_v1.f1) ---"
+
+# Invalid --source value rejected at the skill boundary (server-side default
+# would coerce silently — the skill catches typos early).
+OUTPUT=$(bash "$SCRIPT_DIR/execute.sh" --event-type agent:idle --title "X" --source bogus 2>&1) || true
+assert_contains "Invalid --source rejected" "must be one of: local | remote | any" "$OUTPUT"
 
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="

--- a/specs/cloud-event-fanout-contract.md
+++ b/specs/cloud-event-fanout-contract.md
@@ -1,0 +1,215 @@
+# Cloud Event Fan-out Contract — `'event'` MessageType
+
+**Status:** Frozen v1 contract — autonomy_v1.f1.
+**Audience:** web/ (cloud relay) implementers.
+**OSS-side reference:** `backend/src/services/cloud/cloud-event-bridge.service.ts` + `cloud-event-forwarder.service.ts`.
+**Origin design:** `.crewly/tasks/autonomy_v1/follow-up/cross-machine-event-triggers-decomp.md` § (c) *(repo-local, gitignored)*.
+**Arch verdict:** `.crewly/tmp/arch-verdict-cross-machine-event-triggers-2026-04-28.md` (PASS-WITH-REQUIRED-CHANGES, all conditions adopted) *(repo-local, gitignored)*.
+
+This document is the **single narrow artifact** that the OSS event runtime
+and the web/ Cloud Relay share. Per the compose-at-boundary discipline
+demonstrated by **PR #347** (`BrandOnboarding ⊥ OnboardingService`) and
+**PR #348** (`StatusBadge ⊥ RequestStatusPill`), the two sides keep their
+internal state independent and meet only at this contract. OSS-side may
+ship before / after / independent of web/ — until web/ honours this
+contract, the OSS forwarder/inbound-bridge are no-ops; once web/ ships,
+the loop closes without further OSS changes.
+
+## Goal
+
+Route AgentEvents emitted on device A to triggers on paired devices [B, C, …]
+within ≤ 5 s of remote emission, with at-least-once delivery semantics
+that the OSS-side idempotency stack tolerates.
+
+## Wire format — outbound (origin → cloud)
+
+Origin device calls the existing `/api/cloud/send` endpoint with:
+
+```http
+POST /api/cloud/send
+Authorization: Bearer <device-jwt>
+Content-Type: application/json
+
+{
+  "type": "event",                           // NEW MessageType (v1.f1)
+  "targetMachine": "*broadcast",             // see Routing
+  "payload": {
+    "event": {
+      "id": "<uuid>",                        // origin-assigned, stable across fan-out
+      "type": "xhs:scrape:done",             // canonical event type (string — see § Unknown types)
+      "sessionName": "iriss-air-marketing",
+      "timestamp": "2026-04-28T01:44:12.345Z",
+      "...": "<other AgentEvent fields the publisher set: workItemId, missionId, requestId, etc.>"
+    },
+    "originDeviceId": "<deviceId>",          // origin echoes its own id
+    "originDeviceName": "iriss-air"          // optional human-readable
+  }
+}
+```
+
+**Important:** `event.source` and `event.originDeviceId` are NOT shipped on
+the wire. The receiving CloudEventInboundBridge stamps `source = 'remote'` +
+`originDeviceId` from the message envelope so the contract is symmetric:
+both sides compute the origin tag from the message, never from the
+event payload. This prevents the wire from mutating those fields
+mid-flight.
+
+### Routing semantics
+
+| `targetMachine` value | Meaning |
+|---|---|
+| `"*broadcast"` | Fan out to every paired device in the same tenant. **OSS v1 always uses this.** |
+| `"<deviceId>"` | Direct fan-out to one device (point-to-point). Reserved for v2 — OSS v1 will not use. |
+
+Cloud determines tenant membership and per-device queue routing.
+
+### MessageType parallelism (Arch M1)
+
+| Type | Purpose | Wire shape |
+|---|---|---|
+| `'cross-machine'` | Free-text orchestrator messages, slack-style. | `CommandPayload` / `AgentMessagePayload`. |
+| **`'event'`** *(NEW)* | Typed AgentEvent objects, schema-stable. | `EventMessagePayload` (this doc). |
+
+Two types kept parallel because they have **different consumers** (the
+cross-machine message router vs. the event-bus inbound bridge), **different
+validation paths**, and **different downstream sinks**. The OSS forwarder
+emits `'event'`; the inbound bridge filters on `type === 'event'`.
+
+## Wire format — inbound (cloud → device, polled)
+
+The receiving device polls `/api/cloud/messages/poll` (existing endpoint —
+no new endpoint needed). Cloud returns:
+
+```json
+{
+  "id": "<cloud-message-uuid>",          // cloud-assigned; UNIQUE per fan-out delivery
+  "fromDeviceId": "<origin-deviceId>",
+  "createdAt": "<iso>",
+  "payload": "{\"type\":\"event\",\"data\":{ <same payload as outbound> },\"encrypted\":false,\"fromDeviceName\":\"iriss-air\"}"
+}
+```
+
+This matches the existing `IncomingMessage` envelope wrapping
+(`{type, data, encrypted, fromDeviceName}` JSON-encoded as a string in the
+`payload` field). **No new envelope shape, no new endpoint** — only the
+new `type === 'event'` discriminator.
+
+The OSS-side `CloudSyncService.processedMessageIds` LRU dedupes the
+cloud-assigned `id` upstream of the inbound bridge so duplicate cloud
+deliveries (e.g. retry after ack-loss) don't reach the bridge twice.
+
+## TTL + replay (cloud-side responsibility)
+
+| Constraint | Owner | Notes |
+|---|---|---|
+| Per-event retention in subscriber queues | **Cloud (web/)** | **24 h.** Event older than 24 h on a queue MUST be GC'd to bound storage. |
+| Replay on reconnect after offline | **Cloud (web/)** | When a device reconnects and polls `/messages/poll`, return all unacked events (subject to the 24 h TTL). No new replay endpoint needed — the existing poll IS the replay. |
+| Per-device cursor / offset tracking | **Cloud (web/)** | Cloud tracks each device's last-acked queue position so a reconnecting device receives only what it missed. |
+| Local LRU for at-least-once dedup | OSS-side | `processedMessageIds` Set bounded at `MAX_DEDUP_IDS` — already in place. |
+
+Devices offline > 24 h SHOULD see no replayed events for the missed window
+(the event has expired). OSS-side handles "missing event" naturally: a
+trigger that never fires on a missed event will not double-fire later.
+
+## OSS-side idempotency stack (active when this contract is honoured)
+
+| Layer | Key shape | Source |
+|---|---|---|
+| 1. CloudSync delivery | `cloud-message-id` | `cloud-sync.service.ts` `processedMessageIds` Set. |
+| 2. EventBus recent-publish | `${type}:${sessionName}:${event.id}` | `event-bus.service.ts:224` (post-Slice-1 M2 fix). |
+| 3. **TriggerEngine dedup** *(new)* | `${triggerId}:${event.id}` | `trigger-engine.service.ts` `firedDedup` Set, capacity 2000. |
+| 4. BRIDGE-1 per-handler | `workItemId` / `missionId` / `verifyId` / `retryId` / `escalationId` | `event-to-workitem-bridge.service.ts`. |
+
+Each layer's key is **disjoint** from every other layer's. Cloud's
+at-least-once delivery feeds layer 1 → layer 2 → layer 3, where any
+duplicate is suppressed before it reaches downstream effects. See decomp
+memo § (d) for the full proof.
+
+## Errors
+
+| HTTP | Meaning | OSS handling |
+|---|---|---|
+| 401 / 403 | Auth expired | Existing `handleAuthError()` token-refresh path triggers. |
+| 413 | Event payload too large | Forwarder logs + drops. **Does NOT retry** — payload bloat would compound. |
+| 429 | Cloud rate-limited the origin | Existing CloudSync exponential backoff. |
+| 5xx | Cloud transient | Existing CloudSync retry-with-backoff. |
+
+## Unknown event types from peers (Arch Q4)
+
+The OSS-side `EVENT_TYPES` enum (`backend/src/types/event-bus.types.ts`)
+is closed. Paired devices may roll out new event types one at a time
+WITHOUT requiring fleet-wide deployment ordering — the inbound bridge
+accepts any string at the wire boundary via the runtime-only
+`RemoteEventType = string` alias and casts to `EventType` at the local
+re-publish boundary. Unrecognised types are logged at debug level so
+ops can audit drift.
+
+This means: **cloud SHOULD NOT validate `event.type` against any
+allow-list of known types**. Pass through whatever the origin device
+emitted.
+
+## Forwarder allow-list (origin-side, OSS responsibility)
+
+Each origin device opt-in lists which event types may leave the device,
+read from `<projectPath>/crewly.json` `crossMachineEvents` array. Default:
+empty (no events forwarded). The cloud relay does NOT mirror this list;
+it accepts whatever the origin sends.
+
+This boundary is intentional:
+- **Privacy**: avoids leaking internal events to peers by default.
+- **DoS containment**: a flapping agent on one device cannot saturate
+  peer queues unless the operator explicitly listed the event type.
+- **Payload bloat**: bounded subset of event types over the wire.
+
+## Loop prevention (origin-side, OSS responsibility)
+
+The `CloudEventForwarder` short-circuits on `event.source === 'remote'`
+so the inbound bridge ↔ forwarder pair cannot form a ping-pong loop.
+**Cloud does not need to do anything for loop prevention** — the fence
+is at the origin device.
+
+## Versioning
+
+- v1 / autonomy_v1.f1: this document.
+- v2 (deferred): per-event subscription routing (origin device names
+  subscriber set), encrypted-event option, replay endpoint with cursor.
+
+Future revisions MUST preserve the v1 message wire shape for backward
+compatibility — paired devices on v1 must continue to receive v2-emitted
+events that fit the v1 shape.
+
+## Acceptance for the web/ ticket
+
+- [ ] `/api/cloud/send` accepts `type === 'event'` and per-tenant
+      broadcasts the payload to all paired devices in the same tenant.
+- [ ] Each subscriber queue retains the event for 24 h with per-device
+      cursor / ack tracking.
+- [ ] `/api/cloud/messages/poll` returns retained events on reconnect
+      (existing endpoint; no new shape).
+- [ ] Cloud does NOT validate `event.type` against any allow-list.
+- [ ] Cloud does NOT mutate `event.source` or `event.originDeviceId`
+      (these are absent on the outbound wire).
+- [ ] At-least-once delivery semantics — duplicates with the same
+      cloud-message-id are caught by the OSS-side `processedMessageIds`
+      LRU; cloud is not required to deduplicate.
+
+## OSS-side hand-off summary
+
+| Concern | OSS-side | Web-side |
+|---|---|---|
+| Forwarder allow-list | ✅ ships in Slice 5 | n/a |
+| Loop-prevention fence | ✅ ships in Slice 5 | n/a |
+| Inbound translation to AgentEvent | ✅ ships in Slice 2 | n/a |
+| 4-layer idempotency stack | ✅ ships in Slices 1-3 | n/a (cloud at-least-once OK) |
+| `'event'` MessageType vocabulary | ✅ ships in Slice 1 | accept |
+| Per-tenant broadcast fan-out | n/a | **REQUIRED** |
+| 24 h event TTL + cursor | n/a | **REQUIRED** |
+| Existing `/messages/poll` extends to events | n/a | **REQUIRED** (no shape change) |
+
+## Pattern lineage
+
+This contract is the deliverable form of the *narrow-shared-artifact*
+discipline first cited in PR #347 / PR #348 review, then promoted by
+Arch as the structuring principle for autonomy_v1.f1's OSS ⊥ web/ split
+(verdict 2026-04-28). Future cross-process collaborations should treat
+this doc as a worked example of the pattern.


### PR DESCRIPTION
## Summary

OSS-side delivery of **autonomy_v1.f1 — cross-machine event triggers via Cloud Relay**. Closes the autonomy gap that prompted this ticket (iriss-air → Marketing 2026-04-28 incident: remote events did not auto-fire local triggers across paired devices). 6 atomic commits, ~2.25 dev-days.

**Cloud-side fan-out is a separate web/ ticket** — this PR ships the OSS half against a frozen contract (`specs/cloud-event-fanout-contract.md`). Until web/ honours the contract, the forwarder + inbound bridge are no-ops; once web/ ships, the loop closes without further OSS changes (compose-at-boundary discipline, lineage from PR #347 / #348).

## Slice manifest

| Slice | Commit | Layer | Tests |
|---|---|---|---|
| 1 — Types foundation + M2 fix | `0c2c71ef` | `event-bus.types.ts`, `trigger.types.ts`, `cloud-sync.types.ts`, EventBus `publish` | 205/205 across types + event-bus suites |
| 2 — CloudEventInboundBridge (NEW file per N1) | `d17aa112` | `cloud-event-bridge.service.ts` | 13/13 |
| 3 — TriggerEngine source filter + per-trigger dedup | `0770d629` | `trigger-engine.service.ts` | 10/10 |
| 4 — `watch-for-event --source` flag | `da745c48` | skill | 7/7 bash tests |
| 5 — CloudEventForwarder + allow-list + boot wiring | `0d4b17a1` | `cloud-event-forwarder.service.ts`, `cloud-initializer.ts`, `cloud.controller.ts`, `event-bus.controller.ts` | 14/14 |
| 6 — Cloud contract spec for web/ hand-off | `fcb48c8c` | `specs/cloud-event-fanout-contract.md` | n/a (docs) |

## Arch greenlight conditions — all 4 adopted

| ID | Adopted as |
|---|---|
| **M1** `'event'` vs `'cross-machine'` MessageType | Kept parallel + justification in `cloud-sync.types.ts` JSDoc + spec § "MessageType parallelism". Different shape, different consumer (router vs event-bridge), different validation paths. |
| **M2** §(d) Layer 2 framing | **Option B (real fix).** Recent-publish dedup key widened `${type}:${sessionName}` → `${type}:${sessionName}:${event.id}` at `event-bus.service.ts:224`. 1-line change + co-located test that two distinct events with same `(type, sessionName)` within 5s both publish. Strictly more permissive — true-duplicate suppression preserved. |
| **N1** `CloudEventInboundBridge` separate file | NEW `backend/src/services/cloud/cloud-event-bridge.service.ts`. Cloud-sync stays a transport (it EMITS); event-bridge owns AgentEvent translation. |
| **Q5** Forwarder loop-prevention test | Standalone `it('Q5 LOCKED — does NOT forward events with source="remote"')` in `cloud-event-forwarder.service.test.ts` — fence-at-test-surface pattern (PR #354 N1). |

## 7 Q answers — all locked in code

| # | Question | Implementation |
|---|---|---|
| **Q1** | Forwarder gating | OPT-IN allow-list `crewly.json` `crossMachineEvents`. Empty / malformed = no-op (fail-safe). |
| **Q2** | `SignalTriggerConfig.source` default | `'local'`. WIRE-1 V4 backward-compat lock. |
| **Q3** | sessionName collision | `originDeviceId` added to `AgentEvent` + `EventFilter`. SessionName origin-pristine. |
| **Q4** | Unknown peer event types | `RemoteEventType = string` cast at inbound-bridge boundary. Closed `EVENT_TYPES` enum stays closed. Debug log breadcrumb. |
| **Q5** | Loop prevention | Forwarder skips `source === 'remote'`. Fence locked at test surface. |
| **Q6** | LRU vs restart | Memory-only LRU (capacity 2000), startup warn-log breadcrumb so ops can correlate restart-window double-fires. |
| **Q7** | Effort | 1.75 d baseline + Q1/Q3/M2 cushions = 2.25 dev-days. Actual ≈ 2.0 dev-days. |

## 4-layer idempotency stack — proof live

```
Layer 1: cloud-message-id              (CloudSync.processedMessageIds LRU)
Layer 2: ${type}:${session}:${id}       (EventBus recent-publish — POST M2)
Layer 3: ${triggerId}:${event.id}       (TriggerEngine.firedDedup — NEW)
Layer 4: workItemId / missionId         (BRIDGE-1 per-handler idempotencyKey)
```

No layer key collides with another. Each catches a distinct duplicate-source. Verified by Arch direct code-read (verdict 2026-04-28).

## Test plan

- [x] `npx tsc -p backend/tsconfig.json --noEmit` — clean across all 6 slices
- [x] `npx jest backend/src/services/cloud/cloud-event-bridge.service.test.ts backend/src/services/cloud/cloud-event-forwarder.service.test.ts backend/src/services/event-bus/ backend/src/services/v3/trigger-engine.cross-machine.service.test.ts backend/src/services/cloud/cloud-sync.types.test.ts backend/src/types/v2/trigger.types.test.ts` — **203/203 pass** (8 suites)
- [x] `bash config/skills/agent/core/watch-for-event/execute.test.sh` — 7/7 bash tests pass
- [x] **E2E (deferred to post-web-merge)** — paired iriss-air + MacBook Pro 3 happy path: iriss-air emits `xhs:scrape:done` → MacBook Pro Marketing trigger fires within 5s. Tracked in spec § Acceptance.
- [x] **Pre-existing failures verified on clean main and isolated** — vitest-import test files (request-tracker / project-task-watcher / mission-period etc.), `escalation.service.test.ts` signature drift, `cloud-sync.service.test.ts` device-cache seeding (12 fail / 26 pass on main, identical on this branch). All pre-existing, untouched by this PR.

## Diff stats

```
$ git diff --stat main...HEAD
  16 files changed, 2347 insertions(+), 31 deletions(-)
```

3 NEW services, 1 NEW spec, surgical edits to existing event-bus / trigger-engine / cloud-sync types / cloud controller / boot wiring.

## Out of scope (future tickets)

- **web/ ticket** — implements the `'event'` MessageType fan-out + 24h TTL + per-device cursor in Cloud Relay per `specs/cloud-event-fanout-contract.md`. Until then, OSS-side forwarder + inbound bridge are no-ops (privacy-safe default).
- v2 routing — per-event subscriber selection (origin names subscriber set), encrypted-event option, replay endpoint with cursor. Forward-compatible v1 wire shape preserved.

## Hand-off

- Tag **@Arch** for PR review against the 4 greenlight conditions + 7 Q answers landed in code.
- File a follow-up ticket targeting **web/** with `specs/cloud-event-fanout-contract.md` § "Acceptance for the web/ ticket" as the checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)