### PR TITLE
feat(orchestrator): per-orchestrator modelId support (P1, cloud_pro_v2)

### DIFF
--- a/backend/src/controllers/orchestrator/orchestrator.controller.test.ts
+++ b/backend/src/controllers/orchestrator/orchestrator.controller.test.ts
@@ -1188,4 +1188,168 @@ describe('Orchestrator Handlers', () => {
       expect(typeof orchestratorHandlers.getOrchestratorStatus).toBe('function');
     });
   });
+
+  /**
+   * PUT /api/orchestrator/runtime — extended in P1 (cloud_pro_v2) to accept
+   * an optional modelId alongside the existing runtimeType. Tests cover
+   * each combination of present/absent/invalid fields.
+   */
+  describe('updateOrchestratorRuntime', () => {
+    beforeEach(() => {
+      mockStorageService.updateOrchestratorRuntimeType = jest.fn().mockResolvedValue(undefined);
+      mockStorageService.updateOrchestratorModelId = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it('updates runtimeType only when modelId is absent', async () => {
+      mockRequest.body = { runtimeType: 'crewly-agent' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockStorageService.updateOrchestratorRuntimeType).toHaveBeenCalledWith('crewly-agent');
+      expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ runtimeType: 'crewly-agent' }),
+        })
+      );
+    });
+
+    it('updates modelId only when runtimeType is absent', async () => {
+      mockRequest.body = { modelId: 'deepseek/deepseek-chat' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockStorageService.updateOrchestratorModelId).toHaveBeenCalledWith('deepseek/deepseek-chat');
+      expect(mockStorageService.updateOrchestratorRuntimeType).not.toHaveBeenCalled();
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ modelId: 'deepseek/deepseek-chat' }),
+        })
+      );
+    });
+
+    it('updates both runtimeType and modelId in a single request', async () => {
+      mockRequest.body = {
+        runtimeType: 'crewly-agent',
+        modelId: 'anthropic/claude-sonnet-4-20250514',
+      };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockStorageService.updateOrchestratorRuntimeType).toHaveBeenCalledWith('crewly-agent');
+      expect(mockStorageService.updateOrchestratorModelId).toHaveBeenCalledWith('anthropic/claude-sonnet-4-20250514');
+      const responseBody = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(responseBody.data.runtimeType).toBe('crewly-agent');
+      expect(responseBody.data.modelId).toBe('anthropic/claude-sonnet-4-20250514');
+    });
+
+    it('rejects with 400 when neither field is provided', async () => {
+      mockRequest.body = {};
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockStorageService.updateOrchestratorRuntimeType).not.toHaveBeenCalled();
+      expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 400 when both fields are empty strings', async () => {
+      mockRequest.body = { runtimeType: '', modelId: '' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects with 400 for invalid runtimeType', async () => {
+      mockRequest.body = { runtimeType: 'not-a-real-runtime' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockStorageService.updateOrchestratorRuntimeType).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 400 for malformed modelId (no slash)', async () => {
+      mockRequest.body = { modelId: 'gibberish' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+    });
+
+    it('rejects with 400 for modelId with unsupported provider', async () => {
+      // Format passes regex (provider/modelId) but provider is not in MODEL_PROVIDERS,
+      // so parseModelId() falls back to DEFAULT_MODEL — controller must catch this.
+      mockRequest.body = { modelId: 'fakeprovider/some-model' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+    });
+
+    it('accepts the canonical default modelId without flagging it as invalid', async () => {
+      // Edge case: when the input equals provider/modelId of DEFAULT_MODEL,
+      // parseModelId() returns the default — but that's correct, not a fallback.
+      mockRequest.body = { modelId: 'google/gemini-3-flash-preview' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).not.toHaveBeenCalledWith(400);
+      expect(mockStorageService.updateOrchestratorModelId).toHaveBeenCalledWith('google/gemini-3-flash-preview');
+    });
+
+    it('returns 500 when storage write fails', async () => {
+      mockStorageService.updateOrchestratorModelId.mockRejectedValueOnce(new Error('disk full'));
+      mockRequest.body = { modelId: 'deepseek/deepseek-chat' };
+
+      await orchestratorHandlers.updateOrchestratorRuntime.call(
+        mockApiContext as ApiContext,
+        mockRequest as Request,
+        mockResponse as Response,
+      );
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+    });
+  });
 });

--- a/backend/src/controllers/orchestrator/orchestrator.controller.test.ts
+++ b/backend/src/controllers/orchestrator/orchestrator.controller.test.ts
@@ -1296,7 +1296,7 @@ describe('Orchestrator Handlers', () => {
       expect(mockStorageService.updateOrchestratorRuntimeType).not.toHaveBeenCalled();
     });
 
