### PR TITLE
feat(browser): Chrome ext UX hardening — status field + tabInventory suppress + auto-create tab

### DIFF
--- a/backend/src/services/browser/browser-bridge.service.test.ts
+++ b/backend/src/services/browser/browser-bridge.service.test.ts
@@ -47,6 +47,27 @@ jest.mock('../core/logger.service.js', () => ({
 	},
 }));
 
+const mockRelayAdapter = {
+	isAvailable: jest.fn<boolean, []>(() => false),
+	getExtensionDeviceId: jest.fn<string | null, []>(() => null),
+};
+
+const mockBrowserProxyService = {
+	isAvailable: jest.fn<boolean, []>(() => false),
+};
+
+jest.mock('./browser-relay-adapter.service.js', () => ({
+	BrowserRelayAdapter: {
+		getInstance: () => mockRelayAdapter,
+	},
+}));
+
+jest.mock('./browser-proxy.service.js', () => ({
+	BrowserProxyService: {
+		getInstance: () => mockBrowserProxyService,
+	},
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -93,6 +114,9 @@ describe('BrowserBridgeService', () => {
 		// Tests that override env vars must also clean up; do it here as a safety net.
 		delete process.env.CREWLY_TAB_BIND_MAX;
 		delete process.env.CREWLY_TAB_BIND_TTL_MINUTES;
+		mockRelayAdapter.isAvailable.mockReset().mockReturnValue(false);
+		mockRelayAdapter.getExtensionDeviceId.mockReset().mockReturnValue(null);
+		mockBrowserProxyService.isAvailable.mockReset().mockReturnValue(false);
 	});
 
 	describe('getInstance', () => {
@@ -119,6 +143,17 @@ describe('BrowserBridgeService', () => {
 			expect(status.wsPath).toBe('/ws/browser');
 			// New per-tab field — initially zero.
 			expect(status.bindingCount).toBe(0);
+		});
+
+		it('should return connected when only the proxy path is available', () => {
+			mockBrowserProxyService.isAvailable.mockReturnValue(true);
+			const bridge = BrowserBridgeService.getInstance();
+			const status = bridge.getStatus();
+
+			expect(status.connected).toBe(true);
+			expect(status.clientCount).toBe(0);
+			expect(status.relayAvailable).toBe(false);
+			expect(status.proxyAvailable).toBe(true);
 		});
 	});
 

--- a/backend/src/services/browser/browser-bridge.service.ts
+++ b/backend/src/services/browser/browser-bridge.service.ts
@@ -94,6 +94,8 @@ export interface BrowserBridgeStatus {
 	wsPath: string;
 	/** Whether the Cloud relay path to an Extension is available */
 	relayAvailable?: boolean;
+	/** Whether the Cloud Relay proxy path currently has a reachable browser. */
+	proxyAvailable?: boolean;
 	/** Cloud device ID of the relay-connected Extension (null if not discovered) */
 	relayDeviceId?: string | null;
 	/** Number of currently active agent→tab bindings (per-tab dispatch). */
@@ -798,6 +800,7 @@ export class BrowserBridgeService {
 	getStatus(): BrowserBridgeStatus {
 		const directConnected = this.clients.size > 0;
 		let relayAvailable = false;
+		let proxyAvailable = false;
 		let relayDeviceId: string | null = null;
 
 		try {
@@ -813,11 +816,22 @@ export class BrowserBridgeService {
 			// Relay adapter not available
 		}
 
+		try {
+			const { BrowserProxyService } = nodeRequire('./browser-proxy.service.js');
+			const proxy = BrowserProxyService.getInstance() as {
+				isAvailable: () => boolean;
+			};
+			proxyAvailable = proxy.isAvailable();
+		} catch {
+			// Proxy service not available
+		}
+
 		return {
-			connected: directConnected || relayAvailable,
+			connected: directConnected || relayAvailable || proxyAvailable,
 			clientCount: this.clients.size,
 			wsPath: BROWSER_BRIDGE_CONSTANTS.WS_PATH,
 			relayAvailable,
+			proxyAvailable,
 			relayDeviceId,
 			bindingCount: this.agentTabBindings.size,
 		};


### PR DESCRIPTION
## What changed
- fix `/api/browser/status.connected` so it reflects the real proxy-backed browser path, not just direct WS and relay-adapter availability
- expose `proxyAvailable` alongside the existing status fields for clearer observability
- add a proxy-only unit test for the false-negative case Reed documented

## Why
Reed's RCA showed the live Chrome extension path was healthy through `BrowserProxyService -> Cloud Relay -> Extension`, but `BrowserBridgeService.getStatus()` still returned `connected: false` because it ignored proxy availability.

References:
- `.crewly/tasks/autonomy_v1/follow-up/browser-status-field-fix.md`
- `.crewly/reports/chrome-ext-binding-rca-2026-04-28.md`

## Validation
- `npm test -- --runInBand backend/src/services/browser/browser-bridge.service.test.ts`
- `npm run build:backend`

## Notes
- This is the backend portion of the approved browser UX hardening batch.
- Companion extension PR covers:
  - `.crewly/tasks/autonomy_v1/follow-up/browser-f2-skip-tabinventory-on-relay.md`
  - `.crewly/tasks/autonomy_v1/follow-up/browser-f3-auto-create-tab-on-no-active.md`
- Honest verification note: live manual verification for f3 acceptance #4/#5 is still pending a real backend restart plus Chrome extension reload on the running pair Steve is using.
