### PR TITLE
fix(remote-browser): bash brace-injection bug + selectOption HTTP route

### DIFF
--- a/backend/src/controllers/browser/browser.controller.test.ts
+++ b/backend/src/controllers/browser/browser.controller.test.ts
@@ -170,6 +170,68 @@ describe('Browser Controller', () => {
 			expect(res.status).toBe(503);
 		});
 	});
+
+	describe('POST /api/browser/select-option', () => {
+		it('should return 503 when not connected', async () => {
+			const res = await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#level', value: 'opt2' });
+			expect(res.status).toBe(503);
+		});
+
+		it('forwards selector + value through sendCommand as the selectOption tool', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const sendSpy = jest
+				.spyOn(bridge, 'sendCommand')
+				.mockResolvedValue({
+					id: 'sel-1',
+					success: true,
+					result: { selectedValue: 'opt2', selectedText: 'Option 2' },
+				} as Awaited<ReturnType<typeof bridge.sendCommand>>);
+
+			const res = await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#level', value: 'opt2' });
+
+			expect(res.status).toBe(200);
+			expect(sendSpy).toHaveBeenCalledTimes(1);
+			expect(sendSpy.mock.calls[0][0]).toBe('selectOption');
+			expect(sendSpy.mock.calls[0][1]).toEqual(
+				expect.objectContaining({ selector: '#level', value: 'opt2' }),
+			);
+		});
+
+		it('accepts label / index / strategy alternatives in the body', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const sendSpy = jest
+				.spyOn(bridge, 'sendCommand')
+				.mockResolvedValue({
+					id: 'sel-2',
+					success: true,
+					result: { selectedValue: '', selectedText: '' },
+				} as Awaited<ReturnType<typeof bridge.sendCommand>>);
+
+			await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#level', label: 'Beginner', strategy: 'aria' });
+			expect(sendSpy.mock.calls[0][1]).toEqual(
+				expect.objectContaining({
+					selector: '#level',
+					label: 'Beginner',
+					strategy: 'aria',
+				}),
+			);
+
+			await request(app)
+				.post('/api/browser/select-option')
+				.send({ selector: '#level', index: 2 });
+			expect(sendSpy.mock.calls[1][1]).toEqual(
+				expect.objectContaining({ selector: '#level', index: 2 }),
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -575,6 +575,33 @@ export async function setFileInput(req: Request, res: Response): Promise<void> {
 	await sendToolCommand(req, res, 'setFileInput', req.body || {});
 }
 
+/**
+ * POST /api/browser/select-option
+ *
+ * Select an option in a native HTML `<select>` element. CDP click on
+ * a `<select>` does not open the dropdown (Chrome blocks synthetic
+ * events on native form controls), and `<option>` children are rendered
+ * by the OS rather than the DOM, so the existing `click` flow can't
+ * reach them. This endpoint forwards to the extension's `selectOption`
+ * tool, which sets `el.value` directly and dispatches `input` + `change`
+ * events with `bubbles: true` so frameworks (React, Vue, etc.) pick the
+ * change up via their controlled-component handlers.
+ *
+ * Selection precedence (one of these is required):
+ *   - `value`  — match `<option>` by its `value` attribute
+ *   - `label`  — match `<option>` by its visible text (`.text`)
+ *   - `index`  — match `<option>` by zero-based position
+ *
+ * @param req - Express request with body
+ *   `{ selector: string, value?: string, label?: string, index?: number,
+ *      strategy?: "native" | "aria", tabId?: number }`
+ * @param res - Express response — `{ success, selectedValue, selectedText }`
+ *   on hit; `{ success: false, error }` on miss.
+ */
+export async function selectOption(req: Request, res: Response): Promise<void> {
+	await sendToolCommand(req, res, 'selectOption', req.body || {});
+}
+
 // ---------------------------------------------------------------------------
 // Per-tab dispatch (§4.2) — bind / unbind / list bindings
 // ---------------------------------------------------------------------------

--- a/backend/src/controllers/browser/browser.routes.test.ts
+++ b/backend/src/controllers/browser/browser.routes.test.ts
@@ -72,6 +72,7 @@ describe('createBrowserRouter', () => {
 		expect(routePaths).toContain('POST /get-interactive-elements');
 		expect(routePaths).toContain('POST /search-text');
 		expect(routePaths).toContain('POST /list-options');
+		expect(routePaths).toContain('POST /select-option');
 		expect(routePaths).toContain('POST /set-file-input');
 		// Per-tab dispatch (M2)
 		expect(routePaths).toContain('POST /bind');
@@ -79,10 +80,11 @@ describe('createBrowserRouter', () => {
 		expect(routePaths).toContain('GET /bindings');
 	});
 
-	it('should have exactly 29 routes', () => {
-		// 26 legacy routes + 3 per-tab dispatch routes (bind / unbind / bindings).
+	it('should have exactly 30 routes', () => {
+		// 27 legacy routes (added /select-option) + 3 per-tab dispatch routes
+		// (bind / unbind / bindings).
 		const router = createBrowserRouter();
 		const routes = router.stack.filter((layer: any) => layer.route);
-		expect(routes.length).toBe(29);
+		expect(routes.length).toBe(30);
 	});
 });

--- a/backend/src/controllers/browser/browser.routes.ts
+++ b/backend/src/controllers/browser/browser.routes.ts
@@ -35,6 +35,7 @@ import {
 	getInteractiveElements,
 	searchText,
 	listOptions,
+	selectOption,
 	setFileInput,
 	bindTab,
 	unbindTab,
@@ -123,6 +124,9 @@ export function createBrowserRouter(): Router {
 
 	// POST /api/browser/list-options — list select options
 	router.post('/list-options', listOptions);
+
+	// POST /api/browser/select-option — select an option in a native <select>
+	router.post('/select-option', selectOption);
 
 	// POST /api/browser/set-file-input — set files on file input via CDP
 	router.post('/set-file-input', setFileInput);

--- a/config/skills/agent/remote-browser/execute.sh
+++ b/config/skills/agent/remote-browser/execute.sh
@@ -65,6 +65,8 @@
 #   get-interactive-elements — { textContains?: string }
 #   search-text         — { text: string, exact?: boolean }
 #   list-options        — { selector: string }
+#   select-option       — { selector: string, value?: string, label?: string,
+#                           index?: number, strategy?: "native" | "aria" }
 #   set-file-input      — { selector: string, filePaths: string[] }
 #   bind-tab            — bind a fresh tab for this agent
 #   unbind-tab          — release this agent's bound tab
@@ -145,7 +147,7 @@ while [[ $# -gt 0 ]]; do
       echo "         scroll, hover, press-key, get-element, wait-for-selector,"
       echo "         execute-js, tabs, cookies, console, local-storage,"
       echo "         get-interactive-elements, search-text, full-page-screenshot,"
-      echo "         list-options, set-file-input"
+      echo "         list-options, select-option, set-file-input"
       exit 0
       ;;
     --)
@@ -246,6 +248,29 @@ _purge_cached_tab() {
   rm -f "$cache_path" 2>/dev/null || true
 }
 
+# Returns the JSON body to send: $1 if non-empty, otherwise the canonical
+# empty-object literal `{}`. This replaces the `${EXTRA_PARAMS:-{}}` pattern,
+# which is mis-parsed by bash: the closing `}` of the parameter expansion is
+# the FIRST `}` it sees, so `${EXTRA_PARAMS:-{}}` becomes `${EXTRA_PARAMS:-{}`
+# (default = the literal `{`) followed by a stray literal `}`. The bug only
+# surfaces when EXTRA_PARAMS is set — then the body is `<value>}` with a
+# trailing extra `}` that fails JSON parse server-side, triggering 400 errors
+# on scroll / press-key / local-storage / get-interactive-elements / set-file-input
+# / scroll-in-element / execute-js fallback. When EXTRA_PARAMS is empty, the
+# bug masks itself by accident (the `{` default + stray `}` happen to spell
+# `{}`).
+#
+# @stdout the JSON body string (no trailing newline)
+# @example  BODY=$(_body_or_empty "$EXTRA_PARAMS")
+_body_or_empty() {
+  local v="${1:-}"
+  if [ -n "$v" ]; then
+    printf '%s' "$v"
+  else
+    printf '%s' '{}'
+  fi
+}
+
 # Inject `tabId` into a JSON body if we have one, leaving an explicit override
 # alone. Reads BODY as input, sets BODY to the augmented version. Always emits
 # compact (single-line) JSON via `jq -c` so downstream consumers and test
@@ -333,11 +358,11 @@ case "$ACTION" in
     ;;
   scroll)
     ENDPOINT="/browser/scroll"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   scroll-in-element)
     ENDPOINT="/browser/scroll-in-element"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   hover)
     require_param "selector (--selector)" "$SELECTOR"
@@ -346,7 +371,7 @@ case "$ACTION" in
     ;;
   press-key)
     ENDPOINT="/browser/press-key"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   get-element)
     require_param "selector (--selector)" "$SELECTOR"
@@ -363,7 +388,7 @@ case "$ACTION" in
     if [ -n "$CODE" ]; then
       BODY=$(jq -n --arg c "$CODE" '{code: $c}')
     else
-      BODY="${EXTRA_PARAMS:-{}}"
+      BODY=$(_body_or_empty "$EXTRA_PARAMS")
     fi
     ;;
   tabs)
@@ -380,11 +405,11 @@ case "$ACTION" in
     ;;
   local-storage)
     ENDPOINT="/browser/local-storage"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   get-interactive-elements)
     ENDPOINT="/browser/get-interactive-elements"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   search-text)
     require_param "text (--text)" "$TEXT"
