### PR TITLE
chore: bump version to v1.6.2 — bash brace fix + selectOption route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "main": "dist/cli/cli/src/index.js",


### PR DESCRIPTION
Trivial version bump for v1.6.2 release. Marks the build containing PR #390 (bash brace + selectOption route). Tag v1.6.2 already pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)