### PR TITLE
docs(specs): RCA + terminal-queue eager-monitoring fix spec

### DIFF
--- a/specs/rca-readiness-state-machines-2026-04-29.md
+++ b/specs/rca-readiness-state-machines-2026-04-29.md
@@ -1,0 +1,240 @@
+---
+title: RCA — Browser Binding & Terminal Queue Readiness State Machines
+date: 2026-04-29
+author: Sam (Tech Lead)
+trigger: ORC ad-hoc investigation; Steve customer demo (SteamFun) impact
+scope: Crewly OSS only (backend/). Cloud relay (api.crewlyai.com) called out as upstream cause but not in scope to fix here.
+status: browser symptom RESOLVED in PR #377 (merged 2026-04-29, deploy deferred to next natural OSS restart per ORC); terminal symptom RCA-only — fix design in specs/terminal-queue-eager-monitoring-fix.md (implementation deferred to next sprint per ORC)
+---
+
+# RCA — Two Reconnect-Driven Readiness Bugs
+
+## TL;DR
+
+Two seemingly unrelated symptoms — (1) orc terminal messages queuing until the
+side panel is opened, (2) `/api/browser/navigate` returning 503 even though the
+relay shows two healthy Chrome instances — share a common shape:
+
+> *The backend has live state, but a downstream readiness check fails because
+> a state-machine transition is gated on an event that never fires (or fires
+> on the wrong identity after a reconnect).*
+
+For the browser path, I have a *root cause* and a *small, low-risk patch*
+landed on `fix/proxy-multi-instance-auto-select` (waiting for review). For the
+terminal path, the architectural fix touches the WS gateway lifecycle and is
+not safe to ship without a proper review round — RCA only.
+
+---
+
+## Symptom 1 — Browser navigate returns 503 with 2 live instances
+
+### Evidence (from Steve / ORC)
+
+- `/api/browser/status` snapshot:
+  - `proxy.state: "connected"`, `proxy.available: true`
+  - `proxy.instances`: 2 Chrome entries, `lastSeen` ~now
+  - Top-level `connected: false`, `relayAvailable: false`, `bindingCount: 0`
+- `POST /api/browser/navigate` → `503 NO_BROWSER_CLIENT`
+  with body `proxy-relay: No browser instances connected`.
+- Cloud Portal also reports 2 Chrome instances "Last seen 1m ago".
+- Extension DevTools console shows ~1–2 min reconnect cycles driven by
+  `Pong timeout — connection appears dead, forcing reconnect`. Each
+  reconnect yields a *new relay sessionId* (`74c53f77…` → `27d49b3b…`).
+
+### Root cause (high confidence)
+
+Two compounding issues, only one of which is OSS:
+
+1. **Upstream (cloud relay / extension)** — extension hits a 15 s pong
+   timeout (`PONG_TIMEOUT_MS` in `chrome-extension/src/types.ts:171`),
+   tears down its WS, reconnects, and registers again. The relay does not
+   prune the prior session promptly, so for a window the relay's view
+   contains both the *ghost* (old sessionId) and the *live* (new sessionId)
+   entry for the same physical Chrome — *or* there are genuinely two
+   Chromes, but both are oscillating the same way. From the OSS proxy's
+   perspective the result is the same: `browser_list` arrives with N≥2
+   entries.
+
+2. **OSS (this repo) — `BrowserProxyService.resolveInstance` gives up on
+   N≥2.** When `sendCommand` is called without an explicit `instance`
+   parameter (which is what `/api/browser/navigate` does — see
+   `backend/src/controllers/browser/browser.controller.ts:319-321` and the
+   `sendToolCommand` body around `:289-298`), the proxy's auto-select
+   logic at `backend/src/services/browser/browser-proxy.service.ts:376-389`
+   was:
+
+   ```ts
+   if (!instance) {
+     if (this.instances.size === 1) {
+       return this.instances.values().next().value ?? null;
+     }
+     return null;        // ← bug: also returns null when size > 1
+   }
+   ```
+
+   So the moment the relay's instance count crosses 1, *every* unscoped
+   browser tool call fails with the misleading error
+   `No browser instances connected`. This is exactly the error in Steve's
+   navigate response.
+
+   Note: `bindingCount: 0` in the status payload is **expected** for
+   relay-mode operation — `agentTabBindings` is the *direct-WS* binding
+   table maintained by `BrowserBridgeService`, and we never have a
+   direct WS in cloud-relay mode. It is a red herring for this symptom.
+
+### Why "Path B works" (the user-clicked menu)
+
+Path B forces an explicit `instance` parameter into the request, which
+flips `resolveInstance` onto the search-by-name branch (line 386–390),
+which works regardless of how many candidates are present.
+
+### Fix (landed in this branch)
+
+`fix/proxy-multi-instance-auto-select` (≈25 lines + 2 tests):
+
+- Auto-select now returns the **freshest by `lastSeenAt`** when more than
+  one instance is known. Tolerates ghost entries from reconnect *and* gives
+  the user a sensible default when multiple Chromes are genuinely live.
+- The 0-vs-ambiguous error message is split so future symptoms read
+  unambiguously (`No browser instances connected` vs.
+  `Could not resolve a browser instance from N candidates …`).
+- Tests cover (a) ghost-stale + fresh-live → fresh wins, (b) all-bad
+  timestamps → ambiguous error rather than the misleading "no instances".
+
+Files:
+- `backend/src/services/browser/browser-proxy.service.ts:314-345, 370-414`
+- `backend/src/services/browser/browser-proxy.service.test.ts:444-…`
+
+`backend/src/services/browser` test suite: 99 / 99 pass.
+
+### What this fix does NOT cover
+
+- Why the extension hits a 15 s pong timeout every 1–2 minutes. Two
+  hypotheses — MV3 service-worker suspension between heartbeat send and
+  ack receipt, or the relay occasionally dropping a `heartbeat_ack` under
+  load. Both are outside OSS. *Recommendation*: open a follow-up ticket on
+  crewly-pro relay reliability + chrome-extension SW keep-alive
+  (background.ts:1167-1188 already wires `swKeepAlive`, but if the SW
+  *itself* is suspended mid-heartbeat the timer is useless).
+- Pruning ghosts on the relay side. The OSS proxy now copes; the relay
+  should still drop a session promptly when it closes.
+
+---
+
+## Symptom 2 — Orc terminal messages queue until the side panel is opened
+
+### Evidence (from Steve)
+
+> "I had several messages that were queued but never delivered to orc's
+> terminal. As soon as I opened the frontend side terminal panel, all
+> queued messages flushed at once. Feels like a focus issue."
+
+### Root cause (medium-high confidence — needs runtime verification)
+
+The orchestrator's PTY is created/owned by the backend. The backend's
+**`TerminalGateway` only attaches a PTY `onData` listener when a frontend
+WebSocket client subscribes to that session** (`subscribe_to_session` →
+`startPtyStreaming` at `backend/src/websocket/terminal.gateway.ts:268-330`).
+When all clients disconnect, `stopPtyStreaming`
+(`:340-354`, called from `:420-425`) tears the listener down again.
+
+Meanwhile, the agent message-delivery path
+(`AgentRegistrationService.sendMessageWithRetry` →
+`session.write(...)` at `:3026, :3556`) writes directly into the PTY
+*regardless* of whether anyone is listening. The dispatcher
+(`QueueProcessorService.processNext`) does the same — fire and forget.
+
+So if the user (or another orchestrator) sends a message to `crewly-orc`
+*while no frontend tab is subscribed to its terminal*:
+
+- Bytes arrive at the PTY successfully.
+- Claude (the orc) reads from its stdin and processes them — the agent
+  itself probably *is* responding internally; it just has no listener
+  upstream to broadcast its output.
+- The PTY's stdout still has buffered output, but nothing is forwarded
+  to the frontend until a subscriber attaches.
+- The moment the panel opens, `subscribe_to_session` runs, the `onData`
+  handler is registered, the PTY drains its buffer through the new
+  handler in one burst → "all queued messages just flushed".
+
+So Steve's word "queue" is slightly off — there's no explicit queue in
+the dispatcher. The PTY itself is the queue, and the gateway is the
+gate that lets it drain.
+
+### Why this is the same shape as Symptom 1
+
+Both bugs are **state machines that wait for an event that may never fire**:
+
+| Symptom | "Queued" thing | Gating event |
+|---|---|---|
+| Browser 503 | command waiting for a target | `instance` arg present *or* exactly 1 instance |
+| Terminal stall | PTY stdout bytes | a frontend WS client calls `subscribe_to_session` |
+
+Both can be made robust by giving the readiness check a *fallback path* it
+can take on its own.
+
+### Fix shape (NOT implemented — RCA only)
+
+Three options, in order of safety:
+
+1. **Persistent orc monitoring.** Have the backend, on boot or first
+   message-to-orc, call
+   `getTerminalGateway().startOrchestratorChatMonitoring(ORCHESTRATOR_SESSION_NAME)`
+   so the orc PTY *always* has an `onData` listener — independent of any
+   frontend subscriber. The function exists at
+   `backend/src/websocket/terminal.gateway.ts:363-386`; it's just not
+   guaranteed to be invoked. This is the smallest semantic change.
+
+2. **Queue-time warm-up.** Wrap `sendMessageToAgent` with a step that
+   ensures the gateway has live monitoring for the target session before
+   the write goes through. Slightly more invasive — touches agent
+   delivery — but couples the readiness check tightly to the operation
+   that needs it.
+
+3. **Subscribe-on-write semantics in the gateway.** When `session.write`
+   is called for a session with zero subscribers, the gateway implicitly
+   enters a "persistent monitoring" mode that buffers + replays on
+   first subscribe. Cleanest model, but largest blast radius — every PTY
+   in the system would change behavior.
+
+### Why I am not shipping this in the same patch
+
+- It changes the lifetime contract of an `onData` listener that other
+  features (agent output capture, learning auto-record subscriber,
+  WorkItem heartbeat reviewer) implicitly rely on. Needs a dedicated
+  review round.
+- Steve has Path B working for today's demo. There is no acute pressure
+  to land a fix today, only to *understand* it.
+- The 30-line ceiling Steve set for direct-commit fixes does not fit
+  any of the three options above.
+
+*Recommendation*: file as a P1 follow-up, owner Sam, target the next
+sprint. I'll prep the patch on a branch alongside the gateway tests when
+we get the green light.
+
+---
+
+## Open questions for Steve / ORC
+
+1. The relay-side ghost-session pruning behavior — is that already on
+   crewly-pro's roadmap, or do we need a new ticket?
+2. For the terminal-queue fix, is option 1 (eager orc monitoring) the
+   preferred direction? It's the lowest-risk and matches the spirit of
+   the existing `startOrchestratorChatMonitoring` helper. If yes, I'll
+   spec + ship next slot.
+3. Should we surface the new ambiguous-instance case in the
+   `/api/browser/status` payload (e.g. `proxy.candidateCount`) so the
+   frontend can warn the user when N>1? Not blocking, but cheap to add.
+
+---
+
+## Verification artifacts (browser fix)
+
+- Branch: `fix/proxy-multi-instance-auto-select` (off `main`, no
+  unrelated work piggy-backed).
+- Tests: `npx jest --testPathPattern="backend/src/services/browser"` →
+  **99 passed, 99 total**.
+- Controller tests:
+  `npx jest --testPathPattern="browser.controller"` → **29 passed**.
+- Lines changed: 25 in source, ~70 in tests (2 new test cases). All
+  diffs stay inside `backend/src/services/browser/`.

