### PR TITLE
feat(remote-browser): native <select> select-option + scroll-400 hot-fix

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -122,6 +122,15 @@ export const BROWSER_PROXY_CONSTANTS = {
 	 *  relay/network blips without prematurely evicting a live ext connection
 	 *  (heartbeat fires every 25s, so 5 min = ~12 missed heartbeats). */
 	STALE_PURGE_THRESHOLD_MS: 5 * 60_000,
+	/** Cadence (ms) at which the proxy actively re-requests the relay's full
+	 *  `browser_list` so each live instance's `lastSeenAt` advances before the
+	 *  TTL sweep can mistakenly purge it. Without this active refresh, an
+	 *  idle-but-connected extension (no tool calls in flight) sees its
+	 *  `lastSeenAt` frozen at the moment of the initial `connected` event,
+	 *  and the 5-min sweep evicts the live entry. The refresh interval must
+	 *  be strictly less than `STALE_PURGE_THRESHOLD_MS` — 60s gives a 5×
+	 *  safety margin against transient relay slowdowns. */
+	LIST_BROWSERS_REFRESH_INTERVAL_MS: 60_000,
 } as const;
 
 // Agent runtime types

--- a/backend/src/controllers/browser/browser.controller.test.ts
+++ b/backend/src/controllers/browser/browser.controller.test.ts
@@ -170,6 +170,38 @@ describe('Browser Controller', () => {
 			expect(res.status).toBe(503);
 		});
 	});
