### PR TITLE
feat(observability): minimal internal metrics — agent_behavior_log (P0 / Decision 4)

### DIFF
--- a/backend/src/services/observability/agent-behavior-log.service.test.ts
+++ b/backend/src/services/observability/agent-behavior-log.service.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for `AgentBehaviorLogService`.
+ *
+ * Uses an in-memory SQLite DB so the suite stays hermetic and fast.
+ *
+ * @module services/observability/agent-behavior-log.service.test
+ */
+
+import {
+  AgentBehaviorLogService,
+} from './agent-behavior-log.service.js';
+import {
+  openObservabilityDatabase,
+  type ObservabilityDatabase,
+} from './observability-db.js';
+import { BEHAVIOR_LOG_EVENT_TYPES } from './agent-behavior-log.types.js';
+
+describe('AgentBehaviorLogService', () => {
+  let db: ObservabilityDatabase;
+  let svc: AgentBehaviorLogService;
+  let nowCounter: number;
+
+  beforeEach(() => {
+    db = openObservabilityDatabase({
+      inMemory: true,
+      skipIntegrityCheck: true,
+    });
+    nowCounter = 1_700_000_000_000;
+    svc = new AgentBehaviorLogService({
+      db,
+      now: () => ++nowCounter,
+    });
+  });
+
+  afterEach(() => {
+    svc.close();
+    db.close();
+  });
+
+  describe('record() — agent.action', () => {
+    it('inserts an action event with reason=actionType and JSON details', () => {
+      const id = svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'crewly-orc',
+        actionType: 'delegate',
+        taskId: 'req-42',
+        details: { recipient: 'sam' },
+      });
+
+      expect(id).toBeGreaterThan(0);
+
+      const rows = svc.listRecent(10);
+      expect(rows).toHaveLength(1);
+      const r = rows[0]!;
+      expect(r.eventType).toBe('agent.action');
+      expect(r.agent).toBe('crewly-orc');
+      expect(r.reason).toBe('delegate');
+      expect(r.taskId).toBe('req-42');
+      expect(r.amount).toBe(0);
+      expect(r.details).toEqual({ recipient: 'sam' });
+    });
+
+    it('handles missing optional fields gracefully', () => {
+      const id = svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'a',
+        actionType: 'implement',
+      });
+      expect(id).toBeGreaterThan(0);
+      const r = svc.listRecent(1)[0]!;
+      expect(r.taskId).toBe('');
+      expect(r.details).toEqual({});
+    });
+  });
+
+  describe('record() — agent.escalation', () => {
+    it('writes escalating agent / target / reason correctly', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION,
+        escalatingAgent: 'sam',
+        escalatedTo: 'orchestrator',
+        reason: 'design-decision',
+        taskId: 'task-1',
+        details: { kind: 'arch' },
+      });
+      const r = svc.listRecent(1)[0]!;
+      expect(r.eventType).toBe('agent.escalation');
+      expect(r.agent).toBe('sam');
+      expect(r.subject).toBe('orchestrator');
+      expect(r.reason).toBe('design-decision');
+      expect(r.taskId).toBe('task-1');
+      expect(r.details).toEqual({ kind: 'arch' });
+    });
+  });
+
+  describe('record() — slack.delivery.failed', () => {
+    it('captures thread, agent and reason', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.SLACK_DELIVERY_FAILED,
+        agent: 'crewly-orc',
+        thread: 'D0AC7NF5N7L:123.456',
+        reason: 'no_reply_called',
+      });
+      const r = svc.listRecent(1)[0]!;
+      expect(r.eventType).toBe('slack.delivery.failed');
+      expect(r.agent).toBe('crewly-orc');
+      expect(r.subject).toBe('D0AC7NF5N7L:123.456');
+      expect(r.reason).toBe('no_reply_called');
+    });
+  });
+
+  describe('record() — prompt.size.bytes', () => {
+    it('stores byte count in amount', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES,
+        agent: 'leo',
+        bytes: 12_345,
+        sessionId: 'sess-9',
+      });
+      const r = svc.listRecent(1)[0]!;
+      expect(r.eventType).toBe('prompt.size.bytes');
+      expect(r.agent).toBe('leo');
+      expect(r.subject).toBe('sess-9');
+      expect(r.amount).toBe(12_345);
+    });
+
+    it('floors fractional bytes and clamps negatives to zero', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES,
+        agent: 'a',
+        bytes: 7.9,
+      });
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES,
+        agent: 'b',
+        bytes: -10,
+      });
+      const rows = svc.listRecent(10);
+      // listRecent returns newest first
+      const a = rows.find((r) => r.agent === 'a')!;
+      const b = rows.find((r) => r.agent === 'b')!;
+      expect(a.amount).toBe(7);
+      expect(b.amount).toBe(0);
+    });
+  });
+
+  describe('listRecent()', () => {
+    it('orders newest first and respects the limit', () => {
+      for (let i = 0; i < 5; i++) {
+        svc.record({
+          type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+          agent: 'a',
+          actionType: 'implement',
+          details: { i },
+        });
+      }
+      const rows = svc.listRecent(3);
+      expect(rows).toHaveLength(3);
+      expect((rows[0]!.details as { i: number }).i).toBe(4);
+      expect((rows[2]!.details as { i: number }).i).toBe(2);
+    });
+
+    it('filters by event type', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'a',
+        actionType: 'implement',
+      });
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION,
+        escalatingAgent: 'a',
+        escalatedTo: 'orc',
+        reason: 'x',
+      });
+      const onlyEsc = svc.listRecent(
+        10,
+        BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION,
+      );
+      expect(onlyEsc).toHaveLength(1);
+      expect(onlyEsc[0]!.eventType).toBe('agent.escalation');
+    });
+  });
+
+  describe('countByEvent()', () => {
+    it('groups counts by event_type', () => {
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'a',
+        actionType: 'implement',
+      });
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'b',
+        actionType: 'delegate',
+      });
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES,
+        agent: 'a',
+        bytes: 1,
+      });
+      const counts = svc.countByEvent();
+      expect(counts['agent.action']).toBe(2);
+      expect(counts['prompt.size.bytes']).toBe(1);
+    });
+
+    it('honours the sinceTs cutoff', () => {
+      // First two events at timestamps 1_700_000_000_001 and ..002
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'a',
+        actionType: 'implement',
+      });
+      svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'b',
+        actionType: 'implement',
+      });
+      // Cutoff at 1_700_000_000_002 — only the second event counts.
+      const counts = svc.countByEvent(1_700_000_000_002);
+      expect(counts['agent.action']).toBe(1);
+    });
+  });
+
+  describe('record() resilience', () => {
+    it('returns null and does not throw on insert failure', () => {
+      // Force a failure by closing the DB before record() runs.
+      db.close();
+      const id = svc.record({
+        type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+        agent: 'a',
+        actionType: 'implement',
+      });
+      expect(id).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/observability/agent-behavior-log.service.ts
+++ b/backend/src/services/observability/agent-behavior-log.service.ts
@@ -1,0 +1,386 @@
+/**
+ * Agent Behavior Log — write/read service.
+ *
+ * Translates strongly-typed `BehaviorLogEvent` values into rows of the
+ * `agent_behavior_log` table and reads them back as typed records.
+ *
+ * Design choices:
+ * - One service instance owns one DB handle; tests pass `:memory:`.
+ * - All writes are append-only inserts; no updates, no deletes.
+ * - Best-effort logging — `record()` swallows DB errors after logging
+ *   them, so observability never takes the request path down.
+ * - Read APIs are minimal: this PR ships the schema + write surface.
+ *   Digest/aggregation queries land in a follow-up.
+ *
+ * Wiring of producers (Slack-failure listener, prompt-size sampler,
+ * orchestrator action logger) is intentionally out of scope for this
+ * PR — see P0-5 / prompt-generator follow-ups.
+ *
+ * @module services/observability/agent-behavior-log.service
+ */
+
+import {
+  openObservabilityDatabase,
+  type ObservabilityDatabase,
+  type OpenObservabilityDatabaseOptions,
+} from './observability-db.js';
+import {
+  BEHAVIOR_LOG_EVENT_TYPES,
+  type AgentActionEvent,
+  type AgentEscalationEvent,
+  type BehaviorLogEvent,
+  type BehaviorLogEventType,
+  type BehaviorLogRow,
+  type PromptSizeBytesEvent,
+  type SlackDeliveryFailedEvent,
+} from './agent-behavior-log.types.js';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+// ---------------------------------------------------------------------------
+// Read result shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Decoded behavior log row — `details_json` is parsed back into an
+ * object, and `event_type` is narrowed to the discriminator union.
+ */
+export interface BehaviorLogRecord {
+  id: number;
+  ts: number;
+  eventType: BehaviorLogEventType;
+  agent: string;
+  subject: string;
+  taskId: string;
+  reason: string;
+  amount: number;
+  details: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Construction options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for constructing an `AgentBehaviorLogService`. Either pass an
+ * existing DB handle (preferred for tests) or a set of opener options
+ * the service should use to open its own handle.
+ */
+export interface AgentBehaviorLogServiceOptions {
+  /** Pre-opened database handle. Service does NOT take ownership. */
+  db?: ObservabilityDatabase;
+  /** Opener options used when `db` is not supplied. */
+  openOptions?: OpenObservabilityDatabaseOptions;
+  /** Optional time source — defaults to `Date.now`. Used in tests. */
+  now?: () => number;
+  /** Optional logger override. */
+  logger?: ComponentLogger;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Append-only writer + minimal reader for the `agent_behavior_log`
+ * table.
+ *
+ * @example
+ * ```ts
+ * const svc = new AgentBehaviorLogService();
+ * svc.record({
+ *   type: 'agent.action',
+ *   agent: 'crewly-orc',
+ *   actionType: 'delegate',
+ *   taskId: 'req-123',
+ *   details: { recipient: 'sam' },
+ * });
+ * ```
+ */
+export class AgentBehaviorLogService {
+  private readonly db: ObservabilityDatabase;
+  private readonly ownsDb: boolean;
+  private readonly now: () => number;
+  private readonly logger: ComponentLogger;
+  private insertStmt: import('better-sqlite3').Statement | null = null;
+
+  constructor(options: AgentBehaviorLogServiceOptions = {}) {
+    this.logger =
+      options.logger ??
+      LoggerService.getInstance().createComponentLogger('AgentBehaviorLog');
+    this.now = options.now ?? Date.now;
+
+    if (options.db) {
+      this.db = options.db;
+      this.ownsDb = false;
+    } else {
+      this.db = openObservabilityDatabase(options.openOptions);
+      this.ownsDb = true;
+    }
+  }
+
+  /**
+   * Lazily prepare and cache the insert statement. Avoids paying the
+   * prepare cost for callers that only ever read.
+   */
+  private getInsertStmt(): import('better-sqlite3').Statement {
+    if (!this.insertStmt) {
+      this.insertStmt = this.db.prepare(
+        `INSERT INTO agent_behavior_log
+           (ts, event_type, agent, subject, task_id, reason, amount, details_json)
+         VALUES
+           (@ts, @event_type, @agent, @subject, @task_id, @reason, @amount, @details_json)`,
+      );
+    }
+    return this.insertStmt;
+  }
+
+  /**
+   * Record one behavior event.
+   *
+   * Translates the discriminated `BehaviorLogEvent` into a
+   * `BehaviorLogRow`-compatible parameter object and inserts. Errors
+   * are caught and logged — observability writes must NEVER throw into
+   * the calling code path.
+   *
+   * @param event - The strongly-typed event to record
+   * @returns The newly inserted row id, or `null` if the write failed
+   */
+  public record(event: BehaviorLogEvent): number | null {
+    const params = this.toRowParams(event);
+    try {
+      const result = this.getInsertStmt().run(params);
+      return Number(result.lastInsertRowid);
+    } catch (err) {
+      this.logger.warn('Failed to record behavior log event', {
+        event_type: event.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Translate a `BehaviorLogEvent` into the parameter object expected
+   * by the prepared insert statement.
+   *
+   * The discriminator branch is exhaustive — adding a new event type
+   * forces a TypeScript error here until the new branch is added.
+   */
+  private toRowParams(event: BehaviorLogEvent): {
+    ts: number;
+    event_type: BehaviorLogEventType;
+    agent: string;
+    subject: string;
+    task_id: string;
+    reason: string;
+    amount: number;
+    details_json: string;
+  } {
+    const ts = this.now();
+
+    switch (event.type) {
+      case BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION:
+        return this.buildAgentActionParams(event, ts);
+      case BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION:
+        return this.buildEscalationParams(event, ts);
+      case BEHAVIOR_LOG_EVENT_TYPES.SLACK_DELIVERY_FAILED:
+        return this.buildSlackFailureParams(event, ts);
+      case BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES:
+        return this.buildPromptSizeParams(event, ts);
+      default: {
+        // Exhaustiveness guard — `_never` is `never` if the union is
+        // covered; if a new variant lands and isn't handled above, this
+        // line becomes a TypeScript error.
+        const _never: never = event;
+        throw new Error(
+          `Unhandled behavior log event variant: ${JSON.stringify(_never)}`,
+        );
+      }
+    }
+  }
+
+  /** Build params for an `agent.action` event. */
+  private buildAgentActionParams(
+    event: AgentActionEvent,
+    ts: number,
+  ): ReturnType<AgentBehaviorLogService['toRowParams']> {
+    return {
+      ts,
+      event_type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION,
+      agent: event.agent,
+      subject: '',
+      task_id: event.taskId ?? '',
+      reason: event.actionType,
+      amount: 0,
+      details_json: stringifyDetails(event.details),
+    };
+  }
+
+  /** Build params for an `agent.escalation` event. */
+  private buildEscalationParams(
+    event: AgentEscalationEvent,
+    ts: number,
+  ): ReturnType<AgentBehaviorLogService['toRowParams']> {
+    return {
+      ts,
+      event_type: BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION,
+      agent: event.escalatingAgent,
+      subject: event.escalatedTo,
+      task_id: event.taskId ?? '',
+      reason: event.reason,
+      amount: 0,
+      details_json: stringifyDetails(event.details),
+    };
+  }
+
+  /** Build params for a `slack.delivery.failed` event. */
+  private buildSlackFailureParams(
+    event: SlackDeliveryFailedEvent,
+    ts: number,
+  ): ReturnType<AgentBehaviorLogService['toRowParams']> {
+    return {
+      ts,
+      event_type: BEHAVIOR_LOG_EVENT_TYPES.SLACK_DELIVERY_FAILED,
+      agent: event.agent,
+      subject: event.thread,
+      task_id: '',
+      reason: event.reason,
+      amount: 0,
+      details_json: stringifyDetails(event.details),
+    };
+  }
+
+  /** Build params for a `prompt.size.bytes` event. */
+  private buildPromptSizeParams(
+    event: PromptSizeBytesEvent,
+    ts: number,
+  ): ReturnType<AgentBehaviorLogService['toRowParams']> {
+    return {
+      ts,
+      event_type: BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES,
+      agent: event.agent,
+      subject: event.sessionId ?? '',
+      task_id: '',
+      reason: '',
+      amount: Math.max(0, Math.floor(event.bytes)),
+      details_json: stringifyDetails(event.details),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Read API (minimal — digest queries arrive in follow-up)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Return the most recent N rows, newest first. Optionally filter by
+   * event type. Intended for diagnostics and tests; production digest
+   * code should use a dedicated aggregation query.
+   *
+   * @param limit - Max rows to return (capped at 1000)
+   * @param eventType - Optional event-type filter
+   */
+  public listRecent(
+    limit = 100,
+    eventType?: BehaviorLogEventType,
+  ): BehaviorLogRecord[] {
+    const cappedLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+    const stmt = eventType
+      ? this.db.prepare(
+          `SELECT * FROM agent_behavior_log
+             WHERE event_type = ?
+             ORDER BY id DESC
+             LIMIT ?`,
+        )
+      : this.db.prepare(
+          `SELECT * FROM agent_behavior_log
+             ORDER BY id DESC
+             LIMIT ?`,
+        );
+    const rows = (
+      eventType ? stmt.all(eventType, cappedLimit) : stmt.all(cappedLimit)
+    ) as BehaviorLogRow[];
+    return rows.map(rowToRecord);
+  }
+
+  /**
+   * Count rows by event type since a given timestamp. Useful for the
+   * weekly digest's per-event totals.
+   *
+   * @param sinceTs - Inclusive ms-since-epoch lower bound (default 0 = all time)
+   */
+  public countByEvent(sinceTs = 0): Record<string, number> {
+    const rows = this.db
+      .prepare(
+        `SELECT event_type AS et, COUNT(*) AS n
+           FROM agent_behavior_log
+           WHERE ts >= ?
+           GROUP BY event_type`,
+      )
+      .all(sinceTs) as Array<{ et: string; n: number }>;
+    const out: Record<string, number> = {};
+    for (const r of rows) {
+      out[r.et] = Number(r.n);
+    }
+    return out;
+  }
+
+  /**
+   * Close the underlying DB handle if this service opened it. Safe to
+   * call multiple times.
+   */
+  public close(): void {
+    if (this.ownsDb) {
+      try {
+        this.db.close();
+      } catch (err) {
+        this.logger.warn('Error closing observability DB', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Stringify a details payload to JSON, defaulting to '{}' when no
+ * payload is supplied or the value is not serialisable. Never throws.
+ */
+function stringifyDetails(details: Record<string, unknown> | undefined): string {
+  if (!details) return '{}';
+  try {
+    return JSON.stringify(details);
+  } catch {
+    return '{}';
+  }
+}
+
+/**
+ * Decode a raw `BehaviorLogRow` (as returned by SQLite) into a
+ * domain-friendly `BehaviorLogRecord` with `details_json` parsed.
+ */
+function rowToRecord(row: BehaviorLogRow): BehaviorLogRecord {
+  let details: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(row.details_json || '{}');
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      details = parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* fall through to empty object */
+  }
+  return {
+    id: row.id,
+    ts: row.ts,
+    eventType: row.event_type,
+    agent: row.agent,
+    subject: row.subject,
+    taskId: row.task_id,
+    reason: row.reason,
+    amount: row.amount,
+    details,
+  };
+}

--- a/backend/src/services/observability/agent-behavior-log.types.test.ts
+++ b/backend/src/services/observability/agent-behavior-log.types.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for `agent-behavior-log.types`.
+ *
+ * @module services/observability/agent-behavior-log.types.test
+ */
+
+import {
+  BEHAVIOR_LOG_EVENT_TYPES,
+  isBehaviorLogEventType,
+} from './agent-behavior-log.types.js';
+
+describe('agent-behavior-log.types', () => {
+  describe('BEHAVIOR_LOG_EVENT_TYPES', () => {
+    it('exposes the four canonical event types', () => {
+      expect(BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION).toBe('agent.action');
+      expect(BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION).toBe('agent.escalation');
+      expect(BEHAVIOR_LOG_EVENT_TYPES.SLACK_DELIVERY_FAILED).toBe(
+        'slack.delivery.failed',
+      );
+      expect(BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES).toBe('prompt.size.bytes');
+    });
+
+    it('every value is a unique non-empty string', () => {
+      const values = Object.values(BEHAVIOR_LOG_EVENT_TYPES);
+      expect(values.every((v) => typeof v === 'string' && v.length > 0)).toBe(true);
+      expect(new Set(values).size).toBe(values.length);
+    });
+  });
+
+  describe('isBehaviorLogEventType', () => {
+    it('returns true for every canonical event type', () => {
+      for (const v of Object.values(BEHAVIOR_LOG_EVENT_TYPES)) {
+        expect(isBehaviorLogEventType(v)).toBe(true);
+      }
+    });
+
+    it('returns false for unknown strings', () => {
+      expect(isBehaviorLogEventType('agent.unknown')).toBe(false);
+      expect(isBehaviorLogEventType('')).toBe(false);
+      expect(isBehaviorLogEventType('Agent.Action')).toBe(false);
+    });
+  });
+});

--- a/backend/src/services/observability/agent-behavior-log.types.ts
+++ b/backend/src/services/observability/agent-behavior-log.types.ts
@@ -1,0 +1,171 @@
+/**
+ * Agent Behavior Log — event type definitions.
+ *
+ * The behavior log is a single-table append-only event store backing
+ * Crewly's minimal internal metrics. Each entry is a strongly-typed
+ * domain event the platform records for later analysis (delegation
+ * rates, escalation patterns, Slack delivery failures, prompt size
+ * trends).
+ *
+ * Schema lives in `observability-db.ts`. Service API in
+ * `agent-behavior-log.service.ts`.
+ *
+ * @module services/observability/agent-behavior-log.types
+ */
+
+// ---------------------------------------------------------------------------
+// Event-type discriminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical event type strings stored in the `event_type` column of
+ * `agent_behavior_log`. Adding a new event type is additive — append a
+ * new constant here AND extend `BehaviorLogEvent` below; do not rename
+ * existing values (downstream digests rely on stable keys).
+ */
+export const BEHAVIOR_LOG_EVENT_TYPES = {
+  /** An agent took a top-level action (delegate, implement, ask_human, send_slack, ...). */
+  AGENT_ACTION: 'agent.action',
+  /** An agent escalated a decision/issue to a higher level in the chain. */
+  AGENT_ESCALATION: 'agent.escalation',
+  /** A Slack message could not be delivered (intended-but-not-sent or API failure). */
+  SLACK_DELIVERY_FAILED: 'slack.delivery.failed',
+  /** Snapshot of an agent's compiled prompt size at session/start build time. */
+  PROMPT_SIZE_BYTES: 'prompt.size.bytes',
+} as const;
+
+/** Union of all canonical event-type strings. */
+export type BehaviorLogEventType =
+  (typeof BEHAVIOR_LOG_EVENT_TYPES)[keyof typeof BEHAVIOR_LOG_EVENT_TYPES];
+
+// ---------------------------------------------------------------------------
+// Per-event payloads
+// ---------------------------------------------------------------------------
+
+/**
+ * Vocabulary for `AgentActionEvent.actionType`. Open-ended on purpose —
+ * extending this list is additive, but the four current values cover
+ * the P0 success-metric needs (delegate-first rate, etc.).
+ */
+export type AgentActionType =
+  | 'delegate'
+  | 'implement'
+  | 'ask_human'
+  | 'send_slack'
+  | 'review'
+  | 'verify'
+  | 'other';
+
+/**
+ * One row of `agent_behavior_log` for a top-level agent action.
+ * Fields beyond agent/actionType are optional; callers should provide
+ * `taskId` and `details` whenever known to enrich downstream digests.
+ */
+export interface AgentActionEvent {
+  type: typeof BEHAVIOR_LOG_EVENT_TYPES.AGENT_ACTION;
+  /** Session name of the agent that performed the action. */
+  agent: string;
+  /** Canonical action vocabulary entry. */
+  actionType: AgentActionType;
+  /** Optional related task id (request / work item / spec ticket). */
+  taskId?: string;
+  /** Optional free-form structured details. Stored as JSON. */
+  details?: Record<string, unknown>;
+}
+
+/** One row for an agent → upstream escalation. */
+export interface AgentEscalationEvent {
+  type: typeof BEHAVIOR_LOG_EVENT_TYPES.AGENT_ESCALATION;
+  /** Session name doing the escalating. */
+  escalatingAgent: string;
+  /** Where the escalation went (session name, "owner", "orchestrator", ...). */
+  escalatedTo: string;
+  /** Short reason — kept short on purpose for digest readability. */
+  reason: string;
+  /** Optional related task id. */
+  taskId?: string;
+  /** Optional structured payload for richer review later. */
+  details?: Record<string, unknown>;
+}
+
+/** One row for a Slack delivery that did not land. */
+export interface SlackDeliveryFailedEvent {
+  type: typeof BEHAVIOR_LOG_EVENT_TYPES.SLACK_DELIVERY_FAILED;
+  /** Session name that intended to send. */
+  agent: string;
+  /** Slack thread or channel id (free-form — `channel:thread` is fine). */
+  thread: string;
+  /** Reason: 'no_reply_called' | 'api_error' | 'timeout' | other free string. */
+  reason: string;
+  /** Optional structured payload (response body, status code, etc.). */
+  details?: Record<string, unknown>;
+}
+
+/** One row for a prompt-size sample. */
+export interface PromptSizeBytesEvent {
+  type: typeof BEHAVIOR_LOG_EVENT_TYPES.PROMPT_SIZE_BYTES;
+  /** Session name whose prompt was measured. */
+  agent: string;
+  /** UTF-8 byte size of the compiled prompt. */
+  bytes: number;
+  /** Optional session id discriminator (e.g. registration id). */
+  sessionId?: string;
+  /** Optional structured payload (e.g. component byte breakdown). */
+  details?: Record<string, unknown>;
+}
+
+/** Discriminated union of every behavior-log event the service accepts. */
+export type BehaviorLogEvent =
+  | AgentActionEvent
+  | AgentEscalationEvent
+  | SlackDeliveryFailedEvent
+  | PromptSizeBytesEvent;
+
+// ---------------------------------------------------------------------------
+// Storage row shape (mirrors the `agent_behavior_log` table)
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw row layout for `agent_behavior_log`. The service translates a
+ * `BehaviorLogEvent` into this shape at insert time and back at read
+ * time. Direct callers should generally use the service API rather than
+ * constructing rows by hand.
+ */
+export interface BehaviorLogRow {
+  /** Auto-increment primary key, populated by SQLite. */
+  id: number;
+  /** ms-since-epoch (UTC) of the recording. */
+  ts: number;
+  /** Discriminator string — one of `BehaviorLogEventType`. */
+  event_type: BehaviorLogEventType;
+  /** Primary actor (agent session name) when applicable. May be empty. */
+  agent: string;
+  /** Optional secondary subject (escalatedTo, thread, etc.). May be empty. */
+  subject: string;
+  /** Optional related task id. May be empty. */
+  task_id: string;
+  /** Optional short reason / actionType / etc. May be empty. */
+  reason: string;
+  /** Numeric metric (e.g. prompt byte size); 0 for non-numeric events. */
+  amount: number;
+  /** JSON-encoded details payload; '{}' when no details supplied. */
+  details_json: string;
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true if `value` looks like a known `BehaviorLogEventType`.
+ *
+ * Useful at deserialisation boundaries (e.g. when querying historic
+ * rows) to narrow a generic string into the discriminator union.
+ *
+ * @param value - any string to test
+ */
+export function isBehaviorLogEventType(value: string): value is BehaviorLogEventType {
+  return (
+    Object.values(BEHAVIOR_LOG_EVENT_TYPES).includes(value as BehaviorLogEventType)
+  );
+}

--- a/backend/src/services/observability/observability-db.test.ts
+++ b/backend/src/services/observability/observability-db.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for `observability-db`.
+ *
+ * Uses an in-memory SQLite database so every test starts from a clean
+ * slate without touching the filesystem.
+ *
+ * @module services/observability/observability-db.test
+ */
+
+import {
+  defaultObservabilityDbPath,
+  openObservabilityDatabase,
+  OBSERVABILITY_MIGRATION_SQL,
+  type ObservabilityDatabase,
+} from './observability-db.js';
+
+describe('observability-db', () => {
+  describe('defaultObservabilityDbPath', () => {
+    it('returns an absolute path ending in .crewly/observability.db', () => {
+      const p = defaultObservabilityDbPath();
+      expect(typeof p).toBe('string');
+      expect(p).toMatch(/\.crewly[\\/]observability\.db$/);
+    });
+  });
+
+  describe('OBSERVABILITY_MIGRATION_SQL', () => {
+    it('declares the agent_behavior_log table and indexes', () => {
+      expect(OBSERVABILITY_MIGRATION_SQL).toContain(
+        'CREATE TABLE IF NOT EXISTS agent_behavior_log',
+      );
+      expect(OBSERVABILITY_MIGRATION_SQL).toContain('ix_behavior_log_ts');
+      expect(OBSERVABILITY_MIGRATION_SQL).toContain('ix_behavior_log_event_ts');
+      expect(OBSERVABILITY_MIGRATION_SQL).toContain(
+        'ix_behavior_log_agent_event_ts',
+      );
+    });
+  });
+
+  describe('openObservabilityDatabase', () => {
+    let db: ObservabilityDatabase;
+
+    afterEach(() => {
+      try {
+        db?.close();
+      } catch {
+        /* tolerate double-close in failure paths */
+      }
+    });
+
+    it('opens an in-memory DB and creates the schema', () => {
+      db = openObservabilityDatabase({
+        inMemory: true,
+        skipIntegrityCheck: true,
+      });
+      const tableInfo = db
+        .prepare("PRAGMA table_info('agent_behavior_log')")
+        .all() as Array<{ name: string }>;
+      const cols = tableInfo.map((r) => r.name);
+      expect(cols).toEqual(
+        expect.arrayContaining([
+          'id',
+          'ts',
+          'event_type',
+          'agent',
+          'subject',
+          'task_id',
+          'reason',
+          'amount',
+          'details_json',
+        ]),
+      );
+    });
+
+    it('is idempotent — opening twice does not error', () => {
+      db = openObservabilityDatabase({
+        inMemory: true,
+        skipIntegrityCheck: true,
+      });
+      // A second exec of the same DDL on the same DB must be safe.
+      expect(() => db.exec(OBSERVABILITY_MIGRATION_SQL)).not.toThrow();
+    });
+
+    it('creates the expected indexes', () => {
+      db = openObservabilityDatabase({
+        inMemory: true,
+        skipIntegrityCheck: true,
+      });
+      const indexes = db
+        .prepare(
+          `SELECT name FROM sqlite_master
+             WHERE type='index' AND tbl_name='agent_behavior_log'`,
+        )
+        .all() as Array<{ name: string }>;
+      const names = indexes.map((i) => i.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'ix_behavior_log_ts',
+          'ix_behavior_log_event_ts',
+          'ix_behavior_log_agent_event_ts',
+        ]),
+      );
+    });
+
+    it('accepts inserts after migration', () => {
+      db = openObservabilityDatabase({
+        inMemory: true,
+        skipIntegrityCheck: true,
+      });
+      const stmt = db.prepare(
+        `INSERT INTO agent_behavior_log
+           (ts, event_type, agent, subject, task_id, reason, amount, details_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const info = stmt.run(
+        Date.now(),
+        'agent.action',
+        'crewly-orc',
+        '',
+        'task-1',
+        'delegate',
+        0,
+        '{"foo":1}',
+      );
+      expect(Number(info.lastInsertRowid)).toBeGreaterThan(0);
+
+      const row = db
+        .prepare('SELECT COUNT(*) AS n FROM agent_behavior_log')
+        .get() as { n: number };
+      expect(row.n).toBe(1);
+    });
+  });
+});

--- a/backend/src/services/observability/observability-db.ts
+++ b/backend/src/services/observability/observability-db.ts
@@ -1,0 +1,220 @@
+/**
+ * Observability SQLite bootstrap.
+ *
+ * Opens (or creates) `~/.crewly/observability.db` and applies the
+ * idempotent migration for `agent_behavior_log`. The schema is a
+ * single append-only table that backs Crewly's minimal internal
+ * metrics (delegate-first rate, escalation patterns, slack-delivery
+ * failure counters, prompt-size trends).
+ *
+ * This module mirrors the lazy `better-sqlite3` loader pattern from
+ * `services/chat-v2/sqlite/chat-db.ts` so the native module never
+ * loads at import time — only when an opener is first called.
+ *
+ * @module services/observability/observability-db
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import { existsSync, mkdirSync } from 'fs';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+// ---------------------------------------------------------------------------
+// Lazy better-sqlite3 loader (same pattern as chat-db.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * CJS-style `require` scoped to this module. `better-sqlite3` is a
+ * native addon and must be loaded via CJS `require`, but this module
+ * compiles to ESM where the bare `require` global is undefined.
+ *
+ * Anchored to `process.argv[1]` (entry script) instead of
+ * `import.meta.url` so ts-jest's CJS test compile (which rejects literal
+ * `import.meta`) can still resolve the require root.
+ */
+const nodeRequire: NodeRequire =
+  typeof require === 'function'
+    ? require
+    : createRequire(pathToFileURL(process.argv[1] || process.cwd()).href);
+
+/** Cached reference to the better-sqlite3 module after first successful load. */
+let _BetterSqlite3: typeof import('better-sqlite3') | null = null;
+
+/**
+ * Load `better-sqlite3` on demand. Throws a clear error if the native
+ * addon cannot be loaded (a common symptom after Node upgrades).
+ *
+ * @returns The lazily-imported better-sqlite3 module
+ */
+function getBetterSqlite3(): typeof import('better-sqlite3') {
+  if (!_BetterSqlite3) {
+    try {
+      _BetterSqlite3 = nodeRequire('better-sqlite3');
+    } catch (err) {
+      throw new Error(
+        'better-sqlite3 native module failed to load. Run `npm rebuild better-sqlite3` to fix. ' +
+          `Original error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  return _BetterSqlite3!;
+}
+
+/** Type alias for a `better-sqlite3` Database instance. */
+export type ObservabilityDatabase = import('better-sqlite3').Database;
+
+// ---------------------------------------------------------------------------
+// Migration DDL
+// ---------------------------------------------------------------------------
+
+/**
+ * Idempotent base DDL for the observability database.
+ *
+ * Single table strategy: every behavior event lives in
+ * `agent_behavior_log`, discriminated by `event_type`. Per-event-type
+ * payload variation is captured in the optional `subject`, `task_id`,
+ * `reason`, `amount`, and `details_json` columns. This keeps the
+ * schema small while supporting later additive event types without
+ * migrations.
+ *
+ * Indexes are scoped to the most common query shapes for the weekly
+ * digest (per-agent, per-event-type, per-time-window).
+ */
+export const OBSERVABILITY_MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS agent_behavior_log (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts            INTEGER NOT NULL,
+  event_type    TEXT NOT NULL,
+  agent         TEXT NOT NULL DEFAULT '',
+  subject       TEXT NOT NULL DEFAULT '',
+  task_id       TEXT NOT NULL DEFAULT '',
+  reason        TEXT NOT NULL DEFAULT '',
+  amount        INTEGER NOT NULL DEFAULT 0,
+  details_json  TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS ix_behavior_log_ts
+  ON agent_behavior_log(ts);
+
+CREATE INDEX IF NOT EXISTS ix_behavior_log_event_ts
+  ON agent_behavior_log(event_type, ts);
+
+CREATE INDEX IF NOT EXISTS ix_behavior_log_agent_event_ts
+  ON agent_behavior_log(agent, event_type, ts);
+`;
+
+// ---------------------------------------------------------------------------
+// Default path
+// ---------------------------------------------------------------------------
+
+/**
+ * Default on-disk path for the observability database.
+ *
+ * Lives next to the chat database under `~/.crewly/` so operators have a
+ * single directory to back up / inspect.
+ *
+ * @returns Absolute path to `~/.crewly/observability.db`
+ */
+export function defaultObservabilityDbPath(): string {
+  return path.join(os.homedir(), '.crewly', 'observability.db');
+}
+
+// ---------------------------------------------------------------------------
+// Opener
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by `openObservabilityDatabase`.
+ */
+export interface OpenObservabilityDatabaseOptions {
+  /**
+   * Absolute path to the SQLite file. Parent directories are created
+   * as needed. Defaults to `defaultObservabilityDbPath()`.
+   */
+  dbPath?: string;
+  /**
+   * When true, uses SQLite `:memory:` regardless of `dbPath`. Intended
+   * for unit tests. Defaults to false.
+   */
+  inMemory?: boolean;
+  /**
+   * When true, suppress the integrity-check warning on open. Tests use
+   * this to avoid noisy logs. Defaults to false.
+   */
+  skipIntegrityCheck?: boolean;
+  /** Optional logger override — defaults to `LoggerService`. */
+  logger?: ComponentLogger;
+}
+
+/**
+ * Open (or create) the observability database, apply PRAGMAs, run the
+ * idempotent migration, and run a boot-time integrity check.
+ *
+ * Safe to call multiple times during a single process lifetime — each
+ * call returns a fresh `Database` handle the caller is responsible for
+ * closing. In production, code should hold a single shared handle and
+ * close it during graceful shutdown.
+ *
+ * @param options - Opener options
+ * @returns A ready-to-use better-sqlite3 Database handle
+ *
+ * @example
+ * ```ts
+ * const db = openObservabilityDatabase();
+ * // ... use db ...
+ * db.close();
+ * ```
+ */
+export function openObservabilityDatabase(
+  options: OpenObservabilityDatabaseOptions = {},
+): ObservabilityDatabase {
+  const logger =
+    options.logger ??
+    LoggerService.getInstance().createComponentLogger('ObservabilityDb');
+
+  const dbPath = options.dbPath ?? defaultObservabilityDbPath();
+
+  if (!options.inMemory) {
+    const dir = path.dirname(dbPath);
+    if (dir && dir !== '.' && !existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  const Database = getBetterSqlite3();
+  const target = options.inMemory ? ':memory:' : dbPath;
+  const db = new Database(target);
+
+  // PRAGMAs — must be set outside any transaction.
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  // Apply migration idempotently. `exec` accepts multiple statements.
+  db.exec(OBSERVABILITY_MIGRATION_SQL);
+
+  if (!options.skipIntegrityCheck) {
+    try {
+      const rows = db.pragma('integrity_check') as Array<{
+        integrity_check: string;
+      }>;
+      const first = rows[0]?.integrity_check;
+      if (first && first !== 'ok') {
+        logger.warn('Observability DB integrity check reported issues', {
+          result: first,
+        });
+      }
+    } catch (err) {
+      logger.warn(
+        'Observability DB integrity check threw — continuing without gating startup',
+        {
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+  }
+
+  logger.info('Observability DB opened', { path: target });
+  return db;
+}


### PR DESCRIPTION
## Summary
Lands the **schema + write surface** for Crewly's first-party behavior log — the foundation for the four agent-prompt-improvement P0 metrics agreed in `specs/2026-05-03-agent-improvement-p0-execution.md` (Decision 4):

- `agent.action` — delegate / implement / ask_human / send_slack / review / verify / other
- `agent.escalation` — agent → upstream escalations w/ reason
- `slack.delivery.failed` — Slack messages we intended to deliver but didn't
- `prompt.size.bytes` — per-session compiled-prompt byte size samples

All four schemas land in this PR. Single SQLite table (`agent_behavior_log`) with `event_type` discriminator + flexible row shape (`agent / subject / task_id / reason / amount / details_json`) — additive event types in the future will not need migrations.

## Scope — what's in / what's out

**In this PR (small, reviewable):**
- `services/observability/observability-db.ts` — lazy `better-sqlite3` opener, idempotent migration, indexes for digest queries. Mirrors the proven `chat-v2/sqlite/chat-db.ts` pattern.
- `services/observability/agent-behavior-log.types.ts` — discriminated union of the four event types + storage row shape + type guard.
- `services/observability/agent-behavior-log.service.ts` — typed append-only `record(event)` API + `listRecent` / `countByEvent` for diagnostics. Best-effort writes (never throws into the calling path).
- 1:1 test files per source (per `crewly/CLAUDE.md`).

**Deferred to follow-up PRs (each PR small):**
- **Producer wiring:** `slack.delivery.failed` lands with the P0-5 slack-bridge no-reply detector; `prompt.size.bytes` lands in the prompt-generator follow-up; orchestrator `agent.action` / `agent.escalation` call sites land alongside their respective prompt updates.
- **Aggregation / digest queries:** this PR ships only the helpers needed for diagnostics. The weekly-digest query layer is a separate PR.

## Tier
**Tier:** Fast _(per `config/sops/common/dev-process-tiers.md` — internal-only, additive new service, zero customer-facing surface, no auth/billing impact, low blast radius.)_

## Test plan
- [x] Types unit test (4/4) green locally
- [x] Backend `tsc --noEmit` clean (exit 0, zero diagnostics)
- [ ] CI runs the SQLite-backed tests against an arm64-compiled `better-sqlite3` (this Mac's pre-built binding is x86_64 — same env constraint that excludes `vector-store.service.test.ts`; the `chat-v2/sqlite/chat-db.test.ts` peer follows the same pattern)
- [ ] Reviewer sanity-check on the migration DDL and discriminator branch in `toRowParams`

## Notes
- DB path: `~/.crewly/observability.db` — sits next to `chat.db` so operators have one directory to back up / inspect.
- `record()` is intentionally fire-and-forget; failures are logged, not thrown.
- `toRowParams` uses an exhaustiveness `_never: never` guard so new event types force a TypeScript error until they're handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)