@@ -396,9 +421,28 @@ case "$ACTION" in
     ENDPOINT="/browser/list-options"
     BODY=$(jq -n --arg s "$SELECTOR" '{selector: $s}')
     ;;
+  select-option)
+    # Select an option in a native <select> by value / label / index.
+    # Resolution priority: value > label > index. The selector itself is
+    # always required. When --params is supplied we accept it as the
+    # canonical body source (lets agents pass {label,...} or {index,...}
+    # without dedicated CLI flags); otherwise we project --selector +
+    # --value into the body.
+    require_param "selector (--selector)" "$SELECTOR"
+    ENDPOINT="/browser/select-option"
+    if [ -n "$EXTRA_PARAMS" ]; then
+      # Merge --selector into the supplied params so callers don't have
+      # to duplicate it. `jq` overwrites EXTRA_PARAMS.selector if absent.
+      BODY=$(printf '%s' "$EXTRA_PARAMS" | jq -c --arg s "$SELECTOR" '. + {selector: ($s)}')
+    elif [ -n "$VALUE" ]; then
+      BODY=$(jq -n -c --arg s "$SELECTOR" --arg v "$VALUE" '{selector: $s, value: $v}')
+    else
+      error_exit "select-option requires --value (or --params with value/label/index)"
+    fi
+    ;;
   set-file-input)
     ENDPOINT="/browser/set-file-input"
