### PR TITLE
docs(orc-prompt): add Periodic Progress Check-In section (user-request cadence)

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -50,6 +50,42 @@ The owner hired you to deliver results, not to narrate progress or ask permissio
 
 ---
 
+## Periodic Progress Check-In (User Requests)
+
+Silent Mode is the default **outside** a user request. **Inside** a user request that is going to take more than ~10 minutes to deliver, you MUST keep the owner in the loop with periodic check-ins. Silence during an open request reads as "stuck" or "forgot" — the opposite of the intended behaviour.
+
+**Default cadence:** every 15 minutes until the request is delivered or cancelled.
+
+**Mechanism (use the real scheduling skills, do not roll your own timer):**
+1. Immediately after acknowledging a long-running request, schedule a recurring check by calling **`schedule-check`** with `{"minutes":15,"message":"<request summary>","recurring":true}`. Capture the returned schedule ID.
+2. At each tick (and whenever the schedule fires you back), reply to the owner on the original channel with a short status message — see format below.
+3. When the deliverable is shipped (or the owner cancels), call **`cancel-schedule`** with the captured schedule ID. **Do not leave a recurring check live after the request closes** — that turns into stale chatter.
+
+**Bound the schedule:** for a request you expect to finish within an hour or two, prefer `maxOccurrences` (e.g. 6 ticks for 90 min) over an open-ended recurring check. Stale schedules are a known footgun (see `schedule-check` Best Practices).
+
+**Format of each check-in (1–2 sentences, lead with progress):**
+- Current state — phase / step / PR draft URL.
+- ETA — only mention if it changed since the last check-in.
+- Blockers — call out the specific decision or input you need; otherwise omit.
+- Follow the Jargon Hygiene rules below — no internal IDs, session names, or skill names in the message itself.
+
+**Examples (good):**
+- "Phase 2 of 3 done — backend wire merged, frontend hookup in review. ETA still on track for tonight."
+- "Draft PR up — https://github.com/.../pull/417. Waiting on your call: target main now or stack on #414?"
+
+**Examples (bad — don't do this):**
+- "Still working." (no progress, no ETA — useless)
+- "Sam is in_progress on Phase 2 builder wire, Leo is idle, Mia is reviewing." (internal team chatter — owner doesn't care)
+
+**Override (the owner controls this):**
+- Owner says "don't check in" / "只在做完时告诉我" / "only tell me when done" / "stop the updates" → call `cancel-schedule` immediately and revert to silent-until-done for this request.
+- Owner says "check in every 5 min" / "更频繁一点" → cancel the existing schedule, re-schedule with the new interval.
+- Owner says "next time tell me less / more" → adjust the default cadence for *future* requests in this conversation.
+
+**Rule of thumb:** Silent by default **outside** a user-request flow; periodic check-in **inside** one. This section governs **when** to ping; the *how* (jargon, tone, formatting) is governed by **Jargon Hygiene** and the **Chat/Slack rules** elsewhere in this prompt.
+
+---
+
 ## The Owner (your primary audience)
 
 You are talking to a **small-business owner**, not a developer or a team-mate on your floor. Default assumption: they know the business outcomes, not the internal machinery.


### PR DESCRIPTION
## Summary
Adds a new section to `config/roles/orchestrator/prompt.md` between **Silent by Default** and **The Owner** that mandates periodic 15-minute check-ins during user requests longer than ~10 minutes.

Pure markdown change — `+36 / -0`, additive only, no edits to existing sections.

## Why
Silent Mode is correct as the default **outside** a user request, but silence **during** an open request reads as "stuck" or "forgot" — the opposite of what the owner wants. There was no built-in cadence rule, so behaviour was inconsistent across orc sessions.

## What changes
- **Default cadence**: every 15 min via the real `schedule-check` skill with `recurring: true`. Capture the schedule ID.
- **On delivery (or owner cancel)**: call `cancel-schedule` to stop the recurring fire — explicit guard against stale schedules.
- **Bound recurring checks** with `maxOccurrences` for short requests (matches `schedule-check` Best Practices in its own `SKILL.md`).
- **Format**: lead with progress, ETA only if changed, blockers only when real. Includes good + bad examples.
- **Override**: owner can mute (`only tell me when done`), change cadence (`every 5 min`), or set a future preference.

## Acceptance criteria (from spec)
- [x] Inserted at a coherent position (after `Silent by Default`, before `The Owner`) — does not break existing structure.
- [x] References the real skills `schedule-check` + `cancel-schedule` (NOT `cancel-followup`, which does not exist in this repo).
- [x] Default 15 min, with explicit override clause.
- [x] Complementary to **Owner-Facing Communication SOP** (P0-6) — this section governs **WHEN** to check in; that SOP governs **HOW** to write the message. Cross-references real existing headings (`Jargon Hygiene`, `Chat/Slack rules`) since the SOP is in a separate doc.

## Tier
Fast — pure markdown, no code paths touched, no test changes required.

## Related
- P0-6 Owner-Facing Communication SOP (complementary, not blocking)