### PR TITLE
fix(terminal-gateway): bounded retries close eager-monitoring race (Bug 2 / orc terminal queue delivery)

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -194,6 +194,22 @@ export const TERMINAL_GATEWAY_CONSTANTS = {
 	MAX_BUFFER_SIZE: 100 * 1024,
 	/** Trim threshold for partial line buffer (characters) */
 	BUFFER_TRIM_THRESHOLD: 1000,
+	/**
+	 * Backoff schedule (ms) for retrying eager orchestrator chat monitoring
+	 * when the PTY session is not yet registered in the SessionBackend.
+	 *
+	 * Background: startOrchestratorChatMonitoring is invoked from boot,
+	 * setup, and restart paths immediately after createAgentSession resolves.
+	 * The SessionBackend may not have fully registered the new session by
+	 * then — leaving the orchestrator's PTY without an onData listener for
+	 * the rest of its lifetime, which silently drops responses to user
+	 * messages until the side panel is opened (RCA 2026-04-29 / 2026-04-30).
+	 *
+	 * Total budget ≈ 8.6s with 5 attempts. Tuned to outlast typical
+	 * createAgentSession→backend-register lag (sub-1s on local, up to ~3s
+	 * under heavy load) without unbounded retries.
+	 */
+	MONITORING_RETRY_BACKOFFS_MS: [100, 500, 1000, 2000, 5000] as readonly number[],
 } as const;
 
 // Chat routing constants (message markers and patterns for orchestrator communication)

--- a/backend/src/websocket/terminal.gateway.test.ts
+++ b/backend/src/websocket/terminal.gateway.test.ts
@@ -554,4 +554,121 @@ describe('TerminalGateway', () => {
 			expect(mockLogBuffer.removeListener).toHaveBeenCalledWith('data', expect.any(Function));
 		});
 	});
+
+	describe('startOrchestratorChatMonitoring (eager-attach race fix, RCA 2026-04-30)', () => {
+		const orcSession = 'crewly-orc';
+
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('attaches synchronously when the PTY is already registered', () => {
+			mockSessionBackend.getSession.mockReturnValue(mockSession);
+
+			const result = gateway.startOrchestratorChatMonitoring(orcSession);
+
+			expect(result).toBe(true);
+			expect(mockSession.onData).toHaveBeenCalledTimes(1);
+			expect(gateway.getConnectionStats().activeStreams).toBe(1);
+		});
+
+		it('returns false and schedules a retry when the PTY is not yet registered', () => {
+			mockSessionBackend.getSession.mockReturnValueOnce(null);
+
+			const result = gateway.startOrchestratorChatMonitoring(orcSession);
+
+			expect(result).toBe(false);
+			// Listener not attached on first attempt — backend hadn't registered the session.
+			expect(mockSession.onData).not.toHaveBeenCalled();
+			// Persistent flag must remain set across the retry window so a parallel
+			// subscriber doesn't bypass eventual attachment.
+			expect(gateway.getConnectionStats().activeStreams).toBe(0);
+		});
+
+		it('attaches on a later retry once the session becomes available', () => {
+			// First attempt: session not yet registered. Subsequent attempts: registered.
+			mockSessionBackend.getSession
+				.mockReturnValueOnce(null)
+				.mockReturnValue(mockSession);
+
+			gateway.startOrchestratorChatMonitoring(orcSession);
+			expect(mockSession.onData).not.toHaveBeenCalled();
+
+			// First retry fires after 100ms — should attach.
+			jest.advanceTimersByTime(100);
+
+			expect(mockSession.onData).toHaveBeenCalledTimes(1);
+			expect(gateway.getConnectionStats().activeStreams).toBe(1);
+		});
+
+		it('keeps retrying through the full backoff schedule before giving up', () => {
+			// Backend never registers the session — exhaust all retries.
+			mockSessionBackend.getSession.mockReturnValue(null);
+
+			gateway.startOrchestratorChatMonitoring(orcSession);
+
+			// Total budget = 100 + 500 + 1000 + 2000 + 5000 = 8600ms. Advance past it.
+			jest.advanceTimersByTime(9000);
+
+			// All getSession lookups happened: 1 sync + 5 retries = 6.
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(6);
+			expect(mockSession.onData).not.toHaveBeenCalled();
+			// After exhaustion the persistent flag is dropped so subscriber-driven
+			// attach can still proceed via the normal subscribeToSession path.
+			expect(gateway.getConnectionStats().activeStreams).toBe(0);
+		});
+
+		it('cancels in-flight retries when stopOrchestratorChatMonitoring is called', () => {
+			mockSessionBackend.getSession.mockReturnValue(null);
+
+			gateway.startOrchestratorChatMonitoring(orcSession);
+			// One sync attempt happened; retry queued.
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(1);
+
+			gateway.stopOrchestratorChatMonitoring(orcSession);
+
+			// Advance well past the full backoff window. No further attach attempts
+			// should fire because the retry timer was cleared on stop.
+			jest.advanceTimersByTime(10000);
+
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(1);
+			expect(mockSession.onData).not.toHaveBeenCalled();
+		});
+
+		it('does not leak retry timers when destroy() is called mid-backoff', () => {
+			mockSessionBackend.getSession.mockReturnValue(null);
+
+			gateway.startOrchestratorChatMonitoring(orcSession);
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(1);
+
+			gateway.destroy();
+
+			// After destroy, no queued retry should ever attach a listener.
+			jest.advanceTimersByTime(10000);
+
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(1);
+			expect(mockSession.onData).not.toHaveBeenCalled();
+		});
+
+		it('replaces a stale retry schedule when start is called twice in a row', () => {
+			// First call queues a retry; second call should cancel it before
+			// queuing a fresh schedule (otherwise both schedules would race).
+			mockSessionBackend.getSession.mockReturnValue(null);
+
+			gateway.startOrchestratorChatMonitoring(orcSession);
+			gateway.startOrchestratorChatMonitoring(orcSession);
+
+			// Two sync attempts have happened (one per call). No double-stacking
+			// of timers — we still only see one timer fire per backoff slot.
+			jest.advanceTimersByTime(100);
+
+			// Sync calls (2) + first retry (1) = 3. If the old schedule weren't
+			// cancelled there would be 4 (a duplicate retry for the same slot).
+			expect(mockSessionBackend.getSession).toHaveBeenCalledTimes(3);
+		});
+	});
 });

