### PR TITLE
feat(crewly-agent): add DeepSeek provider via OpenAI-compatible API

### DIFF
--- a/backend/src/services/agent/crewly-agent/model-manager.test.ts
+++ b/backend/src/services/agent/crewly-agent/model-manager.test.ts
@@ -79,6 +79,18 @@ describe('ModelManager', () => {
       expect((model as any).modelId).toBe('llama3.3:70b');
     });
 
+    it('should create a DeepSeek model via the OpenAI-compatible API', async () => {
+      process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+      const model = await manager.getModel({ provider: 'deepseek', modelId: 'deepseek-chat' });
+      expect(model).toBeDefined();
+      // The DeepSeek model is built on top of @ai-sdk/openai's createOpenAI
+      // pointed at https://api.deepseek.com/v1; we only assert that the model
+      // instance is produced without throwing — baseURL routing is exercised
+      // implicitly via the createOpenAI factory, which is covered by upstream
+      // tests in @ai-sdk/openai itself.
+      expect((model as any).modelId).toBe('deepseek-chat');
+    });
+
     it('should use default config when none provided', async () => {
       const model = await manager.getModel();
       expect(model).toBeDefined();
@@ -106,6 +118,7 @@ describe('ModelManager', () => {
       delete process.env.OPENAI_API_KEY;
       delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
       delete process.env.GEMINI_API_KEY;
+      delete process.env.DEEPSEEK_API_KEY;
 
       const available = await manager.getAvailableProviders();
 
@@ -113,6 +126,13 @@ describe('ModelManager', () => {
       expect(available.openai).toBe(false);
       expect(available.google).toBe(false);
       expect(available.ollama).toBe(true); // Ollama is always available (local)
+      expect(available.deepseek).toBe(false);
+    });
+
+    it('should detect DeepSeek API key from env', async () => {
+      process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+      const available = await manager.getAvailableProviders();
+      expect(available.deepseek).toBe(true);
     });
 
     it('should detect Anthropic API key', async () => {

--- a/backend/src/services/agent/crewly-agent/model-manager.test.ts
+++ b/backend/src/services/agent/crewly-agent/model-manager.test.ts
@@ -89,6 +89,10 @@ describe('ModelManager', () => {
       // implicitly via the createOpenAI factory, which is covered by upstream
       // tests in @ai-sdk/openai itself.
       expect((model as any).modelId).toBe('deepseek-chat');
+      // Regression guard: must route via the .chat() factory (chat-completions
+      // path), not the bare function-call form (which @ai-sdk/openai routes to
+      // /responses — unsupported by DeepSeek). See PR #400 review M1 / M2.
+      expect((model as any).provider).toBe('openai.chat');
     });
 
     it('should use default config when none provided', async () => {

--- a/backend/src/services/agent/crewly-agent/model-manager.ts
+++ b/backend/src/services/agent/crewly-agent/model-manager.ts
@@ -8,6 +8,7 @@
  * - ANTHROPIC_API_KEY
  * - OPENAI_API_KEY
  * - GOOGLE_GENERATIVE_AI_API_KEY
+ * - DEEPSEEK_API_KEY (DeepSeek; served via OpenAI-compatible API)
  *
  * Ollama runs locally and does not require an API key.
  * Configure the Ollama base URL via OLLAMA_BASE_URL (default: http://localhost:11434).
@@ -92,6 +93,16 @@ export class ModelManager {
           providerFn = (modelId: string) => ollamaProvider(modelId) as unknown as LanguageModel;
           break;
         }
+        case 'deepseek': {
+          // DeepSeek API is OpenAI-compatible — reuse the OpenAI SDK with a custom baseURL.
+          const { createOpenAI } = await import('@ai-sdk/openai');
+          const deepseekProvider = createOpenAI({
+            baseURL: 'https://api.deepseek.com/v1',
+            apiKey: process.env.DEEPSEEK_API_KEY,
+          });
+          providerFn = (modelId: string) => deepseekProvider(modelId);
+          break;
+        }
         default:
           throw new Error(`Unknown model provider: ${provider}`);
       }
@@ -129,29 +140,39 @@ export class ModelManager {
       openai: !!openaiKey,
       google: !!geminiKey,
       ollama: true, // Ollama runs locally, always "available" if installed
+      // DeepSeek is not yet wired through the settings service (ApiKeyProvider union),
+      // so availability is detected from the env var directly.
+      deepseek: !!process.env.DEEPSEEK_API_KEY,
     };
   }
 
   /**
    * Map model provider name to API key provider name.
-   * Only applicable for cloud providers (not ollama).
+   * Only applicable for cloud providers wired through the settings service
+   * (anthropic, openai, google). Ollama runs locally; DeepSeek currently
+   * reads its key directly from DEEPSEEK_API_KEY (see ensureApiKeyInEnv).
    *
    * @param provider - Cloud model provider (anthropic, openai, or google)
    * @returns Corresponding ApiKeyProvider name
    */
-  private static providerToApiKeyProvider(provider: Exclude<ModelProvider, 'ollama'>): ApiKeyProvider {
+  private static providerToApiKeyProvider(provider: Exclude<ModelProvider, 'ollama' | 'deepseek'>): ApiKeyProvider {
     return provider === 'google' ? 'gemini' : provider;
   }
 
   /**
    * Ensure the API key for a provider is available in process.env
    * by resolving it from settings if not already present.
-   * Ollama runs locally and does not require an API key — this is a no-op for 'ollama'.
+   *
+   * No-op for providers that do not flow through the settings service:
+   * - 'ollama' runs locally and needs no key
+   * - 'deepseek' reads DEEPSEEK_API_KEY directly from the environment
+   *   (will be migrated to the settings service in a follow-up; see PR notes)
    *
    * @param provider - The model provider
    */
   private async ensureApiKeyInEnv(provider: ModelProvider): Promise<void> {
     if (provider === 'ollama') return; // Ollama is local, no API key needed
+    if (provider === 'deepseek') return; // DEEPSEEK_API_KEY read directly from env
     const apiKeyProvider = ModelManager.providerToApiKeyProvider(provider);
     const settingsService = getSettingsService();
     const key = await settingsService.getApiKey(apiKeyProvider, { runtime: 'crewly-agent' });

--- a/backend/src/services/agent/crewly-agent/model-manager.ts
+++ b/backend/src/services/agent/crewly-agent/model-manager.ts
@@ -22,6 +22,14 @@ import { getSettingsService } from '../../settings/settings.service.js';
 import { ApiKeyProvider } from '../../../types/settings.types.js';
 
 /**
+ * Base URL for DeepSeek's OpenAI-compatible chat completions endpoint.
+ * DeepSeek implements /chat/completions only — not /responses — so we
+ * must route via the `.chat(modelId)` factory of @ai-sdk/openai's
+ * createOpenAI() return value. Extracted per CLAUDE.md no-hardcoded-values rule.
+ */
+const DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
+
+/**
  * Factory for creating AI SDK language model instances from configuration.
  *
  * Uses dynamic imports to avoid loading provider SDKs that aren't needed,
@@ -95,12 +103,16 @@ export class ModelManager {
         }
         case 'deepseek': {
           // DeepSeek API is OpenAI-compatible — reuse the OpenAI SDK with a custom baseURL.
+          // IMPORTANT: must call deepseekProvider.chat(modelId), NOT deepseekProvider(modelId).
+          // The bare function-call form on @ai-sdk/openai >=3.x routes to /responses, which
+          // DeepSeek does not implement — it only exposes /chat/completions. The .chat factory
+          // forces the chat-completions path. See PR #400 review for full trace.
           const { createOpenAI } = await import('@ai-sdk/openai');
           const deepseekProvider = createOpenAI({
-            baseURL: 'https://api.deepseek.com/v1',
+            baseURL: DEEPSEEK_BASE_URL,
             apiKey: process.env.DEEPSEEK_API_KEY,
           });
-          providerFn = (modelId: string) => deepseekProvider(modelId);
+          providerFn = (modelId: string) => deepseekProvider.chat(modelId);
           break;
         }
         default:

--- a/backend/src/services/agent/crewly-agent/types.test.ts
+++ b/backend/src/services/agent/crewly-agent/types.test.ts
@@ -27,7 +27,8 @@ describe('Crewly Agent Types', () => {
       expect(MODEL_PROVIDERS).toContain('openai');
       expect(MODEL_PROVIDERS).toContain('google');
       expect(MODEL_PROVIDERS).toContain('ollama');
-      expect(MODEL_PROVIDERS).toHaveLength(4);
+      expect(MODEL_PROVIDERS).toContain('deepseek');
+      expect(MODEL_PROVIDERS).toHaveLength(5);
     });
   });
 

--- a/backend/src/services/agent/crewly-agent/types.ts
+++ b/backend/src/services/agent/crewly-agent/types.ts
@@ -13,9 +13,15 @@ import type { McpServerConfig } from '../../mcp-client.js';
 import type { McpSensitivityOverrides } from './mcp-tool-bridge.js';
 
 /**
- * Supported model providers for Crewly Agent
+ * Supported model providers for Crewly Agent.
+ *
+ * Note: 'deepseek' is served through the OpenAI-compatible API at
+ * https://api.deepseek.com/v1, but is exposed as a distinct provider
+ * so users can select it explicitly. Its API key (DEEPSEEK_API_KEY) is
+ * read from the environment, not from the settings service — see
+ * model-manager.ts for details.
  */
-export type ModelProvider = 'anthropic' | 'openai' | 'google' | 'ollama';
+export type ModelProvider = 'anthropic' | 'openai' | 'google' | 'ollama' | 'deepseek';
 
 /**
  * All valid model providers
@@ -25,6 +31,7 @@ export const MODEL_PROVIDERS: readonly ModelProvider[] = [
   'openai',
   'google',
   'ollama',
+  'deepseek',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Adds `'deepseek'` to the `ModelProvider` union in `crewly-agent/types.ts` and wires it through `ModelManager` so agents can be configured with `provider: 'deepseek', modelId: 'deepseek-chat'`.
- Implementation reuses the already-installed `@ai-sdk/openai` package via `createOpenAI({ baseURL: DEEPSEEK_BASE_URL, apiKey }).chat(modelId)` — DeepSeek's API is OpenAI-compatible, so **no new npm dependency**.
- API key is read from `process.env.DEEPSEEK_API_KEY` directly. Follow-up tracked in **#401**.

## Why
Steve requested DeepSeek support so the `crewly-agent` runtime can be evaluated against deepseek-chat / deepseek-reasoner alongside Anthropic / OpenAI / Google / Ollama. ETA per Steve: 1–2 days through normal cadence; this PR follows the standard merge → next 1.6.x release path (no hotfix, no rsync).

## Files touched (4, ~55 LOC, +`DEEPSEEK_BASE_URL` const)
- `backend/src/services/agent/crewly-agent/types.ts` — extend `ModelProvider` + `MODEL_PROVIDERS`
- `backend/src/services/agent/crewly-agent/types.test.ts` — `MODEL_PROVIDERS` length now 5
- `backend/src/services/agent/crewly-agent/model-manager.ts` — `'deepseek'` switch case routes via `.chat(modelId)` (NOT bare call — DeepSeek does not implement `/responses`); module-local `DEEPSEEK_BASE_URL` const; `getAvailableProviders` includes `deepseek`; `ensureApiKeyInEnv` short-circuits for deepseek
- `backend/src/services/agent/crewly-agent/model-manager.test.ts` — positive case for DeepSeek model creation, regression guard `provider === 'openai.chat'`, env-var detection in `getAvailableProviders`. Unknown-provider negative case (`'azure'`) preserved.

## Critical fix from review (M1)
Per Sam's review: the bare `deepseekProvider(modelId)` form on `@ai-sdk/openai >= 3.x` routes to `/responses`, which DeepSeek does **not** implement (only `/chat/completions`). Updated to `deepseekProvider.chat(modelId)`. Test now asserts `(model as any).provider === 'openai.chat'` so a future refactor cannot silently re-introduce the bug.

## ConfigService / env-var deployment note (for orc)
- **Env var name:** `DEEPSEEK_API_KEY`
- This PR intentionally does **not** add `'deepseek'` to the `ApiKeyProvider` union in `backend/src/types/settings.types.ts`. Reasons:
  1. Keeps the patch minimal (~55 LOC, surface area limited to crewly-agent).
  2. The existing settings.controller test at `settings.controller.test.ts:547` uses `provider: 'deepseek'` as an *invalid* `ApiKeyProvider` example — adding deepseek there would break that test and require a coordinated update.
  3. Frontend `ApiKeysTab.tsx` would also need updating (UI scope), which is better as a follow-up.
- **Follow-up tracked in #401** — full ConfigService + ApiKeysTab wiring so no server-side `.env` edit is needed when subsequent releases ship.
- For this 1.6.x cut: an env-var inject on the node (or `ConfigService` reading `DEEPSEEK_API_KEY` from settings.json's `apiKeys.global` if a similar pattern already exists) is needed before deepseek-backed agents can run in production.

## Test plan
- [x] `npx jest backend/src/services/agent/crewly-agent/model-manager.test.ts` → 15/15 pass (incl. DeepSeek positive case, `.chat` regression guard, env-var detection)
- [x] `npx jest backend/src/services/agent/crewly-agent/types.test.ts` → all pass with updated `MODEL_PROVIDERS` length
- [x] `npx jest backend/src/controllers/settings/settings.controller.test.ts` → 37/37 pass (negative `'deepseek'` test preserved)
- [x] `npm run build` (full: backend + frontend + cli) → clean
- [ ] Manual smoke: `DEEPSEEK_API_KEY=… npm run dev:backend` and instantiate a crewly-agent with `provider: 'deepseek', modelId: 'deepseek-chat'`

## Review history
- **Round 1 (Refactor & Consistency):** mirrored the `'ollama'` short-circuit pattern in `ensureApiKeyInEnv`; reused existing `@ai-sdk/openai` rather than introducing `@ai-sdk/deepseek` (which would need a `package.json` change + lockfile churn).
- **Round 2 (Efficiency & Reliability):** `process.env.DEEPSEEK_API_KEY` resolved at provider-creation time, not request time — missing key fails fast on first model creation.
- **Round 3 (Overall Quality):** JSDoc updated for `providerToApiKeyProvider` + `ensureApiKeyInEnv` to call out which providers bypass the settings service and why; doc header lists `DEEPSEEK_API_KEY` alongside the other env-var names.
- **Sam review (post-open):** M1 `.chat()` routing fix, M2 regression guard, NTH-1 `DEEPSEEK_BASE_URL` const, NTH-2 follow-up issue #401 — all applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)