--- a/specs/terminal-queue-eager-monitoring-fix.md
+++ b/specs/terminal-queue-eager-monitoring-fix.md
@@ -1,0 +1,168 @@
+---
+title: Terminal Queue — Eager Orc-PTY Monitoring (Fix Spec)
+date: 2026-04-29
+author: Sam (Tech Lead)
+status: APPROVED for next sprint (ORC green-light 2026-04-29). NOT for today — Steve's customer demo (SteamFun) is the binding constraint; OSS internals fix may not compete with demo risk budget.
+related:
+  - specs/rca-readiness-state-machines-2026-04-29.md (Symptom 2 RCA)
+  - PR #377 (browser-side companion fix, already merged)
+  - .crewly/specs/rca-readiness-state-machines-2026-04-29.md (local notebook copy)
+---
+
+# Terminal Queue — Eager Orc-PTY Monitoring
+
+## 1. Problem (one paragraph, from RCA)
+
+Messages sent to the orchestrator (`crewly-orc`) PTY appear to "queue up
+and not deliver" until a frontend WebSocket client opens the side
+terminal panel — at which point all queued output flushes in one burst.
+Root cause: `TerminalGateway.startPtyStreaming`
+(`backend/src/websocket/terminal.gateway.ts:268-330`) attaches the PTY's
+`onData` listener **only** when a frontend client calls
+`subscribe_to_session`. `stopPtyStreaming` (`:340-354`, called from
+`:420-425`) tears it down again when the last client disconnects.
+Meanwhile `AgentRegistrationService.sendMessageWithRetry` writes to the
+PTY unconditionally (`:3026, :3556`). With no `onData` handler armed,
+the PTY's stdout buffer accumulates locally; nothing is broadcast to
+the frontend until a subscriber attaches, at which point the buffer
+drains in one burst. From the user's perspective: silence, then "all
+queued messages flushed".
+
+## 2. Why fix it
+
+- *User-visible silence* on a path the orchestrator is supposed to own
+  end-to-end. Steve's "feels like a focus issue" feedback is precisely
+  this. Fix removes the foot-gun.
+- *Hidden inside automation*. The orchestrator runs without a human
+  watching the terminal panel most of the time. Any orc workflow that
+  relies on round-tripping through the PTY (e.g., manual user prompts
+  injected from Slack, future cross-machine event triggers in
+  autonomy_v1.f1) is silently throttled by frontend presence today.
+- *Common shape with PR #377*. Both bugs were "readiness check waits
+  for an event that may never fire." Closing both removes a class of
+  surprise.
+
+## 3. Proposed fix — Option 1 (eager orc monitoring)
+
+The cleanest, smallest change. The helper already exists:
+
+```ts
+// backend/src/websocket/terminal.gateway.ts:363-386
+public startOrchestratorChatMonitoring(sessionName: string): void {
+  // Attaches a persistent onData listener to the orchestrator PTY,
+  // independent of any frontend subscriber. Existing today; just not
+  // guaranteed to be invoked.
+}
+```
+
+### Change shape
+
+1. **Boot wiring.** In `backend/src/index.ts` (or wherever
+   `TerminalGateway` is constructed and wired to the orchestrator
+   session lifecycle), call
+   `terminalGateway.startOrchestratorChatMonitoring(ORCHESTRATOR_SESSION_NAME)`
+   immediately after the gateway is up *and* the orc PTY is known to
+   exist. If the orc PTY is created lazily on first message, wrap the
+   start hook in the orc-PTY-create code path instead.
+
+2. **Defensive idempotency.** Make `startOrchestratorChatMonitoring`
+   safe to call repeatedly — if the PTY already has a persistent
+   listener attached by us, the second call is a no-op. Today the
+   helper does *not* guard against this; second invocation would
+   register a duplicate handler and double-broadcast. Add a guard
+   `Set<sessionName>` on the gateway.
+
+3. **Lifecycle hook.** When the orc session is *destroyed* (e.g., agent
+   stop), tear the persistent listener down so we don't leak handlers
+   into a stale PTY reference. Add a corresponding
+   `stopOrchestratorChatMonitoring(sessionName)` if it doesn't already
+   exist; call it from the agent-stop path.
+
+4. **Tests.**
+   - Unit: gateway with `startOrchestratorChatMonitoring` armed →
+     write to PTY → verify `onData` callbacks fire and broadcast queue
+     receives the bytes, *without* any subscriber having connected.
+   - Unit: idempotent second call → still exactly one listener.
+   - Unit: stop hook removes the listener and does not affect
+     subscriber-driven streaming on other sessions.
+   - Integration: agent-registration `sendMessageToAgent` to orc with
+     zero subscribers → message reaches a separately attached
+     spy-listener. Repro of Steve's exact symptom; should fail before
+     the fix and pass after.
+
+### Estimated diff size
+
+- Source: ~30–60 lines split across `terminal.gateway.ts` (idempotency
+  guard + stop hook) and `index.ts` (boot wiring).
+- Tests: 4 new unit cases + 1 integration case (~120 lines including
+  setup boilerplate the existing suite already establishes).
+
+This does not fit Steve's "<30 lines for direct commit" envelope, hence
+the deferred slot.
+
+## 4. Alternatives considered
+
+### Option 2 — Queue-time warm-up (rejected for now)
+
+Wrap `sendMessageToAgent` so that, before the write, the gateway is
+asked to ensure persistent monitoring for the target session. Tighter
+coupling between the operation that needs the readiness and the check.
+Slightly more invasive; touches agent delivery (`agent-registration.service.ts`
+sits in a high-traffic path). Larger blast radius.
+
+### Option 3 — Subscribe-on-write semantics (rejected)
+
+Change the gateway so any `session.write` for a session with zero
+subscribers implicitly enters persistent-monitoring mode and buffers +
+replays on first subscribe. Cleanest model but every PTY in the system
+would change behavior — not just the orchestrator's. Out of proportion
+to today's bug.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Memory leak from never-detached `onData` listener | Lifecycle hook (#3 above) tied to agent-stop. Plus: idempotent guard prevents accumulation. |
+| Output flood when frontend attaches mid-stream | Already handled by the existing buffering replay logic in `startPtyStreaming` — eager mode just means there's *less* unread buffer at attach time, not more. |
+| Race: orc PTY not ready at gateway boot | Wrap the start call in a "PTY-ready" callback; or retry once after 1s. The existing `startPtyStreaming` already tolerates this race for subscriber paths. |
+| Breaks other features that rely on "no subscriber = no broadcast" | Audited: `agent-output capture`, `learning auto-record subscriber`, and `WorkItem heartbeat reviewer` all read from the gateway's broadcast queue, not directly from PTY events — none of them depend on listener absence as a signal. **Confirm during review round 2.** |
+| Rollback complexity | Single boot-wiring line + one method on the gateway. Trivial revert. |
+
+## 6. Rollout plan
+
+1. Branch off `main` after PR #377 has been deployed (next natural
+   restart). Branch name: `fix/terminal-eager-orc-monitoring`.
+2. Implement option 1 with the four test cases above. Aim for a single
+   atomic commit per the team Code Commit SOP step 1.
+3. Self-review round 1 (refactor & consistency): extract any shared
+   guard into a util only if it's used in 2+ places, otherwise inline.
+4. Self-review round 2 (efficiency & reliability): confirm no double
+   broadcast, confirm no listener leak across PTY restart.
+5. Self-review round 3 (overall quality): JSDoc on new methods, dead
+   code removal.
+6. Open PR, request Arch fast-ACK (no architectural change — just
+   moving an existing helper from "lazy" to "eager"), merge, deploy on
+   next restart.
+7. Post-deploy: smoke test by sending a `send-message` to orc with the
+   frontend tab closed, confirm Slack relay output shows up promptly.
+
+## 7. Definition of done
+
+- [ ] All 5 new tests pass.
+- [ ] `backend` suite still green (current baseline pre-fix as of PR
+      #377: ~all passing; will re-baseline at branch start).
+- [ ] TypeScript compiles clean (`tsc -p backend/tsconfig.json --noEmit`).
+- [ ] Manual repro of Steve's exact symptom: `send-message → orc` with
+      frontend panel closed → message visible in `/api/agent/{orc}/output`
+      within 1s. Today: silence until panel opens. After fix: prompt.
+- [ ] No regression on subscriber-driven path (open panel → live stream
+      still works exactly as before).
+
+## 8. Out of scope (called out for explicit deferral)
+
+- The chrome-extension MV3 service-worker pong-timeout root cause.
+  Owner: chrome-extension repo / crewly-pro relay reliability.
+- The cloud-relay ghost-session pruning behavior. Owner: crewly-pro.
+- Any change to `AgentRegistrationService.sendMessageWithRetry` or
+  `QueueProcessorService.processNext`. We are fixing the *broadcast*
+  side, not the *write* side.


### PR DESCRIPTION
## Summary

Two spec docs landing alongside the merged browser-side fix in PR #377.

- **specs/rca-readiness-state-machines-2026-04-29.md** — full RCA covering both reconnect-driven readiness bugs Steve hit today. Symptom A (browser navigate 503) RESOLVED in PR #377; Symptom B (orc terminal queue stall) RCA-only here.
- **specs/terminal-queue-eager-monitoring-fix.md** — fix design for Symptom B. Eagerly arms the orc PTY's `onData` listener via the existing `startOrchestratorChatMonitoring` helper so output reaches the broadcast queue without waiting for a frontend subscriber. Includes alternatives, risk matrix, rollout plan, and DoD. Implementation deferred to next sprint per ORC — does not fit the <30-line direct-commit envelope.

## Test plan

- [x] Specs render cleanly (markdown).
- [x] Cross-references between RCA and fix spec resolve correctly.
- [x] No code changes — pure docs PR. CI should be a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)