### PR TITLE
[P0 hotfix] browser-proxy: periodic list_browsers refresh — close 5min sweep purge gap

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -122,6 +122,14 @@ export const BROWSER_PROXY_CONSTANTS = {
 	 *  relay/network blips without prematurely evicting a live ext connection
 	 *  (heartbeat fires every 25s, so 5 min = ~12 missed heartbeats). */
 	STALE_PURGE_THRESHOLD_MS: 5 * 60_000,
+	/** Re-issue `list_browsers` to the relay every Nth heartbeat tick.
+	 *  Defensive sync against missing `browser_event:updated` pushes from
+	 *  the cloud relay. With heartbeat at 25s and N=8, refresh fires every
+	 *  ~200s — comfortably under STALE_PURGE_THRESHOLD_MS (300s) so a live
+	 *  ext that is mid-refresh never crosses the purge boundary.
+	 *  Boundary math: register@T0 → first refresh@T0+200s → next sweep
+	 *  evaluates lastSeenAt at most 200s old → far below 300s threshold. */
+	LIST_REFRESH_EVERY_N_HEARTBEATS: 8,
 } as const;
 
 // Agent runtime types

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -1309,4 +1309,275 @@ describe('BrowserProxyService', () => {
       expect(ids).toEqual(['id-new', 'id-old']);
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Periodic list_browsers refresh (P0 hotfix — 2026-04-30 SteamFun demo)
+  // ─────────────────────────────────────────────────────────────────────────
+  // Background: cloud relay does NOT reliably push `browser_event:updated`
+  // on ext heartbeats, so without defensive sync the local `instances`
+  // Map's `lastSeenAt` stays frozen at registration time and the 5-min
+  // sweep purges live ext entries — surfacing 503 NO_BROWSER_CLIENT to
+  // callers. The fix: re-issue `list_browsers` every 8th heartbeat tick
+  // (25s × 8 = 200s, comfortably under the 300s purge threshold).
+  describe('periodic list_browsers refresh (heartbeat-driven resync)', () => {
+    /**
+     * Helper: connect, register, and grab the mock WS instance plus a
+     * helper to count `list_browsers` sends across the WS.send mock.
+     */
+    function setupAndRegister(): {
+      ws: MockWsInstance;
+      proxy: BrowserProxyService;
+      countListBrowsers: () => number;
+    } {
+      const proxy = BrowserProxyService.getInstance();
+      proxy.connect('test-token');
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-x' }),
+      );
+      // The `registered` handler ALWAYS issues an initial `list_browsers`
+      // (browser-proxy.service.ts:461). Tests in this block assert
+      // ADDITIONAL refreshes beyond that initial call.
+      const ws = latestMockWs!;
+      const countListBrowsers = (): number =>
+        ws.send.mock.calls.filter((args) => {
+          try {
+            return (JSON.parse(args[0] as string) as { type: string }).type === 'list_browsers';
+          } catch {
+            return false;
+          }
+        }).length;
+      return { ws, proxy, countListBrowsers };
+    }
+
+    it('does NOT re-issue list_browsers before the 8th heartbeat tick', () => {
+      const { countListBrowsers } = setupAndRegister();
+      const initialCount = countListBrowsers();
+      expect(initialCount).toBe(1); // The one fired by `registered` handler
+
+      // Advance 7 heartbeats × 25s = 175s. Should be exactly 7 heartbeats sent,
+      // and ZERO additional list_browsers (8th tick has not fired yet).
+      jest.advanceTimersByTime(7 * 25_000);
+
+      expect(countListBrowsers()).toBe(initialCount);
+    });
+
+    it('re-issues list_browsers exactly on the 8th heartbeat tick (~200s)', () => {
+      const { countListBrowsers } = setupAndRegister();
+      const initialCount = countListBrowsers();
+
+      // 8 heartbeats × 25s = 200s — defensive resync should fire on the 8th.
+      jest.advanceTimersByTime(8 * 25_000);
+
+      expect(countListBrowsers()).toBe(initialCount + 1);
+    });
+
+    it('re-issues list_browsers every 8 heartbeats (16th, 24th, ...)', () => {
+      const { countListBrowsers } = setupAndRegister();
+      const initialCount = countListBrowsers();
+
+      jest.advanceTimersByTime(24 * 25_000); // 600s = 24 ticks
+
+      // 3 refresh fires at ticks 8, 16, 24.
+      expect(countListBrowsers()).toBe(initialCount + 3);
+    });
+
+    it('keeps the live ext stable past the 260s sweep boundary (regression guard)', () => {
+      // Real-world failure mode the hotfix targets: at T+260s the sweep would
+      // have purged a stale lastSeenAt anchored at T=0 (260s > old threshold
+      // would NOT have purged at 260s either since threshold is 300s, but
+      // by T+305s it WOULD have, see next test). Confirm the periodic
+      // resync at T+200s rebuilds lastSeenAt so the entry survives the sweep
+      // at T+260s.
+      const { ws, proxy } = setupAndRegister();
+
+      // Seed instance via initial list_browsers response.
+      ws._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'ext-fe835f17',
+              instanceName: 'SteamFun Chrome',
+              sessionId: 'bs-1',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+      expect(proxy.getInstances()).toHaveLength(1);
+
+      // Advance to T+200s — periodic resync sends list_browsers.
+      jest.advanceTimersByTime(200_000);
+
+      // Relay responds with the same instance, fresh lastSeenAt.
+      ws._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'ext-fe835f17',
+              instanceName: 'SteamFun Chrome',
+              sessionId: 'bs-1',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+
+      // Advance further to T+260s. Sweep runs at T+60s, T+120s, T+180s, T+240s.
+      // At T+240s the entry's lastSeenAt is from T+200s → 40s old < 300s → safe.
+      jest.advanceTimersByTime(60_000);
+
+      expect(proxy.getInstances()).toHaveLength(1);
+      expect(proxy.getInstances()[0].instanceId).toBe('ext-fe835f17');
+    });
+
+    it('keeps the live ext stable past the 305s sweep boundary', () => {
+      // Without the hotfix, lastSeenAt would be anchored at T=0 → at T+300s
+      // the sweep purges the entry → 503 NO_BROWSER_CLIENT to callers. With
+      // the hotfix, the T+200s refresh anchors lastSeenAt to T+200s; the
+      // sweep at T+300s sees age=100s → safe. Confirm.
+      const { ws, proxy } = setupAndRegister();
+
+      ws._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'ext-fe835f17',
+              instanceName: 'SteamFun Chrome',
+              sessionId: 'bs-1',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+
+      // Advance to T+200s, simulate refresh response.
+      jest.advanceTimersByTime(200_000);
+      ws._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'ext-fe835f17',
+              instanceName: 'SteamFun Chrome',
+              sessionId: 'bs-1',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+
+      // Advance to T+305s — sweep at T+300s evaluates age=100s → safe.
+      jest.advanceTimersByTime(105_000);
+
+      expect(proxy.getInstances()).toHaveLength(1);
+      expect(proxy.getInstances()[0].instanceId).toBe('ext-fe835f17');
+    });
+
+    it('purges if relay stops responding to refresh (cloud truly offline)', () => {
+      // Counter-test: if the relay genuinely loses the ext (so refresh
+      // returns an empty list), the sweep MUST eventually purge. This
+      // prevents the hotfix from masking real disconnections.
+      const { ws, proxy } = setupAndRegister();
+
+      ws._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [
+            {
+              instanceId: 'ext-fe835f17',
+              instanceName: 'SteamFun Chrome',
+              sessionId: 'bs-1',
+              lastSeenAt: new Date().toISOString(),
+            },
+          ],
+        }),
+      );
+
+      // Advance past 8 heartbeats — refresh fires.
+      jest.advanceTimersByTime(200_000);
+
+      // Relay responds with EMPTY list (ext dropped on cloud side).
+      ws._trigger(
+        'message',
+        JSON.stringify({ type: 'browser_list', instances: [] }),
+      );
+
+      // After empty list_browsers, instances should be cleared by
+      // handleBrowserList (it does Map.clear() before rebuilding).
+      expect(proxy.getInstances()).toHaveLength(0);
+    });
+
+    it('resets the heartbeat tick counter on reconnect', () => {
+      const { countListBrowsers, proxy, ws } = setupAndRegister();
+      const initialCount = countListBrowsers();
+
+      // Advance 5 heartbeats — counter at 5, no refresh yet.
+      jest.advanceTimersByTime(5 * 25_000);
+      expect(countListBrowsers()).toBe(initialCount);
+
+      // Simulate a clean disconnect + reconnect cycle.
+      ws.readyState = 3; // CLOSED
+      ws._trigger('close', 1006, Buffer.from(''));
+
+      // Wait for reconnect timer (RECONNECT_DELAY_MS = 5_000).
+      jest.advanceTimersByTime(5_000);
+
+      // After reconnect: re-register and re-establish baseline.
+      latestMockWs!._trigger('open');
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'registered', sessionId: 'sess-y' }),
+      );
+
+      // From this point, advance 7 heartbeats — counter starts at 0 post-reset,
+      // so 7 ticks should NOT trigger a refresh (would have if counter
+      // continued from pre-reconnect state of 5 → 5+7=12 → would fire on 8).
+      // Sanity-check: if pre-reconnect counter persisted, we'd see a refresh.
+      const postReconnectInitial = latestMockWs!.send.mock.calls.filter((args) => {
+        try {
+          return (JSON.parse(args[0] as string) as { type: string }).type === 'list_browsers';
+        } catch {
+          return false;
+        }
+      }).length;
+
+      jest.advanceTimersByTime(7 * 25_000);
+
+      const postReconnectAfter7Ticks = latestMockWs!.send.mock.calls.filter((args) => {
+        try {
+          return (JSON.parse(args[0] as string) as { type: string }).type === 'list_browsers';
+        } catch {
+          return false;
+        }
+      }).length;
+
+      expect(postReconnectAfter7Ticks).toBe(postReconnectInitial);
+
+      // 1 more tick (8 total post-reconnect) — refresh fires.
+      jest.advanceTimersByTime(25_000);
+
+      const postReconnectAfter8Ticks = latestMockWs!.send.mock.calls.filter((args) => {
+        try {
+          return (JSON.parse(args[0] as string) as { type: string }).type === 'list_browsers';
+        } catch {
+          return false;
+        }
+      }).length;
+
+      expect(postReconnectAfter8Ticks).toBe(postReconnectInitial + 1);
+
+      // Silence unused variable warnings.
+      void proxy;
+    });
+  });
 });

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -102,6 +102,15 @@ export class BrowserProxyService {
   /** Reconnect timer */
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   /**
+   * Heartbeat tick counter. Resets on each `startHeartbeat()` call (i.e. on
+   * fresh registration). Used to fire a defensive `list_browsers` re-issue
+   * every {@link BROWSER_PROXY_CONSTANTS.LIST_REFRESH_EVERY_N_HEARTBEATS}
+   * ticks so the local `instances` Map stays bounded against the 5-min
+   * sweep purge even when the cloud relay drops `browser_event:updated`
+   * pushes (observed during 2026-04-30 SteamFun customer demo).
+   */
+  private heartbeatTickCounter = 0;
+  /**
    * Wall-clock TTL sweep timer. Runs every {@link BROWSER_PROXY_CONSTANTS.SWEEP_INTERVAL_MS}
    * and purges any `BrowserInstanceInfo` whose `lastSeenAt` exceeds
    * {@link BROWSER_PROXY_CONSTANTS.STALE_PURGE_THRESHOLD_MS}. Independent of
@@ -707,17 +716,46 @@ export class BrowserProxyService {
 
   /**
    * Start heartbeat interval to keep relay connection alive.
+   *
+   * Beyond the basic relay keepalive, every Nth tick (controlled by
+   * {@link BROWSER_PROXY_CONSTANTS.LIST_REFRESH_EVERY_N_HEARTBEATS}) we
+   * re-issue `list_browsers` so the local `instances` Map is refreshed
+   * even if the cloud relay drops `browser_event:updated` pushes. This
+   * is a defensive sync against a real bug observed during the 2026-04-30
+   * SteamFun customer demo where ext registrations were correctly synced
+   * on initial connect but `lastSeenAt` was never refreshed by ongoing
+   * heartbeats — leading to the 5-min sweep purging live ext entries and
+   * surfacing 503 NO_BROWSER_CLIENT to callers.
+   *
+   * Resets the tick counter so a re-`start` (e.g. after reconnect) does
+   * not accidentally fire the refresh on the very first tick post-reset.
    */
   private startHeartbeat(): void {
     this.stopHeartbeat();
+    this.heartbeatTickCounter = 0;
     this.heartbeatTimer = setInterval(() => {
-      if (this.ws?.readyState === WebSocket.OPEN) {
-        this.sendRaw({ type: 'heartbeat' });
-      } else {
-        // WS not open but heartbeat still running — stop and trigger reconnect
+      if (this.ws?.readyState !== WebSocket.OPEN) {
+        // WS not open but heartbeat still running — stop and trigger reconnect.
         this.logger.warn('Heartbeat firing but WS not open, triggering disconnect');
         this.stopHeartbeat();
         this.handleDisconnect();
+        return;
+      }
+
+      this.sendRaw({ type: 'heartbeat' });
+      this.heartbeatTickCounter += 1;
+
+      if (
+        this.heartbeatTickCounter % BROWSER_PROXY_CONSTANTS.LIST_REFRESH_EVERY_N_HEARTBEATS
+        === 0
+      ) {
+        // Defensive resync — refresh the local instances Map from the relay
+        // snapshot. Idempotent on the relay side and on `handleBrowserList`
+        // (which clears + rebuilds the Map). Logged at debug to avoid noise.
+        this.logger.debug('Re-issuing list_browsers (periodic resync)', {
+          tick: this.heartbeatTickCounter,
+        });
+        this.sendRaw({ type: 'list_browsers' });
       }
     }, HEARTBEAT_INTERVAL_MS);
   }


### PR DESCRIPTION
## Summary

**P0 customer-blocking hotfix.** During the 2026-04-30 SteamFun customer demo, Olivia hit `503 NO_BROWSER_CLIENT` on Crewly browser commands ~5 minutes after the ext registered, despite the ext staying alive and heartbeating to the cloud relay normally. RCA: cloud relay does not push `browser_event:updated` on ext heartbeats, so local OSS `BrowserProxyService.instances` Map `lastSeenAt` stays frozen at registration time and the 5-min sweep (`STALE_PURGE_THRESHOLD_MS`) purges live ext entries.

**Defensive fix:** every 8th heartbeat tick (~200s), re-issue `list_browsers` to the relay so the local cache is refreshed before the 300s purge window expires.

## Files changed (3)

- `backend/src/constants.ts` — +9 lines: new `LIST_REFRESH_EVERY_N_HEARTBEATS = 8` constant with rationale
- `backend/src/services/browser/browser-proxy.service.ts` — +25 lines (~10 changed): adds `heartbeatTickCounter` field, periodic refresh inside `startHeartbeat()`
- `backend/src/services/browser/browser-proxy.service.test.ts` — +271 lines: 7 new test cases

## Boundary math

```
T+0     register, instance lastSeenAt=T+0
T+25s   heartbeat tick 1
...
T+200s  heartbeat tick 8 → list_browsers re-issued
        relay responds → handleBrowserList rebuilds Map
        lastSeenAt refreshed to T+200s
T+240s  sweep: 40s old < 300s → safe
T+300s  sweep: 100s old < 300s → safe
T+400s  heartbeat tick 16 → repeat
```

## Test coverage (7 new)

- [x] Does NOT re-issue before tick 8 (negative cadence)
- [x] Re-issues exactly on tick 8 (~200s)
- [x] Re-issues every 8 ticks (16, 24, ...)
- [x] Sweep boundary 260s — ext stable past first refresh
- [x] Sweep boundary 305s — ext stable past 5-min mark (the reproduction case Olivia hit)
- [x] Cloud truly offline (empty list_browsers response) → ext purged correctly (counter-test ensures hotfix does not mask real disconnections)
- [x] Tick counter resets on reconnect

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | 45 pre-existing errors (same count as `main` HEAD), zero new |
| `npm run build:backend` | Clean |
| `npx jest browser-proxy.service.test.ts` | 54/54 pass (47 prior + 7 new) |
| Wider: `services/browser/`, `services/cloud/`, `controllers/browser/` | 315/327 pass. The 12 failures are pre-existing on main (cloud-sync, cloud-initializer, cloud-connect-e2e) — unrelated |
| Live OSS runtime check | Skipped — OSS already running on port 8787 (PID 13557, Olivia hitting it). Runtime behavior deterministically covered by 7 fake-timer unit tests; Steve will restart post-merge |

## Restart instructions for Steve (post-merge)

```bash
cd /Users/yellowsunhy/Desktop/projects/crewly-projects/crewly
git pull
npm run build:backend
kill 13557   # or whatever PID owns port 8787 at restart time
npm start
```

**Olivia does NOT need to reload the Chrome Extension** — change is purely server-side. After OSS restart, the periodic `list_browsers` refresh begins on first heartbeat tick post-registration. Olivia should be able to repeat browser commands indefinitely.

## Out of scope (separate follow-ups)

- Cloud-side fix: relay should push `browser_event:updated` on ext heartbeats — would let us drop this client-side defensive resync.
- Iframe routing for click/selectOption: separate v0.4.2 ext design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)