-    it('rejects with 400 for malformed modelId (no slash)', async () => {
+    it('rejects with 400 for malformed modelId (no slash) and surfaces "format" error', async () => {
       mockRequest.body = { modelId: 'gibberish' };
 
       await orchestratorHandlers.updateOrchestratorRuntime.call(
@@ -1307,11 +1307,15 @@ describe('Orchestrator Handlers', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+      // Round-1 refactor surfaces a typed "malformed" reason in the error body.
+      const errorBody = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(errorBody.error).toMatch(/format/i);
     });
 
-    it('rejects with 400 for modelId with unsupported provider', async () => {
-      // Format passes regex (provider/modelId) but provider is not in MODEL_PROVIDERS,
-      // so parseModelId() falls back to DEFAULT_MODEL — controller must catch this.
+    it('rejects with 400 for modelId with unsupported provider and surfaces "provider" error', async () => {
+      // Format passes the structural regex (provider/modelId) but the provider
+      // is not in MODEL_PROVIDERS — so isModelProvider() returns false and we
+      // surface a precise "Provider not supported" error message.
       mockRequest.body = { modelId: 'fakeprovider/some-model' };
 
       await orchestratorHandlers.updateOrchestratorRuntime.call(
@@ -1322,6 +1326,8 @@ describe('Orchestrator Handlers', () => {
 
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockStorageService.updateOrchestratorModelId).not.toHaveBeenCalled();
+      const errorBody = (mockResponse.json as jest.Mock).mock.calls[0][0];
+      expect(errorBody.error).toMatch(/Provider not supported/i);
     });
 
     it('accepts the canonical default modelId without flagging it as invalid', async () => {

--- a/backend/src/controllers/orchestrator/orchestrator.controller.ts
+++ b/backend/src/controllers/orchestrator/orchestrator.controller.ts
@@ -16,6 +16,7 @@ import {
 import { getTerminalGateway } from '../../websocket/terminal.gateway.js';
 import { MemoryService } from '../../services/memory/memory.service.js';
 import { LoggerService } from '../../services/core/logger.service.js';
+import { isModelProvider } from '../../services/agent/crewly-agent/types.js';
 
 const logger = LoggerService.getInstance().createComponentLogger('OrchestratorController');
 
@@ -605,20 +606,35 @@ export async function assignTaskToOrchestrator(
 }
 
 /**
- * Validate a modelId string of the form "provider/modelId".
- *
- * Uses a permissive regex first (cheap) then confirms the parsed result is
- * a real ModelConfig — `parseModelId()` falls back to DEFAULT_MODEL on
- * invalid input, so we explicitly check that the parsed result matches
- * the supplied input rather than the default.
- *
- * @param modelId - User-supplied model id (e.g. "deepseek/deepseek-chat")
- * @returns true if the modelId is well-formed AND its provider is supported
+ * Permissive structural regex for a "provider/modelId" pair.
+ * Provider: lowercase letters/digits/hyphens. ModelId: any printable
+ * id-safe character set we've observed across providers.
  */
-function isValidModelIdFormat(modelId: string): boolean {
-	// Cheap structural check — provider/modelId with conservative charsets
-	if (!/^[a-z0-9-]+\/[a-zA-Z0-9.\-_]+$/.test(modelId)) return false;
-	return true;
+const MODEL_ID_FORMAT_RE = /^[a-z0-9-]+\/[a-zA-Z0-9.\-_]+$/;
+
+/**
+ * Validate a user-supplied modelId in two stages:
+ *   1. Cheap structural regex — rejects gibberish without imports.
+ *   2. Provider whitelist via {@link isModelProvider} — rejects providers
+ *      the runtime cannot construct, regardless of structural validity.
+ *
+ * Returning a structured result lets the caller surface a precise 400
+ * error message ("malformed" vs "unsupported provider").
+ *
+ * @param modelId - Format: "provider/modelId"
+ * @returns Validation outcome with a typed reason on failure
+ */
+function validateModelId(modelId: string):
+	| { ok: true }
+	| { ok: false; reason: 'malformed' | 'unsupported_provider' } {
+	if (!MODEL_ID_FORMAT_RE.test(modelId)) {
+		return { ok: false, reason: 'malformed' };
+	}
+	const provider = modelId.substring(0, modelId.indexOf('/'));
+	if (!isModelProvider(provider)) {
+		return { ok: false, reason: 'unsupported_provider' };
+	}
+	return { ok: true };
 }
 
 export async function updateOrchestratorRuntime(
@@ -652,29 +668,16 @@ export async function updateOrchestratorRuntime(
 			}
 		}
 
-		// Validate modelId format when present.
-		// parseModelId() falls back to DEFAULT_MODEL on bad input, so a regex
-		// check up front is the cheapest way to surface a 400 to the caller.
+		// Validate modelId format and provider when present.
 		if (hasModelId) {
-			if (!isValidModelIdFormat(modelId!)) {
+			const validation = validateModelId(modelId!);
+			if (!validation.ok) {
+				const errorMessage = validation.reason === 'malformed'
+					? 'Invalid modelId format. Expected "provider/modelId" (e.g. "deepseek/deepseek-chat")'
+					: 'Invalid modelId. Provider not supported by Crewly Agent runtime.';
 				res.status(400).json({
 					success: false,
-					error: 'Invalid modelId format. Expected "provider/modelId" (e.g. "deepseek/deepseek-chat")',
-				} as ApiResponse);
-				return;
-			}
-			// Defense-in-depth: confirm parseModelId accepts the provider.
-			const { parseModelId, CREWLY_AGENT_DEFAULTS } = await import('../../services/agent/crewly-agent/types.js');
-			const parsed = parseModelId(modelId!);
-			const matchesDefault = parsed.provider === CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.provider
-				&& parsed.modelId === CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.modelId;
-			const expectedDefaultId = `${CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.provider}/${CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.modelId}`;
-			if (matchesDefault && modelId !== expectedDefaultId) {
-				// parseModelId returned the default but the input wasn't asking for it →
-				// the provider was rejected. Surface a 400.
-				res.status(400).json({
-					success: false,
-					error: 'Invalid modelId. Provider not supported by Crewly Agent runtime.',
+					error: errorMessage,
 				} as ApiResponse);
 				return;
 			}

--- a/backend/src/controllers/orchestrator/orchestrator.controller.ts
+++ b/backend/src/controllers/orchestrator/orchestrator.controller.ts
@@ -604,39 +604,101 @@ export async function assignTaskToOrchestrator(
 	}
 }
 
+/**
+ * Validate a modelId string of the form "provider/modelId".
+ *
+ * Uses a permissive regex first (cheap) then confirms the parsed result is
+ * a real ModelConfig — `parseModelId()` falls back to DEFAULT_MODEL on
+ * invalid input, so we explicitly check that the parsed result matches
+ * the supplied input rather than the default.
+ *
+ * @param modelId - User-supplied model id (e.g. "deepseek/deepseek-chat")
+ * @returns true if the modelId is well-formed AND its provider is supported
+ */
+function isValidModelIdFormat(modelId: string): boolean {
+	// Cheap structural check — provider/modelId with conservative charsets
+	if (!/^[a-z0-9-]+\/[a-zA-Z0-9.\-_]+$/.test(modelId)) return false;
+	return true;
+}
+
 export async function updateOrchestratorRuntime(
 	this: ApiContext,
 	req: Request,
 	res: Response
 ): Promise<void> {
 	try {
-		const { runtimeType } = req.body as { runtimeType: string };
+		const { runtimeType, modelId } = req.body as { runtimeType?: string; modelId?: string };
 
-		if (!runtimeType || typeof runtimeType !== 'string') {
+		// At least one field must be provided. Empty strings count as "not provided".
+		const hasRuntimeType = typeof runtimeType === 'string' && runtimeType.length > 0;
+		const hasModelId = typeof modelId === 'string' && modelId.length > 0;
+		if (!hasRuntimeType && !hasModelId) {
 			res.status(400).json({
 				success: false,
-				error: 'runtimeType is required and must be a string',
+				error: 'At least one of runtimeType or modelId must be provided',
 			} as ApiResponse);
 			return;
 		}
 
-		// Validate runtime type
-		const validRuntimeTypes: string[] = Object.values(RUNTIME_TYPES);
-		if (!validRuntimeTypes.includes(runtimeType)) {
-			res.status(400).json({
-				success: false,
-				error: `Invalid runtime type. Must be one of: ${validRuntimeTypes.join(', ')}`,
-			} as ApiResponse);
-			return;
+		// Validate runtimeType when present (preserves existing behavior).
+		if (hasRuntimeType) {
+			const validRuntimeTypes: string[] = Object.values(RUNTIME_TYPES);
+			if (!validRuntimeTypes.includes(runtimeType!)) {
+				res.status(400).json({
+					success: false,
+					error: `Invalid runtime type. Must be one of: ${validRuntimeTypes.join(', ')}`,
+				} as ApiResponse);
+				return;
+			}
 		}
 
-		// Update orchestrator runtime type
-		await this.storageService.updateOrchestratorRuntimeType(runtimeType as RuntimeType);
+		// Validate modelId format when present.
+		// parseModelId() falls back to DEFAULT_MODEL on bad input, so a regex
+		// check up front is the cheapest way to surface a 400 to the caller.
+		if (hasModelId) {
+			if (!isValidModelIdFormat(modelId!)) {
+				res.status(400).json({
+					success: false,
+					error: 'Invalid modelId format. Expected "provider/modelId" (e.g. "deepseek/deepseek-chat")',
+				} as ApiResponse);
+				return;
+			}
+			// Defense-in-depth: confirm parseModelId accepts the provider.
+			const { parseModelId, CREWLY_AGENT_DEFAULTS } = await import('../../services/agent/crewly-agent/types.js');
+			const parsed = parseModelId(modelId!);
+			const matchesDefault = parsed.provider === CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.provider
+				&& parsed.modelId === CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.modelId;
+			const expectedDefaultId = `${CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.provider}/${CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.modelId}`;
+			if (matchesDefault && modelId !== expectedDefaultId) {
+				// parseModelId returned the default but the input wasn't asking for it →
+				// the provider was rejected. Surface a 400.
+				res.status(400).json({
+					success: false,
+					error: 'Invalid modelId. Provider not supported by Crewly Agent runtime.',
+				} as ApiResponse);
+				return;
+			}
+		}
+
+		// Persist both fields independently so partial updates are supported.
+		if (hasRuntimeType) {
+			await this.storageService.updateOrchestratorRuntimeType(runtimeType as RuntimeType);
+		}
+		if (hasModelId) {
+			await this.storageService.updateOrchestratorModelId(modelId);
+		}
+
+		const messageParts: string[] = [];
+		if (hasRuntimeType) messageParts.push(`runtime=${runtimeType}`);
+		if (hasModelId) messageParts.push(`modelId=${modelId}`);
 
 		res.json({
 			success: true,
-			data: { runtimeType },
-			message: `Orchestrator runtime updated to ${runtimeType}`,
+			data: {
+				...(hasRuntimeType ? { runtimeType } : {}),
+				...(hasModelId ? { modelId } : {}),
+			},
+			message: `Orchestrator updated (${messageParts.join(', ')})`,
 		} as ApiResponse);
 	} catch (error) {
 		logger.error('Error updating orchestrator runtime', { error: error instanceof Error ? error.message : String(error) });

--- a/backend/src/controllers/team/team.controller.test.ts
+++ b/backend/src/controllers/team/team.controller.test.ts
@@ -3566,4 +3566,101 @@ describe('Teams Handlers', () => {
       expect(saveCallsAfter).toBe(saveCallsBefore);
     });
   });
+
+  /**
+   * Tests for buildOrchestratorTeam's modelId pass-through.
+   *
+   * The orchestrator-member virtual team member needs to expose any
+   * configured `modelId` so the in-process Crewly Agent runtime can
+   * select a non-default model (e.g. deepseek/deepseek-chat).
+   * The Assistant and Auditor virtual members must NOT receive modelId —
+   * they have their own runtimeType and don't run the configurable runtime.
+   */
+  describe('buildOrchestratorTeam modelId pass-through', () => {
+    /**
+     * Helper: invokes getTeams via the public handler and returns the
+     * orchestrator team object (always at index 0 in the response).
+     */
+    const fetchOrchestratorTeam = async (): Promise<any> => {
+      mockStorageService.getTeams.mockResolvedValue([]);
+      await teamsHandlers.getTeams.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+      const responseData = (responseMock.json as jest.Mock).mock.calls[0][0] as any;
+      return responseData.data[0];
+    };
+
+    it('surfaces modelId on orchestrator-member when set in config', async () => {
+      mockStorageService.getOrchestratorStatus.mockResolvedValue({
+        agentStatus: 'active',
+        workingStatus: 'idle',
+        runtimeType: 'crewly-agent',
+        modelId: 'deepseek/deepseek-chat',
+      });
+
+      const orchestratorTeam = await fetchOrchestratorTeam();
+      const orchestratorMember = orchestratorTeam.members.find(
+        (m: any) => m.id === 'orchestrator-member'
+      );
+
+      expect(orchestratorMember).toBeDefined();
+      expect(orchestratorMember.modelId).toBe('deepseek/deepseek-chat');
+      expect(orchestratorMember.runtimeType).toBe('crewly-agent');
+    });
+
+    it('omits modelId on orchestrator-member when not set (DEFAULT_MODEL semantics)', async () => {
+      mockStorageService.getOrchestratorStatus.mockResolvedValue({
+        agentStatus: 'inactive',
+        workingStatus: 'idle',
+        runtimeType: 'claude-code',
+        // no modelId
+      });
+
+      const orchestratorTeam = await fetchOrchestratorTeam();
+      const orchestratorMember = orchestratorTeam.members.find(
+        (m: any) => m.id === 'orchestrator-member'
+      );
+
+      expect(orchestratorMember).toBeDefined();
+      expect(orchestratorMember.modelId).toBeUndefined();
+    });
+
+    it('omits modelId when orchestratorStatus is null (no config yet)', async () => {
+      mockStorageService.getOrchestratorStatus.mockResolvedValue(null);
+
+      const orchestratorTeam = await fetchOrchestratorTeam();
+      const orchestratorMember = orchestratorTeam.members.find(
+        (m: any) => m.id === 'orchestrator-member'
+      );
+
+      expect(orchestratorMember).toBeDefined();
+      expect(orchestratorMember.modelId).toBeUndefined();
+    });
+
+    it('does not propagate modelId to Assistant or Auditor virtual members', async () => {
+      mockStorageService.getOrchestratorStatus.mockResolvedValue({
+        agentStatus: 'active',
+        workingStatus: 'idle',
+        runtimeType: 'crewly-agent',
+        modelId: 'anthropic/claude-sonnet-4-20250514',
+      });
+
+      const orchestratorTeam = await fetchOrchestratorTeam();
+      const assistant = orchestratorTeam.members.find(
+        (m: any) => m.sessionName === 'crewly-orc-assistant'
+      );
+      const auditor = orchestratorTeam.members.find(
+        (m: any) => m.sessionName === 'crewly-auditor'
+      );
+
+      expect(assistant).toBeDefined();
+      expect(assistant.modelId).toBeUndefined();
+      // Auditor may or may not be present depending on auditor settings
+      if (auditor) {
+        expect(auditor.modelId).toBeUndefined();
+      }
+    });
+  });
 });

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -149,6 +149,8 @@ interface OrchestratorStatusInfo {
   agentStatus?: string;
   workingStatus?: string;
   runtimeType?: string;
+  /** Optional model ID for the in-process Crewly Agent runtime (format: provider/modelId) */
+  modelId?: string;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -226,6 +226,9 @@ function buildOrchestratorTeam(
       agentStatus: actualAgentStatus as TeamMember['agentStatus'],
       workingStatus: (orchestratorStatus?.workingStatus || CREWLY_CONSTANTS.WORKING_STATUSES.IDLE) as TeamMember['workingStatus'],
       runtimeType: (orchestratorStatus?.runtimeType || 'claude-code') as TeamMember['runtimeType'],
+      // Surface configured modelId so the in-process Crewly Agent runtime can use it.
+      // Only set when present — undefined preserves "use DEFAULT_MODEL" semantics.
+      ...(orchestratorStatus?.modelId ? { modelId: orchestratorStatus.modelId } : {}),
       createdAt: orchestratorStatus?.createdAt || now,
       updatedAt: orchestratorStatus?.updatedAt || now
     },

--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -3057,6 +3057,160 @@ describe('AgentRegistrationService', () => {
 			expect(routeSpy).not.toHaveBeenCalled();
 			routeSpy.mockRestore();
 		});
+
+		// ──────────────────────────────────────────────────────────────────
+		// Orchestrator modelId resolution (P1 fix, cloud_pro_v2)
+		// ──────────────────────────────────────────────────────────────────
+		// storage.service.ts:413 excludes the orchestrator from getTeams(),
+		// so the orchestrator's modelId must be read via getOrchestratorStatus
+		// as a fallback. Without this branch, the orchestrator silently
+		// defaults to DEFAULT_MODEL even when a modelId is configured.
+		describe('orchestrator modelId resolution', () => {
+			it('uses orchestratorStatus.modelId when starting the orchestrator session', async () => {
+				mockReadFile.mockResolvedValue('System prompt');
+				mockAccess.mockRejectedValue(new Error('ENOENT'));
+				mockStorageService.getTeams.mockResolvedValue([]); // orchestrator excluded
+				(mockStorageService.getOrchestratorStatus as any).mockResolvedValue({
+					sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+					agentStatus: 'active',
+					workingStatus: 'idle',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT,
+					modelId: 'deepseek/deepseek-chat',
+				});
+
+				await service.createAgentSession({
+					sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+					role: 'orchestrator',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+				});
+
+				expect(mockCrewlyRuntime.initializeInProcess).toHaveBeenCalled();
+				const initArgs = mockCrewlyRuntime.initializeInProcess.mock.calls[0];
+				const config = initArgs[1];
+				expect(config.model).toBeDefined();
+				expect(config.model.provider).toBe('deepseek');
+				expect(config.model.modelId).toBe('deepseek-chat');
+			});
+
+			it('uses orchestratorStatus.modelId when memberId is "orchestrator-member"', async () => {
+				mockReadFile.mockResolvedValue('System prompt');
+				mockAccess.mockRejectedValue(new Error('ENOENT'));
+				mockStorageService.getTeams.mockResolvedValue([]);
+				(mockStorageService.getOrchestratorStatus as any).mockResolvedValue({
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT,
+					modelId: 'anthropic/claude-sonnet-4-20250514',
+				});
+
+				// Use a non-orchestrator session name but the canonical orch member id —
+				// some flows pass memberId without a matching session name (e.g. virtual member).
+				await service.createAgentSession({
+					sessionName: 'crewly-orc-virtual',
+					role: 'orchestrator',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+					memberId: 'orchestrator-member',
+				} as any);
+
+				expect(mockCrewlyRuntime.initializeInProcess).toHaveBeenCalled();
+				const config = mockCrewlyRuntime.initializeInProcess.mock.calls[0][1];
+				expect(config.model).toBeDefined();
+				expect(config.model.provider).toBe('anthropic');
+				expect(config.model.modelId).toBe('claude-sonnet-4-20250514');
+			});
+
+			it('falls back to DEFAULT_MODEL when orchestrator has no modelId configured', async () => {
+				mockReadFile.mockResolvedValue('System prompt');
+				mockAccess.mockRejectedValue(new Error('ENOENT'));
+				mockStorageService.getTeams.mockResolvedValue([]);
+				(mockStorageService.getOrchestratorStatus as any).mockResolvedValue({
+					sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+					agentStatus: 'active',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT,
+					// no modelId
+				});
+
+				await service.createAgentSession({
+					sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+					role: 'orchestrator',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+				});
+
+				expect(mockCrewlyRuntime.initializeInProcess).toHaveBeenCalled();
+				const config = mockCrewlyRuntime.initializeInProcess.mock.calls[0][1];
+				// No model override → runtime applies its DEFAULT_MODEL.
+				expect(config.model).toBeUndefined();
+			});
+
+			it('does not call getOrchestratorStatus for non-orchestrator agents', async () => {
+				mockReadFile.mockResolvedValue('System prompt');
+				mockAccess.mockRejectedValue(new Error('ENOENT'));
+				mockStorageService.getTeams.mockResolvedValue([
+					{
+						id: 'team-1',
+						name: 'Team 1',
+						members: [
+							{ id: 'm-leo', name: 'Leo', sessionName: 'leo-session', role: 'developer',
+							  runtimeType: 'crewly-agent', modelId: 'openai/gpt-4o',
+							  systemPrompt: '', agentStatus: 'inactive', workingStatus: 'idle',
+							  createdAt: '', updatedAt: '' },
+						],
+						projectIds: [], createdAt: '', updatedAt: '',
+					},
+				] as any);
+				const orchSpy = mockStorageService.getOrchestratorStatus as any;
+				orchSpy.mockClear();
+
+				await service.createAgentSession({
+					sessionName: 'leo-session',
+					role: 'developer',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+					memberId: 'm-leo',
+				} as any);
+
+				expect(mockCrewlyRuntime.initializeInProcess).toHaveBeenCalled();
+				const config = mockCrewlyRuntime.initializeInProcess.mock.calls[0][1];
+				expect(config.model).toBeDefined();
+				expect(config.model.provider).toBe('openai');
+				expect(config.model.modelId).toBe('gpt-4o');
+				// Orchestrator fallback must not be consulted for regular team members.
+				expect(orchSpy).not.toHaveBeenCalled();
+			});
+
+			it('prefers team-member modelId over orchestrator modelId when both exist', async () => {
+				// Edge case: orchestrator-member id present in a team config (shouldn't
+				// happen in practice, but the resolution order should still favor the
+				// team-member match found first).
+				mockReadFile.mockResolvedValue('System prompt');
+				mockAccess.mockRejectedValue(new Error('ENOENT'));
+				mockStorageService.getTeams.mockResolvedValue([
+					{
+						id: 'team-x', name: 'X',
+						members: [
+							{ id: 'orchestrator-member', name: 'O', sessionName: 'crewly-orc-x',
+							  role: 'orchestrator', runtimeType: 'crewly-agent',
+							  modelId: 'google/gemini-2.5-flash-preview-05-20',
+							  systemPrompt: '', agentStatus: 'inactive', workingStatus: 'idle',
+							  createdAt: '', updatedAt: '' },
+						],
+						projectIds: [], createdAt: '', updatedAt: '',
+					},
+				] as any);
+				(mockStorageService.getOrchestratorStatus as any).mockResolvedValue({
+					modelId: 'deepseek/deepseek-chat',
+				});
+
+				await service.createAgentSession({
+					sessionName: 'crewly-orc-x',
+					role: 'orchestrator',
+					runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+					memberId: 'orchestrator-member',
+				} as any);
+
+				const config = mockCrewlyRuntime.initializeInProcess.mock.calls[0][1];
+				// Team-member modelId wins.
+				expect(config.model.provider).toBe('google');
+				expect(config.model.modelId).toBe('gemini-2.5-flash-preview-05-20');
+			});
+		});
 	});
 
 	describe('provisionRuntimeConfigFile', () => {

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -2513,7 +2513,18 @@ After checking in, just say "Ready for tasks" and wait for me to send you work.`
 
 				const crewlyRuntime = this.createRuntimeService(runtimeType) as CrewlyAgentRuntimeService;
 
-				// Look up member's modelId from team config (if available)
+				// Look up modelId for this session.
+				//
+				// Resolution order:
+				//   1. Team-member lookup (storage.service.getTeams iterates persisted
+				//      team configs, matched by config.memberId).
+				//   2. Orchestrator fallback — storage.service.getTeams() explicitly
+				//      EXCLUDES the orchestrator directory (storage.service.ts:413),
+				//      so the orchestrator's modelId lives in teams/orchestrator/config.json
+				//      and must be read separately via getOrchestratorStatus().
+				//
+				// Without this orchestrator branch, the orchestrator's modelId would
+				// silently default to DEFAULT_MODEL even when configured.
 				let memberModelId: string | undefined;
 				if (config.memberId) {
 					try {
@@ -2524,6 +2535,22 @@ After checking in, just say "Ready for tasks" and wait for me to send you work.`
 								memberModelId = member.modelId;
 								break;
 							}
+						}
+					} catch {
+						// Non-critical — fall back to orchestrator/default model
+					}
+				}
+
+				// Orchestrator fallback: getTeams() doesn't surface the orchestrator,
+				// so look it up via getOrchestratorStatus when this is the orchestrator
+				// session (or its virtual member id) and no team-level modelId was found.
+				const isOrchestrator = sessionName === ORCHESTRATOR_SESSION_NAME
+					|| config.memberId === 'orchestrator-member';
+				if (!memberModelId && isOrchestrator) {
+					try {
+						const orchestratorStatus = await this.storageService.getOrchestratorStatus();
+						if (orchestratorStatus?.modelId) {
+							memberModelId = orchestratorStatus.modelId;
 						}
 					} catch {
 						// Non-critical — fall back to default model

--- a/backend/src/services/core/storage.service.test.ts
+++ b/backend/src/services/core/storage.service.test.ts
@@ -556,4 +556,160 @@ describe('StorageService', () => {
       spy.mockRestore();
     });
   });
+
+  describe('Orchestrator modelId management', () => {
+    /**
+     * existsSync mock that returns true for the orchestrator config file but
+     * false for the legacy teams.json file. This skips the legacy migration
+     * path (which would otherwise consume our readFile mock).
+     */
+    const setOrchestratorExists = (orchestratorExists: boolean): void => {
+      mockFs.existsSync.mockImplementation((p: any) => {
+        if (typeof p !== 'string') return true;
+        if (p.endsWith('teams.json')) return false; // skip legacy migration
+        if (p.includes('orchestrator')) return orchestratorExists;
+        return true;
+      });
+    };
+
+    beforeEach(() => {
+      setOrchestratorExists(true);
+      mockFsPromises.readdir.mockResolvedValue([]); // no flat team files
+    });
+
+    test('updateOrchestratorModelId writes modelId while preserving runtimeType and agentStatus', async () => {
+      const existing = {
+        sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+        agentStatus: CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE,
+        workingStatus: CREWLY_CONSTANTS.WORKING_STATUSES.IDLE,
+        runtimeType: 'crewly-agent',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(existing));
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+
+      await storageService.updateOrchestratorModelId('deepseek/deepseek-chat');
+
+      // atomicWriteFile uses a temp file then rename — find the writeFile call against the orch file or its tmp variant
+      const writeCalls = mockFsPromises.writeFile.mock.calls;
+      const orchWriteCall = writeCalls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('orchestrator')
+      );
+      expect(orchWriteCall).toBeDefined();
+      const written = JSON.parse(orchWriteCall![1] as string);
+      expect(written.modelId).toBe('deepseek/deepseek-chat');
+      // runtimeType and agentStatus must be preserved
+      expect(written.runtimeType).toBe('crewly-agent');
+      expect(written.agentStatus).toBe(CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE);
+      // updatedAt is refreshed
+      expect(written.updatedAt).not.toBe(existing.updatedAt);
+    });
+
+    test('updateOrchestratorModelId(undefined) clears the field', async () => {
+      const existing = {
+        sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+        agentStatus: CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE,
+        workingStatus: CREWLY_CONSTANTS.WORKING_STATUSES.IDLE,
+        runtimeType: 'claude-code',
+        modelId: 'deepseek/deepseek-chat',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(existing));
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+
+      await storageService.updateOrchestratorModelId(undefined);
+
+      const writeCalls = mockFsPromises.writeFile.mock.calls;
+      const orchWriteCall = writeCalls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('orchestrator')
+      );
+      expect(orchWriteCall).toBeDefined();
+      const written = JSON.parse(orchWriteCall![1] as string);
+      expect('modelId' in written).toBe(false);
+      // runtimeType is preserved
+      expect(written.runtimeType).toBe('claude-code');
+    });
+
+    test('updateOrchestratorModelId initializes default config when file missing', async () => {
+      setOrchestratorExists(false);
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+
+      await storageService.updateOrchestratorModelId('anthropic/claude-sonnet-4-20250514');
+
+      const writeCalls = mockFsPromises.writeFile.mock.calls;
+      const orchWriteCall = writeCalls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('orchestrator')
+      );
+      expect(orchWriteCall).toBeDefined();
+      const written = JSON.parse(orchWriteCall![1] as string);
+      expect(written.modelId).toBe('anthropic/claude-sonnet-4-20250514');
+      expect(written.sessionName).toBe(CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME);
+      expect(written.runtimeType).toBeDefined();
+    });
+
+    test('getOrchestratorStatus surfaces modelId when present in config', async () => {
+      const existing = {
+        sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+        agentStatus: CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE,
+        workingStatus: CREWLY_CONSTANTS.WORKING_STATUSES.IDLE,
+        runtimeType: 'crewly-agent',
+        modelId: 'deepseek/deepseek-chat',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      };
+      setOrchestratorExists(true);
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(existing));
+
+      const status = await storageService.getOrchestratorStatus();
+
+      expect(status).not.toBeNull();
+      expect(status!.modelId).toBe('deepseek/deepseek-chat');
+      expect(status!.runtimeType).toBe('crewly-agent');
+    });
+
+    test('getOrchestratorStatus returns no modelId when not set', async () => {
+      const existing = {
+        sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+        agentStatus: CREWLY_CONSTANTS.AGENT_STATUSES.INACTIVE,
+        workingStatus: CREWLY_CONSTANTS.WORKING_STATUSES.IDLE,
+        runtimeType: 'claude-code',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      };
+      setOrchestratorExists(true);
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(existing));
+
+      const status = await storageService.getOrchestratorStatus();
+
+      expect(status).not.toBeNull();
+      expect(status!.modelId).toBeUndefined();
+    });
+
+    test('updateOrchestratorRuntimeType does not affect existing modelId', async () => {
+      const existing = {
+        sessionName: CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME,
+        agentStatus: CREWLY_CONSTANTS.AGENT_STATUSES.ACTIVE,
+        workingStatus: CREWLY_CONSTANTS.WORKING_STATUSES.IDLE,
+        runtimeType: 'claude-code',
+        modelId: 'openai/gpt-4o',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      };
+      mockFsPromises.readFile.mockResolvedValue(JSON.stringify(existing));
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
+
+      await storageService.updateOrchestratorRuntimeType('crewly-agent');
+
+      const writeCalls = mockFsPromises.writeFile.mock.calls;
+      const orchWriteCall = writeCalls.find((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('orchestrator')
+      );
+      expect(orchWriteCall).toBeDefined();
+      const written = JSON.parse(orchWriteCall![1] as string);
+      expect(written.runtimeType).toBe('crewly-agent');
+      expect(written.modelId).toBe('openai/gpt-4o');
+    });
+  });
 });

--- a/backend/src/services/core/storage.service.ts
+++ b/backend/src/services/core/storage.service.ts
@@ -1420,7 +1420,7 @@ This is a foundational task that should be completed first before other developm
    *
    * @returns Orchestrator status object or null if not found
    */
-  async getOrchestratorStatus(): Promise<{ sessionName: string; agentStatus: AgentStatus; workingStatus: WorkingStatus; runtimeType: RuntimeType; createdAt: string; updatedAt: string } | null> {
+  async getOrchestratorStatus(): Promise<{ sessionName: string; agentStatus: AgentStatus; workingStatus: WorkingStatus; runtimeType: RuntimeType; modelId?: string; createdAt: string; updatedAt: string } | null> {
     try {
       // Migrate from legacy format if needed
       await this.migrateFromLegacyTeamsFile();
@@ -1571,6 +1571,48 @@ This is a foundational task that should be completed first before other developm
         this.logger.debug('Updated orchestrator runtime type', { runtimeType });
       } catch (error) {
         this.logger.error('Error updating orchestrator runtime type', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    });
+  }
+
+  /**
+   * Update orchestrator model ID in teams/orchestrator.json.
+   *
+   * The orchestrator's `modelId` controls which AI model the in-process
+   * Crewly Agent runtime uses (e.g. `deepseek/deepseek-chat`,
+   * `google/gemini-3-flash-preview`). Pass `undefined` to clear the field
+   * and fall back to {@link CREWLY_AGENT_DEFAULTS}.DEFAULT_MODEL.
+   *
+   * Other orchestrator fields (runtimeType, agentStatus, workingStatus) are
+   * preserved by reading the existing config first and merging.
+   *
+   * @param modelId - Format: "provider/modelId" (e.g. "google/gemini-3-flash-preview"), or undefined to clear
+   */
+  async updateOrchestratorModelId(modelId: string | undefined): Promise<void> {
+    return withOperationLock(this.orchestratorFile, async () => {
+      try {
+        let orchestrator;
+        if (existsSync(this.orchestratorFile)) {
+          const content = await fs.readFile(this.orchestratorFile, 'utf-8');
+          orchestrator = JSON.parse(content);
+        } else {
+          orchestrator = this.createDefaultOrchestrator();
+        }
+
+        if (modelId === undefined) {
+          delete orchestrator.modelId;
+        } else {
+          orchestrator.modelId = modelId;
+        }
+        orchestrator.updatedAt = new Date().toISOString();
+
+        await atomicWriteFile(this.orchestratorFile, JSON.stringify(orchestrator, null, 2));
+        this.logger.debug('Updated orchestrator model ID', { modelId: modelId ?? '<cleared>' });
+      } catch (error) {
+        this.logger.error('Error updating orchestrator model ID', {
           error: error instanceof Error ? error.message : String(error),
         });
         throw error;


### PR DESCRIPTION
## Summary

Closes the P1 cloud_pro_v2 ticket on orchestrator-modelId support. ESTestNode admin can now run the in-process Crewly Agent on **any supported provider** (DeepSeek, Anthropic, OpenAI, Ollama, Google) instead of being silently pinned to `google/gemini-3-flash-preview`.

**Root cause** (from spec): `storage.service.ts:413` excludes `teams/orchestrator/` from `getTeams()`, so the existing modelId lookup loop in `agent-registration.service.ts:2516-2531` never finds the orchestrator's modelId — even after we added it to disk. The fix wires an orchestrator-specific fallback through every layer.

## Commits (5, atomic per Code Commit SOP)

| # | Commit | Layer |
|---|---|---|
| 1 | `feat(orchestrator): add modelId field on storage and surface in OrchestratorStatusInfo` | Types + storage |
| 2 | `feat(orchestrator): pass modelId through buildOrchestratorTeam` | Virtual orchestrator team |
| 3 | `feat(orchestrator): resolve modelId for orchestrator session via getOrchestratorStatus fallback` | **The critical fix** — agent-registration.service.ts orchestrator branch |
| 4 | `feat(orchestrator): accept modelId on PUT /orchestrator/runtime` | API endpoint |
| 5 | `refactor: apply review round 1 feedback` | Validation polish |

## What changed

- **`OrchestratorStatusInfo`** + **`getOrchestratorStatus()` return type** extended with `modelId?: string`.
- **`StorageService.updateOrchestratorModelId(modelId | undefined)`** mirroring `updateOrchestratorRuntimeType` (atomic write, lock-protected, supports clear).
- **`buildOrchestratorTeam`** spreads `modelId` onto the orchestrator-member only — Assistant / Auditor unaffected.
- **`agent-registration.service.ts`** — orchestrator-specific fallback: when `sessionName === ORCHESTRATOR_SESSION_NAME` or `memberId === 'orchestrator-member'` and no team-member modelId was found, read `getOrchestratorStatus().modelId`. Resolution order: team-member → orchestrator → DEFAULT_MODEL.
- **`PUT /api/orchestrator/runtime`** — body now accepts `{ runtimeType?, modelId? }`; at least one required; modelId validated via regex + `isModelProvider` whitelist; both setters can run in a single request.

## Tests

25 new co-located cases across the 4 touched test files:

- `storage.service.test.ts` — 6 cases (set / clear / preserve runtimeType / surfaces in getOrchestratorStatus / no modelId / runtimeType update doesn't clobber modelId)
- `team.controller.test.ts` — 4 cases (modelId on orchestrator-member / unset / null status / Assistant+Auditor isolation)
- `agent-registration.service.test.ts` — 5 cases (orchestrator session uses orchestratorStatus.modelId / orchestrator-member id triggers fallback / DEFAULT_MODEL fallthrough / no fallback for non-orch / team-member wins over orch)
- `orchestrator.controller.test.ts` — 10 cases (runtimeType-only / modelId-only / both / neither / empty / invalid runtimeType / malformed modelId / unsupported provider / canonical default / 500 on storage failure)

All new tests pass. The 2 pre-existing failures in `team.controller.test.ts` ("orchestrator auto-subscription to agent events") and the 2 pre-existing failures in `agent-registration.service.test.ts` ("output-change false positive", "{{AGENT_SKILLS_PATH}}") **also fail on `main`** before this PR — confirmed by stash-and-rerun. Unrelated.

## Out of scope (Sam handles)

- Version bump 1.6.2 → 1.6.3 in `package.json`
- `npm publish`
- ESTestNode redeploy + verification

## Test plan

- [x] `npm run build:backend` clean
- [x] `npm run lint` exit 0
- [x] All 4 touched test files green for new cases
- [x] Branch pushed to `origin/feat/orchestrator-modelid`
- [ ] Sam reviews + merges
- [ ] Sam ships 1.6.3 + ESTestNode smoke test (DeepSeek model in `crewly-pro` startup logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)