+
+	describe('POST /api/browser/select-option', () => {
+		it('should return 503 when not connected', async () => {
+			const res = await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#status', value: 'active' });
+			expect(res.status).toBe(503);
+		});
+
+		it('should forward selector + value + label + index to the bridge', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const sendSpy = jest
+				.spyOn(bridge, 'sendCommand')
+				.mockResolvedValue({ id: 'mock', success: true, result: { selected: true } });
+
+			const res = await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#status', label: 'Active', index: 2 });
+
+			expect(res.status).toBe(200);
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+			expect(sendSpy.mock.calls[0][0]).toBe('selectOption');
+			expect(sendSpy.mock.calls[0][1]).toEqual(
+				expect.objectContaining({
+					selector: '#status',
+					label: 'Active',
+					index: 2,
+				}),
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/controllers/browser/browser.controller.test.ts
+++ b/backend/src/controllers/browser/browser.controller.test.ts
@@ -201,6 +201,27 @@ describe('Browser Controller', () => {
 				}),
 			);
 		});
+
+		// Customer-demo 2026-04-30: ARIA combobox strategy must reach the
+		// extension verbatim. Backend handler is body-passthrough so the only
+		// risk is a future refactor that strips unknown fields — this test
+		// locks the contract.
+		it('should forward strategy=aria to the extension verbatim', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const sendSpy = jest
+				.spyOn(bridge, 'sendCommand')
+				.mockResolvedValue({ id: 'mock', success: true, result: { selected: true, strategy: 'aria' } });
+
+			const res = await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '[role=combobox]', label: 'Math 101', strategy: 'aria' });
+
+			expect(res.status).toBe(200);
+			expect(sendSpy.mock.calls[0][1]).toEqual(
+				expect.objectContaining({ strategy: 'aria' }),
+			);
+		});
 	});
 });
 

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -566,21 +566,33 @@ export async function listOptions(req: Request, res: Response): Promise<void> {
 
 /**
  * POST /api/browser/select-option
- * Set the selected option of a native HTML <select> element.
+ * Set the selected option of a dropdown — native HTML `<select>` OR
+ * ARIA-pattern custom React combobox (Radix / HeadlessUI / MUI / Mantine /
+ * Ant Design).
  *
- * Native <select> elements cannot be operated by CDP click — clicking the
- * <select> opens an OS-level popup the debugger cannot reach, and clicking
- * <option> children is a no-op (options are not real DOM click targets).
- * This handler delegates to the Extension which sets HTMLSelectElement.value
- * (or selectedIndex) programmatically and dispatches input + change events
- * so framework onChange handlers (React/Vue/Svelte) fire.
+ * Native `<select>` elements cannot be operated by CDP click — the OS-level
+ * popup is unreachable to the debugger and clicking `<option>` children is a
+ * no-op. Custom comboboxes have a different problem: clicking the trigger
+ * may not expand the listbox because focus management is JS-driven. This
+ * handler covers both via two strategies:
+ *
+ *   - `strategy: "native"` (default): the Extension sets
+ *     `HTMLSelectElement.value` via the prototype's native setter (Playwright
+ *     / Cypress pattern — required for React controlled components) and
+ *     dispatches input + change events.
+ *
+ *   - `strategy: "aria"`: the Extension focuses the combobox trigger,
+ *     dispatches keydown ArrowDown to open the listbox, polls for the
+ *     `[role="listbox"]` node, finds the matching `[role="option"]`, and
+ *     synthesizes the full mouse sequence (mousedown → mouseup → click).
  *
  * Selection precedence: `index` > `value` > `label`. Exactly one MUST be
  * supplied — the Extension returns `{ selected: false, error: ... }` when
- * no selector matches.
+ * no option matches and includes `availableOptions` for caller diagnostics.
  *
  * @param req - Express request with body
- *   { selector: string, value?: string, label?: string, index?: number }
+ *   { selector: string, value?: string, label?: string, index?: number,
+ *     strategy?: "native" | "aria" }
  * @param res - Express response
  */
 export async function selectOption(req: Request, res: Response): Promise<void> {

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -565,6 +565,29 @@ export async function listOptions(req: Request, res: Response): Promise<void> {
 }
 
 /**
+ * POST /api/browser/select-option
+ * Set the selected option of a native HTML <select> element.
+ *
+ * Native <select> elements cannot be operated by CDP click — clicking the
+ * <select> opens an OS-level popup the debugger cannot reach, and clicking
+ * <option> children is a no-op (options are not real DOM click targets).
+ * This handler delegates to the Extension which sets HTMLSelectElement.value
+ * (or selectedIndex) programmatically and dispatches input + change events
+ * so framework onChange handlers (React/Vue/Svelte) fire.
+ *
+ * Selection precedence: `index` > `value` > `label`. Exactly one MUST be
+ * supplied — the Extension returns `{ selected: false, error: ... }` when
+ * no selector matches.
+ *
+ * @param req - Express request with body
+ *   { selector: string, value?: string, label?: string, index?: number }
+ * @param res - Express response
+ */
+export async function selectOption(req: Request, res: Response): Promise<void> {
+	await sendToolCommand(req, res, 'selectOption', req.body || {});
+}
+
+/**
  * POST /api/browser/set-file-input
  * Set files on a file input element using CDP, bypassing the OS file picker.
  *

--- a/backend/src/controllers/browser/browser.routes.test.ts
+++ b/backend/src/controllers/browser/browser.routes.test.ts
@@ -72,6 +72,7 @@ describe('createBrowserRouter', () => {
 		expect(routePaths).toContain('POST /get-interactive-elements');
 		expect(routePaths).toContain('POST /search-text');
 		expect(routePaths).toContain('POST /list-options');
+		expect(routePaths).toContain('POST /select-option');
 		expect(routePaths).toContain('POST /set-file-input');
 		// Per-tab dispatch (M2)
 		expect(routePaths).toContain('POST /bind');
@@ -79,10 +80,12 @@ describe('createBrowserRouter', () => {
 		expect(routePaths).toContain('GET /bindings');
 	});
 
-	it('should have exactly 29 routes', () => {
-		// 26 legacy routes + 3 per-tab dispatch routes (bind / unbind / bindings).
+	it('should have exactly 30 routes', () => {
+		// 27 legacy routes + 3 per-tab dispatch routes (bind / unbind / bindings).
+		// Bumped from 29 → 30 with addition of POST /select-option for native
+		// <select> dropdown support.
 		const router = createBrowserRouter();
 		const routes = router.stack.filter((layer: any) => layer.route);
-		expect(routes.length).toBe(29);
+		expect(routes.length).toBe(30);
 	});
 });

--- a/backend/src/controllers/browser/browser.routes.ts
+++ b/backend/src/controllers/browser/browser.routes.ts
@@ -35,6 +35,7 @@ import {
 	getInteractiveElements,
 	searchText,
 	listOptions,
+	selectOption,
 	setFileInput,
 	bindTab,
 	unbindTab,
@@ -123,6 +124,9 @@ export function createBrowserRouter(): Router {
 
 	// POST /api/browser/list-options — list select options
 	router.post('/list-options', listOptions);
+
+	// POST /api/browser/select-option — set selected option of a native <select>
+	router.post('/select-option', selectOption);
 
 	// POST /api/browser/set-file-input — set files on file input via CDP
 	router.post('/set-file-input', setFileInput);

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -1309,4 +1309,155 @@ describe('BrowserProxyService', () => {
       expect(ids).toEqual(['id-new', 'id-old']);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Periodic list_browsers refresh
+  //
+  // Spec: fix/browser-proxy-periodic-refresh — without this refresh, an
+  // idle-but-connected extension's `lastSeenAt` freezes at the initial
+  // `connected` event timestamp. The TTL sweep then evicts the live entry at
+  // the 5-min mark even though the extension is heartbeating to the relay.
+  // ---------------------------------------------------------------------------
+  describe('periodic list_browsers refresh', () => {
+    /**
+     * Helper: bring the proxy to the connected state so `startRefreshTimer`
+     * has fired alongside `startSweepTimer`.
+     */
+    function connectAndRegister(): void {
+      const proxy = BrowserProxyService.getInstance();
+      proxy.connect('test-token');
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-1' }),
+      );
+    }
+
+    /**
+     * Count `list_browsers` messages in `mockWs.send.mock.calls`. Each call
+     * receives a single string argument — JSON-encoded message — so we filter
+     * by `type === 'list_browsers'`.
+     */
+    function countListBrowsersSends(): number {
+      const ws = latestMockWs!;
+      return ws.send.mock.calls.reduce((acc: number, call: unknown[]) => {
+        try {
+          const payload = JSON.parse(call[0] as string) as { type?: string };
+          return payload?.type === 'list_browsers' ? acc + 1 : acc;
+        } catch {
+          return acc;
+        }
+      }, 0);
+    }
+
+    it('sends list_browsers periodically after registration', () => {
+      connectAndRegister();
+
+      // One initial list_browsers fires inside the `case 'registered'` handler.
+      const initialSends = countListBrowsersSends();
+      expect(initialSends).toBe(1);
+
+      // After 1 refresh interval, the timer should have fired exactly once.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS + 1,
+      );
+      expect(countListBrowsersSends()).toBe(initialSends + 1);
+
+      // After two more intervals, two more sends.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 2 + 1,
+      );
+      expect(countListBrowsersSends()).toBe(initialSends + 3);
+    });
+
+    it('keeps a live extension visible past STALE_PURGE_THRESHOLD_MS when relay refreshes lastSeenAt', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+
+      // Initial relay snapshot: one connected ext.
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'id-live',
+              instanceName: 'Live Chrome',
+              sessionId: 'bs-live',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+      expect(proxy.getInstances()).toHaveLength(1);
+
+      // Walk forward 6 min in 60s steps. Each tick:
+      //   1. Refresh timer fires → proxy sends list_browsers
+      //   2. We simulate the relay responding with a fresh lastSeenAt
+      //   3. Sweep timer fires → entry survives because lastSeenAt was just refreshed
+      const stepMs = BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS;
+      const totalMs = 6 * 60_000; // exceeds the 5-min purge threshold
+      let elapsed = 0;
+      while (elapsed < totalMs) {
+        jest.advanceTimersByTime(stepMs);
+        elapsed += stepMs;
+        // Simulate the relay's response carrying a current timestamp. In
+        // production the relay knows the ext is alive because it is still
+        // receiving heartbeats from it.
+        latestMockWs!._trigger(
+          'message',
+          JSON.stringify({
+            type: 'browser_list',
+            instances: [
+              {
+                instanceId: 'id-live',
+                instanceName: 'Live Chrome',
+                sessionId: 'bs-live',
+                lastSeenAt: new Date().toISOString(),
+              },
+            ],
+          }),
+        );
+      }
+
+      expect(proxy.getInstances()).toHaveLength(1);
+      expect(proxy.getInstances()[0].instanceId).toBe('id-live');
+    });
+
+    it('disconnect clears the refresh timer (no leaked interval after teardown)', () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+      const ws = latestMockWs!;
+
+      // Confirm the timer is running by advancing one interval and observing
+      // a refresh send.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS + 1,
+      );
+      const sendsBeforeDisconnect = countListBrowsersSends();
+
+      proxy.disconnect();
+
+      // After disconnect, advancing past several refresh intervals must NOT
+      // produce additional list_browsers sends. If the timer were leaked,
+      // the fake-timer scheduler would still fire it.
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 5,
+      );
+      // After disconnect, the WS reference is detached. We assert no NEW
+      // list_browsers sends happened on the captured ws mock (the singleton's
+      // `this.ws` is now null and any leaked timer would no-op via the
+      // readyState guard, but a leaked timer would still try to fire — the
+      // most direct check is: no new list_browsers sends on the ws we held).
+      expect(countListBrowsersSends()).toBe(sendsBeforeDisconnect);
+      // Defensive: ensure the ws reference we captured did not receive any
+      // additional sends post-disconnect (catches future regressions where
+      // the timer might dereference a stale ws).
+      const totalSendsOnWs = ws.send.mock.calls.length;
+      jest.advanceTimersByTime(
+        BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS * 3,
+      );
+      expect(ws.send.mock.calls.length).toBe(totalSendsOnWs);
+    });
+  });
 });

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -108,6 +108,16 @@ export class BrowserProxyService {
    * the heartbeat — guards against the relay dropping a `disconnected` event.
    */
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Periodic `list_browsers` refresh timer. Runs every
+   * {@link BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS} and asks
+   * the relay for a fresh snapshot. The handler updates `lastSeenAt` on each
+   * live instance, which is what protects an idle-but-connected extension
+   * from being purged by `sweepTimer`. Without this timer, an extension that
+   * registers but receives no tool calls keeps its initial `lastSeenAt` and
+   * is evicted at the 5-min mark even though it is heartbeating to the relay.
+   */
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
   /** Auth token for relay registration */
   private authToken: string | null = null;
   /** Relay WebSocket URL */
@@ -456,6 +466,7 @@ export class BrowserProxyService {
         this.reconnectAttempts = 0; // Reset backoff on successful registration
         this.startHeartbeat();
         this.startSweepTimer();
+        this.startRefreshTimer();
         this.logger.info('Registered with relay', { sessionId: this.sessionId });
         // Request browser instance list
         this.sendRaw({ type: 'list_browsers' });
@@ -790,6 +801,47 @@ export class BrowserProxyService {
   }
 
   /**
+   * Start the periodic `list_browsers` refresh timer.
+   *
+   * Every {@link BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS} the
+   * proxy asks the relay for the current set of connected browsers. The
+   * relay's response is handled by {@link handleBrowserList}, which rebuilds
+   * `this.instances` and refreshes each entry's `lastSeenAt`. This is the
+   * mechanism that keeps an idle-but-live extension visible — without an
+   * active refresh, `lastSeenAt` would freeze at the initial `connected`
+   * event and the TTL sweep would evict the live entry once the threshold
+   * elapsed.
+   *
+   * Why active polling rather than passive listening: the relay does not
+   * push periodic heartbeat-derived updates per-instance. Tool-response
+   * `relay` messages do refresh `lastSeenAt` (see {@link handleMessage}
+   * `case 'relay'`), but extensions that connect without receiving any tool
+   * calls would never trigger that path.
+   *
+   * Idempotent: calls {@link stopRefreshTimer} first to avoid stacking
+   * intervals on reconnect / re-registration.
+   */
+  private startRefreshTimer(): void {
+    this.stopRefreshTimer();
+    this.refreshTimer = setInterval(() => {
+      if (this.state !== 'connected') return;
+      if (this.ws?.readyState !== WebSocket.OPEN) return;
+      this.sendRaw({ type: 'list_browsers' });
+    }, BROWSER_PROXY_CONSTANTS.LIST_BROWSERS_REFRESH_INTERVAL_MS);
+  }
+
+  /**
+   * Stop the periodic `list_browsers` refresh timer. Safe to call when no
+   * timer is running (no-op via the null guard).
+   */
+  private stopRefreshTimer(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  /**
    * Collapse older entries in `this.instances` that share a `deviceFingerprint`
    * with the incoming entry.
    *
@@ -841,6 +893,7 @@ export class BrowserProxyService {
     this.sessionId = null;
     this.stopHeartbeat();
     this.stopSweepTimer();
+    this.stopRefreshTimer();
 
     // Clean up old WebSocket reference
     if (this.ws) {
@@ -936,6 +989,7 @@ export class BrowserProxyService {
   private cleanup(): void {
     this.stopHeartbeat();
     this.stopSweepTimer();
+    this.stopRefreshTimer();
 
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);

--- a/config/skills/agent/remote-browser/execute.sh
+++ b/config/skills/agent/remote-browser/execute.sh
@@ -65,12 +65,18 @@
 #   get-interactive-elements — { textContains?: string }
 #   search-text         — { text: string, exact?: boolean }
 #   list-options        — { selector: string }
-#   select-option       — { selector: string, value?: string, label?: string, index?: number }
-#                          Operates native <select> dropdowns by setting
-#                          HTMLSelectElement value programmatically and
-#                          dispatching input + change events. CDP-click on
-#                          a <select> opens an OS popup the debugger cannot
-#                          reach — use this action instead.
+#   select-option       — { selector: string, value?: string, label?: string,
+#                            index?: number, strategy?: "native" | "aria" }
+#                          Operates dropdowns. strategy="native" (default) for
+#                          real <select> elements: sets HTMLSelectElement value
+#                          via the prototype native setter (React-friendly) and
+#                          dispatches input + change events.
+#                          strategy="aria" for custom React combobox patterns
+#                          (Radix / HeadlessUI / MUI / Mantine / Ant Design):
+#                          focuses the trigger, dispatches ArrowDown to open,
+#                          polls for [role="listbox"], finds the matching
+#                          [role="option"], and synthesizes the full mouse
+#                          sequence (mousedown → mouseup → click).
 #   set-file-input      — { selector: string, filePaths: string[] }
 #   bind-tab            — bind a fresh tab for this agent
 #   unbind-tab          — release this agent's bound tab
@@ -421,12 +427,14 @@ case "$ACTION" in
     BODY=$(jq -n --arg s "$SELECTOR" '{selector: $s}')
     ;;
   select-option)
-    # Native <select> dropdowns can't be operated by CDP click (the OS popup
-    # is unreachable). This action sets HTMLSelectElement.value/selectedIndex
-    # programmatically and dispatches input + change events so React/Vue
-    # onChange handlers fire. One of {value, label, index} must be supplied.
+    # Operates dropdowns — both native <select> and ARIA-pattern custom
+    # React comboboxes (Radix / HeadlessUI / MUI / Mantine / Ant Design).
+    # Native <select> can't be operated by CDP click (OS popup unreachable);
+    # custom comboboxes can't be opened reliably by click either (focus
+    # management is JS-driven).
     #
-    # Body shape: { selector, value? , label? , index? }
+    # Body shape: { selector, value? , label? , index? , strategy? }
+    #   strategy: "native" (default) for <select>, "aria" for combobox.
     # Selection precedence (matches backend/extension): index > value > label.
     # Always emit compact JSON (jq -c) so wire shape is stable for tests and
     # downstream consumers.
@@ -434,7 +442,7 @@ case "$ACTION" in
     ENDPOINT="/browser/select-option"
     # Start from EXTRA_PARAMS (pass-through) merged with --selector; if --value
     # is set we treat it as the option value (NOT the form-field value used by
-    # `fill`).
+    # `fill`). strategy comes through EXTRA_PARAMS when supplied via JSON.
     if [ -n "$EXTRA_PARAMS" ]; then
       BODY=$(printf '%s' "$EXTRA_PARAMS" | jq -c --arg s "$SELECTOR" '. + {selector: $s}')
     elif [ -n "$VALUE" ]; then

--- a/config/skills/agent/remote-browser/execute.sh
+++ b/config/skills/agent/remote-browser/execute.sh
@@ -65,6 +65,12 @@
 #   get-interactive-elements — { textContains?: string }
 #   search-text         — { text: string, exact?: boolean }
 #   list-options        — { selector: string }
+#   select-option       — { selector: string, value?: string, label?: string, index?: number }
+#                          Operates native <select> dropdowns by setting
+#                          HTMLSelectElement value programmatically and
+#                          dispatching input + change events. CDP-click on
+#                          a <select> opens an OS popup the debugger cannot
+#                          reach — use this action instead.
 #   set-file-input      — { selector: string, filePaths: string[] }
 #   bind-tab            — bind a fresh tab for this agent
 #   unbind-tab          — release this agent's bound tab
@@ -145,7 +151,7 @@ while [[ $# -gt 0 ]]; do
       echo "         scroll, hover, press-key, get-element, wait-for-selector,"
       echo "         execute-js, tabs, cookies, console, local-storage,"
       echo "         get-interactive-elements, search-text, full-page-screenshot,"
-      echo "         list-options, set-file-input"
+      echo "         list-options, select-option, set-file-input"
       exit 0
       ;;
     --)
@@ -279,6 +285,24 @@ _effective_tab_id() {
 
 # ---- Map action to HTTP method + endpoint + body ----
 
+# Helper: emit the body for a passthrough action. Returns EXTRA_PARAMS verbatim
+# when set, otherwise the literal "{}".
+#
+# Why a helper instead of `${EXTRA_PARAMS:-{}}`: bash's parameter-expansion
+# parser greedily consumes the first `}` after `:-` to close the expansion,
+# so `${VAR:-{}}` becomes `${VAR:-{}` plus a literal trailing `}`. When VAR is
+# non-empty (e.g. `{"direction":"down"}`), the leftover `}` is concatenated,
+# producing malformed JSON like `{"direction":"down"}}` and a 400 from
+# express.json(). Using a quoted default does not help (quotes leak into the
+# value); a tiny helper is the clearest fix.
+emit_body() {
+  if [ -n "$EXTRA_PARAMS" ]; then
+    printf '%s' "$EXTRA_PARAMS"
+  else
+    printf '%s' '{}'
+  fi
+}
+
 METHOD="POST"
 ENDPOINT=""
 BODY=""
@@ -333,11 +357,11 @@ case "$ACTION" in
     ;;
   scroll)
     ENDPOINT="/browser/scroll"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   scroll-in-element)
     ENDPOINT="/browser/scroll-in-element"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   hover)
     require_param "selector (--selector)" "$SELECTOR"
@@ -346,7 +370,7 @@ case "$ACTION" in
     ;;
   press-key)
     ENDPOINT="/browser/press-key"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   get-element)
     require_param "selector (--selector)" "$SELECTOR"
@@ -363,7 +387,7 @@ case "$ACTION" in
     if [ -n "$CODE" ]; then
       BODY=$(jq -n --arg c "$CODE" '{code: $c}')
     else
-      BODY="${EXTRA_PARAMS:-{}}"
+      BODY="$(emit_body)"
     fi
     ;;
   tabs)
@@ -380,11 +404,11 @@ case "$ACTION" in
     ;;
   local-storage)
     ENDPOINT="/browser/local-storage"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   get-interactive-elements)
     ENDPOINT="/browser/get-interactive-elements"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   search-text)
     require_param "text (--text)" "$TEXT"
@@ -396,9 +420,32 @@ case "$ACTION" in
     ENDPOINT="/browser/list-options"
     BODY=$(jq -n --arg s "$SELECTOR" '{selector: $s}')
     ;;
+  select-option)
+    # Native <select> dropdowns can't be operated by CDP click (the OS popup
+    # is unreachable). This action sets HTMLSelectElement.value/selectedIndex
+    # programmatically and dispatches input + change events so React/Vue
+    # onChange handlers fire. One of {value, label, index} must be supplied.
+    #
+    # Body shape: { selector, value? , label? , index? }
+    # Selection precedence (matches backend/extension): index > value > label.
+    # Always emit compact JSON (jq -c) so wire shape is stable for tests and
+    # downstream consumers.
+    require_param "selector (--selector)" "$SELECTOR"
+    ENDPOINT="/browser/select-option"
+    # Start from EXTRA_PARAMS (pass-through) merged with --selector; if --value
+    # is set we treat it as the option value (NOT the form-field value used by
+    # `fill`).
+    if [ -n "$EXTRA_PARAMS" ]; then
+      BODY=$(printf '%s' "$EXTRA_PARAMS" | jq -c --arg s "$SELECTOR" '. + {selector: $s}')
+    elif [ -n "$VALUE" ]; then
+      BODY=$(jq -n -c --arg s "$SELECTOR" --arg v "$VALUE" '{selector: $s, value: $v}')
+    else
+      BODY=$(jq -n -c --arg s "$SELECTOR" '{selector: $s}')
+    fi
+    ;;
   set-file-input)
     ENDPOINT="/browser/set-file-input"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY="$(emit_body)"
     ;;
   proxy-connect)
     ENDPOINT="/browser/proxy/connect"

--- a/config/skills/agent/remote-browser/execute.test.sh
+++ b/config/skills/agent/remote-browser/execute.test.sh
@@ -410,6 +410,19 @@ assert_contains "body has label" "$body" '"label":"Active"'
 assert_contains "body has index" "$body" '"index":2'
 scenario_teardown
 
+# Scenario 13: select-option with strategy="aria" passes through verbatim
+# Used for custom React comboboxes (Radix/HeadlessUI/MUI/Mantine/Ant Design).
+scenario_init "scenario 13: select-option strategy=aria passthrough"
+queue_response '{"success":true,"data":{"selected":true,"strategy":"aria","matchedBy":"label"}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" '{"action":"select-option","selector":"[role=combobox]","label":"Math 101","strategy":"aria"}' > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+assert_contains "body has strategy:aria" "$body" '"strategy":"aria"'
+assert_contains "body has selector" "$body" '"selector":"[role=combobox]"'
+assert_contains "body has label" "$body" '"label":"Math 101"'
+scenario_teardown
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------

--- a/config/skills/agent/remote-browser/execute.test.sh
+++ b/config/skills/agent/remote-browser/execute.test.sh
@@ -342,6 +342,74 @@ assert_eq "no X-Agent-Session header" "" "$hdr"
   || fail "body has no tabId field" "body=$body"
 scenario_teardown
 
+# Scenario 9: scroll with passthrough params produces valid JSON body
+# Regression guard for the `${EXTRA_PARAMS:-{}}` bash bug — when EXTRA_PARAMS
+# was non-empty, the literal trailing `}` from the default leaked through and
+# produced `{"direction":"down"}}` (invalid JSON), causing express.json() to
+# reject the request with HTTP 400. The fix routes through emit_body().
+scenario_init "scenario 9: scroll with extra params emits valid JSON"
+queue_response '{"success":true,"data":{"scrolled":true}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" '{"action":"scroll","direction":"down","amount":500}' > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+# Body must be parseable JSON — the old buggy path would emit a stray `}`.
+if printf '%s' "$body" | python3 -c 'import sys, json; json.loads(sys.stdin.read())' 2>/dev/null; then
+  pass "scroll body parses as JSON"
+else
+  fail "scroll body parses as JSON" "body=$body"
+fi
+assert_contains "scroll body has direction:down" "$body" '"direction":"down"'
+assert_contains "scroll body has amount:500" "$body" '"amount":500'
+# Negative assertion: no double-closing brace
+case "$body" in
+  *'}}'*) fail "scroll body must not have trailing }}" "body=$body" ;;
+  *) pass "scroll body has no trailing }}" ;;
+esac
+scenario_teardown
+
+# Scenario 10: scroll with NO extra params emits valid `{}`
+scenario_init "scenario 10: scroll without params emits {}"
+queue_response '{"success":true,"data":{"scrolled":false}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action scroll > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+assert_eq "empty-params scroll body == {}" '{}' "$body"
+scenario_teardown
+
+# Scenario 11: select-option with explicit value
+# Native <select> dropdowns can't be operated by CDP click — verify the new
+# select-option action routes to /browser/select-option with selector+value.
+scenario_init "scenario 11: select-option with --selector + --value"
+queue_response '{"success":true,"data":{"selected":true,"matchedBy":"value"}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action select-option --selector "#status" --value "active" > /dev/null 2>&1 || true
+assert_eq "POST /api/browser/select-option" "POST /api/browser/select-option" "$(request_field 0 method) $(request_field 0 path)"
+body=$(request_field 0 body)
+assert_contains "body has selector" "$body" '"selector":"#status"'
+assert_contains "body has value" "$body" '"value":"active"'
+scenario_teardown
+
+# Scenario 12: select-option via JSON input — label + index pass through
+scenario_init "scenario 12: select-option JSON with label + index"
+queue_response '{"success":true,"data":{"selected":true,"matchedBy":"index"}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" '{"action":"select-option","selector":".course-filter","label":"Active","index":2}' > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+# Body must be valid JSON (regression on the same bash gotcha from scenario 9).
+if printf '%s' "$body" | python3 -c 'import sys, json; json.loads(sys.stdin.read())' 2>/dev/null; then
+  pass "select-option body parses as JSON"
+else
+  fail "select-option body parses as JSON" "body=$body"
+fi
+assert_contains "body has selector" "$body" '"selector":".course-filter"'
+assert_contains "body has label" "$body" '"label":"Active"'
+assert_contains "body has index" "$body" '"index":2'
+scenario_teardown
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Customer-demo P1 sweep (2026-04-30, Steve+Olivia). Two related fixes shipped together:

- **Issue 1** — scroll API 400 malformed-body **(hot-fix)**. Bash `${VAR:-{}}` parser bug in remote-browser skill — produced `{"direction":"down"}}` (invalid JSON), express.json rejected with 400. Fixed with `emit_body()` helper, replaced 7 sites.
- **Issue 3** — native `<select>` dropdowns. CDP click can't operate native HTML `<select>` (OS popup unreachable, `<option>` clicks no-op). Adds `select-option` action across skill + backend + Chrome Extension that sets `HTMLSelectElement.value`/`.selectedIndex` and dispatches input + change events.

The Chrome Extension half lives in the `crewly-extension` repo on branch `feat/native-select-option` (commit `edbc14b`). Both must merge for select-option to work end-to-end.

## What changed

| File | Change |
|---|---|
| `config/skills/agent/remote-browser/execute.sh` | `emit_body()` helper (Issue 1) + `select-option` case (Issue 3) |
| `config/skills/agent/remote-browser/execute.test.sh` | Scenarios 9/10 (Issue 1 regression guards) + 11/12 (Issue 3) |
| `backend/src/controllers/browser/browser.controller.ts` | `selectOption` handler |
| `backend/src/controllers/browser/browser.controller.test.ts` | Forward-test asserting selector+label+index reach the bridge |
| `backend/src/controllers/browser/browser.routes.ts` | `POST /select-option` route |
| `backend/src/controllers/browser/browser.routes.test.ts` | Route-existence + 30-route count bump |

## Test plan

- [x] Skill 28/28 scenarios pass (`bash config/skills/agent/remote-browser/execute.test.sh`)
- [x] Backend 33/33 pass (`npx jest backend/src/controllers/browser/`)
- [x] `npm run build:backend` clean (no TS errors)
- [ ] After merge + Sora deploy + Steve extension reload, Olivia tests one native `<select>` from SteamFun teacher portal end-to-end

## Demo-day workaround if extension reload is delayed

Use `execute-js` action with this snippet — Olivia can call it instead of `select-option`:

```js
(() => { const s = document.querySelector("<SEL>");
  s.value = "<VAL>";
  s.dispatchEvent(new Event("input",{bubbles:true}));
  s.dispatchEvent(new Event("change",{bubbles:true}));
  return { ok: true, value: s.value }; })()
```

## Related

- Issue 2 (proxy per-tab dispatch gap) filed as #384 — deferred to next sprint as P0.
- Issue 4 (orc message-delivery focus-bug) — RCA in flight, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)