### PR TITLE
feat(onboarding-v3): cold-start state machine + integrated prompt/skills (B1–B4 + B9)

### DIFF
--- a/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.controller.test.ts
+++ b/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.controller.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the orchestrator-onboarding controller.
+ *
+ * Covers the request-shape validation + happy paths for both routes.
+ * The pure logic itself is tested in the corresponding service tests
+ * (recommend-team.test.ts / materialize-team.test.ts) — these tests
+ * focus on parsing, defaults, and error mapping.
+ *
+ * @module controllers/orchestrator-onboarding/orchestrator-onboarding.controller.test
+ */
+
+import express from 'express';
+import request from 'supertest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import { createOrchestratorOnboardingRouter } from './orchestrator-onboarding.routes.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/orchestrator/onboarding', createOrchestratorOnboardingRouter());
+  return app;
+}
+
+describe('POST /api/orchestrator/onboarding/recommend-team', () => {
+  const app = makeApp();
+
+  it('returns a valid recommendation for a well-shaped request', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/recommend-team')
+      .send({
+        industry: 'small Shopify skincare shop',
+        scale: 'solo',
+        tasks: [
+          { name: 'weekly content', tier: 'yes-today' },
+          { name: 'customer support', tier: 'yes-today' },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.recommendation.templateId).toBe('dtc-viral-content-team');
+    expect(res.body.recommendation.agents.length).toBe(2);
+    expect(res.body.recommendation.source).toBe('hardcoded:ecommerce-content-support');
+  });
+
+  it('returns 400 when industry is missing', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/recommend-team')
+      .send({ scale: 'solo', tasks: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toMatch(/industry/);
+  });
+
+  it('returns 400 for an unknown scale', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/recommend-team')
+      .send({ industry: 'x', scale: 'huge', tasks: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/scale/);
+  });
+
+  it('returns 400 for an unknown tier', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/recommend-team')
+      .send({
+        industry: 'x',
+        scale: 'solo',
+        tasks: [{ name: 't', tier: 'maybe-someday' }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/tier/);
+  });
+
+  it('returns 400 when tasks is not an array', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/recommend-team')
+      .send({ industry: 'x', scale: 'solo', tasks: 'nope' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/tasks/);
+  });
+});
+
+describe('POST /api/orchestrator/onboarding/materialize-team', () => {
+  const app = makeApp();
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = path.join(
+      os.tmpdir(),
+      `materialize-route-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    await fs.mkdir(tmpRoot, { recursive: true });
+  });
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  const sampleRec = {
+    templateId: 'dtc-viral-content-team',
+    agents: [
+      {
+        role: 'content-drafter',
+        responsibilities: 'Drafts content.',
+        skillIds: ['content-drafter'],
+      },
+      {
+        role: 'support-triage',
+        responsibilities: 'Triages support.',
+        skillIds: ['support-triage'],
+      },
+    ],
+    reasoning: 'because',
+    source: 'hardcoded:ecommerce-content-support',
+  };
+
+  it('writes the team config + flag and returns 200', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/materialize-team')
+      .send({
+        recommendation: sampleRec,
+        teamsDir: path.join(tmpRoot, 'teams'),
+        projectFlagPath: path.join(tmpRoot, 'flag.json'),
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.result.onboardingComplete).toBe(true);
+    expect(typeof res.body.result.teamId).toBe('string');
+
+    const written = await fs.readFile(res.body.result.teamConfigPath, 'utf8');
+    const parsed = JSON.parse(written);
+    expect(parsed.templateId).toBe('dtc-viral-content-team');
+    expect(parsed.members.length).toBe(2);
+
+    const flag = JSON.parse(await fs.readFile(path.join(tmpRoot, 'flag.json'), 'utf8'));
+    expect(flag.onboardingComplete).toBe(true);
+  });
+
+  it('returns 400 when recommendation is missing', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/materialize-team')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/recommendation/);
+  });
+
+  it('returns 400 when recommendation.templateId is empty', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/materialize-team')
+      .send({ recommendation: { ...sampleRec, templateId: '' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/templateId/);
+  });
+
+  it('returns 400 when recommendation.agents is empty', async () => {
+    const res = await request(app)
+      .post('/api/orchestrator/onboarding/materialize-team')
+      .send({ recommendation: { ...sampleRec, agents: [] } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/agents/);
+  });
+});

--- a/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.controller.ts
+++ b/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.controller.ts
@@ -1,0 +1,248 @@
+/**
+ * Orchestrator-Onboarding REST Controller
+ *
+ * HTTP surface for the two onboarding-only skills orc invokes during
+ * the v3 cold-start conversation flow:
+ *
+ *   - POST /api/orchestrator/onboarding/recommend-team
+ *   - POST /api/orchestrator/onboarding/materialize-team
+ *
+ * Both endpoints are thin wrappers around the pure logic in
+ * `services/orchestrator/onboarding/{recommend,materialize}-team.ts`.
+ * The controller validates request shape, calls the logic, and shapes
+ * the JSON response.
+ *
+ * @module controllers/orchestrator-onboarding/orchestrator-onboarding.controller
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  recommendTeam,
+  type BusinessContext,
+  type FeasibilityTier,
+  type BusinessScale,
+} from '../../services/orchestrator/onboarding/recommend-team.js';
+import {
+  materializeTeam,
+  type MaterializeOptions,
+} from '../../services/orchestrator/onboarding/materialize-team.js';
+import type { TeamRecommendation } from '../../services/orchestrator/onboarding/recommend-team.js';
+import { LoggerService } from '../../services/core/logger.service.js';
+
+const logger = LoggerService.getInstance().createComponentLogger(
+  'OrchestratorOnboardingController',
+);
+
+const VALID_TIERS: ReadonlySet<FeasibilityTier> = new Set([
+  'yes-today',
+  'collaborative',
+  'roadmap',
+  'out-of-scope',
+]);
+const VALID_SCALES: ReadonlySet<BusinessScale> = new Set([
+  'solo',
+  'small-team',
+  'company',
+]);
+
+/**
+ * Default teams directory used when the request does not override it.
+ * Mirrors the convention used by team config storage (`~/.crewly/teams`).
+ */
+function defaultTeamsDir(): string {
+  return path.join(os.homedir(), '.crewly', 'teams');
+}
+
+/**
+ * Default project flag path (Mon-EOD stub: a tiny JSON file under
+ * `~/.crewly`). Wed–Fri this will move into the orchestrator state
+ * persistence file proper.
+ */
+function defaultProjectFlagPath(): string {
+  return path.join(os.homedir(), '.crewly', 'onboarding-complete.json');
+}
+
+/**
+ * POST /api/orchestrator/onboarding/recommend-team
+ *
+ * Body: { industry: string, scale: BusinessScale, tasks: NamedTask[] }
+ *
+ * Returns 200 with the {@link TeamRecommendation} on success, 400 on
+ * malformed input. The function never falls back to a 500 — recommend
+ * itself is total.
+ */
+export async function recommendTeamRoute(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const ctx = parseBusinessContext(req.body);
+    if (!ctx.ok) {
+      res.status(400).json({ success: false, error: ctx.error });
+      return;
+    }
+    const recommendation = recommendTeam(ctx.value);
+    res.status(200).json({ success: true, recommendation });
+  } catch (err) {
+    logger.error('recommend-team route failed', { err });
+    next(err);
+  }
+}
+
+/**
+ * POST /api/orchestrator/onboarding/materialize-team
+ *
+ * Body: { recommendation: TeamRecommendation, teamsDir?: string, projectFlagPath?: string }
+ *
+ * Writes the team config + flips `onboardingComplete`. v0 stub —
+ * the real provisioning lands Wed–Fri.
+ *
+ * Returns 200 with the materialize result on success; 400 if the
+ * recommendation body is malformed; 500 only on actual filesystem
+ * errors (orc surfaces those honestly to the user).
+ */
+export async function materializeTeamRoute(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const parsed = parseRecommendation(req.body?.recommendation);
+    if (!parsed.ok) {
+      res.status(400).json({ success: false, error: parsed.error });
+      return;
+    }
+
+    const opts: MaterializeOptions = {
+      teamsDir:
+        typeof req.body?.teamsDir === 'string' && req.body.teamsDir.length > 0
+          ? req.body.teamsDir
+          : defaultTeamsDir(),
+      projectFlagPath:
+        typeof req.body?.projectFlagPath === 'string' &&
+        req.body.projectFlagPath.length > 0
+          ? req.body.projectFlagPath
+          : defaultProjectFlagPath(),
+      log: (m: string) => logger.info(m),
+    };
+
+    const result = await materializeTeam(parsed.value, opts);
+    res.status(200).json({ success: true, result });
+  } catch (err) {
+    logger.error('materialize-team route failed', { err });
+    res.status(500).json({
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// =============================================================================
+// Parsers
+// =============================================================================
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function parseBusinessContext(
+  body: unknown,
+): ParseResult<BusinessContext> {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'request body must be an object' };
+  }
+  const b = body as Record<string, unknown>;
+
+  if (typeof b.industry !== 'string') {
+    return { ok: false, error: 'industry must be a string' };
+  }
+  if (typeof b.scale !== 'string' || !VALID_SCALES.has(b.scale as BusinessScale)) {
+    return {
+      ok: false,
+      error: `scale must be one of: ${[...VALID_SCALES].join(', ')}`,
+    };
+  }
+  if (!Array.isArray(b.tasks)) {
+    return { ok: false, error: 'tasks must be an array' };
+  }
+
+  const tasks: { name: string; tier: FeasibilityTier }[] = [];
+  for (let i = 0; i < b.tasks.length; i++) {
+    const t = b.tasks[i] as Record<string, unknown> | undefined;
+    if (!t || typeof t.name !== 'string') {
+      return { ok: false, error: `tasks[${i}].name must be a string` };
+    }
+    if (typeof t.tier !== 'string' || !VALID_TIERS.has(t.tier as FeasibilityTier)) {
+      return {
+        ok: false,
+        error: `tasks[${i}].tier must be one of: ${[...VALID_TIERS].join(', ')}`,
+      };
+    }
+    tasks.push({ name: t.name, tier: t.tier as FeasibilityTier });
+  }
+
+  return {
+    ok: true,
+    value: {
+      industry: b.industry,
+      scale: b.scale as BusinessScale,
+      tasks,
+    },
+  };
+}
+
+function parseRecommendation(body: unknown): ParseResult<TeamRecommendation> {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'recommendation must be an object' };
+  }
+  const r = body as Record<string, unknown>;
+  if (typeof r.templateId !== 'string' || r.templateId.length === 0) {
+    return { ok: false, error: 'recommendation.templateId must be a non-empty string' };
+  }
+  if (!Array.isArray(r.agents) || r.agents.length === 0) {
+    return { ok: false, error: 'recommendation.agents must be a non-empty array' };
+  }
+  if (typeof r.reasoning !== 'string') {
+    return { ok: false, error: 'recommendation.reasoning must be a string' };
+  }
+  if (typeof r.source !== 'string') {
+    return { ok: false, error: 'recommendation.source must be a string' };
+  }
+
+  const agents: { role: string; responsibilities: string; skillIds: string[] }[] = [];
+  for (let i = 0; i < r.agents.length; i++) {
+    const a = r.agents[i] as Record<string, unknown> | undefined;
+    if (!a || typeof a.role !== 'string') {
+      return { ok: false, error: `recommendation.agents[${i}].role must be a string` };
+    }
+    if (typeof a.responsibilities !== 'string') {
+      return {
+        ok: false,
+        error: `recommendation.agents[${i}].responsibilities must be a string`,
+      };
+    }
+    if (!Array.isArray(a.skillIds)) {
+      return {
+        ok: false,
+        error: `recommendation.agents[${i}].skillIds must be an array`,
+      };
+    }
+    agents.push({
+      role: a.role,
+      responsibilities: a.responsibilities,
+      skillIds: a.skillIds.map((s) => String(s)),
+    });
+  }
+
+  return {
+    ok: true,
+    value: {
+      templateId: r.templateId,
+      agents,
+      reasoning: r.reasoning,
+      source: r.source,
+    },
+  };
+}

--- a/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.routes.ts
+++ b/backend/src/controllers/orchestrator-onboarding/orchestrator-onboarding.routes.ts
@@ -1,0 +1,31 @@
+/**
+ * Orchestrator-Onboarding REST Routes
+ *
+ * Mounts the recommend-team + materialize-team endpoints used by the
+ * onboarding-only bash skills. Mounted at `/api/orchestrator/onboarding`
+ * by `routes/api.routes.ts`.
+ *
+ * @module controllers/orchestrator-onboarding/orchestrator-onboarding.routes
+ */
+
+import { Router } from 'express';
+import {
+  recommendTeamRoute,
+  materializeTeamRoute,
+} from './orchestrator-onboarding.controller.js';
+
+/**
+ * Build the orchestrator-onboarding router.
+ *
+ * Endpoints:
+ *   - POST /recommend-team      — turn discovery answers into a proposal
+ *   - POST /materialize-team    — write the team config + flip the flag
+ *
+ * @returns Configured Express router.
+ */
+export function createOrchestratorOnboardingRouter(): Router {
+  const router = Router();
+  router.post('/recommend-team', recommendTeamRoute);
+  router.post('/materialize-team', materializeTeamRoute);
+  return router;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1179,6 +1179,27 @@ export class CrewlyServer {
 					path: '/ws/chat',
 					authMode: jwtSecret ? 'jwt' : 'dev-anonymous',
 				});
+
+				// Onboarding v3 (B1) — wire the cold-start detector with the
+				// chat-v2 service we just stood up. The orc bootstrap path
+				// (CrewlyAgentRuntimeService.detectOnboardingMode) probes this
+				// singleton; null means "skip the cold-start probe", so this
+				// wiring is what flips onboarding mode on for the demo path.
+				try {
+					const { OnboardingBootstrapService, setOnboardingBootstrapService } =
+						await import('./services/orchestrator/onboarding-bootstrap.service.js');
+					setOnboardingBootstrapService(
+						new OnboardingBootstrapService({
+							storage: this.storageService,
+							chat: { countAllMessages: () => chatService.countAllMessages() },
+						}),
+					);
+					this.logger.info('OnboardingBootstrapService wired with storage + chat probes');
+				} catch (wireErr) {
+					this.logger.warn('Failed to wire OnboardingBootstrapService (non-critical)', {
+						error: wireErr instanceof Error ? wireErr.message : String(wireErr),
+					});
+				}
 			} catch (error) {
 				this.logger.warn('Failed to start chat-v2 WS gateway (non-critical)', {
 					error: error instanceof Error ? error.message : String(error),

--- a/backend/src/models/Project.test.ts
+++ b/backend/src/models/Project.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for ProjectModel.
+ *
+ * Covers the constructor's defaulting behaviour and the JSON round-trip,
+ * including the `firstLaunchedAt` field added for Onboarding v3 (B1).
+ *
+ * @module models/Project.test
+ */
+
+import { ProjectModel } from './Project.js';
+import type { Project } from '../types/index.js';
+
+describe('ProjectModel', () => {
+  describe('constructor', () => {
+    it('defaults missing fields and stamps timestamps', () => {
+      const model = new ProjectModel({ id: 'p1', name: 'New', path: '/tmp/p1' });
+      expect(model.id).toBe('p1');
+      expect(model.name).toBe('New');
+      expect(model.path).toBe('/tmp/p1');
+      expect(model.teams).toEqual({});
+      expect(model.status).toBe('stopped');
+      expect(model.firstLaunchedAt).toBeUndefined();
+      expect(model.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(model.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('preserves explicit firstLaunchedAt', () => {
+      const stamp = '2026-04-01T12:00:00.000Z';
+      const model = new ProjectModel({ id: 'p1', firstLaunchedAt: stamp });
+      expect(model.firstLaunchedAt).toBe(stamp);
+    });
+  });
+
+  describe('toJSON / fromJSON round-trip (Onboarding v3 — B1)', () => {
+    it('omits firstLaunchedAt when not set, so legacy records stay clean', () => {
+      const model = new ProjectModel({ id: 'p1', name: 'p', path: '/tmp/p' });
+      const json = model.toJSON();
+      // `firstLaunchedAt` must be absent (not present-as-undefined) so JSON
+      // serialization doesn't emit a noisy null/undefined.
+      expect('firstLaunchedAt' in json).toBe(false);
+    });
+
+    it('emits firstLaunchedAt when set, and round-trips back via fromJSON', () => {
+      const stamp = '2026-04-01T12:00:00.000Z';
+      const model = new ProjectModel({ id: 'p1', firstLaunchedAt: stamp });
+      const json = model.toJSON();
+      expect(json.firstLaunchedAt).toBe(stamp);
+
+      const restored = ProjectModel.fromJSON(json);
+      expect(restored.firstLaunchedAt).toBe(stamp);
+    });
+
+    it('round-trips a fully-populated project through JSON', () => {
+      const data: Project = {
+        id: 'p1',
+        name: 'Full Project',
+        path: '/abs/path',
+        teams: { developer: ['t1'] },
+        status: 'active',
+        firstLaunchedAt: '2026-04-01T12:00:00.000Z',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-04-01T12:00:00.000Z',
+      };
+      const restored = ProjectModel.fromJSON(data).toJSON();
+      expect(restored).toEqual(data);
+    });
+  });
+
+  describe('team management helpers', () => {
+    it('assignTeam adds a team to the role bucket and bumps updatedAt', async () => {
+      const model = new ProjectModel({ id: 'p1' });
+      const before = model.updatedAt;
+      // Wait a tick so the timestamps differ; toISOString resolution is ms.
+      await new Promise((r) => setTimeout(r, 5));
+      model.assignTeam('team-1', 'developer');
+      expect(model.teams.developer).toContain('team-1');
+      expect(model.updatedAt).not.toBe(before);
+    });
+
+    it('assignTeam is idempotent for the same (team,role) pair', () => {
+      const model = new ProjectModel({ id: 'p1' });
+      model.assignTeam('team-1', 'developer');
+      model.assignTeam('team-1', 'developer');
+      expect(model.teams.developer).toEqual(['team-1']);
+    });
+
+    it('unassignTeam removes the team from a specific role', () => {
+      const model = new ProjectModel({ id: 'p1' });
+      model.assignTeam('team-1', 'developer');
+      model.assignTeam('team-2', 'developer');
+      model.unassignTeam('team-1', 'developer');
+      expect(model.teams.developer).toEqual(['team-2']);
+    });
+
+    it('unassignTeam without role removes the team from every role and prunes empties', () => {
+      const model = new ProjectModel({ id: 'p1' });
+      model.assignTeam('team-1', 'developer');
+      model.assignTeam('team-1', 'tester');
+      model.unassignTeam('team-1');
+      expect(model.teams.developer).toBeUndefined();
+      expect(model.teams.tester).toBeUndefined();
+    });
+
+    it('getAssignedTeams returns the flattened set of team IDs', () => {
+      const model = new ProjectModel({ id: 'p1' });
+      model.assignTeam('team-1', 'developer');
+      model.assignTeam('team-2', 'tester');
+      expect(model.getAssignedTeams().sort()).toEqual(['team-1', 'team-2']);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('changes status and bumps updatedAt', async () => {
+      const model = new ProjectModel({ id: 'p1', status: 'stopped' });
+      const before = model.updatedAt;
+      await new Promise((r) => setTimeout(r, 5));
+      model.updateStatus('active');
+      expect(model.status).toBe('active');
+      expect(model.updatedAt).not.toBe(before);
+    });
+  });
+});

--- a/backend/src/models/Project.ts
+++ b/backend/src/models/Project.ts
@@ -6,6 +6,8 @@ export class ProjectModel implements Project {
   path: string;
   teams: Record<string, string[]>;
   status: 'active' | 'paused' | 'completed' | 'stopped';
+  /** Onboarding v3 (B1) — see `Project.firstLaunchedAt` for semantics. */
+  firstLaunchedAt?: string;
   createdAt: string;
   updatedAt: string;
 
@@ -15,6 +17,7 @@ export class ProjectModel implements Project {
     this.path = data.path || '';
     this.teams = data.teams || {};
     this.status = data.status || 'stopped';
+    this.firstLaunchedAt = data.firstLaunchedAt;
     this.createdAt = data.createdAt || new Date().toISOString();
     this.updatedAt = data.updatedAt || new Date().toISOString();
   }
@@ -60,7 +63,7 @@ export class ProjectModel implements Project {
   }
 
   toJSON(): Project {
-    return {
+    const json: Project = {
       id: this.id,
       name: this.name,
       path: this.path,
@@ -69,6 +72,12 @@ export class ProjectModel implements Project {
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };
+    // Onboarding v3 (B1) — only emit `firstLaunchedAt` when set, so legacy
+    // project records round-trip without acquiring an `undefined` field.
+    if (this.firstLaunchedAt !== undefined) {
+      json.firstLaunchedAt = this.firstLaunchedAt;
+    }
+    return json;
   }
 
   static fromJSON(data: Project): ProjectModel {

--- a/backend/src/routes/api.routes.test.ts
+++ b/backend/src/routes/api.routes.test.ts
@@ -61,6 +61,7 @@ jest.mock('../controllers/browser/browser.routes.js', () => ({ createBrowserRout
 jest.mock('../controllers/cross-machine/index.js', () => ({ createCrossMachineRouter: () => Router() }));
 jest.mock('../controllers/onboarding/website-analysis.routes.js', () => ({ createWebsiteAnalysisRouter: () => Router() }));
 jest.mock('../controllers/onboarding/onboarding.routes.js', () => ({ createOnboardingRouter: () => Router() }));
+jest.mock('../controllers/orchestrator-onboarding/orchestrator-onboarding.routes.js', () => ({ createOrchestratorOnboardingRouter: () => Router() }));
 jest.mock('../controllers/data/data.routes.js', () => ({ createDataRouter: () => Router() }));
 jest.mock('../controllers/intent-task/intent-task.routes.js', () => ({ createIntentTaskRouter: () => Router() }));
 jest.mock('../controllers/task-pool/task-pool.routes.js', () => ({ createTaskPoolRouter: () => Router() }));

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -34,6 +34,7 @@ import { createBrowserRouter } from '../controllers/browser/browser.routes.js';
 import { createCrossMachineRouter } from '../controllers/cross-machine/index.js';
 import { createWebsiteAnalysisRouter } from '../controllers/onboarding/website-analysis.routes.js';
 import { createOnboardingRouter } from '../controllers/onboarding/onboarding.routes.js';
+import { createOrchestratorOnboardingRouter } from '../controllers/orchestrator-onboarding/orchestrator-onboarding.routes.js';
 import { createDataRouter } from '../controllers/data/data.routes.js';
 import { createIntentTaskRouter } from '../controllers/intent-task/intent-task.routes.js';
 import { createTaskPoolRouter } from '../controllers/task-pool/task-pool.routes.js';
@@ -146,6 +147,10 @@ export function createApiRoutes(apiController: ApiController): Router {
 
   // Onboarding session routes for KR3 Cloud Portal onboarding flow
   router.use('/onboarding', createOnboardingRouter());
+
+  // Orchestrator-Onboarding routes (v3 cold-start) — recommend-team + materialize-team.
+  // Invoked by the onboarding-only bash skills under config/skills/agent/onboarding/.
+  router.use('/orchestrator/onboarding', createOrchestratorOnboardingRouter());
 
   // Data Architecture V2 — Unified Data Model, Schemas, Sinks
   router.use('/v2/data', createDataRouter());

--- a/backend/src/services/agent/crewly-agent/crewly-agent-runtime.service.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-runtime.service.ts
@@ -29,6 +29,9 @@ import { PtyActivityTrackerService } from '../pty-activity-tracker.service.js';
 import { TokenUsageService } from '../../monitoring/token-usage.service.js';
 import { getSettingsService } from '../../settings/settings.service.js';
 import { AgentStreamService } from './agent-stream.service.js';
+import { getOnboardingBootstrapService } from '../../orchestrator/onboarding-bootstrap.service.js';
+import { loadOnboardingPrompt } from '../../orchestrator/onboarding-mode-loader.js';
+import { getStatePersistenceService } from '../../orchestrator/state-persistence.service.js';
 
 
 /**
@@ -147,6 +150,13 @@ export class CrewlyAgentRuntimeService extends RuntimeAgentService {
    * Loads the system prompt from config/roles/orchestrator/prompt.md,
    * creates the AgentRunnerService (in-process or worker), and initializes the model.
    *
+   * Onboarding v3 (B3): when the role is `'orchestrator'` and the cold-start
+   * detector ({@link OnboardingBootstrapService}) reports a fresh OSS install,
+   * the runtime swaps the role prompt for the onboarding-mode prompt
+   * ({@link loadOnboardingPrompt}) and flips persisted state to
+   * `mode: 'onboarding'`. The state-persistence checkpoint is saved before
+   * the AgentRunner initialises so a crash mid-init still resumes correctly.
+   *
    * @param sessionName - Session name for this agent instance
    * @param config - Optional partial config overrides. Set `useWorkerProcess: true` to run in a child process.
    * @param roleName - Role name for system prompt lookup (default: 'orchestrator')
@@ -160,8 +170,17 @@ export class CrewlyAgentRuntimeService extends RuntimeAgentService {
     this.currentMemberId = config?.memberId;
     this.useWorkerProcess = config?.useWorkerProcess ?? false;
 
-    // Build enhanced system prompt with skills and addon awareness
-    const systemPrompt = await this.buildEnhancedSystemPrompt(roleName || 'orchestrator');
+    const effectiveRoleName = roleName || 'orchestrator';
+
+    // Onboarding v3 (B3) — cold-start detection. Only the orc bootstrap
+    // path participates; subordinate agents always use their role prompt.
+    const onboardingMode = await this.detectOnboardingMode(effectiveRoleName);
+
+    // Build enhanced system prompt with skills and addon awareness, OR
+    // swap to the onboarding-mode prompt when cold-start fired.
+    const systemPrompt = onboardingMode
+      ? await loadOnboardingPrompt()
+      : await this.buildEnhancedSystemPrompt(effectiveRoleName);
 
     // Build full config with defaults
     const fullConfig: CrewlyAgentConfig = {
@@ -208,7 +227,112 @@ export class CrewlyAgentRuntimeService extends RuntimeAgentService {
       mode,
       model: `${fullConfig.model.provider}/${fullConfig.model.modelId}`,
       maxSteps: fullConfig.maxSteps,
+      onboardingMode,
     });
+
+    // Onboarding v3 (B3) — best-effort first-launch marker. Runs after
+    // bootstrap success regardless of mode; idempotent on repeated boots.
+    // Errors are swallowed by `markProjectAsLaunched` so a marker write
+    // hiccup never fails the demo path.
+    if (effectiveRoleName === 'orchestrator' && config?.projectPath) {
+      await this.markFirstLaunchForCwd(config.projectPath);
+    }
+  }
+
+  /**
+   * Decide whether this orc bootstrap should enter onboarding mode.
+   *
+   * Returns false (no-op) for non-orchestrator roles, when the bootstrap
+   * service hasn't been wired yet, or when detection throws — fail-closed
+   * so transient errors never falsely trigger onboarding.
+   *
+   * Side effects: when true, flips the persisted orchestrator mode to
+   * `'onboarding'` and saves a checkpoint immediately, so a crash before
+   * the AgentRunner finishes initialising still resumes in onboarding mode.
+   *
+   * @param roleName - The resolved role name for this bootstrap
+   * @returns True iff cold-start fired and the prompt should be swapped
+   */
+  private async detectOnboardingMode(roleName: string): Promise<boolean> {
+    if (roleName !== 'orchestrator') {
+      return false;
+    }
+
+    const detector = getOnboardingBootstrapService();
+    if (!detector) {
+      this.logger.debug('OnboardingBootstrapService not wired; skipping cold-start probe');
+      return false;
+    }
+
+    let isCold: boolean;
+    try {
+      isCold = await detector.shouldEnterOnboardingMode();
+    } catch (err) {
+      this.logger.warn('Cold-start probe threw; defaulting to normal mode', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+
+    if (!isCold) {
+      return false;
+    }
+
+    // Flip persisted state immediately so a crash between here and
+    // AgentRunner.initialize() still resumes in onboarding mode (B4).
+    try {
+      const stateService = getStatePersistenceService();
+      if (stateService.isInitialized()) {
+        stateService.setMode('onboarding');
+        await stateService.saveState('user_request');
+      } else {
+        this.logger.debug('State-persistence not initialized; mode flip deferred to caller');
+      }
+    } catch (err) {
+      // Don't abort the demo just because the checkpoint write failed.
+      this.logger.warn('Failed to persist onboarding mode flip; in-memory mode still applied', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return true;
+  }
+
+  /**
+   * Best-effort `firstLaunchedAt` marker write for the project at
+   * `projectPath`.
+   *
+   * Resolves the project record by matching `Project.path` against the
+   * given path, then delegates to `OnboardingBootstrapService.markProjectAsLaunched`.
+   * No-op if the bootstrap service isn't wired or if no project record
+   * matches (fresh installs without an explicit project bind never reach
+   * this branch — the orc bootstrap doesn't pass `projectPath` then).
+   *
+   * @param projectPath - Absolute filesystem path of the bound project
+   */
+  private async markFirstLaunchForCwd(projectPath: string): Promise<void> {
+    const detector = getOnboardingBootstrapService();
+    if (!detector) return;
+
+    // The detector's storage probe already resolves projects; reuse it
+    // here to avoid an extra import. Marker resolution is best-effort —
+    // any throw is logged at warn and swallowed.
+    try {
+      // Late-bind the storage probe via a fresh getProjects() call. The
+      // bootstrap service's internal storage was injected at wire time;
+      // this method is intentionally narrow (no extra coupling).
+      const { StorageService } = await import('../../core/storage.service.js');
+      const projects = await StorageService.getInstance().getProjects();
+      const target = projects.find((p) => p.path === projectPath);
+      if (target) {
+        await detector.markProjectAsLaunched(target.id);
+      }
+    } catch (err) {
+      this.logger.warn('First-launch marker write skipped', {
+        projectPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /**

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -805,4 +805,35 @@ describe('ChatV2Service', () => {
       ).toThrow(ChatError);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // countAllMessages — Onboarding v3 (B1) cold-start probe
+  // -------------------------------------------------------------------------
+
+  describe('countAllMessages (Onboarding v3 — B1)', () => {
+    it('returns 0 on a fresh service before any channel exists', () => {
+      expect(service.countAllMessages()).toBe(0);
+    });
+
+    it('counts messages across the channels owned by every principal', () => {
+      // Two channels, two owners, three messages — sum is 3.
+      const ch1 = createSam();
+      const ch2 = service.createChannel({
+        agentSession: 'sess-b',
+        name: 'Other Agent',
+        principal: otherUser,
+      });
+      service.sendMessage({ channelId: ch1.id, principal: owner, content: 'a' });
+      service.sendMessage({ channelId: ch1.id, principal: owner, content: 'b' });
+      service.sendMessage({ channelId: ch2.id, principal: otherUser, content: 'c' });
+
+      expect(service.countAllMessages()).toBe(3);
+    });
+
+    it('is callable without an HTTP-request principal (orc bootstrap path)', () => {
+      // The orc bootstrap calls this from a closure with no principal —
+      // verify there's no implicit auth guard that would throw.
+      expect(() => service.countAllMessages()).not.toThrow();
+    });
+  });
 });

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -212,6 +212,22 @@ export class ChatV2Service {
     }
   }
 
+  /**
+   * Count every persisted chat message across every channel.
+   *
+   * Onboarding v3 (B1) — surfaced for the cold-start detector. Defers to
+   * `MessageStore.countAll()`. Intentionally bypasses the principal /
+   * authorization layer because the caller is the orchestrator bootstrap,
+   * which runs without an HTTP-request principal context. The detector
+   * only needs an unsigned "is the store empty" answer; no row contents
+   * are exposed.
+   *
+   * @returns Total message count across all channels (0 on a fresh install)
+   */
+  countAllMessages(): number {
+    return this.messages.countAll();
+  }
+
   // -------------------------------------------------------------------------
   // Channel operations
   // -------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/sqlite/message.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/message.store.test.ts
@@ -375,4 +375,34 @@ describe('MessageStore', () => {
       expect(messages.getLastSeq(channelId)).toBe(2);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // countAll — Onboarding v3 (B1) cold-start signal
+  // -------------------------------------------------------------------------
+
+  describe('countAll (Onboarding v3 — B1)', () => {
+    it('returns 0 on a fresh database with no messages', () => {
+      expect(messages.countAll()).toBe(0);
+    });
+
+    it('counts messages across multiple channels', () => {
+      const otherChannelId = channels.create({
+        agentSession: 'sess-b',
+        ownerUserId: 'user-b',
+        name: 'Other',
+        nowMs: 200,
+      }).id;
+
+      messages.insert({ channelId, senderType: 'user', senderId: 'user-a', content: 'a' });
+      messages.insert({ channelId, senderType: 'user', senderId: 'user-a', content: 'b' });
+      messages.insert({ channelId: otherChannelId, senderType: 'user', senderId: 'user-b', content: 'c' });
+
+      expect(messages.countAll()).toBe(3);
+    });
+
+    it('reflects single-channel inserts the same as count(channelId)', () => {
+      messages.insert({ channelId, senderType: 'user', senderId: 'user-a', content: 'a' });
+      expect(messages.countAll()).toBe(messages.count(channelId));
+    });
+  });
 });

--- a/backend/src/services/chat-v2/sqlite/message.store.ts
+++ b/backend/src/services/chat-v2/sqlite/message.store.ts
@@ -430,4 +430,28 @@ export class MessageStore {
       .get(channelId) as { n: number };
     return row.n;
   }
+
+  /**
+   * Count all messages across every channel in the database.
+   *
+   * Onboarding v3 (B1) — used by the cold-start detector to decide whether
+   * a fresh OSS install should auto-launch onboarding. The "any chat at all
+   * means user has been here before" semantics is intentional: the detector
+   * combines this with the per-project `firstLaunchedAt` marker to defend
+   * against the case where chat-v2 is wiped accidentally on an existing
+   * install (a non-zero count short-circuits onboarding before the marker
+   * is even consulted).
+   *
+   * Single COUNT(*) over the index — O(rows) in the worst case but
+   * negligible at install time when the table is empty (the only time the
+   * caller actually cares about the result).
+   *
+   * @returns Total number of persisted chat messages
+   */
+  countAll(): number {
+    const row = this.db
+      .prepare('SELECT COUNT(*) AS n FROM chat_messages')
+      .get() as { n: number };
+    return row.n;
+  }
 }

--- a/backend/src/services/orchestrator/onboarding-bootstrap.service.test.ts
+++ b/backend/src/services/orchestrator/onboarding-bootstrap.service.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for OnboardingBootstrapService (Onboarding v3 — B1).
+ *
+ * Covers all four scenarios from Sam's substrate brief:
+ * - Empty chat-v2 + null `firstLaunchedAt`               → enter onboarding
+ * - Non-empty chat-v2 + null `firstLaunchedAt`           → no onboarding
+ * - Empty chat-v2 + non-null `firstLaunchedAt`           → no onboarding
+ * - Non-empty chat-v2 + non-null `firstLaunchedAt`       → no onboarding
+ *
+ * Plus: optional vs explicit `projectId`, idempotent marker writes,
+ * fail-closed behaviour on storage errors, and the singleton accessor.
+ *
+ * @module services/orchestrator/onboarding-bootstrap.service.test
+ */
+
+import {
+  OnboardingBootstrapService,
+  type ChatMessageCounter,
+  type OnboardingBootstrapDependencies,
+  getOnboardingBootstrapService,
+  setOnboardingBootstrapService,
+  resetOnboardingBootstrapServiceForTesting,
+} from './onboarding-bootstrap.service.js';
+import type { StorageService } from '../core/storage.service.js';
+import type { Project } from '../../types/index.js';
+
+/**
+ * Build a minimal `Project` with the fields the detector cares about.
+ * Other fields are present so the type-checker is happy but irrelevant
+ * to the assertions.
+ */
+function makeProject(overrides: Partial<Project>): Project {
+  return {
+    id: overrides.id ?? 'p-default',
+    name: overrides.name ?? 'Test Project',
+    path: overrides.path ?? '/tmp/test-project',
+    teams: overrides.teams ?? {},
+    status: overrides.status ?? 'active',
+    firstLaunchedAt: overrides.firstLaunchedAt,
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+/**
+ * Build a fake StorageService whose `getProjects` returns the supplied
+ * snapshot and whose `saveProject` mutates the snapshot in place. We
+ * don't need the rest of the surface for B1 tests.
+ */
+function makeFakeStorage(initialProjects: Project[] = []): {
+  storage: StorageService;
+  saveCalls: Project[];
+  store: Project[];
+} {
+  const store: Project[] = [...initialProjects];
+  const saveCalls: Project[] = [];
+  const storage = {
+    getProjects: jest.fn(async () => [...store]),
+    saveProject: jest.fn(async (project: Project) => {
+      saveCalls.push(project);
+      const idx = store.findIndex((p) => p.id === project.id);
+      if (idx >= 0) {
+        store[idx] = project;
+      } else {
+        store.push(project);
+      }
+    }),
+  } as unknown as StorageService;
+  return { storage, saveCalls, store };
+}
+
+/** Build a fake chat counter that returns a constant. */
+function makeChat(count: number): ChatMessageCounter {
+  return { countAllMessages: () => count };
+}
+
+/** Build a chat counter that throws — simulates a sqlite hiccup. */
+function makeBrokenChat(): ChatMessageCounter {
+  return {
+    countAllMessages: () => {
+      throw new Error('chat-v2 sqlite handle exploded');
+    },
+  };
+}
+
+function makeService(deps: OnboardingBootstrapDependencies): OnboardingBootstrapService {
+  return new OnboardingBootstrapService(deps);
+}
+
+describe('OnboardingBootstrapService (Onboarding v3 — B1)', () => {
+  describe('shouldEnterOnboardingMode — Sam\'s 4 substrate cases', () => {
+    it('empty chat + null firstLaunchedAt → returns true (cold start)', async () => {
+      const { storage } = makeFakeStorage([]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(true);
+    });
+
+    it('non-empty chat + null firstLaunchedAt → returns false (chat wiped manually edge case)', async () => {
+      // Steve's substrate edge case: existing user whose project record
+      // was deleted but chat-v2 still has prior messages — must NOT
+      // false-trigger onboarding.
+      const { storage } = makeFakeStorage([]);
+      const service = makeService({ storage, chat: makeChat(1) });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(false);
+    });
+
+    it('empty chat + non-null firstLaunchedAt → returns false (chat wiped manually)', async () => {
+      // The other side of the same edge case: chat-v2 deleted by hand,
+      // but the per-project marker survives — onboarding must not fire.
+      const { storage } = makeFakeStorage([
+        makeProject({ id: 'p1', firstLaunchedAt: '2026-04-01T00:00:00.000Z' }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode('p1')).resolves.toBe(false);
+    });
+
+    it('non-empty chat + non-null firstLaunchedAt → returns false (normal user)', async () => {
+      const { storage } = makeFakeStorage([
+        makeProject({ id: 'p1', firstLaunchedAt: '2026-04-01T00:00:00.000Z' }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(42) });
+      await expect(service.shouldEnterOnboardingMode('p1')).resolves.toBe(false);
+    });
+  });
+
+  describe('shouldEnterOnboardingMode — projectId scoping', () => {
+    it('without projectId, broadens marker check to "any project has marker"', async () => {
+      // Three projects, one launched. With no projectId, the broad check
+      // sees the launched marker and short-circuits.
+      const { storage } = makeFakeStorage([
+        makeProject({ id: 'p1' }),
+        makeProject({ id: 'p2', firstLaunchedAt: '2026-04-01T00:00:00.000Z' }),
+        makeProject({ id: 'p3' }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(false);
+    });
+
+    it('with projectId pointing at an unlaunched project, ignores other projects\' markers', async () => {
+      // p2 is launched, but the caller is asking about p1 specifically.
+      const { storage } = makeFakeStorage([
+        makeProject({ id: 'p1' }), // unlaunched
+        makeProject({ id: 'p2', firstLaunchedAt: '2026-04-01T00:00:00.000Z' }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode('p1')).resolves.toBe(true);
+    });
+
+    it('with projectId that does not exist, treats as cold (project deleted under us)', async () => {
+      const { storage } = makeFakeStorage([makeProject({ id: 'p2' })]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode('does-not-exist')).resolves.toBe(true);
+    });
+
+    it('without projectId and zero projects records → cold start (very fresh install)', async () => {
+      const { storage } = makeFakeStorage([]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(true);
+    });
+  });
+
+  describe('shouldEnterOnboardingMode — fail-closed semantics', () => {
+    it('returns false when storage.getProjects throws', async () => {
+      const storage = {
+        getProjects: jest.fn(async () => {
+          throw new Error('projects.json corrupt');
+        }),
+        saveProject: jest.fn(),
+      } as unknown as StorageService;
+      const service = makeService({ storage, chat: makeChat(0) });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(false);
+    });
+
+    it('returns false when chat counter throws', async () => {
+      const { storage } = makeFakeStorage([]);
+      const service = makeService({ storage, chat: makeBrokenChat() });
+      await expect(service.shouldEnterOnboardingMode()).resolves.toBe(false);
+    });
+  });
+
+  describe('markProjectAsLaunched', () => {
+    it('writes firstLaunchedAt as an ISO timestamp on a fresh project', async () => {
+      const { storage, saveCalls, store } = makeFakeStorage([makeProject({ id: 'p1' })]);
+      const service = makeService({ storage, chat: makeChat(0) });
+
+      await service.markProjectAsLaunched('p1');
+
+      expect(saveCalls).toHaveLength(1);
+      const saved = saveCalls[0];
+      expect(saved.id).toBe('p1');
+      expect(typeof saved.firstLaunchedAt).toBe('string');
+      // ISO 8601 with milliseconds + Z suffix
+      expect(saved.firstLaunchedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(store[0].firstLaunchedAt).toBe(saved.firstLaunchedAt);
+    });
+
+    it('is idempotent — preserves the original timestamp on second call', async () => {
+      const original = '2026-04-01T12:00:00.000Z';
+      const { storage, saveCalls } = makeFakeStorage([
+        makeProject({ id: 'p1', firstLaunchedAt: original }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(0) });
+
+      await service.markProjectAsLaunched('p1');
+      await service.markProjectAsLaunched('p1');
+
+      expect(saveCalls).toHaveLength(0); // never wrote
+    });
+
+    it('is a no-op (with warning) when the project does not exist', async () => {
+      const { storage, saveCalls } = makeFakeStorage([makeProject({ id: 'p1' })]);
+      const service = makeService({ storage, chat: makeChat(0) });
+
+      await service.markProjectAsLaunched('does-not-exist');
+
+      expect(saveCalls).toHaveLength(0);
+    });
+
+    it('does not throw when storage.saveProject fails — logs and swallows', async () => {
+      const storage = {
+        getProjects: jest.fn(async () => [makeProject({ id: 'p1' })]),
+        saveProject: jest.fn(async () => {
+          throw new Error('disk full');
+        }),
+      } as unknown as StorageService;
+      const service = makeService({ storage, chat: makeChat(0) });
+
+      await expect(service.markProjectAsLaunched('p1')).resolves.toBeUndefined();
+    });
+
+    it('updates the project\'s updatedAt timestamp alongside firstLaunchedAt', async () => {
+      const { storage, saveCalls } = makeFakeStorage([
+        makeProject({
+          id: 'p1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      ]);
+      const service = makeService({ storage, chat: makeChat(0) });
+
+      await service.markProjectAsLaunched('p1');
+
+      const saved = saveCalls[0];
+      expect(saved.updatedAt).toBe(saved.firstLaunchedAt);
+      expect(saved.createdAt).toBe('2026-01-01T00:00:00.000Z'); // unchanged
+    });
+  });
+
+  describe('singleton accessor', () => {
+    afterEach(() => {
+      resetOnboardingBootstrapServiceForTesting();
+    });
+
+    it('returns null before wiring', () => {
+      expect(getOnboardingBootstrapService()).toBeNull();
+    });
+
+    it('returns the wired instance after setOnboardingBootstrapService', () => {
+      const { storage } = makeFakeStorage([]);
+      const service = makeService({ storage, chat: makeChat(0) });
+      setOnboardingBootstrapService(service);
+      expect(getOnboardingBootstrapService()).toBe(service);
+    });
+
+    it('reset returns to null', () => {
+      const { storage } = makeFakeStorage([]);
+      setOnboardingBootstrapService(makeService({ storage, chat: makeChat(0) }));
+      resetOnboardingBootstrapServiceForTesting();
+      expect(getOnboardingBootstrapService()).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/orchestrator/onboarding-bootstrap.service.ts
+++ b/backend/src/services/orchestrator/onboarding-bootstrap.service.ts
@@ -1,0 +1,229 @@
+/**
+ * Onboarding Bootstrap Service (Onboarding v3 — B1).
+ *
+ * Detects whether a freshly-launched Crewly OSS instance should enter
+ * onboarding mode. Two AND-ed signals are required:
+ *
+ * 1. **Project marker** — `Project.firstLaunchedAt` is unset (or no project
+ *    record exists yet). Set on first successful orc bootstrap and never
+ *    overwritten thereafter; defends the cold-start signal against the
+ *    edge case where chat-v2 is wiped accidentally on an existing install.
+ *
+ * 2. **Chat-v2 emptiness** — `ChatV2Service.countAllMessages() === 0`.
+ *    Captures "user has not spoken to Crewly yet" — Steve's exact phrasing.
+ *
+ * If EITHER signal says "user has been here before", onboarding does NOT
+ * trigger. This intentional belt-and-braces design follows Sam's substrate
+ * note 2026-05-03.
+ *
+ * Hook point: `crewly-agent-runtime.service.initializeInProcess()` calls
+ * `shouldEnterOnboardingMode()` before composing the system prompt and
+ * branches on the result (B3). After bootstrap success, the orc bootstrap
+ * also calls `markProjectAsLaunched()` to set the marker.
+ *
+ * @module services/orchestrator/onboarding-bootstrap.service
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import type { StorageService } from '../core/storage.service.js';
+import type { Project } from '../../types/index.js';
+
+/**
+ * Minimal contract for the chat-v2 emptiness probe.
+ *
+ * Decoupled from the concrete `ChatV2Service` so tests can inject a fake
+ * counter without bringing up sqlite. Production wiring resolves to
+ * `getChatV2Service().countAllMessages.bind(...)`.
+ */
+export interface ChatMessageCounter {
+  /** @returns Total count of persisted chat messages across all channels */
+  countAllMessages(): number;
+}
+
+/**
+ * Constructor dependencies for `OnboardingBootstrapService`.
+ */
+export interface OnboardingBootstrapDependencies {
+  /** Source of project records (provides `getProjects` + `saveProject`). */
+  storage: StorageService;
+  /** Source of chat-v2 emptiness signal. */
+  chat: ChatMessageCounter;
+}
+
+/**
+ * Cold-start detector for the orchestrator's onboarding mode.
+ *
+ * The two helpers are called from the orc bootstrap path:
+ * - `shouldEnterOnboardingMode()` — branch on this BEFORE composing the
+ *   system prompt; if true, load `ONBOARDING_MODE_SYSTEM_PROMPT` instead
+ *   of the role prompt.
+ * - `markProjectAsLaunched(projectId)` — call AFTER bootstrap succeeds,
+ *   regardless of mode, to write the per-project first-launch marker.
+ *
+ * @example
+ * ```typescript
+ * const detector = new OnboardingBootstrapService({ storage, chat });
+ * if (await detector.shouldEnterOnboardingMode()) {
+ *   stateService.setMode('onboarding');
+ * }
+ * // ... orc init succeeds ...
+ * if (currentProjectId) {
+ *   await detector.markProjectAsLaunched(currentProjectId);
+ * }
+ * ```
+ */
+export class OnboardingBootstrapService {
+  private readonly storage: StorageService;
+  private readonly chat: ChatMessageCounter;
+  private readonly logger: ComponentLogger;
+
+  constructor(deps: OnboardingBootstrapDependencies) {
+    this.storage = deps.storage;
+    this.chat = deps.chat;
+    this.logger = LoggerService.getInstance().createComponentLogger('OnboardingBootstrap');
+  }
+
+  /**
+   * Decide whether the orchestrator should enter onboarding mode.
+   *
+   * Both signals must agree on "this is a cold start":
+   *
+   * 1. The targeted project's `firstLaunchedAt` marker is unset. When
+   *    `projectId` is omitted, the check broadens to "no project at all
+   *    has the marker set" — appropriate for the orc bootstrap path,
+   *    which runs before any user has bound a project.
+   * 2. Chat-v2 has zero persisted messages.
+   *
+   * Errors in either probe are treated as "user has been here before"
+   * (returns false) — failing closed avoids false-triggering onboarding
+   * on a transient storage hiccup.
+   *
+   * @param projectId - Optional project to scope the marker check to.
+   *   Omit during orc bootstrap (no project context yet).
+   * @returns True iff this looks like a fresh OSS install
+   */
+  async shouldEnterOnboardingMode(projectId?: string): Promise<boolean> {
+    // --- Signal 1: project firstLaunchedAt marker ---
+    let projectMarkerIsCold: boolean;
+    try {
+      const projects = await this.storage.getProjects();
+      if (projectId !== undefined) {
+        const target = projects.find((p) => p.id === projectId);
+        // Missing project (deleted under us) and absent marker both count
+        // as "cold". Any value (string, even empty string) means the user
+        // has been here before — only `undefined` clears the gate.
+        projectMarkerIsCold = !target || target.firstLaunchedAt === undefined;
+      } else {
+        projectMarkerIsCold = !projects.some((p) => p.firstLaunchedAt !== undefined);
+      }
+    } catch (err) {
+      this.logger.warn('Failed to read project marker; failing closed (no onboarding)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+
+    if (!projectMarkerIsCold) {
+      this.logger.debug('Project firstLaunchedAt is set — skipping onboarding', { projectId });
+      return false;
+    }
+
+    // --- Signal 2: chat-v2 emptiness ---
+    let chatIsEmpty: boolean;
+    try {
+      chatIsEmpty = this.chat.countAllMessages() === 0;
+    } catch (err) {
+      this.logger.warn('Failed to read chat-v2 count; failing closed (no onboarding)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+
+    if (!chatIsEmpty) {
+      this.logger.debug('Chat-v2 has prior messages — skipping onboarding');
+      return false;
+    }
+
+    this.logger.info('Cold-start detected — entering onboarding mode', { projectId });
+    return true;
+  }
+
+  /**
+   * Set `firstLaunchedAt` on the named project record.
+   *
+   * Idempotent: a no-op if the marker is already set (logged at debug),
+   * preserving the original launch timestamp. No-op (warn) if the project
+   * record cannot be located. Errors are caught and logged so the
+   * bootstrap path is not destabilised by a marker-write failure.
+   *
+   * @param projectId - Target project ID
+   */
+  async markProjectAsLaunched(projectId: string): Promise<void> {
+    try {
+      const projects = await this.storage.getProjects();
+      const target = projects.find((p) => p.id === projectId);
+      if (!target) {
+        this.logger.warn('markProjectAsLaunched: project not found', { projectId });
+        return;
+      }
+      if (target.firstLaunchedAt) {
+        this.logger.debug('markProjectAsLaunched: marker already set, no-op', {
+          projectId,
+          existingValue: target.firstLaunchedAt,
+        });
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const updated: Project = {
+        ...target,
+        firstLaunchedAt: now,
+        updatedAt: now,
+      };
+      await this.storage.saveProject(updated);
+      this.logger.info('Project marked as launched', { projectId, firstLaunchedAt: now });
+    } catch (err) {
+      this.logger.error('markProjectAsLaunched: storage write failed', {
+        projectId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton accessor — wired by the bootstrap layer once dependencies exist
+// ---------------------------------------------------------------------------
+
+let onboardingBootstrapInstance: OnboardingBootstrapService | null = null;
+
+/**
+ * Wire (or replace) the process-wide `OnboardingBootstrapService`.
+ *
+ * Called once during server bootstrap after `StorageService` and
+ * `ChatV2Service` are constructed. Subsequent calls overwrite the binding
+ * (used by tests and graceful-restart paths).
+ *
+ * @param service - The configured service instance
+ */
+export function setOnboardingBootstrapService(service: OnboardingBootstrapService | null): void {
+  onboardingBootstrapInstance = service;
+}
+
+/**
+ * Resolve the process-wide `OnboardingBootstrapService`.
+ *
+ * Returns null when not yet wired — callers must tolerate that case
+ * (the orc bootstrap path does, because cold-start detection is a "best
+ * effort, default to normal mode" probe).
+ *
+ * @returns The shared service instance, or null if not wired
+ */
+export function getOnboardingBootstrapService(): OnboardingBootstrapService | null {
+  return onboardingBootstrapInstance;
+}
+
+/** Reset the singleton — test-only helper. */
+export function resetOnboardingBootstrapServiceForTesting(): void {
+  onboardingBootstrapInstance = null;
+}

--- a/backend/src/services/orchestrator/onboarding-cold-start.smoke.test.ts
+++ b/backend/src/services/orchestrator/onboarding-cold-start.smoke.test.ts
@@ -1,0 +1,167 @@
+/**
+ * End-to-end smoke test for Onboarding v3 cold-start (Sun EOD prototype).
+ *
+ * Exercises the full signal-chain that drives the prototype demo:
+ *
+ *  1. Empty `~/.crewly` (zero projects, zero chat-v2 messages) →
+ *     `OnboardingBootstrapService.shouldEnterOnboardingMode()` returns true.
+ *  2. Once onboarding fires, `loadOnboardingPrompt()` resolves Max's
+ *     production prompt (5-phase, anchor transcript, capability list).
+ *  3. `loadOnboardingSkillAllowlist()` resolves Max's production allowlist
+ *     and excludes destructive delegation skills.
+ *  4. After bootstrap success, `markProjectAsLaunched(projectId)` flips the
+ *     marker so a second boot returns false (warm-start path) — proves
+ *     the cold-start fires exactly once for the demo.
+ *  5. The two signals are AND-ed: if EITHER the marker exists OR chat-v2
+ *     has messages, onboarding does NOT trigger. Both directions covered.
+ *
+ * This is the smoke transcript Mia can read to verify the prototype.
+ *
+ * @module services/orchestrator/onboarding-cold-start.smoke.test
+ */
+
+import {
+  OnboardingBootstrapService,
+  type ChatMessageCounter,
+} from './onboarding-bootstrap.service.js';
+import {
+  loadOnboardingPrompt,
+  loadOnboardingSkillAllowlist,
+  _resetOnboardingModeLoaderForTesting,
+} from './onboarding-mode-loader.js';
+import type { StorageService } from '../core/storage.service.js';
+import type { Project } from '../../types/index.js';
+
+/**
+ * Minimal storage stub that satisfies `OnboardingBootstrapService`'s
+ * `Pick<StorageService, 'getProjects' | 'saveProject'>` contract via duck
+ * typing. Holds projects in an in-memory map so we can assert the
+ * marker round-trip end-to-end.
+ */
+function createStorageStub(seed: Project[] = []): StorageService {
+  const projects = new Map<string, Project>(seed.map((p) => [p.id, { ...p }]));
+  const stub = {
+    getProjects: jest.fn(async () => Array.from(projects.values()).map((p) => ({ ...p }))),
+    saveProject: jest.fn(async (project: Project) => {
+      projects.set(project.id, { ...project });
+    }),
+  };
+  return stub as unknown as StorageService;
+}
+
+/** Chat counter that returns whatever value the test stages. */
+function createChatStub(initialCount = 0): ChatMessageCounter & { setCount: (n: number) => void } {
+  let count = initialCount;
+  return {
+    countAllMessages: () => count,
+    setCount: (n: number) => {
+      count = n;
+    },
+  };
+}
+
+describe('Onboarding v3 cold-start smoke (Sun EOD prototype)', () => {
+  beforeEach(() => {
+    _resetOnboardingModeLoaderForTesting();
+  });
+
+  it('full happy path: empty storage + empty chat → cold-start fires + production prompt loads + marker round-trips', async () => {
+    const storage = createStorageStub([]);
+    const chat = createChatStub(0);
+    const service = new OnboardingBootstrapService({ storage, chat });
+
+    // (1) Cold-start probe fires.
+    const cold = await service.shouldEnterOnboardingMode();
+    expect(cold).toBe(true);
+
+    // (2) Production prompt loads — Max's 5-phase onboarding prompt.
+    const prompt = await loadOnboardingPrompt();
+    expect(prompt.length).toBeGreaterThan(1000);
+    // Anchor on Max's exact phase markers to assert the production
+    // module loaded (NOT the inline fallback stub).
+    expect(prompt).toContain('PHASE 1 — OPEN');
+    expect(prompt).toContain('PHASE 2 — BUSINESS DISCOVERY');
+    expect(prompt).toContain('PHASE 3 — FEASIBILITY JUDGMENT');
+    expect(prompt).toContain('PHASE 4 — TEAM RECOMMENDATION');
+    expect(prompt).toContain('PHASE 5 — CONFIRM + MATERIALIZE');
+
+    // (3) Skill allowlist excludes destructive delegation skills, includes
+    //     the onboarding-only skills.
+    const allowlist = await loadOnboardingSkillAllowlist();
+    expect(allowlist).toContain('recall');
+    expect(allowlist).toContain('remember');
+    expect(allowlist).toContain('record-learning');
+    expect(allowlist).toContain('recommend-team');
+    expect(allowlist).toContain('materialize-team');
+    expect(allowlist).not.toContain('delegate-task');
+    expect(allowlist).not.toContain('start-agent');
+    expect(allowlist).not.toContain('stop-agent');
+
+    // (4) After bootstrap succeeds, marker the project. We need a real
+    //     project record to mark — seed one.
+    const seededProject: Project = {
+      id: 'demo-project-001',
+      name: 'Demo Project',
+      path: '/tmp/demo',
+      teams: {},
+      status: 'active',
+      createdAt: new Date('2026-05-03').toISOString(),
+      updatedAt: new Date('2026-05-03').toISOString(),
+    };
+    const storageWithProject = createStorageStub([seededProject]);
+    const serviceWithProject = new OnboardingBootstrapService({
+      storage: storageWithProject,
+      chat,
+    });
+    await serviceWithProject.markProjectAsLaunched('demo-project-001');
+
+    // (5) Re-probe — marker now set on this project, broad cold-start
+    //     check sees it and returns false (warm start). This is the demo
+    //     invariant: cold-start fires exactly once per install.
+    const warm = await serviceWithProject.shouldEnterOnboardingMode();
+    expect(warm).toBe(false);
+  });
+
+  it('AND-gate signal 1: chat has messages → cold-start does NOT fire even if no project marker', async () => {
+    const storage = createStorageStub([]);
+    const chatWithMessages = createChatStub(7); // user has spoken before
+    const service = new OnboardingBootstrapService({ storage, chat: chatWithMessages });
+
+    const cold = await service.shouldEnterOnboardingMode();
+    expect(cold).toBe(false);
+  });
+
+  it('AND-gate signal 2: a project carries firstLaunchedAt → cold-start does NOT fire even if chat is empty', async () => {
+    const launchedProject: Project = {
+      id: 'old-project',
+      name: 'Old Project',
+      path: '/tmp/old',
+      teams: {},
+      status: 'active',
+      createdAt: new Date('2026-04-01').toISOString(),
+      updatedAt: new Date('2026-04-01').toISOString(),
+      firstLaunchedAt: new Date('2026-04-01').toISOString(),
+    };
+    const storage = createStorageStub([launchedProject]);
+    const emptyChat = createChatStub(0);
+    const service = new OnboardingBootstrapService({ storage, chat: emptyChat });
+
+    const cold = await service.shouldEnterOnboardingMode();
+    expect(cold).toBe(false);
+  });
+
+  it('demo transcript: prompt content includes anchor 4-tier feasibility vocabulary', async () => {
+    // Read-only smoke: confirm the production prompt contains the
+    // semantic anchors Mia's spec v3 requires (Yes-today / Collaborative /
+    // Roadmap / Out-of-scope). These are the discriminator for the
+    // onboarding-mode prompt vs. any future swap.
+    const prompt = await loadOnboardingPrompt();
+    // Max's prompt phrases the four tiers as: "Yes, today" /
+    // "Collaborative" / "Roadmap" / "Out of scope". Each tier appears
+    // multiple times across the table + the few-shot anchor transcript.
+    expect(prompt).toMatch(/Yes,\s*today/i);
+    expect(prompt).toMatch(/Collaborative/i);
+    expect(prompt).toMatch(/Roadmap/i);
+    expect(prompt).toMatch(/Out\s*of\s*scope/i);
+  });
+});

--- a/backend/src/services/orchestrator/onboarding-mode-loader.test.ts
+++ b/backend/src/services/orchestrator/onboarding-mode-loader.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the onboarding-mode loader (Onboarding v3 — B3).
+ *
+ * Note: We can't easily mock dynamic imports of relative paths in jest
+ * (ts-jest CommonJS transform turns `import()` into a Promise wrapper
+ * around `require`), so the integration with Max's real modules is
+ * exercised end-to-end after both branches merge. Here we cover:
+ *
+ * - Fallback constant shape (matches brief's prescribed allowlist)
+ * - Loader returns the fallback when the production module is absent
+ *   (which is the actual state on this branch)
+ * - Result is cached across calls
+ * - Reset helper clears the cache
+ *
+ * @module services/orchestrator/onboarding-mode-loader.test
+ */
+
+import {
+  ONBOARDING_FALLBACK_PROMPT,
+  ONBOARDING_FALLBACK_ALLOWLIST,
+  loadOnboardingPrompt,
+  loadOnboardingSkillAllowlist,
+  _resetOnboardingModeLoaderForTesting,
+} from './onboarding-mode-loader.js';
+
+describe('Onboarding mode loader (Onboarding v3 — B3)', () => {
+  beforeEach(() => {
+    _resetOnboardingModeLoaderForTesting();
+  });
+
+  describe('fallback constants', () => {
+    it('fallback prompt is a non-empty string with a friendly greeting', () => {
+      expect(typeof ONBOARDING_FALLBACK_PROMPT).toBe('string');
+      expect(ONBOARDING_FALLBACK_PROMPT.length).toBeGreaterThan(20);
+      expect(ONBOARDING_FALLBACK_PROMPT.toLowerCase()).toContain('crewly');
+    });
+
+    it('fallback allowlist matches Sam\'s brief: read-only memory + 2 onboarding skills', () => {
+      // Brief: "restrict orc skills to: recall, remember, record-learning,
+      // plus 2 onboarding-specific skills (recommend-team, materialize-team)."
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).toContain('recall');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).toContain('remember');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).toContain('record-learning');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).toContain('recommend-team');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).toContain('materialize-team');
+    });
+
+    it('fallback allowlist explicitly excludes destructive skills', () => {
+      // Brief: "Disable delegate-task, start-agent, stop-agent — orc cannot
+      // delegate while onboarding the customer."
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).not.toContain('delegate-task');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).not.toContain('start-agent');
+      expect(ONBOARDING_FALLBACK_ALLOWLIST).not.toContain('stop-agent');
+    });
+
+    it('fallback allowlist is frozen so callers cannot mutate the shared instance', () => {
+      expect(Object.isFrozen(ONBOARDING_FALLBACK_ALLOWLIST)).toBe(true);
+    });
+  });
+
+  describe('loadOnboardingPrompt', () => {
+    it('returns a non-empty string on this branch (fallback path)', async () => {
+      const prompt = await loadOnboardingPrompt();
+      expect(typeof prompt).toBe('string');
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+
+    it('caches the resolved value across calls', async () => {
+      const first = await loadOnboardingPrompt();
+      const second = await loadOnboardingPrompt();
+      expect(second).toBe(first); // identity, not just equality
+    });
+
+    it('reset clears the cache so a new resolution can occur', async () => {
+      const first = await loadOnboardingPrompt();
+      _resetOnboardingModeLoaderForTesting();
+      const second = await loadOnboardingPrompt();
+      // Same value (fallback), but the resolution path ran twice — that's
+      // verified by the reset call, not by identity here.
+      expect(second).toBe(first);
+    });
+  });
+
+  describe('loadOnboardingSkillAllowlist', () => {
+    it('returns the fallback allowlist on this branch', async () => {
+      const list = await loadOnboardingSkillAllowlist();
+      expect(list).toEqual(ONBOARDING_FALLBACK_ALLOWLIST);
+    });
+
+    it('caches the resolved allowlist', async () => {
+      const first = await loadOnboardingSkillAllowlist();
+      const second = await loadOnboardingSkillAllowlist();
+      expect(second).toBe(first);
+    });
+
+    it('returned allowlist is frozen — callers cannot mutate it', async () => {
+      const list = await loadOnboardingSkillAllowlist();
+      expect(Object.isFrozen(list)).toBe(true);
+    });
+  });
+});

--- a/backend/src/services/orchestrator/onboarding-mode-loader.test.ts
+++ b/backend/src/services/orchestrator/onboarding-mode-loader.test.ts
@@ -59,7 +59,7 @@ describe('Onboarding mode loader (Onboarding v3 — B3)', () => {
   });
 
   describe('loadOnboardingPrompt', () => {
-    it('returns a non-empty string on this branch (fallback path)', async () => {
+    it('returns a non-empty string (fallback or production)', async () => {
       const prompt = await loadOnboardingPrompt();
       expect(typeof prompt).toBe('string');
       expect(prompt.length).toBeGreaterThan(0);
@@ -75,16 +75,38 @@ describe('Onboarding mode loader (Onboarding v3 — B3)', () => {
       const first = await loadOnboardingPrompt();
       _resetOnboardingModeLoaderForTesting();
       const second = await loadOnboardingPrompt();
-      // Same value (fallback), but the resolution path ran twice — that's
-      // verified by the reset call, not by identity here.
-      expect(second).toBe(first);
+      // Resolution path ran twice — second call reaches the dynamic import
+      // again; equality (not identity) is the invariant that holds across
+      // both fallback and production paths.
+      expect(second).toEqual(first);
     });
   });
 
   describe('loadOnboardingSkillAllowlist', () => {
-    it('returns the fallback allowlist on this branch', async () => {
+    /**
+     * Post-integration with Max's `onboarding-mode.skill-allowlist.ts`, the
+     * loader resolves the production allowlist (which is a strict superset
+     * of the fallback). Pre-integration this test asserted the fallback
+     * was returned. We keep both invariants below: the fallback is the
+     * minimum contract and the production list satisfies it.
+     */
+    it('returns an allowlist that satisfies the brief (superset of fallback)', async () => {
       const list = await loadOnboardingSkillAllowlist();
-      expect(list).toEqual(ONBOARDING_FALLBACK_ALLOWLIST);
+      // Every fallback skill MUST be in the resolved list — that is the
+      // contract the loader honours regardless of which path resolved.
+      for (const skill of ONBOARDING_FALLBACK_ALLOWLIST) {
+        expect(list).toContain(skill);
+      }
+    });
+
+    it('explicitly excludes destructive delegation skills', async () => {
+      // Sam's brief: orc cannot delegate while onboarding the customer.
+      // This invariant must hold whether the loader picks the fallback
+      // or the production allowlist.
+      const list = await loadOnboardingSkillAllowlist();
+      expect(list).not.toContain('delegate-task');
+      expect(list).not.toContain('start-agent');
+      expect(list).not.toContain('stop-agent');
     });
 
     it('caches the resolved allowlist', async () => {

--- a/backend/src/services/orchestrator/onboarding-mode-loader.ts
+++ b/backend/src/services/orchestrator/onboarding-mode-loader.ts
@@ -1,0 +1,158 @@
+/**
+ * Onboarding mode prompt + skill allowlist loader (Onboarding v3 — B3).
+ *
+ * Resolves the onboarding-mode system prompt and skill allowlist that the
+ * orc loads when cold-start detection (B1) fires. The real content is
+ * authored by Max on `feat/onboarding-v3-orc-prompt-skills`:
+ *
+ * - `backend/src/services/orchestrator/prompts/onboarding-mode.prompt.ts`
+ *   exports `ONBOARDING_MODE_SYSTEM_PROMPT: string`
+ * - `backend/src/services/orchestrator/onboarding-mode.skill-allowlist.ts`
+ *   exports `ONBOARDING_SKILL_ALLOWLIST: readonly string[]` plus
+ *   `isOnboardingSkillAllowed(name)` / `filterAllowedOnboardingSkills(names)`.
+ *
+ * Until Max's branch merges, those modules don't exist on this branch.
+ * This loader uses a dynamic-import-with-fallback so the build is atomic
+ * and the orc still has *something* to load on a cold start. After Max's
+ * branch merges, the real exports take over with no rebuild needed.
+ *
+ * Decoupled module path (string variable, not literal) is intentional —
+ * keeps TypeScript's module resolver from emitting a compile error when
+ * the target file is absent.
+ *
+ * @module services/orchestrator/onboarding-mode-loader
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+/**
+ * Default onboarding-mode system prompt — used when Max's prompt module
+ * is not yet available. Mon EOD demo can run on this; Max replaces it
+ * with the production prompt at the import path below when his branch
+ * lands.
+ */
+export const ONBOARDING_FALLBACK_PROMPT =
+  'You are Crewly, an AI team orchestrator. The user is onboarding for ' +
+  'the first time. Greet them warmly, then ask about their business so ' +
+  'you can recommend an initial AI team and workflow.';
+
+/**
+ * Default skill allowlist — used when Max's allowlist module is not yet
+ * available. Matches the brief: recall / remember / record-learning +
+ * the 2 onboarding-specific skills (`recommend-team`, `materialize-team`).
+ * `delegate-task`, `start-agent`, `stop-agent` are intentionally absent.
+ */
+export const ONBOARDING_FALLBACK_ALLOWLIST: readonly string[] = Object.freeze([
+  'recall',
+  'remember',
+  'record-learning',
+  'recommend-team',
+  'materialize-team',
+]);
+
+/**
+ * Module specifiers that reach Max's exports after his branch merges.
+ *
+ * Stored in `let`-typed `string` variables (not literal strings or template
+ * literals) so TypeScript treats the dynamic `import(spec)` call as
+ * `Promise<any>` rather than attempting to resolve the path at compile
+ * time. This keeps the build atomic even when the target files are absent.
+ */
+const PROMPT_MODULE_PATH: string = './prompts/onboarding-mode.prompt.js';
+const ALLOWLIST_MODULE_PATH: string = './onboarding-mode.skill-allowlist.js';
+
+const PROMPT_EXPORT_NAME = 'ONBOARDING_MODE_SYSTEM_PROMPT';
+const ALLOWLIST_EXPORT_NAME = 'ONBOARDING_SKILL_ALLOWLIST';
+
+let cachedPrompt: string | null = null;
+let cachedAllowlist: readonly string[] | null = null;
+
+const getLogger = (): ComponentLogger =>
+  LoggerService.getInstance().createComponentLogger('OnboardingModeLoader');
+
+/**
+ * Dynamic import that swallows ENOENT-style failures.
+ *
+ * Cast to `unknown` so callers narrow with their own type guard — keeps
+ * the loader safe even if Max changes the export shape unexpectedly.
+ */
+async function tryImport(specifier: string): Promise<unknown> {
+  try {
+    return (await import(specifier)) as unknown;
+  } catch (err) {
+    getLogger().debug('Dynamic import failed; using fallback', {
+      specifier,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Resolve the onboarding-mode system prompt.
+ *
+ * On first call, attempts to load the production prompt module; on
+ * subsequent calls returns the cached value. Failure (module missing,
+ * export missing, wrong type) returns the fallback.
+ *
+ * @returns Onboarding-mode system prompt string
+ */
+export async function loadOnboardingPrompt(): Promise<string> {
+  if (cachedPrompt !== null) return cachedPrompt;
+
+  const mod = await tryImport(PROMPT_MODULE_PATH);
+  if (mod && typeof mod === 'object' && PROMPT_EXPORT_NAME in mod) {
+    const value = (mod as Record<string, unknown>)[PROMPT_EXPORT_NAME];
+    if (typeof value === 'string' && value.length > 0) {
+      getLogger().info('Loaded production onboarding prompt', {
+        promptLength: value.length,
+      });
+      cachedPrompt = value;
+      return cachedPrompt;
+    }
+  }
+
+  getLogger().warn('Onboarding prompt module unavailable; using fallback stub');
+  cachedPrompt = ONBOARDING_FALLBACK_PROMPT;
+  return cachedPrompt;
+}
+
+/**
+ * Resolve the onboarding-mode skill allowlist.
+ *
+ * Caching, fallback semantics, and validation mirror `loadOnboardingPrompt`.
+ *
+ * @returns Allowed skill names (kebab-case match against `mcp-tool-definitions`)
+ */
+export async function loadOnboardingSkillAllowlist(): Promise<readonly string[]> {
+  if (cachedAllowlist !== null) return cachedAllowlist;
+
+  const mod = await tryImport(ALLOWLIST_MODULE_PATH);
+  if (mod && typeof mod === 'object' && ALLOWLIST_EXPORT_NAME in mod) {
+    const value = (mod as Record<string, unknown>)[ALLOWLIST_EXPORT_NAME];
+    if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+      getLogger().info('Loaded production onboarding skill allowlist', {
+        count: value.length,
+      });
+      cachedAllowlist = Object.freeze([...(value as string[])]);
+      return cachedAllowlist;
+    }
+  }
+
+  getLogger().warn('Onboarding skill allowlist module unavailable; using fallback stub');
+  cachedAllowlist = ONBOARDING_FALLBACK_ALLOWLIST;
+  return cachedAllowlist;
+}
+
+/**
+ * Reset the cached prompt + allowlist. Test-only helper.
+ *
+ * Production callers should leave the cache alone — the modules are
+ * effectively immutable for the lifetime of the process.
+ *
+ * @internal
+ */
+export function _resetOnboardingModeLoaderForTesting(): void {
+  cachedPrompt = null;
+  cachedAllowlist = null;
+}

--- a/backend/src/services/orchestrator/onboarding-mode.skill-allowlist.test.ts
+++ b/backend/src/services/orchestrator/onboarding-mode.skill-allowlist.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the onboarding-mode skill allowlist.
+ *
+ * Guards:
+ *   - The 6 expected skills are present.
+ *   - Spawn-worker skills are NOT present (delegate-task / start-agent / stop-agent).
+ *   - Helpers behave correctly for empty / unknown inputs.
+ *
+ * @module services/orchestrator/onboarding-mode.skill-allowlist.test
+ */
+
+import {
+  ONBOARDING_SKILL_ALLOWLIST,
+  isOnboardingSkillAllowed,
+  filterAllowedOnboardingSkills,
+} from './onboarding-mode.skill-allowlist.js';
+
+describe('ONBOARDING_SKILL_ALLOWLIST', () => {
+  it('contains exactly the six expected skills', () => {
+    // Order doesn't matter for this assertion — sort for stability.
+    const sorted = [...ONBOARDING_SKILL_ALLOWLIST].sort();
+    expect(sorted).toEqual(
+      [
+        'materialize-team',
+        'recall',
+        'recommend-team',
+        'record-learning',
+        'remember',
+        'report-status',
+      ].sort(),
+    );
+  });
+
+  it('is frozen (cannot be mutated at runtime)', () => {
+    expect(Object.isFrozen(ONBOARDING_SKILL_ALLOWLIST)).toBe(true);
+  });
+
+  it('does NOT include any spawn-worker skill', () => {
+    for (const forbidden of ['delegate-task', 'start-agent', 'stop-agent']) {
+      expect(ONBOARDING_SKILL_ALLOWLIST).not.toContain(forbidden);
+    }
+  });
+});
+
+describe('isOnboardingSkillAllowed()', () => {
+  it('returns true for every allowed skill', () => {
+    for (const skill of ONBOARDING_SKILL_ALLOWLIST) {
+      expect(isOnboardingSkillAllowed(skill)).toBe(true);
+    }
+  });
+
+  it('returns false for forbidden skills', () => {
+    for (const forbidden of [
+      'delegate-task',
+      'start-agent',
+      'stop-agent',
+      'send-message',
+      '',
+      'unknown-skill',
+    ]) {
+      expect(isOnboardingSkillAllowed(forbidden)).toBe(false);
+    }
+  });
+
+  it('is case-sensitive (matches by exact name)', () => {
+    // Allowlist values are lower-kebab-case; uppercase variants must reject.
+    expect(isOnboardingSkillAllowed('Recall')).toBe(false);
+    expect(isOnboardingSkillAllowed('RECALL')).toBe(false);
+  });
+});
+
+describe('filterAllowedOnboardingSkills()', () => {
+  it('returns only allowed skills, preserving input order', () => {
+    const input = [
+      'delegate-task', // forbidden
+      'recall',         // allowed
+      'remember',       // allowed
+      'start-agent',    // forbidden
+      'materialize-team', // allowed
+    ];
+    expect(filterAllowedOnboardingSkills(input)).toEqual([
+      'recall',
+      'remember',
+      'materialize-team',
+    ]);
+  });
+
+  it('returns an empty array when nothing is allowed', () => {
+    expect(filterAllowedOnboardingSkills(['delegate-task', 'start-agent'])).toEqual([]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(filterAllowedOnboardingSkills([])).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['recall', 'delegate-task'];
+    const snapshot = [...input];
+    filterAllowedOnboardingSkills(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/backend/src/services/orchestrator/onboarding-mode.skill-allowlist.ts
+++ b/backend/src/services/orchestrator/onboarding-mode.skill-allowlist.ts
@@ -1,0 +1,80 @@
+/**
+ * Onboarding-Mode Skill Allowlist
+ *
+ * When the orchestrator is in `'onboarding'` mode, only the skills in
+ * {@link ONBOARDING_SKILL_ALLOWLIST} are callable. The runtime gate that
+ * enforces this lives in Leo's mcp-tool-definitions / skill-registry
+ * filter; this file is the single source of truth for the allow set.
+ *
+ * Matching is **by skill name** (e.g. `"recall"`), not by file path. The
+ * runtime walks the registry, takes each tool's logical name, and keeps
+ * the entry only if the name appears here.
+ *
+ * Why an allowlist (not a denylist):
+ *   - Onboarding is a tightly-scoped 5-min flow.
+ *   - Spawning workers (delegate-task / start-agent / stop-agent) before
+ *     the team is materialized would create orphan agents.
+ *   - Future skills get added to Crewly without thinking about
+ *     onboarding; default-deny keeps onboarding hermetic.
+ *
+ * @module services/orchestrator/onboarding-mode.skill-allowlist
+ */
+
+/**
+ * The exhaustive list of skills callable while orc is in onboarding mode.
+ *
+ * Keep this list in sync with the SKILL ACCESS section of
+ * {@link ./prompts/onboarding-mode.prompt.ts}; the prompt test asserts
+ * each name appears in the prompt, so divergence is caught at test time.
+ *
+ * Imported by:
+ *   - The orchestrator runtime / skill-registry filter (Leo).
+ *   - The allowlist test in this directory.
+ */
+export const ONBOARDING_SKILL_ALLOWLIST: readonly string[] = Object.freeze([
+  // Memory — orc must be able to recall + remember during the chat.
+  'recall',
+  'remember',
+  'record-learning',
+
+  // Onboarding-only skills — turn discovery answers into a real team.
+  'recommend-team',
+  'materialize-team',
+
+  // Escalation — surface to TL on blocker.
+  'report-status',
+]);
+
+/**
+ * Type-narrowed alias of an allowlisted skill name. Useful for callers
+ * that want compile-time guarantees (e.g. tests, registry filters).
+ */
+export type OnboardingAllowedSkill = (typeof ONBOARDING_SKILL_ALLOWLIST)[number];
+
+/**
+ * Predicate: is the named skill callable in onboarding mode?
+ *
+ * @param skillName - Skill logical name (e.g. `"delegate-task"`).
+ * @returns `true` iff the skill is on the allowlist.
+ *
+ * @example
+ * ```ts
+ * if (isOnboardingSkillAllowed(tool.name)) registry.register(tool);
+ * ```
+ */
+export function isOnboardingSkillAllowed(skillName: string): boolean {
+  return ONBOARDING_SKILL_ALLOWLIST.includes(skillName);
+}
+
+/**
+ * Filter helper: given a list of skill names, return only those allowed
+ * in onboarding mode, preserving the input order.
+ *
+ * @param skillNames - Candidate skill names.
+ * @returns Subset of skillNames that are on the allowlist.
+ */
+export function filterAllowedOnboardingSkills(
+  skillNames: readonly string[],
+): string[] {
+  return skillNames.filter(isOnboardingSkillAllowed);
+}

--- a/backend/src/services/orchestrator/onboarding/materialize-team.test.ts
+++ b/backend/src/services/orchestrator/onboarding/materialize-team.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for materialize-team logic.
+ *
+ * Covers:
+ *   - Team config file is created at the expected path with the expected shape.
+ *   - `onboardingComplete = true` flag is persisted.
+ *   - Agents in the recommendation flow through to `members[]`.
+ *   - Errors propagate (caller decides how to surface).
+ *   - Logger sink fires with both stub log lines.
+ *
+ * Tests use a tmp dir per case so they are hermetic.
+ *
+ * @module services/orchestrator/onboarding/materialize-team.test
+ */
+
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { materializeTeam, type MaterializeOptions } from './materialize-team.js';
+import type { TeamRecommendation } from './recommend-team.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FIXED_NOW = new Date('2026-05-04T12:00:00.000Z');
+const FIXED_UUID = '00000000-0000-4000-8000-000000000001';
+
+function fixedOpts(testRoot: string): MaterializeOptions {
+  const logs: string[] = [];
+  const opts: MaterializeOptions & { __logs: string[] } = {
+    teamsDir: path.join(testRoot, 'teams'),
+    projectFlagPath: path.join(testRoot, 'onboarding-complete.json'),
+    uuid: () => FIXED_UUID,
+    now: () => FIXED_NOW,
+    log: (msg: string) => { logs.push(msg); },
+    __logs: logs,
+  };
+  return opts;
+}
+
+const sampleRec: TeamRecommendation = {
+  templateId: 'dtc-viral-content-team',
+  agents: [
+    {
+      role: 'content-drafter',
+      responsibilities: 'Drafts weekly content.',
+      skillIds: ['content-drafter', 'content-calendar'],
+    },
+    {
+      role: 'support-triage',
+      responsibilities: 'Triages support and drafts replies.',
+      skillIds: ['support-triage'],
+    },
+  ],
+  reasoning: 'You named e-commerce + content + support.',
+  source: 'hardcoded:ecommerce-content-support',
+};
+
+async function makeTmpRoot(label: string): Promise<string> {
+  const root = path.join(os.tmpdir(), `materialize-team-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+async function rmTmpRoot(root: string): Promise<void> {
+  await fs.rm(root, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Suites
+// ---------------------------------------------------------------------------
+
+describe('materializeTeam — happy path', () => {
+  let root: string;
+  beforeEach(async () => { root = await makeTmpRoot('happy'); });
+  afterEach(async () => { await rmTmpRoot(root); });
+
+  it('returns a result with onboardingComplete = true', async () => {
+    const opts = fixedOpts(root);
+    const result = await materializeTeam(sampleRec, opts);
+    expect(result.onboardingComplete).toBe(true);
+    expect(result.teamId).toBe(FIXED_UUID);
+    expect(result.recommendation).toEqual(sampleRec);
+  });
+
+  it('writes a team config.json under teamsDir/<id>/', async () => {
+    const opts = fixedOpts(root);
+    const result = await materializeTeam(sampleRec, opts);
+
+    const expectedPath = path.join(opts.teamsDir, FIXED_UUID, 'config.json');
+    expect(result.teamConfigPath).toBe(expectedPath);
+
+    const raw = await fs.readFile(expectedPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.id).toBe(FIXED_UUID);
+    expect(parsed.templateId).toBe('dtc-viral-content-team');
+    expect(parsed.onboardingSource).toBe('hardcoded:ecommerce-content-support');
+    expect(parsed.createdBy).toBe('onboarding-v3');
+    expect(parsed.createdAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it('every agent in the recommendation flows through to members[]', async () => {
+    const opts = fixedOpts(root);
+    await materializeTeam(sampleRec, opts);
+
+    const raw = await fs.readFile(
+      path.join(opts.teamsDir, FIXED_UUID, 'config.json'),
+      'utf8',
+    );
+    const parsed = JSON.parse(raw);
+    expect(parsed.members.length).toBe(sampleRec.agents.length);
+    for (let i = 0; i < sampleRec.agents.length; i++) {
+      expect(parsed.members[i].role).toBe(sampleRec.agents[i].role);
+      expect(parsed.members[i].responsibilities).toBe(
+        sampleRec.agents[i].responsibilities,
+      );
+      expect(parsed.members[i].skillIds).toEqual([
+        ...sampleRec.agents[i].skillIds,
+      ]);
+      expect(parsed.members[i].agentStatus).toBe('inactive');
+      expect(parsed.members[i].workingStatus).toBe('idle');
+    }
+  });
+
+  it('persists the project onboarding-complete flag', async () => {
+    const opts = fixedOpts(root);
+    const result = await materializeTeam(sampleRec, opts);
+
+    expect(result.projectFlagPath).toBe(opts.projectFlagPath);
+    const raw = await fs.readFile(opts.projectFlagPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.onboardingComplete).toBe(true);
+    expect(parsed.completedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it('emits both stub log lines when a logger is provided', async () => {
+    const logs: string[] = [];
+    const opts = {
+      ...fixedOpts(root),
+      log: (m: string) => { logs.push(m); },
+    } satisfies MaterializeOptions;
+
+    await materializeTeam(sampleRec, opts);
+
+    expect(logs.length).toBe(2);
+    expect(logs[0]).toContain('would materialize team for template');
+    expect(logs[0]).toContain('dtc-viral-content-team');
+    expect(logs[0]).toContain('id=' + FIXED_UUID);
+    expect(logs[1]).toContain('flipped onboardingComplete');
+  });
+
+  it('humanises the template id into the team name', async () => {
+    const opts = fixedOpts(root);
+    await materializeTeam(sampleRec, opts);
+    const parsed = JSON.parse(
+      await fs.readFile(path.join(opts.teamsDir, FIXED_UUID, 'config.json'), 'utf8'),
+    );
+    expect(parsed.name).toBe('Dtc Viral Content Team');
+  });
+});
+
+describe('materializeTeam — defaults & resilience', () => {
+  let root: string;
+  beforeEach(async () => { root = await makeTmpRoot('defaults'); });
+  afterEach(async () => { await rmTmpRoot(root); });
+
+  it('falls back to a real UUID when no uuid generator is provided', async () => {
+    // No injected uuid → real randomUUID — should be a valid v4 shape.
+    const result = await materializeTeam(sampleRec, {
+      teamsDir: path.join(root, 'teams'),
+      projectFlagPath: path.join(root, 'flag.json'),
+    });
+    expect(result.teamId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(result.onboardingComplete).toBe(true);
+  });
+
+  it('falls back to wall-clock time when no clock is provided', async () => {
+    const before = new Date().toISOString();
+    const result = await materializeTeam(sampleRec, {
+      teamsDir: path.join(root, 'teams'),
+      projectFlagPath: path.join(root, 'flag.json'),
+    });
+    const after = new Date().toISOString();
+    const raw = await fs.readFile(result.teamConfigPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    // createdAt is a real ISO string between before and after.
+    expect(parsed.createdAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+    );
+    expect(parsed.createdAt >= before).toBe(true);
+    expect(parsed.createdAt <= after).toBe(true);
+  });
+
+  it('creates teamsDir if it does not exist', async () => {
+    const opts = fixedOpts(root);
+    // teamsDir doesn't exist yet — materialize must create it.
+    await expect(fs.access(opts.teamsDir)).rejects.toThrow();
+    await materializeTeam(sampleRec, opts);
+    await expect(fs.access(opts.teamsDir)).resolves.toBeUndefined();
+  });
+});
+
+describe('materializeTeam — error handling', () => {
+  it('rejects when teamsDir cannot be created (parent path is a file)', async () => {
+    const root = await makeTmpRoot('err');
+    try {
+      // Make a file at the path we'll try to use as a directory parent.
+      const blocker = path.join(root, 'blocker');
+      await fs.writeFile(blocker, 'not-a-dir', 'utf8');
+      const opts: MaterializeOptions = {
+        teamsDir: path.join(blocker, 'teams'),
+        projectFlagPath: path.join(root, 'flag.json'),
+        uuid: () => FIXED_UUID,
+        now: () => FIXED_NOW,
+      };
+      await expect(materializeTeam(sampleRec, opts)).rejects.toThrow();
+    } finally {
+      await rmTmpRoot(root);
+    }
+  });
+});

--- a/backend/src/services/orchestrator/onboarding/materialize-team.ts
+++ b/backend/src/services/orchestrator/onboarding/materialize-team.ts
@@ -1,0 +1,234 @@
+/**
+ * Materialize-Team Logic (Onboarding v3, v0)
+ *
+ * v0 stub: writes a minimal team `config.json` under `<teamsDir>/<id>/`
+ * and flips a project `onboardingComplete` flag. Real provisioning
+ * (template-engine wiring, agent-soul generation, system-prompt
+ * personalisation) lands Wed–Fri — Sam's brief explicitly says a
+ * "logs + flips flag" stub is acceptable for the Mon 5/4 EOD demo.
+ *
+ * The function is async + injection-friendly: callers pass a
+ * `teamsDir`, a `projectFlagPath`, a UUID generator, and a clock — so
+ * tests exercise the real write path with tmp dirs and deterministic
+ * IDs.
+ *
+ * Wired downstream: when this module is upgraded post-Mon, swap the
+ * inline write for a delegation to
+ * `backend/src/services/onboarding/onboarding-provision.service.ts`
+ * (it already provisions teams via TemplateService — see that file's
+ * `provisionFromOnboarding`).
+ *
+ * @module services/orchestrator/onboarding/materialize-team
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+import type { TeamRecommendation } from './recommend-team.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Side-effects the materialize step needs. Injected so tests can run
+ * against a tmp dir without touching the real `~/.crewly` tree.
+ */
+export interface MaterializeOptions {
+  /** Root teams directory (e.g. `~/.crewly/teams`). */
+  readonly teamsDir: string;
+  /** File path for the project onboarding-complete flag. */
+  readonly projectFlagPath: string;
+  /** UUID generator — defaults to {@link crypto.randomUUID} when omitted. */
+  readonly uuid?: () => string;
+  /** Clock — defaults to `() => new Date()` when omitted. */
+  readonly now?: () => Date;
+  /**
+   * Optional logger sink. When provided, the function writes the
+   * Mon-EOD-stub log lines through it (so tests can assert).
+   */
+  readonly log?: (message: string) => void;
+}
+
+/**
+ * Outcome of a successful materialize call.
+ */
+export interface MaterializeResult {
+  /** Newly-generated team ID (UUID). */
+  readonly teamId: string;
+  /** Absolute path to the team's `config.json`. */
+  readonly teamConfigPath: string;
+  /**
+   * Always `true` for a successful call — mirrors the brief's spec:
+   * "flips `onboardingComplete = true`".
+   */
+  readonly onboardingComplete: true;
+  /** Echo of the recommendation that was materialized (for orc to summarise back to the user). */
+  readonly recommendation: TeamRecommendation;
+  /**
+   * Where the project flag was persisted. The flag is a tiny JSON file
+   * (`{ onboardingComplete: true, completedAt }`).
+   */
+  readonly projectFlagPath: string;
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Materialize a {@link TeamRecommendation} into a team config file +
+ * project onboarding-complete flag.
+ *
+ * v0 (Mon 5/4 EOD) writes a minimal config:
+ * ```json
+ * {
+ *   "id":   "<uuid>",
+ *   "name": "<recommendation.templateId> Team",
+ *   "createdAt": "...",
+ *   "createdBy": "onboarding-v3",
+ *   "templateId": "...",
+ *   "members": [ ... ]
+ * }
+ * ```
+ * No agent-soul personalisation, no project linkage, no goals.md
+ * generation — those land Wed–Fri when this calls into
+ * `onboarding-provision.service.ts`.
+ *
+ * @param recommendation - Output of {@link recommendTeam} that the user confirmed.
+ * @param opts - Side-effect injection (teamsDir, projectFlagPath, etc.).
+ * @returns The team ID + config path + flag-path on success.
+ * @throws If the team config write fails (filesystem error). Caller is
+ *         expected to surface a brief, honest error to the user
+ *         ("I couldn't create the team — error: …") rather than retry
+ *         silently.
+ *
+ * @example
+ * ```ts
+ * const result = await materializeTeam(rec, {
+ *   teamsDir: path.join(os.homedir(), '.crewly/teams'),
+ *   projectFlagPath: path.join(os.homedir(), '.crewly/onboarding-complete.json'),
+ * });
+ * console.log(result.teamId, '→', result.teamConfigPath);
+ * ```
+ */
+export async function materializeTeam(
+  recommendation: TeamRecommendation,
+  opts: MaterializeOptions,
+): Promise<MaterializeResult> {
+  const uuid = opts.uuid ?? defaultUuid;
+  const now = opts.now ?? defaultNow;
+  const log = opts.log ?? noopLog;
+
+  const teamId = uuid();
+  const teamDir = path.join(opts.teamsDir, teamId);
+  const teamConfigPath = path.join(teamDir, 'config.json');
+  const createdAt = now().toISOString();
+
+  log(
+    `[materialize-team] would materialize team for template "${recommendation.templateId}" with ${recommendation.agents.length} agents (id=${teamId})`,
+  );
+
+  // 1. Write the team config.
+  const config = buildTeamConfig(recommendation, teamId, createdAt);
+  await fs.mkdir(teamDir, { recursive: true });
+  await fs.writeFile(teamConfigPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+
+  // 2. Flip the project onboarding-complete flag.
+  const flag = { onboardingComplete: true, completedAt: createdAt };
+  await fs.mkdir(path.dirname(opts.projectFlagPath), { recursive: true });
+  await fs.writeFile(
+    opts.projectFlagPath,
+    JSON.stringify(flag, null, 2) + '\n',
+    'utf8',
+  );
+
+  log(`[materialize-team] flipped onboardingComplete = true at ${opts.projectFlagPath}`);
+
+  return {
+    teamId,
+    teamConfigPath,
+    onboardingComplete: true,
+    recommendation,
+    projectFlagPath: opts.projectFlagPath,
+  };
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Build the minimal v0 team config. Members are derived 1:1 from the
+ * recommendation's agents list.
+ */
+function buildTeamConfig(
+  rec: TeamRecommendation,
+  teamId: string,
+  createdAt: string,
+): Record<string, unknown> {
+  return {
+    id: teamId,
+    name: humanizeTemplateName(rec.templateId),
+    description: rec.reasoning,
+    templateId: rec.templateId,
+    createdAt,
+    createdBy: 'onboarding-v3',
+    onboardingSource: rec.source,
+    members: rec.agents.map((a, idx) => ({
+      id: `${teamId}-${idx}`,
+      name: humanizeRoleName(a.role),
+      role: a.role,
+      responsibilities: a.responsibilities,
+      skillIds: [...a.skillIds],
+      systemPrompt: '',
+      agentStatus: 'inactive',
+      workingStatus: 'idle',
+    })),
+  };
+}
+
+/**
+ * Convert a kebab-case template id → human team name
+ * (`"dtc-viral-content-team"` → `"Dtc Viral Content Team"`). The full
+ * personalisation pass happens post-Mon when we wire into
+ * `onboarding-provision.service.ts` — that service already builds
+ * proper names.
+ */
+function humanizeTemplateName(templateId: string): string {
+  return templateId
+    .split('-')
+    .map((p) => (p.length ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(' ');
+}
+
+/**
+ * Convert a kebab-case role → human display name.
+ */
+function humanizeRoleName(role: string): string {
+  return role
+    .split('-')
+    .map((p) => (p.length ? p[0].toUpperCase() + p.slice(1) : p))
+    .join(' ');
+}
+
+/**
+ * Default UUID generator. Uses Node's `crypto.randomUUID` so we don't
+ * pull in a dep, and so the output is deterministic-shaped.
+ */
+function defaultUuid(): string {
+  // Lazy require to keep the import surface minimal and avoid loading
+  // `node:crypto` at module load.
+  const { randomUUID } = require('node:crypto') as typeof import('node:crypto');
+  return randomUUID();
+}
+
+/** Default clock — wall-clock time. */
+function defaultNow(): Date {
+  return new Date();
+}
+
+/** Default log sink — drops the message on the floor. */
+function noopLog(_message: string): void {
+  /* intentional no-op */
+}

--- a/backend/src/services/orchestrator/onboarding/recommend-team.test.ts
+++ b/backend/src/services/orchestrator/onboarding/recommend-team.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for recommend-team logic.
+ *
+ * Covers:
+ *   - Each of the 5 hardcoded mappings fires for its anchor input.
+ *   - Generic fallback fires when nothing matches.
+ *   - Returned shape is well-formed (templateId, ≥2 agents, reasoning, source).
+ *   - Pure function: same input twice → identical output.
+ *
+ * @module services/orchestrator/onboarding/recommend-team.test
+ */
+
+import {
+  recommendTeam,
+  HARDCODED_MAPPING_COUNT,
+  HARDCODED_MAPPING_KEYS,
+  type BusinessContext,
+  type TeamRecommendation,
+} from './recommend-team.js';
+
+const baseTask = (name: string) =>
+  ({ name, tier: 'yes-today' } as const);
+
+const baseCtx = (industry: string, tasks: string[]): BusinessContext => ({
+  industry,
+  scale: 'solo',
+  tasks: tasks.map(baseTask),
+});
+
+function expectShape(rec: TeamRecommendation) {
+  expect(typeof rec.templateId).toBe('string');
+  expect(rec.templateId.length).toBeGreaterThan(0);
+  expect(Array.isArray(rec.agents)).toBe(true);
+  expect(rec.agents.length).toBeGreaterThanOrEqual(2);
+  expect(rec.agents.length).toBeLessThanOrEqual(4);
+  for (const a of rec.agents) {
+    expect(typeof a.role).toBe('string');
+    expect(a.role.length).toBeGreaterThan(0);
+    expect(typeof a.responsibilities).toBe('string');
+    expect(a.responsibilities.length).toBeGreaterThan(0);
+    expect(Array.isArray(a.skillIds)).toBe(true);
+  }
+  expect(typeof rec.reasoning).toBe('string');
+  expect(rec.reasoning.length).toBeGreaterThan(0);
+  expect(typeof rec.source).toBe('string');
+}
+
+describe('recommendTeam — hardcoded mappings', () => {
+  it('exposes exactly 5 hardcoded mappings (the spec target)', () => {
+    expect(HARDCODED_MAPPING_COUNT).toBe(5);
+    expect(HARDCODED_MAPPING_KEYS.length).toBe(5);
+  });
+
+  it('e-commerce + content + support → dtc-viral-content-team (2 agents)', () => {
+    const rec = recommendTeam(
+      baseCtx('small Shopify skincare shop', [
+        'weekly blog content',
+        'customer support replies',
+      ]),
+    );
+    expect(rec.templateId).toBe('dtc-viral-content-team');
+    expect(rec.agents.length).toBe(2);
+    expect(rec.source).toBe('hardcoded:ecommerce-content-support');
+    expectShape(rec);
+  });
+
+  it('solo creator (TikTok / YouTube) → ai-video-social-team (2 agents)', () => {
+    const rec = recommendTeam(
+      baseCtx('solo TikTok + YouTube creator focused on productivity', [
+        'video editing',
+        'newsletter drafts',
+      ]),
+    );
+    expect(rec.templateId).toBe('ai-video-social-team');
+    expect(rec.agents.length).toBe(2);
+    expect(rec.source).toBe('hardcoded:solo-creator');
+    expectShape(rec);
+  });
+
+  it('solo SaaS dev → pragmatic-mvp-dev-team (2 agents)', () => {
+    const rec = recommendTeam({
+      industry: 'solo SaaS founder building a B2B platform',
+      scale: 'solo',
+      tasks: [
+        baseTask('code review on PRs'),
+        baseTask('weekly metrics digest'),
+      ],
+    });
+    expect(rec.templateId).toBe('pragmatic-mvp-dev-team');
+    expect(rec.agents.length).toBe(2);
+    expect(rec.source).toBe('hardcoded:engineering');
+    expectShape(rec);
+  });
+
+  it('small dev team → web-dev-team (different template than solo path)', () => {
+    const rec = recommendTeam({
+      industry: 'small SaaS engineering team building developer tools',
+      scale: 'small-team',
+      tasks: [
+        baseTask('code review'),
+        baseTask('product metrics'),
+      ],
+    });
+    expect(rec.templateId).toBe('web-dev-team');
+    expect(rec.agents.length).toBe(2);
+    expect(rec.source).toBe('hardcoded:engineering');
+    expectShape(rec);
+  });
+
+  it('support / ops focus → customer-ops-team (2 agents)', () => {
+    const rec = recommendTeam(
+      baseCtx('B2B SaaS focused on customer service operations', [
+        'helpdesk tickets',
+        'feedback summary',
+      ]),
+    );
+    // 'b2b' matches engineering, 'helpdesk' + 'feedback' + 'service' + 'tickets' match support-ops
+    // support-ops should win on score.
+    expect(rec.templateId).toBe('customer-ops-team');
+    expect(rec.source).toBe('hardcoded:support-ops');
+    expectShape(rec);
+  });
+
+  it('growth / marketing focus → growth-marketing-team (3 agents)', () => {
+    const rec = recommendTeam(
+      baseCtx('growth marketing agency running paid ads + SEO', [
+        'lead gen pipeline',
+        'content distribution',
+      ]),
+    );
+    expect(rec.templateId).toBe('growth-marketing-team');
+    expect(rec.agents.length).toBe(3);
+    expect(rec.source).toBe('hardcoded:growth-marketing');
+    expectShape(rec);
+  });
+});
+
+describe('recommendTeam — fallback', () => {
+  it('falls back to startup-team for unrecognised input', () => {
+    const rec = recommendTeam({
+      industry: 'professional underwater basket weaving',
+      scale: 'solo',
+      tasks: [baseTask('something obscure')],
+    });
+    expect(rec.templateId).toBe('startup-team');
+    expect(rec.source).toBe('fallback');
+    expect(rec.agents.length).toBe(2);
+    expectShape(rec);
+  });
+
+  it('falls back when industry + tasks are empty', () => {
+    const rec = recommendTeam({
+      industry: '',
+      scale: 'solo',
+      tasks: [],
+    });
+    expect(rec.templateId).toBe('startup-team');
+    expect(rec.source).toBe('fallback');
+    expectShape(rec);
+  });
+
+  it('falls back gracefully when tasks have whitespace-only names', () => {
+    const rec = recommendTeam({
+      industry: '',
+      scale: 'company',
+      tasks: [{ name: '   ', tier: 'yes-today' }],
+    });
+    expect(rec.source).toBe('fallback');
+    expectShape(rec);
+  });
+});
+
+describe('recommendTeam — properties', () => {
+  it('is pure: same input twice → deeply equal output', () => {
+    const ctx = baseCtx('Shopify e-commerce skincare', [
+      'content', 'support',
+    ]);
+    expect(recommendTeam(ctx)).toEqual(recommendTeam(ctx));
+  });
+
+  it('every recommendation declares a real-looking template id (kebab-case, ≥2 segments)', () => {
+    // Walk all 5 hardcoded scenarios + the fallback.
+    const samples: BusinessContext[] = [
+      baseCtx('shopify', ['support', 'content']),
+      baseCtx('youtube creator', ['video']),
+      baseCtx('saas startup', ['code review']),
+      baseCtx('helpdesk operations', ['tickets']),
+      baseCtx('growth marketing agency', ['ads']),
+      baseCtx('???', ['???']),
+    ];
+    for (const s of samples) {
+      const rec = recommendTeam(s);
+      expect(rec.templateId).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(rec.templateId.split('-').length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('every recommendation has a non-empty reasoning string', () => {
+    const samples: BusinessContext[] = [
+      baseCtx('shopify', ['support']),
+      baseCtx('???', ['???']),
+    ];
+    for (const s of samples) {
+      const rec = recommendTeam(s);
+      expect(rec.reasoning.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('agents always have at least one skillId', () => {
+    const rec = recommendTeam(baseCtx('shopify', ['support', 'content']));
+    for (const a of rec.agents) {
+      expect(a.skillIds.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/backend/src/services/orchestrator/onboarding/recommend-team.ts
+++ b/backend/src/services/orchestrator/onboarding/recommend-team.ts
@@ -1,0 +1,451 @@
+/**
+ * Recommend-Team Logic (Onboarding v3, v0)
+ *
+ * Pure function: turns a business-context payload (collected during the
+ * onboarding conversation) into a concrete team recommendation
+ * (template + agents + responsibilities).
+ *
+ * v0 strategy: 5 hardcoded heuristic mappings that cover the ~80% case
+ * Steve and Sam expect to see during the Mon 5/4 EOD demo, plus a
+ * generic 2-agent fallback for everything else. Real RAG over Mia's
+ * spec v3 + doc 69 + the live template registry lands Wed–Fri.
+ *
+ * Importantly, the function is **pure** (no FS, no API, no clock) —
+ * tests exercise the mapping logic directly without mocks.
+ *
+ * @module services/orchestrator/onboarding/recommend-team
+ */
+
+// =============================================================================
+// Types — kept inline so this module has no cross-package dependencies.
+// =============================================================================
+
+/**
+ * Feasibility tier for a single user-named task. Mirrors the four tiers
+ * the system prompt requires orc to use literally.
+ */
+export type FeasibilityTier =
+  | 'yes-today'       // ✅ Crewly does this autonomously today.
+  | 'collaborative'   // 🤝 Crewly does this with user input/approval.
+  | 'roadmap'         // ⏳ Planned, not shipped.
+  | 'out-of-scope';   // ❌ Won't do.
+
+/**
+ * Scale buckets — the conversation captures one of these in phase 2.
+ */
+export type BusinessScale = 'solo' | 'small-team' | 'company';
+
+/**
+ * One task the user named, with the feasibility verdict orc reached
+ * during phase 3.
+ */
+export interface NamedTask {
+  /** Free-text task name as the user said it. */
+  readonly name: string;
+  /** Feasibility verdict orc decided on. */
+  readonly tier: FeasibilityTier;
+}
+
+/**
+ * Business context collected by phases 1–3 of the onboarding flow.
+ * Passed to {@link recommendTeam} to produce the proposal.
+ */
+export interface BusinessContext {
+  /** Free-text industry / domain (e.g. "e-commerce skincare on Shopify"). */
+  readonly industry: string;
+  /** Coarse team-size bucket. */
+  readonly scale: BusinessScale;
+  /** Tasks the user named, with orc's feasibility verdict per task. */
+  readonly tasks: readonly NamedTask[];
+}
+
+/**
+ * One agent the recommendation proposes.
+ */
+export interface RecommendedAgent {
+  /** Logical role (e.g. "content-drafter", "support-triage"). */
+  readonly role: string;
+  /** One-sentence responsibility blurb shown to the user during phase 4. */
+  readonly responsibilities: string;
+  /** Skills the agent will be given. */
+  readonly skillIds: readonly string[];
+}
+
+/**
+ * The recommendation returned to orc and shown to the user before
+ * confirmation.
+ */
+export interface TeamRecommendation {
+  /** Template ID from `config/templates/*.json`. */
+  readonly templateId: string;
+  /** 2–4 agents, each with role + responsibilities + skills. */
+  readonly agents: readonly RecommendedAgent[];
+  /** Short rationale string ("why this team for you"). */
+  readonly reasoning: string;
+  /** Which mapping fired (`"hardcoded:<key>"` or `"fallback"`). */
+  readonly source: string;
+}
+
+// =============================================================================
+// Hardcoded mappings — v0 (Mon 5/4 EOD)
+// =============================================================================
+
+/**
+ * Match strategy for one hardcoded mapping. We score each mapping
+ * against the input by counting keyword hits in the industry string +
+ * task names; the highest score wins. Ties break by mapping order
+ * (first declared wins) — keep the most specific mappings at the top.
+ */
+interface HardcodedMapping {
+  /** Stable identifier — also used in `recommendation.source`. */
+  readonly key: string;
+  /** Lowercase keywords that, when matched, increase the score. */
+  readonly keywords: readonly string[];
+  /** Built recommendation when this mapping wins. */
+  readonly build: (ctx: BusinessContext) => TeamRecommendation;
+}
+
+/**
+ * Build a recommendation given a key + template + agents + rationale.
+ * Internal helper to avoid repeating the source/reasoning shape.
+ */
+function build(
+  key: string,
+  templateId: string,
+  agents: readonly RecommendedAgent[],
+  reasoning: string,
+): TeamRecommendation {
+  return {
+    templateId,
+    agents,
+    reasoning,
+    source: `hardcoded:${key}`,
+  };
+}
+
+/**
+ * The 5 hardcoded mappings — ordered most-specific first.
+ *
+ * Each mapping is keyed off a small lowercase keyword set; the
+ * highest-scoring mapping wins. If no mapping scores ≥1, the generic
+ * fallback fires.
+ */
+const HARDCODED_MAPPINGS: readonly HardcodedMapping[] = [
+  // --- 1. E-commerce + content + customer support (Steve's anchor demo)
+  {
+    key: 'ecommerce-content-support',
+    keywords: [
+      'shopify',
+      'e-commerce',
+      'ecommerce',
+      'dtc',
+      'skincare',
+      'apparel',
+      'retail',
+      'storefront',
+      'support',
+      'content',
+    ],
+    build: (ctx) =>
+      build(
+        'ecommerce-content-support',
+        'dtc-viral-content-team',
+        [
+          {
+            role: 'content-drafter',
+            responsibilities:
+              'Drafts weekly blog + social content tuned to your storefront and audience.',
+            skillIds: ['content-drafter', 'content-calendar'],
+          },
+          {
+            role: 'support-triage',
+            responsibilities:
+              'Triages incoming customer messages and prepares first-draft replies for your approval.',
+            skillIds: ['support-triage'],
+          },
+        ],
+        `You named e-commerce + content + support. The content drafter handles your weekly publishing cadence; the support triage agent keeps inbound from piling up while leaving the send button to you. ${ctx.scale === 'solo' ? 'Sized 2-agent because solo founders should not babysit a big team.' : ''}`.trim(),
+      ),
+  },
+  // --- 2. Solo content creator / social-first
+  {
+    key: 'solo-creator',
+    keywords: [
+      'creator',
+      'youtube',
+      'tiktok',
+      'instagram',
+      'newsletter',
+      'blog',
+      'podcast',
+      'video',
+      'social',
+    ],
+    build: () =>
+      build(
+        'solo-creator',
+        'ai-video-social-team',
+        [
+          {
+            role: 'content-drafter',
+            responsibilities:
+              'Plans + drafts your content schedule across platforms.',
+            skillIds: ['content-drafter', 'content-calendar', 'content-repurposer'],
+          },
+          {
+            role: 'trend-monitor',
+            responsibilities:
+              'Watches the trends and topic signals in your niche so your drafts ride the wave.',
+            skillIds: ['trend-monitor'],
+          },
+        ],
+        'Your work centres on content production. Drafting + trend monitoring is the smallest team that meaningfully removes the daily-content treadmill.',
+      ),
+  },
+  // --- 3. Engineering / SaaS dev team
+  {
+    key: 'engineering',
+    keywords: [
+      'saas',
+      'software',
+      'engineering',
+      'dev',
+      'developer',
+      'startup',
+      'product',
+      'b2b',
+      'platform',
+      'mvp',
+    ],
+    build: (ctx) =>
+      build(
+        'engineering',
+        ctx.scale === 'solo' ? 'pragmatic-mvp-dev-team' : 'web-dev-team',
+        [
+          {
+            role: 'code-reviewer',
+            responsibilities:
+              'Reviews pull requests for style, obvious bugs, and missing tests.',
+            skillIds: ['code-reviewer'],
+          },
+          {
+            role: 'data-analyst',
+            responsibilities:
+              'Pulls product metrics into a daily report so you do not lose signal in the build cycle.',
+            skillIds: ['data-summarizer', 'scheduled-reporter'],
+          },
+        ],
+        `For a ${ctx.scale === 'solo' ? 'solo MVP push' : 'small engineering team'}, the highest-leverage agents are code review + a data summariser that surfaces the metrics you forget to check.`,
+      ),
+  },
+  // --- 4. Customer support / ops focus
+  {
+    key: 'support-ops',
+    keywords: [
+      'support',
+      'helpdesk',
+      'tickets',
+      'customer service',
+      'cs',
+      'ops',
+      'operations',
+      'feedback',
+    ],
+    build: () =>
+      build(
+        'support-ops',
+        'customer-ops-team',
+        [
+          {
+            role: 'support-triage',
+            responsibilities:
+              'Triages inbound and drafts replies; you stay in the loop on send.',
+            skillIds: ['support-triage'],
+          },
+          {
+            role: 'data-analyst',
+            responsibilities:
+              'Summarises ticket trends so the same issue does not surprise you twice.',
+            skillIds: ['feedback-analyzer', 'data-summarizer'],
+          },
+        ],
+        'Your time-sinks are on the support side. A triage agent removes the inbox sprint; a feedback analyst catches the patterns under the noise.',
+      ),
+  },
+  // --- 5. Growth / marketing-heavy
+  {
+    key: 'growth-marketing',
+    keywords: [
+      'marketing',
+      'growth',
+      'seo',
+      'ads',
+      'paid',
+      'distribution',
+      'pipeline',
+      'lead gen',
+      'leadgen',
+      'agency',
+    ],
+    build: () =>
+      build(
+        'growth-marketing',
+        'growth-marketing-team',
+        [
+          {
+            role: 'content-drafter',
+            responsibilities:
+              'Drafts the content side of your growth pipeline (blog / social / newsletter).',
+            skillIds: ['content-drafter', 'content-calendar'],
+          },
+          {
+            role: 'data-analyst',
+            responsibilities:
+              'Tracks growth metrics across channels and flags drops before they compound.',
+            skillIds: ['data-summarizer', 'scheduled-reporter'],
+          },
+          {
+            role: 'trend-monitor',
+            responsibilities:
+              'Surfaces topic + competitor signals so your distribution stays current.',
+            skillIds: ['trend-monitor', 'competitor-content-tracker'],
+          },
+        ],
+        'You named growth / distribution as the core. Three agents — drafting + analytics + trend-watching — cover the production / measurement / sensing loop.',
+      ),
+  },
+];
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Map a {@link BusinessContext} to a {@link TeamRecommendation}.
+ *
+ * Strategy (v0):
+ *   1. Score every hardcoded mapping by counting keyword hits across
+ *      `industry` + each task name.
+ *   2. Highest-scoring mapping wins (ties broken by declaration order).
+ *   3. If no mapping scores ≥1, fire the generic 2-agent fallback.
+ *
+ * The function never throws — invalid input degrades to the fallback so
+ * the conversation can keep moving even if discovery captured nothing
+ * useful.
+ *
+ * @param ctx - Business context collected during phases 1–3.
+ * @returns A team recommendation ready for phase 4.
+ *
+ * @example
+ * ```ts
+ * recommendTeam({
+ *   industry: 'small Shopify skincare shop',
+ *   scale: 'solo',
+ *   tasks: [
+ *     { name: 'weekly blog content', tier: 'yes-today' },
+ *     { name: 'customer support replies', tier: 'yes-today' },
+ *   ],
+ * });
+ * // → templateId: 'dtc-viral-content-team', 2 agents, …
+ * ```
+ */
+export function recommendTeam(ctx: BusinessContext): TeamRecommendation {
+  const haystack = buildHaystack(ctx);
+
+  let bestScore = 0;
+  let best: HardcodedMapping | null = null;
+
+  for (const mapping of HARDCODED_MAPPINGS) {
+    const score = scoreMapping(mapping, haystack);
+    if (score > bestScore) {
+      bestScore = score;
+      best = mapping;
+    }
+  }
+
+  if (best && bestScore > 0) {
+    return best.build(ctx);
+  }
+
+  return genericFallback(ctx);
+}
+
+/**
+ * Generic 2-agent fallback when no hardcoded mapping fires. Picks
+ * `startup-team` (the most general template) and a content + analyst
+ * pair, which has been the highest-utility default in our discovery
+ * data.
+ *
+ * @param ctx - Original business context (used only for rationale).
+ * @returns A safe, neutral recommendation.
+ */
+function genericFallback(ctx: BusinessContext): TeamRecommendation {
+  const tasksLine = ctx.tasks.length
+    ? `you mentioned ${ctx.tasks.map((t) => t.name).join(' / ')}`
+    : 'we did not nail the time-sinks down yet';
+  return {
+    templateId: 'startup-team',
+    agents: [
+      {
+        role: 'content-drafter',
+        responsibilities:
+          'Drafts written content (blog / social / internal updates) on a schedule.',
+        skillIds: ['content-drafter'],
+      },
+      {
+        role: 'data-analyst',
+        responsibilities:
+          'Summarises whatever data feed you connect (sheets / API / CSV) into a daily report.',
+        skillIds: ['data-summarizer', 'scheduled-reporter'],
+      },
+    ],
+    reasoning: `I did not match a precise mapping for your shape — ${tasksLine} — so I am proposing a safe 2-agent default. We can adjust before I create anything.`,
+    source: 'fallback',
+  };
+}
+
+// =============================================================================
+// Internals
+// =============================================================================
+
+/**
+ * Build a single lowercase haystack string from the context's industry
+ * + task names. Keyword matches are checked against this string.
+ */
+function buildHaystack(ctx: BusinessContext): string {
+  const parts: string[] = [];
+  parts.push(ctx.industry ?? '');
+  for (const t of ctx.tasks) {
+    parts.push(t.name);
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+/**
+ * Count how many of a mapping's keywords appear in the haystack.
+ */
+function scoreMapping(mapping: HardcodedMapping, haystack: string): number {
+  let score = 0;
+  for (const kw of mapping.keywords) {
+    if (haystack.includes(kw)) score += 1;
+  }
+  return score;
+}
+
+// =============================================================================
+// Exports for tests / wiring
+// =============================================================================
+
+/**
+ * Exposed for test introspection — the count is asserted against the
+ * spec ("5 hardcoded mappings cover 80% of users").
+ */
+export const HARDCODED_MAPPING_COUNT = HARDCODED_MAPPINGS.length;
+
+/**
+ * Exposed for test introspection — list of mapping keys, useful for
+ * asserting coverage without opening the array.
+ */
+export const HARDCODED_MAPPING_KEYS: readonly string[] = HARDCODED_MAPPINGS.map(
+  (m) => m.key,
+);

--- a/backend/src/services/orchestrator/prompts/onboarding-mode.prompt.test.ts
+++ b/backend/src/services/orchestrator/prompts/onboarding-mode.prompt.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the onboarding-mode system prompt v0.
+ *
+ * The prompt is a string constant that drives a 5-phase onboarding
+ * conversation. These tests guard against accidental edits that strip
+ * structural markers, the few-shot anchor, or the capability-grounding
+ * language — all of which Steve and Sam called out as the differentiator.
+ *
+ * @module services/orchestrator/prompts/onboarding-mode.prompt.test
+ */
+
+import {
+  ONBOARDING_MODE_SYSTEM_PROMPT,
+  ONBOARDING_PHASE_MARKERS,
+  ONBOARDING_CAPABILITY_MARKERS,
+  ONBOARDING_FEW_SHOT_ANCHOR_MARKER,
+  findMissingPromptMarkers,
+} from './onboarding-mode.prompt.js';
+
+describe('ONBOARDING_MODE_SYSTEM_PROMPT', () => {
+  it('exports a non-empty string', () => {
+    expect(typeof ONBOARDING_MODE_SYSTEM_PROMPT).toBe('string');
+    expect(ONBOARDING_MODE_SYSTEM_PROMPT.length).toBeGreaterThan(1000);
+  });
+
+  it('contains every one of the 5 phase markers', () => {
+    for (const marker of ONBOARDING_PHASE_MARKERS) {
+      expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain(marker);
+    }
+  });
+
+  it('contains all capability-grounding language markers (case-insensitive)', () => {
+    const lower = ONBOARDING_MODE_SYSTEM_PROMPT.toLowerCase();
+    for (const marker of ONBOARDING_CAPABILITY_MARKERS) {
+      expect(lower).toContain(marker.toLowerCase());
+    }
+  });
+
+  it('embeds the four feasibility tier glyphs (✅ 🤝 ⏳ ❌)', () => {
+    for (const glyph of ['✅', '🤝', '⏳', '❌']) {
+      expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain(glyph);
+    }
+  });
+
+  it('embeds the few-shot anchor transcript header', () => {
+    expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain(ONBOARDING_FEW_SHOT_ANCHOR_MARKER);
+  });
+
+  it('few-shot anchor names at least two concrete capability skills', () => {
+    // The differentiator is naming the underlying skill, not vague claims.
+    expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain('content-drafter');
+    expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain('support-triage');
+  });
+
+  it('lists every allowed skill in onboarding mode', () => {
+    const allowed = [
+      'recall',
+      'remember',
+      'record-learning',
+      'recommend-team',
+      'materialize-team',
+      'report-status',
+    ];
+    for (const skill of allowed) {
+      expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain(skill);
+    }
+  });
+
+  it('explicitly forbids spawn-worker skills', () => {
+    for (const forbidden of ['delegate-task', 'start-agent', 'stop-agent']) {
+      expect(ONBOARDING_MODE_SYSTEM_PROMPT).toContain(forbidden);
+    }
+  });
+
+  it('opens with a ~5 minute time budget statement', () => {
+    expect(ONBOARDING_MODE_SYSTEM_PROMPT).toMatch(/5\s*minutes|~5\s*min|≈5\s*min/i);
+  });
+});
+
+describe('findMissingPromptMarkers()', () => {
+  it('returns empty array for the canonical prompt', () => {
+    expect(findMissingPromptMarkers(ONBOARDING_MODE_SYSTEM_PROMPT)).toEqual([]);
+  });
+
+  it('returns every marker for an empty prompt', () => {
+    const missing = findMissingPromptMarkers('');
+    // 5 phase + 3 capability + 1 anchor = 9
+    const expected =
+      ONBOARDING_PHASE_MARKERS.length + ONBOARDING_CAPABILITY_MARKERS.length + 1;
+    expect(missing.length).toBe(expected);
+  });
+
+  it('reports just the dropped marker when one is removed', () => {
+    const stripped = ONBOARDING_MODE_SYSTEM_PROMPT.replace(
+      'PHASE 3 — FEASIBILITY JUDGMENT',
+      '',
+    );
+    expect(findMissingPromptMarkers(stripped)).toEqual([
+      'PHASE 3 — FEASIBILITY JUDGMENT',
+    ]);
+  });
+});

--- a/backend/src/services/orchestrator/prompts/onboarding-mode.prompt.ts
+++ b/backend/src/services/orchestrator/prompts/onboarding-mode.prompt.ts
@@ -1,0 +1,292 @@
+/**
+ * Onboarding-Mode System Prompt v0
+ *
+ * Loaded by the orchestrator when it enters `onboarding` mode on a fresh
+ * Crewly OSS install (no chat history detected). Drives a 5-phase
+ * conversation that ends with a materialized AI team, all without Steve
+ * (or any operator) on the call.
+ *
+ * Goal-anchor (Steve's own words, 2026-05-03):
+ *   "新的 crewly oss 启动后 如果还没有说过话 就会自动启动这个 onboarding，
+ *    然后 orc 就会开始进入 onboarding 模式与用户说话"
+ *   = Fresh OSS install → no chat history → auto-launch onboarding →
+ *     orc itself enters "onboarding mode" and converses with the user.
+ *
+ * G/O/E:
+ *   - Goal:       Customer onboards fully self-service.
+ *   - Outcome:    Fresh OSS install → ≤5 min orc-conversation → user has
+ *                 a configured, working AI team.
+ *   - Evaluation: Steve or SteamFun runs through it as a real customer,
+ *                 no Steve intervention, AI team works.
+ *
+ * The prompt is intentionally exhaustive: orc must produce *concrete*,
+ * *capability-grounded* replies rather than vague AI-marketing speak.
+ * That specificity is the differentiator and is enforced by the
+ * "feasibility judgment" phase in the body of the prompt.
+ *
+ * v0 capability list is hardcoded inside the prompt so Mon-EOD demos work
+ * without RAG. When Mia's spec v3 + doc 69 land (Wed–Fri), the hardcoded
+ * list will be swapped for runtime-injected RAG snippets — the export
+ * surface (a single string constant) does not change.
+ *
+ * @module services/orchestrator/prompts/onboarding-mode.prompt
+ */
+
+/**
+ * Phase markers — also used by the prompt test to assert structural
+ * integrity. Keep in sync with the body of the prompt below.
+ */
+export const ONBOARDING_PHASE_MARKERS = [
+  'PHASE 1 — OPEN',
+  'PHASE 2 — BUSINESS DISCOVERY',
+  'PHASE 3 — FEASIBILITY JUDGMENT',
+  'PHASE 4 — TEAM RECOMMENDATION',
+  'PHASE 5 — CONFIRM + MATERIALIZE',
+] as const;
+
+/**
+ * Capability-grounding language markers. The prompt test asserts these
+ * appear so future edits cannot silently strip the differentiator.
+ */
+export const ONBOARDING_CAPABILITY_MARKERS = [
+  'capability-grounded',
+  'no vague claims',
+  'cite the underlying skill',
+] as const;
+
+/**
+ * Few-shot anchor transcript — embedded in the prompt body. The prompt
+ * test asserts this anchor stays present (regression guard).
+ */
+export const ONBOARDING_FEW_SHOT_ANCHOR_MARKER = 'FEW-SHOT ANCHOR — TONE + SPECIFICITY BAR';
+
+/**
+ * The system prompt orc loads when its mode is `'onboarding'`.
+ *
+ * Imported by:
+ *   - The orchestrator runtime / state machine (Leo) when it detects a
+ *     cold-start and swaps to `onboarding` mode.
+ *   - The prompt test (this directory) for structural assertions.
+ */
+export const ONBOARDING_MODE_SYSTEM_PROMPT: string = `
+# Crewly Onboarding Mode — Orchestrator System Prompt (v0)
+
+You are Crewly's orchestrator running in **onboarding mode**.
+
+A user has just installed Crewly OSS for the first time. There is no chat
+history. Your single job during this conversation is to take them from
+"fresh install" to "working AI team" in ≤5 minutes, fully self-service,
+with no human operator on the call.
+
+You will drive the conversation through five phases. Stay warm and
+conversational; do **not** sound like a sales pitch or a marketing
+brochure. Be concrete. Be capability-grounded. **No vague claims.**
+
+---
+
+## PHASE 1 — OPEN
+
+Greet the user warmly in one or two short sentences.
+
+State plainly that this is a one-time setup, time budget ≈5 minutes, that
+the result will be a small AI team configured to fit their work.
+
+Ask the **first business-discovery question**. Keep it open: "what does
+your business or work focus on?" or equivalent. Do not list options yet —
+let the user describe themselves.
+
+---
+
+## PHASE 2 — BUSINESS DISCOVERY
+
+Collect three things, **one question at a time**, conversational not
+interrogative:
+
+1. **Industry / domain** (e-commerce, SaaS, content creator, agency,
+   internal team, etc.).
+2. **Scale** (solo / 2–5 people / 5+ / company).
+3. **Two-to-three biggest time-sinks** where AI could plausibly help —
+   ask the user to name them in their own words (content, customer
+   support, analytics, scheduling, etc.).
+
+If the user volunteers more than one in one turn, accept it and move on —
+do not re-ask. If the user is vague ("I do marketing"), ask one
+clarifying question before continuing.
+
+---
+
+## PHASE 3 — FEASIBILITY JUDGMENT
+
+This phase is the differentiator. **For every task the user names**, you
+must place it on one of four feasibility tiers and say so explicitly.
+You must cite the underlying skill or capability when claiming "yes".
+**No vague claims — no "Crewly can definitely help with that".**
+
+Tier vocabulary you must use literally in replies:
+
+| Tier               | Meaning                                                        | Phrasing                                |
+| ------------------ | -------------------------------------------------------------- | --------------------------------------- |
+| ✅ Yes, today       | Crewly does X autonomously today                               | "Yes, Crewly does X today (Skill: …)"   |
+| 🤝 Collaborative    | Crewly does X with the user supplying inputs / approval         | "Crewly does X with collaboration"      |
+| ⏳ Roadmap          | Planned, not shipped                                            | "Roadmap (≈Q3); not today."             |
+| ❌ Out of scope     | Crewly does not do this and won't soon                          | "Out of scope; Crewly won't do this."   |
+
+For v0, use this hardcoded capability list as your ground truth (when
+runtime RAG is wired this list will be replaced):
+
+- ✅ **Weekly / scheduled content drafts** (blog, social, newsletter).
+  Skill: \`content-drafter\`.
+- ✅ **Customer support triage + first-draft replies**, with user
+  approval before send. Skill: \`support-triage\`.
+- ✅ **Slack-thread monitoring + daily summary**. Skill:
+  \`slack-thread-monitor\`.
+- ✅ **Code review on pull requests** (style, obvious bugs, missing
+  tests). Skill: \`code-reviewer\`.
+- ✅ **Data summarization from CSV / sheets / API** into a daily report.
+  Skill: \`data-summarizer\`.
+- ✅ **Scheduled reports** at fixed cadences. Skill:
+  \`scheduled-reporter\`.
+- 🤝 **Daily TikTok / short-form video editing** — collaborative only;
+  user supplies clips, agent assembles.
+- ⏳ **Inventory forecasting** — Q3 roadmap; not today.
+- ⏳ **Voice / phone-call agents** — Q3 roadmap; not today.
+- ❌ **Autonomous purchases / financial transactions** — out of scope.
+- ❌ **Account creation on third-party sites that require human KYC** —
+  out of scope.
+
+If the user names a task that is not on the list above and you are not
+sure, say so plainly: "I'm not certain Crewly does that today — let me
+flag it as roadmap, you can confirm later." Do not invent capabilities.
+
+---
+
+## PHASE 4 — TEAM RECOMMENDATION
+
+Based on the feasible tasks (✅ and 🤝 only — never recommend agents for
+roadmap or out-of-scope items), recommend **one team** with **2–4
+agents**.
+
+Pick from the available templates:
+
+- \`ai-video-social-team\` — content creator / social-first
+- \`customer-ops-team\` — support + ops + feedback analyst
+- \`growth-marketing-team\` — content + distribution + analytics
+- \`dtc-viral-content-team\` — DTC e-commerce content
+- \`customer-loyalty-team\` — retention, lifecycle, CS
+- \`web-dev-team\` — engineering / shipping product
+- \`startup-team\` — early-stage generalist team
+- \`pragmatic-mvp-dev-team\` — fast-shipping engineer team
+- \`expert-innovation-team\` — research / R&D
+- \`research-team\` — analyst-first
+
+When you recommend, **explain why each agent role exists** in one
+sentence per agent. Then ask the user to confirm before you create
+anything: "Want me to spin this up? (yes / no / adjust)".
+
+If the user wants to adjust (swap an agent, drop one, add one), do so
+within the bounds of the available templates and skills. Do not invent
+agents.
+
+---
+
+## PHASE 5 — CONFIRM + MATERIALIZE
+
+On user confirmation:
+
+1. Invoke the \`materialize-team\` skill with the agreed
+   \`templateId\` + agent role list.
+2. Wait for the skill to return success.
+3. Tell the user the team is live, name the agents, and tell them the
+   one next step ("you can now message any of them in Slack /
+   web UI / etc.").
+4. Exit onboarding mode by reporting \`onboardingComplete = true\` via
+   the \`materialize-team\` skill (the skill flips the flag).
+
+If the skill returns an error, surface a brief, honest message ("I
+couldn't create the team — error: <message>. Want me to retry, or
+adjust?") and do **not** silently exit onboarding mode.
+
+---
+
+## SKILL ACCESS
+
+In onboarding mode you may invoke **only these skills**:
+
+- \`recall\`, \`remember\`, \`record-learning\` — memory
+- \`recommend-team\` — turn discovery answers into a concrete proposal
+- \`materialize-team\` — create the team and flip \`onboardingComplete\`
+- \`report-status\` — surface to your TL on blocker
+
+You may **not** invoke: \`delegate-task\`, \`start-agent\`,
+\`stop-agent\`, or anything that spawns workers. The runtime enforces
+this; respect it.
+
+---
+
+## TONE BAR
+
+- Friendly, confident, never salesy.
+- Short sentences. One question per turn until you reach phase 4.
+- Concrete examples over abstractions.
+- If a user's request is out of scope or roadmap, say so directly —
+  honesty here is the brand.
+
+---
+
+## FEW-SHOT ANCHOR — TONE + SPECIFICITY BAR
+
+Use this as your model of voice and specificity. Match this density and
+this honesty about feasibility tiers.
+
+\`\`\`
+USER: Hi
+ORC: Hi! I'm Crewly. Before we start, let me set up an AI team that fits
+     your work — should take ~5 minutes. What does your business or work
+     focus on?
+
+USER: I run a small e-commerce shop selling skincare on Shopify.
+ORC: Got it. A few quick questions so I can suggest the right team:
+     1. How many people are on the team today (solo, 2–5, 5+)?
+     2. What's eating the most of your time right now — content /
+        customer support / inventory / analytics?
+
+USER: Solo. Mostly content + customer support.
+ORC: That's helpful. Crewly handles both, but let me be specific about
+     what we do well today versus what we don't yet:
+     - ✅ **Weekly content drafts** (blog/social) — yes, autonomous
+       (Skill: content-drafter).
+     - ✅ **Customer support triage + first-draft replies** — yes, with
+       your approval before send (Skill: support-triage).
+     - 🤝 **Daily TikTok video editing** — collaborative only (you
+       supply clips, agent assembles); no autonomous video gen yet.
+     - ⏳ **Inventory forecasting** — Q3 roadmap, not today.
+
+     Want me to spin up a 2-agent team (content + support) you can try
+     right now?
+\`\`\`
+
+That is the bar. If your reply would not pass that bar, rewrite it
+before sending.
+`.trim();
+
+/**
+ * Convenience: validate a candidate prompt body contains every required
+ * structural marker. The prompt test uses this; downstream callers may
+ * use it as a runtime guard if they ever swap the prompt at runtime.
+ *
+ * @param prompt - The prompt string to inspect.
+ * @returns Array of marker strings that are MISSING. Empty array → ok.
+ */
+export function findMissingPromptMarkers(prompt: string): string[] {
+  const missing: string[] = [];
+  for (const marker of ONBOARDING_PHASE_MARKERS) {
+    if (!prompt.includes(marker)) missing.push(marker);
+  }
+  for (const marker of ONBOARDING_CAPABILITY_MARKERS) {
+    if (!prompt.toLowerCase().includes(marker.toLowerCase())) missing.push(marker);
+  }
+  if (!prompt.includes(ONBOARDING_FEW_SHOT_ANCHOR_MARKER)) {
+    missing.push(ONBOARDING_FEW_SHOT_ANCHOR_MARKER);
+  }
+  return missing;
+}

--- a/backend/src/services/orchestrator/state-persistence.service.test.ts
+++ b/backend/src/services/orchestrator/state-persistence.service.test.ts
@@ -147,6 +147,128 @@ describe('StatePersistenceService', () => {
     });
   });
 
+  describe('orchestrator mode round-trip (Onboarding v3 — B2)', () => {
+    it('should default to "normal" on a fresh state', async () => {
+      await service.initialize();
+      expect(service.getMode()).toBe('normal');
+      const state = service.getState();
+      expect(state?.mode).toBe('normal');
+    });
+
+    it('should round-trip the "onboarding" mode through atomicWriteJson', async () => {
+      await service.initialize();
+      service.setMode('onboarding');
+      await service.saveState('user_request');
+
+      // Re-read via a fresh service to prove it survives the disk hop.
+      const service2 = new StatePersistenceService(testDir);
+      additionalServices.push(service2);
+      const loadedState = await service2.initialize();
+
+      expect(loadedState).not.toBeNull();
+      expect(loadedState?.mode).toBe('onboarding');
+      expect(service2.getMode()).toBe('onboarding');
+    });
+
+    it('should round-trip the "onboarding-provisioning" future-reserved value', async () => {
+      await service.initialize();
+      service.setMode('onboarding-provisioning');
+      await service.saveState('scheduled');
+
+      const service2 = new StatePersistenceService(testDir);
+      additionalServices.push(service2);
+      const loadedState = await service2.initialize();
+
+      expect(loadedState?.mode).toBe('onboarding-provisioning');
+    });
+
+    it('should backfill mode to "normal" when loading legacy state files', async () => {
+      // Simulate a state file written by a Crewly version that predates
+      // the `mode` field. The loader must not crash; it must default.
+      const stateDir = path.join(testDir, STATE_PATHS.STATE_DIR);
+      await fs.mkdir(stateDir, { recursive: true });
+      const legacyState: Omit<OrchestratorState, 'mode'> = {
+        id: 'legacy-state',
+        version: STATE_VERSION,
+        checkpointedAt: new Date().toISOString(),
+        checkpointReason: 'scheduled',
+        conversations: [],
+        tasks: [],
+        agents: [],
+        projects: [],
+        metadata: {
+          version: STATE_VERSION,
+          hostname: 'legacy-host',
+          pid: 1,
+          startedAt: new Date().toISOString(),
+          uptimeSeconds: 0,
+          restartCount: 0,
+        },
+      };
+      await fs.writeFile(
+        path.join(stateDir, STATE_PATHS.CURRENT_STATE),
+        JSON.stringify(legacyState),
+        'utf-8',
+      );
+
+      const service2 = new StatePersistenceService(testDir);
+      additionalServices.push(service2);
+      const loadedState = await service2.initialize();
+
+      expect(loadedState).not.toBeNull();
+      expect(loadedState?.mode).toBe('normal');
+    });
+
+    it('should sanitize unknown mode values to the default', async () => {
+      // Defends against a future Crewly writing a value this build doesn't
+      // recognize, or a hand-edited / corrupted state file.
+      const stateDir = path.join(testDir, STATE_PATHS.STATE_DIR);
+      await fs.mkdir(stateDir, { recursive: true });
+      const corruptState = {
+        id: 'corrupt-state',
+        version: STATE_VERSION,
+        checkpointedAt: new Date().toISOString(),
+        checkpointReason: 'scheduled',
+        mode: 'totally-bogus-mode',
+        conversations: [],
+        tasks: [],
+        agents: [],
+        projects: [],
+        metadata: {
+          version: STATE_VERSION,
+          hostname: 'corrupt-host',
+          pid: 1,
+          startedAt: new Date().toISOString(),
+          uptimeSeconds: 0,
+          restartCount: 0,
+        },
+      };
+      await fs.writeFile(
+        path.join(stateDir, STATE_PATHS.CURRENT_STATE),
+        JSON.stringify(corruptState),
+        'utf-8',
+      );
+
+      const service2 = new StatePersistenceService(testDir);
+      additionalServices.push(service2);
+      const loadedState = await service2.initialize();
+
+      expect(loadedState?.mode).toBe('normal');
+    });
+
+    it('setMode should be idempotent', async () => {
+      await service.initialize();
+      service.setMode('onboarding');
+      service.setMode('onboarding'); // second call — no change expected
+      expect(service.getMode()).toBe('onboarding');
+    });
+
+    it('getMode should return default before initialization', () => {
+      // Pre-init: no currentState yet — must not throw, must return default.
+      expect(service.getMode()).toBe('normal');
+    });
+  });
+
   describe('getState', () => {
     it('should return null before initialization', () => {
       expect(service.getState()).toBeNull();

--- a/backend/src/services/orchestrator/state-persistence.service.ts
+++ b/backend/src/services/orchestrator/state-persistence.service.ts
@@ -21,11 +21,14 @@ import {
   SelfImprovementState,
   OrchestratorMetadata,
   CheckpointReason,
+  OrchestratorMode,
   ResumeInstructions,
   STATE_PATHS,
   STATE_VERSION,
   MAX_PERSISTED_MESSAGES,
   CHECKPOINT_INTERVAL_MS,
+  DEFAULT_ORCHESTRATOR_MODE,
+  isValidOrchestratorMode,
 } from '../../types/orchestrator-state.types.js';
 
 /**
@@ -100,6 +103,18 @@ export class StatePersistenceService {
 
     // Initialize current state
     this.currentState = this.createEmptyState();
+
+    // Onboarding v3 (B2): top-level scalars on `OrchestratorState` (mode)
+    // restore automatically into the fresh currentState so `getMode()`
+    // returns the correct value across restart. Entity collections
+    // (conversations, tasks, agents, projects) intentionally do NOT
+    // auto-restore here — callers consume `previousState` from the return
+    // value and re-add entities they want to resume. This matches the
+    // existing "fresh currentState, generate resume instructions" pattern.
+    if (previousState && isValidOrchestratorMode(previousState.mode)) {
+      this.currentState.mode = previousState.mode;
+    }
+
     this.initialized = true;
 
     // Start periodic checkpointing
@@ -128,6 +143,10 @@ export class StatePersistenceService {
       version: STATE_VERSION,
       checkpointedAt: new Date().toISOString(),
       checkpointReason: 'scheduled',
+      // Onboarding v3 (B2): always start with the default mode. The orc
+      // bootstrap path (`crewly-agent-runtime.service`) flips this to
+      // `'onboarding'` via `setMode()` if cold-start detection (B1) fires.
+      mode: DEFAULT_ORCHESTRATOR_MODE,
       conversations: [],
       tasks: [],
       agents: [],
@@ -170,6 +189,20 @@ export class StatePersistenceService {
       if (state.version !== STATE_VERSION) {
         this.logger.info('State version mismatch, migration needed');
         return await this.migrateState(state);
+      }
+
+      // Onboarding v3 (B2): backfill `mode` for state files written before
+      // the field existed, and sanitize unknown values from a future
+      // version that this code doesn't recognize. Treat anything we can't
+      // identify as the safe default; corrupt values must not crash boot.
+      if (!isValidOrchestratorMode(state.mode)) {
+        if (state.mode !== undefined) {
+          this.logger.warn('Persisted orchestrator mode is unknown; defaulting', {
+            persistedMode: state.mode,
+            defaultedTo: DEFAULT_ORCHESTRATOR_MODE,
+          });
+        }
+        state.mode = DEFAULT_ORCHESTRATOR_MODE;
       }
 
       return state;
@@ -414,6 +447,43 @@ export class StatePersistenceService {
   updateSelfImprovement(state: SelfImprovementState): void {
     if (!this.currentState) return;
     this.currentState.selfImprovement = state;
+  }
+
+  /**
+   * Set the orchestrator's runtime mode (Onboarding v3 — B2).
+   *
+   * Called by the orc bootstrap path (`crewly-agent-runtime.service`)
+   * after cold-start detection. Idempotent — repeated calls with the same
+   * mode are no-ops aside from a debug log. The mode is persisted on the
+   * next checkpoint (`saveState`), which the bootstrap path triggers
+   * explicitly so a restart mid-conversation resumes in the right mode.
+   *
+   * @param mode - The new orchestrator mode
+   */
+  setMode(mode: OrchestratorMode): void {
+    if (!this.currentState) return;
+    if (this.currentState.mode === mode) {
+      this.logger.debug('Orchestrator mode unchanged', { mode });
+      return;
+    }
+    this.logger.info('Orchestrator mode changed', {
+      from: this.currentState.mode ?? DEFAULT_ORCHESTRATOR_MODE,
+      to: mode,
+    });
+    this.currentState.mode = mode;
+  }
+
+  /**
+   * Get the orchestrator's current runtime mode.
+   *
+   * Returns `DEFAULT_ORCHESTRATOR_MODE` when state is uninitialized or the
+   * field is missing; never returns undefined so callers can branch
+   * unambiguously on the union value.
+   *
+   * @returns Current orchestrator mode (defaults to `'normal'`)
+   */
+  getMode(): OrchestratorMode {
+    return this.currentState?.mode ?? DEFAULT_ORCHESTRATOR_MODE;
   }
 
   /**

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -215,6 +215,17 @@ export interface Project {
   teams: Record<string, string[]>; // team assignments
   status: 'active' | 'paused' | 'completed' | 'stopped';
   scheduledMessageId?: string; // ID of auto-assignment scheduled message
+  /**
+   * ISO timestamp of the first successful orchestrator bootstrap against
+   * this project (Onboarding v3 — B1). Set once on first orc launch and
+   * never overwritten thereafter; absence (or undefined) signals a
+   * "cold-start" candidate to the onboarding bootstrap detector.
+   *
+   * Defends the cold-start signal against the edge case where chat-v2 is
+   * wiped accidentally — if the user has been here before, this marker
+   * stays set even if the chat store is empty.
+   */
+  firstLaunchedAt?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/backend/src/types/orchestrator-state.types.test.ts
+++ b/backend/src/types/orchestrator-state.types.test.ts
@@ -11,11 +11,15 @@ import {
   MAX_PERSISTED_MESSAGES,
   CHECKPOINT_INTERVAL_MS,
   CHECKPOINT_REASONS,
+  ORCHESTRATOR_MODES,
+  DEFAULT_ORCHESTRATOR_MODE,
   isValidCheckpointReason,
   isValidTaskStatus,
   isValidTaskPriority,
   isValidConversationSource,
+  isValidOrchestratorMode,
   OrchestratorState,
+  OrchestratorMode,
   TaskState,
   ConversationState,
   AgentState,
@@ -86,6 +90,22 @@ describe('Orchestrator State Types', () => {
         expect(CHECKPOINT_REASONS).toHaveLength(6);
       });
     });
+
+    describe('ORCHESTRATOR_MODES (Onboarding v3 — B2)', () => {
+      it('should contain all expected modes', () => {
+        expect(ORCHESTRATOR_MODES).toContain('normal');
+        expect(ORCHESTRATOR_MODES).toContain('onboarding');
+        expect(ORCHESTRATOR_MODES).toContain('onboarding-provisioning');
+      });
+
+      it('should have exactly 3 modes', () => {
+        expect(ORCHESTRATOR_MODES).toHaveLength(3);
+      });
+
+      it('should default to normal', () => {
+        expect(DEFAULT_ORCHESTRATOR_MODE).toBe('normal');
+      });
+    });
   });
 
   describe('Type Guards', () => {
@@ -147,6 +167,28 @@ describe('Orchestrator State Types', () => {
         expect(isValidConversationSource('')).toBe(false);
       });
     });
+
+    describe('isValidOrchestratorMode (Onboarding v3 — B2)', () => {
+      it('should return true for each declared mode', () => {
+        expect(isValidOrchestratorMode('normal')).toBe(true);
+        expect(isValidOrchestratorMode('onboarding')).toBe(true);
+        expect(isValidOrchestratorMode('onboarding-provisioning')).toBe(true);
+      });
+
+      it('should return false for unknown strings', () => {
+        expect(isValidOrchestratorMode('idle')).toBe(false);
+        expect(isValidOrchestratorMode('')).toBe(false);
+        expect(isValidOrchestratorMode('NORMAL')).toBe(false); // case-sensitive
+      });
+
+      it('should return false for non-string inputs (defends against corrupt JSON)', () => {
+        expect(isValidOrchestratorMode(undefined)).toBe(false);
+        expect(isValidOrchestratorMode(null)).toBe(false);
+        expect(isValidOrchestratorMode(0)).toBe(false);
+        expect(isValidOrchestratorMode({ mode: 'normal' })).toBe(false);
+        expect(isValidOrchestratorMode(['normal'])).toBe(false);
+      });
+    });
   });
 
   describe('Type Interfaces', () => {
@@ -174,6 +216,80 @@ describe('Orchestrator State Types', () => {
         expect(state.id).toBe('state-123');
         expect(state.conversations).toHaveLength(0);
         expect(state.metadata.pid).toBe(12345);
+      });
+
+      it('should accept state with onboarding mode (Onboarding v3 — B2)', () => {
+        const state: OrchestratorState = {
+          id: 'state-onboarding',
+          version: '1.0.0',
+          checkpointedAt: new Date().toISOString(),
+          checkpointReason: 'scheduled',
+          mode: 'onboarding',
+          conversations: [],
+          tasks: [],
+          agents: [],
+          projects: [],
+          metadata: {
+            version: '1.0.0',
+            hostname: 'test-host',
+            pid: 12345,
+            startedAt: new Date().toISOString(),
+            uptimeSeconds: 0,
+            restartCount: 0,
+          },
+        };
+
+        expect(state.mode).toBe('onboarding');
+      });
+
+      it('should accept state with onboarding-provisioning mode (future-reserved)', () => {
+        const mode: OrchestratorMode = 'onboarding-provisioning';
+        const state: OrchestratorState = {
+          id: 'state-prov',
+          version: '1.0.0',
+          checkpointedAt: new Date().toISOString(),
+          checkpointReason: 'scheduled',
+          mode,
+          conversations: [],
+          tasks: [],
+          agents: [],
+          projects: [],
+          metadata: {
+            version: '1.0.0',
+            hostname: 'test-host',
+            pid: 12345,
+            startedAt: new Date().toISOString(),
+            uptimeSeconds: 0,
+            restartCount: 0,
+          },
+        };
+
+        expect(state.mode).toBe('onboarding-provisioning');
+      });
+
+      it('should treat mode as optional for backwards compatibility', () => {
+        // State files written before the `mode` field existed must still
+        // parse — the loader backfills via `DEFAULT_ORCHESTRATOR_MODE`.
+        const state: OrchestratorState = {
+          id: 'state-legacy',
+          version: '1.0.0',
+          checkpointedAt: new Date().toISOString(),
+          checkpointReason: 'scheduled',
+          conversations: [],
+          tasks: [],
+          agents: [],
+          projects: [],
+          metadata: {
+            version: '1.0.0',
+            hostname: 'test-host',
+            pid: 12345,
+            startedAt: new Date().toISOString(),
+            uptimeSeconds: 0,
+            restartCount: 0,
+          },
+        };
+
+        expect(state.mode).toBeUndefined();
       });
 
       it('should accept state with selfImprovement', () => {

--- a/backend/src/types/orchestrator-state.types.ts
+++ b/backend/src/types/orchestrator-state.types.ts
@@ -37,6 +37,50 @@ export const MAX_PERSISTED_MESSAGES = 50;
 export const CHECKPOINT_INTERVAL_MS = 60000;
 
 // =============================================================================
+// Orchestrator Mode (Onboarding v3 — B2)
+// =============================================================================
+
+/**
+ * Top-level orchestrator runtime mode.
+ *
+ * - `'normal'` — Standard orchestrator behavior; the role prompt at
+ *   `config/roles/orchestrator/prompt.md` is loaded and the full skill set
+ *   is available.
+ * - `'onboarding'` — Cold-start onboarding mode. The `ONBOARDING_MODE_SYSTEM_PROMPT`
+ *   is loaded instead of the normal role prompt, and the skill set is
+ *   filtered to the `ONBOARDING_SKILL_ALLOWLIST` (recall/remember/record-learning
+ *   + 2 onboarding-specific skills). `delegate-task`, `start-agent`, `stop-agent`
+ *   are disabled — orc cannot delegate while onboarding the customer.
+ * - `'onboarding-provisioning'` — Future-reserved (Onboarding v3 W3+, materializer
+ *   2-phase commit). Declared now so persisted states from later milestones
+ *   round-trip cleanly through `state-persistence.service`. Not wired in W1.
+ *
+ * Detection of the cold-start condition lives in `OnboardingBootstrapService`
+ * (B1); the mode is set during orc bootstrap by `crewly-agent-runtime.service`
+ * before the system prompt is composed.
+ */
+export type OrchestratorMode =
+  | 'normal'
+  | 'onboarding'
+  | 'onboarding-provisioning';
+
+/**
+ * Valid orchestrator modes array — single source of truth for runtime
+ * validation and the type guard below.
+ */
+export const ORCHESTRATOR_MODES: readonly OrchestratorMode[] = [
+  'normal',
+  'onboarding',
+  'onboarding-provisioning',
+] as const;
+
+/**
+ * Default orchestrator mode used when state is freshly initialized or
+ * round-tripped from an older state file that predates the `mode` field.
+ */
+export const DEFAULT_ORCHESTRATOR_MODE: OrchestratorMode = 'normal';
+
+// =============================================================================
 // Checkpoint Reasons
 // =============================================================================
 
@@ -467,6 +511,15 @@ export interface OrchestratorState {
   /** Reason for checkpoint */
   checkpointReason: CheckpointReason;
 
+  /**
+   * Top-level orchestrator runtime mode (Onboarding v3 — B2).
+   *
+   * Optional for backwards compatibility: state files written by versions
+   * predating the field load with `mode === undefined`. Loaders should
+   * default to `DEFAULT_ORCHESTRATOR_MODE` when absent.
+   */
+  mode?: OrchestratorMode;
+
   /** Active conversation contexts */
   conversations: ConversationState[];
   /** Pending/in-progress tasks */
@@ -586,6 +639,20 @@ export interface ResumeInstructions {
  */
 export function isValidCheckpointReason(value: string): value is CheckpointReason {
   return CHECKPOINT_REASONS.includes(value as CheckpointReason);
+}
+
+/**
+ * Check if a value is a valid OrchestratorMode (Onboarding v3 — B2).
+ *
+ * Used by `state-persistence.service` when round-tripping a persisted
+ * state to fall back to `DEFAULT_ORCHESTRATOR_MODE` if the file contains
+ * a corrupted or future-unknown value. Narrows the input to the union.
+ *
+ * @param value - Value to check
+ * @returns True if valid OrchestratorMode
+ */
+export function isValidOrchestratorMode(value: unknown): value is OrchestratorMode {
+  return typeof value === 'string' && ORCHESTRATOR_MODES.includes(value as OrchestratorMode);
 }
 
 /**

--- a/config/skills/agent/onboarding/materialize-team/SKILL.md
+++ b/config/skills/agent/onboarding/materialize-team/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: Materialize Team
+description: Materialize a confirmed team recommendation — writes the team config and flips the onboardingComplete flag. Onboarding-only.
+version: 0.1.0
+category: onboarding
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+triggers:
+  - materialize team
+  - create team
+  - confirm team
+tags:
+  - onboarding
+  - materialize
+  - team
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
+# Materialize Team (Onboarding v3)
+
+Take a confirmed `recommendation` (the object returned from
+`recommend-team`) and create the actual team:
+
+1. Writes `<teamsDir>/<uuid>/config.json` describing the team.
+2. Persists `{ onboardingComplete: true, completedAt }` to
+   `<projectFlagPath>` so the runtime knows onboarding is done.
+
+Returns the new `teamId` + the on-disk paths.
+
+This skill is callable **only when orc is in `'onboarding'` mode**.
+
+## Parameters
+
+| Flag                       | JSON Field         | Required | Description |
+|----------------------------|--------------------|----------|-------------|
+| `--recommendation` / `-r`  | `recommendation`   | Yes      | JSON object from `recommend-team` (templateId + agents + reasoning + source) |
+| `--teams-dir`              | `teamsDir`         | No       | Override the teams directory (default: `~/.crewly/teams`) |
+| `--project-flag-path`      | `projectFlagPath`  | No       | Override the project-flag path (default: `~/.crewly/onboarding-complete.json`) |
+| `--json` / `-j`            | —                  | No       | Whole request as a JSON object |
+
+## Examples
+
+```bash
+# Full payload via stdin
+cat <<'EOF' | bash execute.sh
+{
+  "recommendation": {
+    "templateId": "dtc-viral-content-team",
+    "agents": [
+      { "role": "content-drafter", "responsibilities": "...", "skillIds": ["content-drafter"] },
+      { "role": "support-triage",  "responsibilities": "...", "skillIds": ["support-triage"]  }
+    ],
+    "reasoning": "...",
+    "source": "hardcoded:ecommerce-content-support"
+  }
+}
+EOF
+
+# Or pass the recommendation JSON directly
+bash execute.sh --recommendation '{"templateId":"...","agents":[...],"reasoning":"...","source":"..."}'
+```
+
+## Output
+
+```json
+{
+  "success": true,
+  "result": {
+    "teamId": "ea0dd57a-15a9-4a34-9c6f-8f04534d89e7",
+    "teamConfigPath": "/Users/.../.crewly/teams/<uuid>/config.json",
+    "onboardingComplete": true,
+    "projectFlagPath": "/Users/.../.crewly/onboarding-complete.json",
+    "recommendation": { "...": "echo of the input" }
+  }
+}
+```
+
+## Notes
+
+- v0 (Mon 5/4 EOD): writes a minimal team config (id, templateId,
+  members[], onboardingSource) and flips the flag. No agent-soul
+  personalisation, no project linkage.
+- Wed–Fri: this skill will delegate to
+  `services/onboarding/onboarding-provision.service.ts` for full
+  template-engine provisioning + agent souls + goals.md generation.
+  The skill's input/output shape stays stable.
+- Errors propagate as `{success:false,error:"..."}`; orc surfaces them
+  honestly to the user rather than retrying silently.

--- a/config/skills/agent/onboarding/materialize-team/execute.sh
+++ b/config/skills/agent/onboarding/materialize-team/execute.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Materialize a confirmed team recommendation: write the team config and flip
+# the project onboardingComplete flag. Onboarding-only.
+# Wraps POST /api/orchestrator/onboarding/materialize-team.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../_common/lib.sh"
+
+INPUT_JSON=""
+RECOMMENDATION=""
+TEAMS_DIR=""
+PROJECT_FLAG_PATH=""
+
+# Detect legacy JSON argument
+if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
+  INPUT_JSON="$1"
+  shift || true
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --recommendation|-r)
+      RECOMMENDATION="$2"
+      shift 2
+      ;;
+    --teams-dir)
+      TEAMS_DIR="$2"
+      shift 2
+      ;;
+    --project-flag-path)
+      PROJECT_FLAG_PATH="$2"
+      shift 2
+      ;;
+    --json|-j)
+      INPUT_JSON="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Usage: execute.sh --recommendation '<json>' \\
+                  [--teams-dir <path>] [--project-flag-path <path>]
+
+Or pipe a full request via stdin / --json:
+  {"recommendation": {...}, "teamsDir": "...", "projectFlagPath": "..."}
+
+The "recommendation" payload is the JSON object returned from
+the recommend-team skill (templateId + agents + reasoning + source).
+EOF
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      if [[ -z "$INPUT_JSON" && ${1:0:1} == '{' ]]; then
+        INPUT_JSON="$1"
+        shift
+      else
+        error_exit "Unknown argument: $1"
+      fi
+      ;;
+  esac
+done
+
+# Read from stdin if nothing else
+if [ -z "$INPUT_JSON" ] && [ -z "$RECOMMENDATION" ] && [ ! -t 0 ]; then
+  STDIN_DATA="$(cat)"
+  if [[ ${STDIN_DATA:0:1} == '{' ]]; then
+    INPUT_JSON="$STDIN_DATA"
+  fi
+fi
+
+# Parse JSON wrapper if provided
+if [ -n "$INPUT_JSON" ]; then
+  INPUT=$(read_json_input "$INPUT_JSON")
+  if [ -z "$RECOMMENDATION" ]; then
+    REC_FROM_JSON=$(printf '%s' "$INPUT" | jq -c '.recommendation // empty')
+    [ -n "$REC_FROM_JSON" ] && RECOMMENDATION="$REC_FROM_JSON"
+  fi
+  [ -z "$TEAMS_DIR" ]          && TEAMS_DIR=$(printf '%s' "$INPUT" | jq -r '.teamsDir // empty')
+  [ -z "$PROJECT_FLAG_PATH" ]  && PROJECT_FLAG_PATH=$(printf '%s' "$INPUT" | jq -r '.projectFlagPath // empty')
+fi
+
+require_param "recommendation (--recommendation)" "$RECOMMENDATION"
+
+export _MT_REC="$RECOMMENDATION"
+BODY=$(jq -n '{recommendation: (env._MT_REC | fromjson)}')
+unset _MT_REC
+
+if [ -n "$TEAMS_DIR" ]; then
+  BODY=$(echo "$BODY" | jq --arg p "$TEAMS_DIR" '. + {teamsDir: $p}')
+fi
+if [ -n "$PROJECT_FLAG_PATH" ]; then
+  BODY=$(echo "$BODY" | jq --arg p "$PROJECT_FLAG_PATH" '. + {projectFlagPath: $p}')
+fi
+
+api_call POST "/orchestrator/onboarding/materialize-team" "$BODY"

--- a/config/skills/agent/onboarding/recommend-team/SKILL.md
+++ b/config/skills/agent/onboarding/recommend-team/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: Recommend Team
+description: Recommend a team configuration (template + agents) based on the user's business context. Onboarding-only.
+version: 0.1.0
+category: onboarding
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+triggers:
+  - recommend a team
+  - propose team
+  - suggest team
+  - team recommendation
+tags:
+  - onboarding
+  - recommendation
+  - team
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 10000
+---
+
+# Recommend Team (Onboarding v3)
+
+Turn the discovery answers gathered in phases 1–3 of the onboarding
+conversation into a concrete team proposal: a template id + 2–4 agents
+with responsibilities and skill ids.
+
+This skill is callable **only when orc is in `'onboarding'` mode**. The
+runtime gate enforces that via `ONBOARDING_SKILL_ALLOWLIST`.
+
+## Parameters
+
+| Flag             | JSON Field | Required | Description |
+|------------------|------------|----------|-------------|
+| `--industry` / `-i` | `industry` | Yes | Free-text industry / domain (e.g. "small Shopify skincare shop") |
+| `--scale` / `-s`    | `scale`    | Yes | One of: `solo`, `small-team`, `company` |
+| `--tasks` / `-t`    | `tasks`    | No  | JSON array of `{ name: string, tier: <FeasibilityTier> }`. Empty allowed. |
+| `--json` / `-j`     | —          | No  | Whole request as a JSON object. |
+
+Feasibility tier vocabulary (must match the system prompt):
+`yes-today` | `collaborative` | `roadmap` | `out-of-scope`.
+
+## Examples
+
+```bash
+# Anchor demo (Steve's e-commerce skincare shop)
+bash execute.sh \
+  --industry "small Shopify skincare shop" \
+  --scale solo \
+  --tasks '[{"name":"weekly content","tier":"yes-today"},{"name":"customer support","tier":"yes-today"}]'
+
+# Or one-shot JSON
+bash execute.sh '{
+  "industry": "growth marketing agency",
+  "scale": "small-team",
+  "tasks": [
+    {"name":"lead gen","tier":"yes-today"},
+    {"name":"content distribution","tier":"yes-today"}
+  ]
+}'
+```
+
+## Output
+
+```json
+{
+  "success": true,
+  "recommendation": {
+    "templateId": "dtc-viral-content-team",
+    "agents": [
+      { "role": "content-drafter", "responsibilities": "...", "skillIds": [...] },
+      { "role": "support-triage",  "responsibilities": "...", "skillIds": [...] }
+    ],
+    "reasoning": "...",
+    "source": "hardcoded:ecommerce-content-support"
+  }
+}
+```
+
+## Notes
+
+- v0 (Mon 5/4 EOD): 5 hardcoded heuristic mappings + a generic 2-agent
+  fallback. ~80% of users land on a hardcoded mapping.
+- Wed–Fri: real RAG over Mia's spec v3 + doc 69 + the live template
+  registry. The `recommendation` shape stays stable — orc does not need
+  to be re-prompted when the strategy changes.

--- a/config/skills/agent/onboarding/recommend-team/execute.sh
+++ b/config/skills/agent/onboarding/recommend-team/execute.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Recommend a team configuration based on the user's business context.
+# Wraps POST /api/orchestrator/onboarding/recommend-team. Onboarding-only.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../_common/lib.sh"
+
+INPUT_JSON=""
+INDUSTRY=""
+SCALE=""
+TASKS_JSON=""
+
+# Detect legacy JSON argument
+if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
+  INPUT_JSON="$1"
+  shift || true
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --industry|-i)
+      INDUSTRY="$2"
+      shift 2
+      ;;
+    --scale|-s)
+      SCALE="$2"
+      shift 2
+      ;;
+    --tasks|-t)
+      TASKS_JSON="$2"
+      shift 2
+      ;;
+    --json|-j)
+      INPUT_JSON="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Usage: execute.sh --industry "<text>" --scale solo|small-team|company \\
+                  --tasks '[{"name":"…","tier":"yes-today"}]'
+
+Or:    execute.sh '{"industry":"…","scale":"solo","tasks":[…]}'
+
+Tier values: yes-today | collaborative | roadmap | out-of-scope
+EOF
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      if [[ -z "$INPUT_JSON" && ${1:0:1} == '{' ]]; then
+        INPUT_JSON="$1"
+        shift
+      else
+        error_exit "Unknown argument: $1"
+      fi
+      ;;
+  esac
+done
+
+# Read from stdin if nothing else supplied
+if [ -z "$INPUT_JSON" ] && [ -z "$INDUSTRY" ] && [ ! -t 0 ]; then
+  STDIN_DATA="$(cat)"
+  if [[ ${STDIN_DATA:0:1} == '{' ]]; then
+    INPUT_JSON="$STDIN_DATA"
+  fi
+fi
+
+# Parse JSON if provided — flag-based fields take priority
+if [ -n "$INPUT_JSON" ]; then
+  INPUT=$(read_json_input "$INPUT_JSON")
+  [ -z "$INDUSTRY" ]   && INDUSTRY=$(printf '%s' "$INPUT" | jq -r '.industry // empty')
+  [ -z "$SCALE" ]      && SCALE=$(printf '%s' "$INPUT" | jq -r '.scale // empty')
+  [ -z "$TASKS_JSON" ] && TASKS_JSON=$(printf '%s' "$INPUT" | jq -c '.tasks // empty')
+fi
+
+require_param "industry (--industry)" "$INDUSTRY"
+require_param "scale (--scale)" "$SCALE"
+[ -z "$TASKS_JSON" ] && TASKS_JSON='[]'
+
+# Build request body via env vars (safe-escape)
+export _RT_INDUSTRY="$INDUSTRY"
+export _RT_SCALE="$SCALE"
+export _RT_TASKS="$TASKS_JSON"
+
+BODY=$(jq -n '{
+  industry: env._RT_INDUSTRY,
+  scale: env._RT_SCALE,
+  tasks: (env._RT_TASKS | fromjson)
+}')
+
+unset _RT_INDUSTRY _RT_SCALE _RT_TASKS
+
+api_call POST "/orchestrator/onboarding/recommend-team" "$BODY"


### PR DESCRIPTION
## Summary

Integration PR for **Onboarding v3** — orchestrator-mode pivot per [spec section 1–5](.crewly/tasks/onboarding_v3/71-onboarding-spec-v3-final.md).

Includes the full B1→B4 cold-start state machine (Leo) **plus** the integrated B5/B9 onboarding-mode prompt + `recommend-team`/`materialize-team` skills (Max). Supersedes `feat/onboarding-v3-orc-prompt-skills` (those 3 commits are cherry-picked here for atomic ship).

### What this delivers
- **B1 — Cold-start detection**: `OnboardingBootstrapService.shouldEnterOnboardingMode()` returns true iff `chat-v2` history is empty AND `project.firstLaunchedAt` is unset/null. Idempotent first-launch marker write.
- **B2 — `OrchestratorState` union**: adds `'onboarding'` (and reserved `'onboarding-provisioning'`) to the mode union; `state-persistence.service` round-trips the new value.
- **B3 — Prompt-swap hook**: `onboarding-mode-loader` loads `ONBOARDING_MODE_SYSTEM_PROMPT` instead of the normal orc prompt when in onboarding mode. Skill allowlist (`onboarding-mode.skill-allowlist.ts`) restricts callable skills to memory + `recommend-team` + `materialize-team` + `report-status` (disables `delegate-task`/`start-agent`/`stop-agent`).
- **B4 — App-boot wiring**: `OnboardingBootstrapService` registered at backend boot; restart preserves mode mid-conversation.
- **B5 (prompt) + B9 (materialize)**: 5-phase conversational system prompt (Open → Discovery → Feasibility → Recommend → Materialize) with capability-grounded, anchor-quote tone. `recommend-team` (5 hardcoded mappings + generic fallback) and `materialize-team` (provisions team config + flips `onboardingComplete`) wired via REST controller `POST /api/orchestrator/onboarding/{recommend,materialize}-team` and bash wrappers.

### Path decision (B9)
- `materialize-team` skill lives at `config/skills/agent/onboarding/materialize-team/` (namespaced under `onboarding/` alongside sibling `recommend-team`).
- Spec section 5 specifies the skill name only; physical path is namespaced for bundle scannability. Tracking decision per Steve's 2026-05-03 ruling.

## Files changed (+4245 / -3, 35 files)

Backend (29 files):
- `backend/src/services/orchestrator/onboarding-bootstrap.service.{ts,test.ts}` — B1
- `backend/src/services/orchestrator/onboarding-mode-loader.{ts,test.ts}` — B3
- `backend/src/services/orchestrator/onboarding-mode.skill-allowlist.{ts,test.ts}` — B3
- `backend/src/services/orchestrator/prompts/onboarding-mode.prompt.{ts,test.ts}` — B5
- `backend/src/services/orchestrator/onboarding/{recommend,materialize}-team.{ts,test.ts}` — B9
- `backend/src/controllers/orchestrator-onboarding/{controller,routes,test}.ts` — REST
- `backend/src/services/orchestrator/onboarding-cold-start.smoke.test.ts` — E2E smoke (Sun EOD)
- `backend/src/types/orchestrator-state.types.{ts,test.ts}` + `state-persistence.service.{ts,test.ts}` — B2
- `backend/src/models/Project.{ts,test.ts}` + `chat-v2/{service,sqlite/message.store}.{ts,test.ts}` — substrate hooks

Skills (4 files):
- `config/skills/agent/onboarding/{materialize,recommend}-team/{SKILL.md,execute.sh}`

## Test plan

- [x] `npm run build` clean
- [x] `npm run typecheck` clean
- [x] B1/B2/B3/B4 unit tests pass (1:1 ratio, ≥80% coverage on new code)
- [x] `materialize-team.test.ts` + `recommend-team.test.ts` pass
- [x] `onboarding-cold-start.smoke.test.ts` end-to-end passes locally
- [ ] Post-merge: full E2E validation against empty `~/.crewly` (Sam will run)

## Coordination

- Authored by Leo (B1/B2/B3/B4 state machine) + Max (B5/B9 prompts/skills), integrated by Leo, reviewed by Sam (TL).
- After this lands, `feat/onboarding-v3-orc-prompt-skills` will be a no-op vs main and will be closed as superseded.

## OKR linkage

Q2 KR3 (≤5-min onboarding) — Steve's "auto-start orc conversation" mandate (2026-05-03). Spec: [.crewly/tasks/onboarding_v3/71-onboarding-spec-v3-final.md](.crewly/tasks/onboarding_v3/71-onboarding-spec-v3-final.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)