### PR TITLE
fix(browser-proxy): periodic list_browsers refresh prevents live ext eviction

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -122,6 +122,15 @@ export const BROWSER_PROXY_CONSTANTS = {
 	 *  relay/network blips without prematurely evicting a live ext connection
 	 *  (heartbeat fires every 25s, so 5 min = ~12 missed heartbeats). */
 	STALE_PURGE_THRESHOLD_MS: 5 * 60_000,
+	/** Cadence (ms) at which the proxy actively re-requests the relay's full
+	 *  `browser_list` so each live instance's `lastSeenAt` advances before the
+	 *  TTL sweep can mistakenly purge it. Without this active refresh, an
+	 *  idle-but-connected extension (no tool calls in flight) sees its
+	 *  `lastSeenAt` frozen at the moment of the initial `connected` event,
+	 *  and the 5-min sweep evicts the live entry. The refresh interval must
+	 *  be strictly less than `STALE_PURGE_THRESHOLD_MS` — 60s gives a 5×
+	 *  safety margin against transient relay slowdowns. */
+	LIST_BROWSERS_REFRESH_INTERVAL_MS: 60_000,
 } as const;
 
 // Agent runtime types

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -1309,4 +1309,155 @@ describe('BrowserProxyService', () => {
       expect(ids).toEqual(['id-new', 'id-old']);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Periodic list_browsers refresh
+  //
+  // Spec: fix/browser-proxy-periodic-refresh — without this refresh, an
+  // idle-but-connected extension's `lastSeenAt` freezes at the initial
+  // `connected` event timestamp. The TTL sweep then evicts the live entry at
+  // the 5-min mark even though the extension is heartbeating to the relay.
+  // ---------------------------------------------------------------------------
+  describe('periodic list_browsers refresh', () => {
+    /**
+     * Helper: bring the proxy to the connected state so `startRefreshTimer`
+     * has fired alongside `startSweepTimer`.
+     */
+    function connectAndRegister(): void {
+      const proxy = BrowserProxyService.getInstance();
+      proxy.connect('test-token');
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-1' }),
+      );
+    }
+
+    /**
+     * Count `list_browsers` messages in `mockWs.send.mock.calls`. Each call
+     * receives a single string argument — JSON-encoded message — so we filter
+     * by `type === 'list_browsers'`.
+     */
+    function countListBrowsersSends(): number {
+      const ws = latestMockWs!;
+      return ws.send.mock.calls.reduce((acc: number, call: unknown[]) => {
+        try {
+          const payload = JSON.parse(call[0] as string) as { type?: string };
+          return payload?.type === 'list_browsers' ? acc + 1 : acc;
+        } catch {
+          return acc;
+        }
+      }, 0);
+    }
+
+    it('sends list_browsers periodically after registration', () => {
+      connectAndRegister();
+
+      // One initial list_browsers fires inside the `case 'registered'` handler.
+      const initialSends = countListBrowsersSends();
+      expect(initialSends).toBe(1);
+
+      // After 1 refresh interval, the timer should have fired exactly once.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS + 1,
+      );
+      expect(countListBrowsersSends()).toBe(initialSends + 1);
+
+      // After two more intervals, two more sends.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 2 + 1,
+      );
+      expect(countListBrowsersSends()).toBe(initialSends + 3);
+    });
+
+    it('keeps a live extension visible past STALE_PURGE_THRESHOLD_MS when relay refreshes lastSeenAt', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+
+      // Initial relay snapshot: one connected ext.
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'id-live',
+              instanceName: 'Live Chrome',
+              sessionId: 'bs-live',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+      expect(proxy.getInstances()).toHaveLength(1);
+
+      // Walk forward 6 min in 60s steps. Each tick:
+      //   1. Refresh timer fires → proxy sends list_browsers
+      //   2. We simulate the relay responding with a fresh lastSeenAt
+      //   3. Sweep timer fires → entry survives because lastSeenAt was just refreshed
+      const stepMs = BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS;
+      const totalMs = 6 * 60_000; // exceeds the 5-min purge threshold
+      let elapsed = 0;
+      while (elapsed < totalMs) {
+        jest.advanceTimersByTime(stepMs);
+        elapsed += stepMs;
+        // Simulate the relay's response carrying a current timestamp. In
+        // production the relay knows the ext is alive because it is still
+        // receiving heartbeats from it.
+        latestMockWs!._trigger(
+          'message',
+          JSON.stringify({
+            type: 'browser_list',
+            instances: [
+              {
+                instanceId: 'id-live',
+                instanceName: 'Live Chrome',
+                sessionId: 'bs-live',
+                lastSeenAt: new Date().toISOString(),
+              },
+            ],
+          }),
+        );
+      }
+
+      expect(proxy.getInstances()).toHaveLength(1);
+      expect(proxy.getInstances()[0].instanceId).toBe('id-live');
+    });
+
+    it('disconnect clears the refresh timer (no leaked interval after teardown)', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+      const ws = latestMockWs!;
+
+      // Confirm the timer is running by advancing one interval and observing
+      // a refresh send.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS + 1,
+      );
+      const sendsBeforeDisconnect = countListBrowsersSends();
+
+      proxy.disconnect();
+
+      // After disconnect, advancing past several refresh intervals must NOT
+      // produce additional list_browsers sends. If the timer were leaked,
+      // the fake-timer scheduler would still fire it.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 5,
+      );
+      // After disconnect, the WS reference is detached. We assert no NEW
+      // list_browsers sends happened on the captured ws mock (the singleton's
+      // `this.ws` is now null and any leaked timer would no-op via the
+      // readyState guard, but a leaked timer would still try to fire — the
+      // most direct check is: no new list_browsers sends on the ws we held).
+      expect(countListBrowsersSends()).toBe(sendsBeforeDisconnect);
+      // Defensive: ensure the ws reference we captured did not receive any
+      // additional sends post-disconnect (catches future regressions where
+      // the timer might dereference a stale ws).
+      const totalSendsOnWs = ws.send.mock.calls.length;
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 3,
+      );
+      expect(ws.send.mock.calls.length).toBe(totalSendsOnWs);
+    });
+  });
 });

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -108,6 +108,16 @@ export class BrowserProxyService {
    * the heartbeat — guards against the relay dropping a `disconnected` event.
    */
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Periodic `list_browsers` refresh timer. Runs every
+   * {@link BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS} and asks
+   * the relay for a fresh snapshot. The handler updates `lastSeenAt` on each
+   * live instance, which is what protects an idle-but-connected extension
+   * from being purged by `sweepTimer`. Without this timer, an extension that
+   * registers but receives no tool calls keeps its initial `lastSeenAt` and
+   * is evicted at the 5-min mark even though it is heartbeating to the relay.
+   */
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
   /** Auth token for relay registration */
   private authToken: string | null = null;
   /** Relay WebSocket URL */
@@ -456,6 +466,7 @@ export class BrowserProxyService {
         this.reconnectAttempts = 0; // Reset backoff on successful registration
         this.startHeartbeat();
         this.startSweepTimer();
+        this.startRefreshTimer();
         this.logger.info('Registered with relay', { sessionId: this.sessionId });
         // Request browser instance list
         this.sendRaw({ type: 'list_browsers' });
@@ -790,6 +801,47 @@ export class BrowserProxyService {
   }
 
   /**
+   * Start the periodic `list_browsers` refresh timer.
+   *
+   * Every {@link BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS} the
+   * proxy asks the relay for the current set of connected browsers. The
+   * relay's response is handled by {@link handleBrowserList}, which rebuilds
+   * `this.instances` and refreshes each entry's `lastSeenAt`. This is the
+   * mechanism that keeps an idle-but-live extension visible — without an
+   * active refresh, `lastSeenAt` would freeze at the initial `connected`
+   * event and the TTL sweep would evict the live entry once the threshold
+   * elapsed.
+   *
+   * Why active polling rather than passive listening: the relay does not
+   * push periodic heartbeat-derived updates per-instance. Tool-response
+   * `relay` messages do refresh `lastSeenAt` (see {@link handleMessage}
+   * `case 'relay'`), but extensions that connect without receiving any tool
+   * calls would never trigger that path.
+   *
+   * Idempotent: calls {@link stopRefreshTimer} first to avoid stacking
+   * intervals on reconnect / re-registration.
+   */
+  private startRefreshTimer(): void {
+    this.stopRefreshTimer();
+    this.refreshTimer = setInterval(() => {
+      if (this.state !== 'connected') return;
+      if (this.ws?.readyState !== WebSocket.OPEN) return;
+      this.sendRaw({ type: 'list_browsers' });
+    }, BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS);
+  }
+
+  /**
+   * Stop the periodic `list_browsers` refresh timer. Safe to call when no
+   * timer is running (no-op via the null guard).
+   */
+  private stopRefreshTimer(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  /**
    * Collapse older entries in `this.instances` that share a `deviceFingerprint`
    * with the incoming entry.
    *
@@ -841,6 +893,7 @@ export class BrowserProxyService {
     this.sessionId = null;
     this.stopHeartbeat();
     this.stopSweepTimer();
+    this.stopRefreshTimer();
 
     // Clean up old WebSocket reference
     if (this.ws) {
@@ -936,6 +989,7 @@ export class BrowserProxyService {
   private cleanup(): void {
     this.stopHeartbeat();
     this.stopSweepTimer();
+    this.stopRefreshTimer();
 
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);


### PR DESCRIPTION
## Summary

Fixes Steve's bug from 2026-04-30: Chrome ext shows **Connected** via Cloud Relay (91ms RTT, heartbeats flowing) but OSS backend `/api/browser/instances` returns `[]`.

This is a regression introduced by #379. The TTL sweep added there evicts live extensions because the `lastSeenAt` field never advances for an idle-but-connected ext (no tool calls = no relay events = frozen timestamp). 5 min after registration, the sweep purges the live entry.

**Smoking gun from `~/.crewly/logs/crewly-2026-04-30.log`:**
```
02:09:38  INFO  [BrowserProxy] Browser instance connected | count: 1
02:15:27  INFO  [BrowserProxy] Purged stale browser instance | lastSeenAt: 02:09:38
```
Exactly the 5-min mark, and the ext is still heartbeating to the relay the whole time.

## Fix

Add a periodic `list_browsers` refresh (60s cadence) so the proxy actively re-asks the relay for the current set. The relay knows the ext is alive (it's receiving heartbeats from it) and returns a fresh `lastSeenAt`, which `handleBrowserList` propagates onto the in-memory entry. Refresh interval (60s) is strictly less than the purge threshold (5 min), giving a 5× safety margin against transient relay slowdowns.

- New constant: `BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS = 60_000`
- New private fields/methods: `refreshTimer`, `startRefreshTimer()`, `stopRefreshTimer()`
- Symmetric lifecycle with `sweepTimer`: starts from `case 'registered'`, stops in both `handleDisconnect` and `cleanup` (no leaked intervals on reconnect)

## Tests (3 new, 50 total passing on this file)

- `sends list_browsers periodically after registration` — counts JSON-decoded `list_browsers` payloads on the mock WS
- `keeps a live extension visible past STALE_PURGE_THRESHOLD_MS when relay refreshes lastSeenAt` — drives 6 min of fake-time in 60s steps, simulating relay's snapshot response each tick
- `disconnect clears the refresh timer (no leaked interval after teardown)` — asserts no additional `list_browsers` sends after `disconnect()` across multiple intervals

## Test plan

- [x] `npx jest backend/src/services/browser/browser-proxy.service.test.ts` — 50/50 pass
- [x] `npm run build:backend` — clean
- [x] Confirmed pre-existing cloud-test failures (`cloud-sync.service`, `cloud-initializer`, `cloud-connect-e2e`) reproduce identically on `main` without these changes — unrelated regression to file separately if not already tracked
- [ ] After merge: restart local OSS backend on Steve's machine; verify `/api/browser/instances` shows the live ext for >5 min without bouncing

## Workaround until merge

Restart the OSS backend — the proxy re-registers, `list_browsers` populates the map, and the ext stays visible for the next 5 min before re-eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)