--- a/backend/src/websocket/terminal.gateway.ts
+++ b/backend/src/websocket/terminal.gateway.ts
@@ -44,6 +44,15 @@ export class TerminalGateway {
 	/** Set of sessions with persistent monitoring (not stopped on client disconnect) */
 	private persistentMonitoringSessions: Set<string> = new Set();
 
+	/**
+	 * Pending retry timers for eager monitoring attempts that fired before the
+	 * PTY session was registered in the SessionBackend.
+	 *
+	 * Keyed by session name. Cleared on first successful attach, on stop, and
+	 * on destroy so a backoff schedule never leaks a timer past the gateway.
+	 */
+	private pendingMonitoringRetries: Map<string, NodeJS.Timeout> = new Map();
+
 	/** Current active chat conversation ID for orchestrator responses */
 	private activeConversationId: string | null = null;
 
@@ -355,13 +364,26 @@ export class TerminalGateway {
 
 	/**
 	 * Start persistent monitoring for the orchestrator session.
-	 * This ensures chat responses are captured even when no WebSocket clients are viewing the terminal.
+	 *
+	 * Ensures chat responses are captured even when no WebSocket clients are
+	 * viewing the terminal. If the PTY session is not yet registered in the
+	 * SessionBackend (e.g. eager call from boot fires before
+	 * createAgentSession's backend registration completes), schedules bounded
+	 * retries on the {@link TERMINAL_GATEWAY_CONSTANTS.MONITORING_RETRY_BACKOFFS_MS}
+	 * backoff schedule. Persistent flag stays set across retries so a parallel
+	 * subscriber path doesn't bypass eventual attachment.
 	 *
 	 * @param sessionName - The orchestrator session name to monitor
-	 * @returns True if monitoring started successfully
+	 * @returns True if monitoring started synchronously on first attempt; false
+	 *          if a retry was scheduled (caller-visible failure is reserved for
+	 *          terminal failure after all retries, surfaced via ERROR log only).
 	 */
 	startOrchestratorChatMonitoring(sessionName: string): boolean {
 		this.logger.info('Starting persistent orchestrator chat monitoring', { sessionName });
+
+		// Cancel any in-flight retry from a previous start call so we don't
+		// stack two backoff schedules on the same session.
+		this.clearPendingMonitoringRetry(sessionName);
 
 		// Force cleanup any stale subscription from a previous session.
 		// When the orchestrator is restarted, the old PTY session is destroyed but
@@ -378,20 +400,108 @@ export class TerminalGateway {
 		this.persistentMonitoringSessions.add(sessionName);
 
 		const started = this.startPtyStreaming(sessionName);
-		if (!started) {
-			this.logger.warn('Failed to start orchestrator chat monitoring', { sessionName });
-			this.persistentMonitoringSessions.delete(sessionName);
+		if (started) {
+			return true;
 		}
-		return started;
+
+		// Backend hasn't registered the session yet (race with createAgentSession).
+		// Keep persistentMonitoringSessions flagged and schedule bounded retries.
+		this.logger.warn(
+			'PTY not ready for orchestrator chat monitoring, scheduling retries',
+			{ sessionName, schedule: TERMINAL_GATEWAY_CONSTANTS.MONITORING_RETRY_BACKOFFS_MS },
+		);
+		this.scheduleMonitoringRetry(sessionName, 0);
+		return false;
+	}
+
+	/**
+	 * Schedule the next bounded retry attempt to attach orchestrator monitoring.
+	 *
+	 * @param sessionName - Session name being monitored
+	 * @param attemptIndex - 0-based index into MONITORING_RETRY_BACKOFFS_MS
+	 */
+	private scheduleMonitoringRetry(sessionName: string, attemptIndex: number): void {
+		const schedule = TERMINAL_GATEWAY_CONSTANTS.MONITORING_RETRY_BACKOFFS_MS;
+
+		if (attemptIndex >= schedule.length) {
+			// Exhausted retries — log diagnostics and give up. Drop the
+			// persistent flag so a subsequent subscriber-driven attach can
+			// still proceed via the normal subscribeToSession path.
+			const backend = getSessionBackendSync();
+			this.logger.error(
+				'Orchestrator chat monitoring failed after all retries — orc output will not stream until a client subscribes',
+				{
+					sessionName,
+					attempts: schedule.length,
+					availableSessions: backend?.listSessions() ?? [],
+				},
+			);
+			this.persistentMonitoringSessions.delete(sessionName);
+			this.pendingMonitoringRetries.delete(sessionName);
+			return;
+		}
+
+		const delayMs = schedule[attemptIndex];
+		const timer = setTimeout(() => {
+			this.pendingMonitoringRetries.delete(sessionName);
+
+			// Stop guard: the persistent flag is cleared by
+			// stopOrchestratorChatMonitoring. If it's gone, abandon retry.
+			if (!this.persistentMonitoringSessions.has(sessionName)) {
+				this.logger.debug('Monitoring retry abandoned — persistent flag cleared', {
+					sessionName,
+					attemptIndex,
+				});
+				return;
+			}
+
+			const started = this.startPtyStreaming(sessionName);
+			if (started) {
+				this.logger.info('Orchestrator chat monitoring attached on retry', {
+					sessionName,
+					attemptIndex: attemptIndex + 1,
+					delayMs,
+				});
+				return;
+			}
+
+			this.scheduleMonitoringRetry(sessionName, attemptIndex + 1);
+		}, delayMs);
+
+		// Allow the process to exit even if a retry is still pending.
+		// Without unref, lingering timers keep node alive past graceful shutdown.
+		if (typeof timer.unref === 'function') {
+			timer.unref();
+		}
+		this.pendingMonitoringRetries.set(sessionName, timer);
+	}
+
+	/**
+	 * Clear any pending monitoring retry timer for a session.
+	 *
+	 * Idempotent — safe to call when no retry is queued.
+	 *
+	 * @param sessionName - Session name whose retry should be cleared
+	 */
+	private clearPendingMonitoringRetry(sessionName: string): void {
+		const timer = this.pendingMonitoringRetries.get(sessionName);
+		if (timer) {
+			clearTimeout(timer);
+			this.pendingMonitoringRetries.delete(sessionName);
+		}
 	}
 
 	/**
 	 * Stop persistent monitoring for the orchestrator session.
 	 *
+	 * Cancels any in-flight retry schedule so a stop mid-backoff doesn't leak
+	 * a timer that later attaches to a session the caller already gave up on.
+	 *
 	 * @param sessionName - The orchestrator session name
 	 */
 	stopOrchestratorChatMonitoring(sessionName: string): void {
 		this.logger.info('Stopping persistent orchestrator chat monitoring', { sessionName });
+		this.clearPendingMonitoringRetry(sessionName);
 		this.stopPtyStreaming(sessionName, true);
 	}
 
@@ -908,6 +1018,14 @@ export class TerminalGateway {
 	 * Destroy the gateway and clean up all subscriptions.
 	 */
 	destroy(): void {
+		// Cancel any pending monitoring retries before tearing down.
+		// Otherwise a queued retry could fire after destroy and attach
+		// a listener to a session whose owner has gone away.
+		for (const timer of this.pendingMonitoringRetries.values()) {
+			clearTimeout(timer);
+		}
+		this.pendingMonitoringRetries.clear();
+
 		// Unsubscribe from all PTY sessions
 		for (const unsubscribe of this.sessionSubscriptions.values()) {
 			unsubscribe();


### PR DESCRIPTION
## Summary

- **RCA reframe:** Steve's "messages queued and never delivered to orc terminal" is an **OUTPUT visibility** bug, not an input-delivery one. Dispatcher (`QueueProcessorService → AgentRegistrationService.sendMessageToAgent → session.write`) is independent of subscribers and was working. The bug lives in the OUTPUT path: when no client is subscribed, `terminal.gateway.startPtyStreaming` pipes bytes through `io.to('terminal_<session>').emit(...)` which is a silent no-op — bytes are lost in the gateway and survive only in the headless-terminal buffer. Opening the panel triggers `sendCurrentTerminalState` which drains the buffer in one burst → "all messages flushed at once."
- **Spec gap:** `.crewly/specs/rca-readiness-state-machines-2026-04-29.md` recommended Option 1 (eager `startOrchestratorChatMonitoring` at boot/setup/restart). That wiring is **already on `main`** at `index.ts:2052`, `orchestrator.controller.ts:426`, `orchestrator-restart.service.ts:257`. The spec's premise — "function exists but is never invoked" — is outdated.
- **Residual hole this PR closes:** the eager call fires the moment `createAgentSession` resolves, but `SessionBackend` may not have registered the new PTY by then. `startPtyStreaming` returns `false` → `persistentMonitoringSessions.delete()` runs synchronously → **no retry** → no `onData` listener for the entire orc lifetime, until a client subscribes.

## Patch

`backend/src/websocket/terminal.gateway.ts` (~80 LOC source, ~120 LOC tests):

1. `startOrchestratorChatMonitoring` schedules bounded retries on a `100/500/1000/2000/5000ms` backoff (≈8.6s budget, covers typical sub-1s backend-register lag with headroom for ~3s heavy-load case). Backoffs live in `TERMINAL_GATEWAY_CONSTANTS.MONITORING_RETRY_BACKOFFS_MS`.
2. `persistentMonitoringSessions` stays flagged across the retry window so a parallel `subscribeToSession` path doesn't bypass eventual attach.
3. `stopOrchestratorChatMonitoring` and `destroy()` clear pending retry timers so a queued retry never fires after the caller gave up.
4. Timers are `.unref()`'d so they never keep the node process alive past graceful shutdown.
5. Calling `start` twice replaces the stale schedule (no double-stacking).
6. On full retry exhaustion: `ERROR` log with `backend.listSessions()` for diagnostics; persistent flag dropped so subscriber-driven attach can still proceed.

## Out of scope (separate follow-ups)

These shipped in Steve's original cluster but are **different code paths** — flagged for their own tickets, NOT included here per the "only modify terminal queue delivery" constraint:

- (B) `delegate-task → "Failed to create WorkItem in TaskPool"` — `TaskPoolService.addToPool` path.
- (C) heartbeat `queuePending` / `queueProcessing = "?"` — UI exposure, fields not surfaced by current heartbeat endpoint.

## Test plan

- [x] Targeted: `npx jest --testPathPattern="backend/src/websocket/terminal.gateway.test.ts"` → **46 / 46 pass** (39 prior + 7 new).
- [x] Wider regression: `npx jest --testPathPattern="backend/src/(websocket|services/orchestrator|controllers/orchestrator)"` → **340 / 340 pass** (2 skipped, unrelated to this change).
- [x] `npm run build` → green.
- [x] `npx tsc --noEmit` (backend) → clean.

## New test cases

In `backend/src/websocket/terminal.gateway.test.ts`:
- Sync attach when PTY pre-registered (happy path unchanged).
- First-attempt false + retry queued when PTY missing.
- Attach on later retry once session becomes available.
- Full schedule exhaustion when session never registers.
- Stop mid-backoff cancels in-flight retries (no leaks).
- Destroy mid-backoff clears retry timers (no leaks).
- Double-start replaces stale schedule (no double-stacking).

## Acceptance criteria for Steve

- After this lands: `send-message → orc` continues writing into the orc PTY as before (no input-path change), AND orc's stdout streams to subscribers from the moment the eager monitor attaches — even if the user never opens the side panel for the rest of the orc's lifetime.
- "Burst on panel open" symptom should disappear because there's no longer a window where orc output goes to /dev/null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)