-    BODY="${EXTRA_PARAMS:-{}}"
+    BODY=$(_body_or_empty "$EXTRA_PARAMS")
     ;;
   proxy-connect)
     ENDPOINT="/browser/proxy/connect"

--- a/config/skills/agent/remote-browser/execute.test.sh
+++ b/config/skills/agent/remote-browser/execute.test.sh
@@ -343,6 +343,132 @@ assert_eq "no X-Agent-Session header" "" "$hdr"
 scenario_teardown
 
 # ---------------------------------------------------------------------------
+# Scenarios 9–13: brace-injection bug regression coverage
+#
+# Repro: `BODY="${EXTRA_PARAMS:-{}}"` was mis-parsed by bash — the closing
+# `}` of the parameter expansion was the FIRST `}`, so `${EXTRA_PARAMS:-{}}`
+# was read as `${EXTRA_PARAMS:-{}` (default = literal `{`) followed by a
+# stray literal `}`. With EXTRA_PARAMS set, body became `<value>}` —
+# malformed JSON. With EXTRA_PARAMS empty, the bug coincidentally produced
+# `{}` and masked itself. Fix replaces the pattern with `_body_or_empty`.
+#
+# These scenarios drive --params with a non-empty value through every
+# affected action and assert the wire body is parseable JSON without a
+# trailing stray `}`. Each action is a separate scenario so a regression
+# in one branch does not mask another.
+# ---------------------------------------------------------------------------
+
+# Helper for the brace-bug regression scenarios — drives one action with
+# a known payload and asserts the body is exactly that payload (no stray
+# trailing `}`).
+_assert_brace_clean() {
+  local action="$1" payload="$2"
+  scenario_init "scenario brace-clean: $action --params"
+  queue_response '{"success":true,"data":{}}'
+  start_stub
+  unset CREWLY_SESSION_NAME
+  "$SKILL" --action "$action" --params "$payload" > /dev/null 2>&1 || true
+  local body
+  body=$(request_field 0 body)
+  # Body must parse cleanly as JSON (the bug appended a literal `}`).
+  if printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
+    pass "[$action] body parses as JSON"
+  else
+    fail "[$action] body parses as JSON" "body=$body"
+  fi
+  # Body must equal the payload byte-for-byte (no trailing extra char).
+  assert_eq "[$action] body == payload" "$payload" "$body"
+  scenario_teardown
+}
+
+# Scenario 9: scroll
+_assert_brace_clean "scroll" '{"direction":"down","amount":500}'
+# Scenario 10: scroll-in-element
+_assert_brace_clean "scroll-in-element" '{"selector":".sb","amount":200}'
+# Scenario 11: press-key
+_assert_brace_clean "press-key" '{"key":"Enter","modifiers":["Shift"]}'
+# Scenario 12: local-storage
+_assert_brace_clean "local-storage" '{"keys":["uid","theme"]}'
+# Scenario 13: get-interactive-elements
+_assert_brace_clean "get-interactive-elements" '{"textContains":"Submit"}'
+# Scenario 14: set-file-input (was missing from Olivias original list)
+_assert_brace_clean "set-file-input" '{"selector":"input","filePaths":["/tmp/a"]}'
+
+# Scenario 15: empty --params still produces a valid `{}` body
+scenario_init "scenario 15: empty --params produces {} (back-compat)"
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action scroll > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+assert_eq "empty params → body is canonical {}" "{}" "$body"
+scenario_teardown
+
+# ---------------------------------------------------------------------------
+# Scenarios 16–18: select-option route + body shapes
+# ---------------------------------------------------------------------------
+
+# Scenario 16: select-option with --value projects {selector, value}
+scenario_init "scenario 16: select-option --selector --value"
+queue_response '{"success":true,"data":{"selectedValue":"opt2","selectedText":"Option 2"}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action select-option --selector "#level" --value "opt2" > /dev/null 2>&1 || true
+assert_eq "POST /api/browser/select-option" \
+  "POST /api/browser/select-option" \
+  "$(request_field 0 method) $(request_field 0 path)"
+body=$(request_field 0 body)
+assert_eq "body has selector" "#level" "$(printf '%s' "$body" | jq -r '.selector')"
+assert_eq "body has value" "opt2" "$(printf '%s' "$body" | jq -r '.value')"
+scenario_teardown
+
+# Scenario 17: select-option with --params (label-based)
+scenario_init "scenario 17: select-option --params with label"
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action select-option --selector "#level" \
+  --params '{"label":"Beginner"}' > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+assert_eq "body has selector merged from --selector" "#level" \
+  "$(printf '%s' "$body" | jq -r '.selector')"
+assert_eq "body has label from --params" "Beginner" \
+  "$(printf '%s' "$body" | jq -r '.label')"
+# Must be parseable JSON (regression guard against the brace bug since
+# this path also uses EXTRA_PARAMS in a jq pipeline).
+if printf '%s' "$body" | jq -e . >/dev/null 2>&1; then
+  pass "select-option --params body parses as JSON"
+else
+  fail "select-option --params body parses as JSON" "body=$body"
+fi
+scenario_teardown
+
+# Scenario 18: select-option with --params (index-based)
+scenario_init "scenario 18: select-option --params with index"
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+"$SKILL" --action select-option --selector "#level" \
+  --params '{"index":2}' > /dev/null 2>&1 || true
+body=$(request_field 0 body)
+assert_eq "body has index from --params" "2" \
+  "$(printf '%s' "$body" | jq -r '.index')"
+scenario_teardown
+
+# Scenario 19: select-option missing --value AND --params errors out
+scenario_init "scenario 19: select-option without value or params errors"
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+out=$("$SKILL" --action select-option --selector "#level" 2>&1) || true
+assert_contains "error message mentions value/params requirement" "$out" \
+  "select-option requires"
+# Stub should NOT have received any request (hard-fail before HTTP).
+total_reqs=$(wc -l < "$LOG_FILE" | tr -d ' ')
+assert_eq "stub received 0 requests" "0" "$total_reqs"
+scenario_teardown
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary

