### PR TITLE
fix(browser): auto-select freshest instance on N>1 to survive relay reconnect ghosts

### DIFF
--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -455,6 +455,82 @@ describe('BrowserProxyService', () => {
         'No browser instances connected',
       );
     });
+
+    it('auto-selects the freshest instance when multiple are connected and no target specified', async () => {
+      const proxy = BrowserProxyService.getInstance();
+      proxy.connect('test-token');
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-1' }),
+      );
+      // Two instances: 'Stale' seen 5min ago, 'Fresh' seen just now.
+      // Mirrors the extension-reconnect ghost scenario where the relay still
+      // reports a previous sessionId alongside the live one.
+      const now = Date.now();
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'id-stale',
+              instanceName: 'Stale',
+              sessionId: 'bs-old',
+              lastSeenAt: new Date(now - 5 * 60_000).toISOString(),
+            },
+            {
+              instanceId: 'id-fresh',
+              instanceName: 'Fresh',
+              sessionId: 'bs-new',
+              lastSeenAt: new Date(now).toISOString(),
+            },
+          ],
+        }),
+      );
+
+      const cmdPromise = proxy.sendCommand('getTabs');
+      const sentMsg = JSON.parse(latestMockWs!.send.mock.lastCall![0] as string);
+      expect(sentMsg.type).toBe('relay_to');
+      expect(sentMsg.targetInstance).toBe('Fresh');
+
+      // Resolve to avoid hanging promise
+      const payload = JSON.parse(sentMsg.payload as string);
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          payload: JSON.stringify({ id: payload.id, success: true, result: [] }),
+        }),
+      );
+      await cmdPromise;
+    });
+
+    it('auto-select error message distinguishes empty from ambiguous when all timestamps are unparseable', async () => {
+      const proxy = BrowserProxyService.getInstance();
+      proxy.connect('test-token');
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-1' }),
+      );
+      // Two instances with garbage timestamps so resolveInstance returns null
+      // even though instances.size > 0. This validates the new error branch.
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            { instanceId: 'a', instanceName: 'A', sessionId: 's-a', lastSeenAt: 'not-a-date' },
+            { instanceId: 'b', instanceName: 'B', sessionId: 's-b', lastSeenAt: 'also-bad' },
+          ],
+        }),
+      );
+
+      await expect(proxy.sendCommand('navigate')).rejects.toThrow(
+        /Could not resolve a browser instance from 2 candidates/,
+      );
+    });
   });
 
   describe('getInstances', () => {

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -329,7 +329,9 @@ export class BrowserProxyService {
       throw new Error(
         instance
           ? `Browser instance "${instance}" not found. Available: ${available || 'none'}`
-          : `No browser instances connected`,
+          : this.instances.size === 0
+            ? `No browser instances connected`
+            : `Could not resolve a browser instance from ${this.instances.size} candidates (none have a recent lastSeenAt). Available: ${available}`,
       );
     }
 
@@ -370,16 +372,39 @@ export class BrowserProxyService {
   /**
    * Resolve which browser instance to target.
    *
+   * Auto-select rules when no explicit `instance` is provided:
+   *   - 0 instances → null (caller raises "No browser instances connected")
+   *   - 1 instance  → that instance
+   *   - N>1 instances → the freshest by `lastSeenAt`. This handles two cases:
+   *       (a) Multiple Chromes connected (user gets the most-recently-active one).
+   *       (b) Ghost entries left behind by a relay that has not yet pruned a
+   *           stale session after the extension reconnected with a new sessionId.
+   *           The freshest entry is the live one.
+   *     Ties on `lastSeenAt` are broken by insertion order (Map iteration).
+   *
    * @param instance - Explicit instance name/ID, or undefined for auto-select
    * @returns Matching BrowserInstanceInfo or null
    */
   private resolveInstance(instance?: string): BrowserInstanceInfo | null {
     if (!instance) {
-      // Auto-select: use the only instance if there's exactly one
-      if (this.instances.size === 1) {
+      const size = this.instances.size;
+      if (size === 0) return null;
+      if (size === 1) {
         return this.instances.values().next().value ?? null;
       }
-      return null;
+      // Multiple candidates → pick the freshest by lastSeenAt to tolerate
+      // ghost entries from extension reconnect cycles and to pick the most
+      // active browser when several are genuinely connected.
+      let freshest: BrowserInstanceInfo | null = null;
+      let freshestTs = -Infinity;
+      for (const info of this.instances.values()) {
+        const ts = Date.parse(info.lastSeenAt);
+        if (Number.isFinite(ts) && ts > freshestTs) {
+          freshestTs = ts;
+          freshest = info;
+        }
+      }
+      return freshest;
     }
 
     // Search by name or ID


### PR DESCRIPTION
## Hot bug — customer-demo-adjacent investigation (ORC-driven)

### Summary
- `BrowserProxyService.resolveInstance` returned `null` for `instances.size > 1` when no explicit `instance` parameter was provided.
- During an extension pong-timeout reconnect (every ~1–2 min in repro), the cloud relay briefly reports both the ghost session (old `sessionId`) and the live session (new `sessionId`) for the same Chrome. From OSS's perspective: `proxy.instances.size` flips to 2.
- Every unscoped `/api/browser/*` call (which is what `navigate`, `screenshot`, `getTabs`, etc. all do — see `browser.controller.ts:319-321`) then failed with the misleading `503 NO_BROWSER_CLIENT` body `proxy-relay: No browser instances connected`.
- `bindingCount: 0` in `/api/browser/status` is **expected** in cloud-relay mode — `agentTabBindings` is the *direct-WS* table, never populated when the extension talks via the relay. Red herring.

### Fix
- Auto-select now picks the **freshest** instance by `lastSeenAt` when the candidate set has more than one entry. Tolerates ghost entries from reconnect cycles AND gives a sensible default when multiple Chromes are genuinely connected.
- Error message split: `0 instances` keeps `"No browser instances connected"`; `N>1 with no parseable timestamps` returns the new `Could not resolve a browser instance from N candidates …`. The original symptom would have been diagnosed in seconds with this message.

### Test plan
- [x] `npx jest --testPathPattern="backend/src/services/browser"` → 99 / 99 pass (was 97 — added 2 new cases).
- [x] `npx jest --testPathPattern="browser.controller"` → 29 / 29 pass.
- [x] New tests cover (a) ghost-stale + fresh-live → fresh wins, (b) all-bad-timestamps → ambiguous-candidates error.

### Out of scope (filed separately)
- Pong-timeout root cause itself — chrome-extension MV3 SW suspension OR cloud relay `heartbeat_ack` reliability. Both crewly-pro / chrome-extension territory.
- Relay-side ghost-session pruning on registration collision.
- Terminal-queue stall (orc PTY `onData` listener attached lazily on frontend `subscribe_to_session`). RCA in `specs/rca-readiness-state-machines-2026-04-29.md`; fix design in `specs/terminal-queue-eager-monitoring-fix.md` — implementation deferred to next sprint per ORC.

### Deploy notes
ORC directive: **merge but do NOT restart OSS service today.** Steve is mid-flight on a SteamFun customer demo (manual Path B). Let this fix land silently and pick up on the next natural restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)