Two surgical fixes that unblock Olivia's 4/30 SteamFun matrix demo. Combined PR per orc directive (optimize for ship time).

### Fix 1 — Bash brace-injection bug in `execute.sh`

`BODY="${EXTRA_PARAMS:-{}}"` was mis-parsed by bash (closing `}` of parameter expansion is the FIRST `}` it sees → default = literal `{` + stray trailing `}`). With EXTRA_PARAMS set, body became `<value>}` — malformed JSON, backend rejects with 400. Empty path coincidentally produced `{}` and masked the bug.

**Affected actions:** `scroll`, `scroll-in-element`, `press-key`, `execute-js` fallback, `local-storage`, `get-interactive-elements`, `set-file-input` (7 sites total — Olivia identified 6, `set-file-input` was missed during her grep).

**Fix:** introduced `_body_or_empty` helper; replaced all 7 occurrences. Helper-based approach eliminates the 7-site duplication and inline-documents the bug so the next reader doesn't re-introduce it. Olivia explicitly endorsed this variant in her spec.

### Fix 2 — POST `/api/browser/select-option`

The chrome extension already supports `toolSelectOption` (lands via Olivia's `feat/native-select-option` branch), but OSS backend never exposed an HTTP route. Agents had to fall back to URL-query workarounds for native `<select>` because:
- CDP click on `<select>` doesn't open the dropdown (Chrome blocks synthetic events on native form controls)
- `<option>` children are OS-rendered, not DOM-rendered → existing click can't reach them

**Adds:**
- `POST /api/browser/select-option` controller — forwards body to the extension's `selectOption` tool. Body: `{ selector, value?, label?, index?, strategy?, tabId? }`. One of value/label/index required.
- Route registration (path `/select-option`, tool `selectOption`)
- Skill action `select-option` — `--selector --value` projection, or `--selector --params '{...}'` for label/index variants
- Updated supported-actions doc block + `--help` output

## Test plan

- [x] **Skill suite** (`bash config/skills/agent/remote-browser/execute.test.sh`): **38/38 pass** (was 18)
  - 6 brace-bug regression scenarios (one per affected action) — drive non-empty `--params`, assert wire body parses as JSON byte-for-byte equal to payload
  - 1 back-compat guard (empty `--params` still produces canonical `{}`)
  - 4 select-option scenarios (value, label, index, missing-criteria error)
- [x] **Backend browser suite** (`npx jest backend/src/controllers/browser/`): **34/34 pass** (was 31)
  - 3 new controller tests: 503 when not connected, forwards selector+value, accepts label/index/strategy
  - 1 routes test update: route count 30 (was 29), path coverage expanded
- [x] **Backend typecheck**: clean (pre-existing whatsapp dep error in `whatsapp.service.ts:95` is unchanged from `origin/main` — not introduced by this PR)
- [x] **Pre-existing flake** in unrelated suites (whatsapp / chat-v2 / mission / v3) is unchanged — verified via stash-test-restore vs `origin/main`

## Customer impact

Combined with [chrome-ext v0.3.4](https://github.com/stevehuang0115/crewly-extension/pull/3) (any-tab screenshot, already merged), this ships the all-PASS matrix. Olivia's 4 BLOCKED items (#6 / #9 / #11 / #14) unblock end-to-end — drives native `<select>` in SteamFun admin / teacher / parent flows without URL-query hacks.

## Code-location callout

> **NOTE:** Patches OSS browser-bridge code per existing reality. Per workspace `CLAUDE.md` the canonical home is `crewly-pro/src/browser-bridge/` (tracked in [crewly-pro#2](https://github.com/stevehuang0115/crewly-pro/issues/2)). This PR does NOT introduce a new violation — it patches existing wrong-shelved code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)