### PR TITLE
fix(memory): #415 — rewire M1 mission-context to PromptBuilderService (live path)

### DIFF
--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -726,6 +726,35 @@ describe('PromptBuilderService', () => {
 			});
 			expect(config.subordinates?.[0].name).toBe('Pre-resolved');
 		});
+
+		// Mission/OKR card plumbing — fix #415 secondary findings.
+		// Slug is required to resolve `<slug>-team-sub-okr.md`; ancestor
+		// chain is required for the OKR-hierarchy filter widening.
+		describe('mission-context plumbing (#415)', () => {
+			it('slugifies team.name into teamSlug (lowercase, hyphenated, alnum-only)', () => {
+				const team = { ...buildTeam(), name: 'Crewly Product!' } as Team;
+				const config = buildModuleConfigFromTeamMember(buildMember(), team, runtime);
+				expect(config.teamSlug).toBe('crewly-product');
+			});
+
+			it('teamSlug is undefined when team.name is empty', () => {
+				const team = { ...buildTeam(), name: '' } as Team;
+				const config = buildModuleConfigFromTeamMember(buildMember(), team, runtime);
+				expect(config.teamSlug).toBeUndefined();
+			});
+
+			it('teamAncestorIds contains parentTeamId when set', () => {
+				const team = { ...buildTeam(), parentTeamId: 'parent-team-x' } as Team;
+				const config = buildModuleConfigFromTeamMember(buildMember(), team, runtime);
+				expect(config.teamAncestorIds).toEqual(['parent-team-x']);
+			});
+
+			it('teamAncestorIds is undefined when team has no parent', () => {
+				const team = { ...buildTeam(), parentTeamId: undefined } as Team;
+				const config = buildModuleConfigFromTeamMember(buildMember(), team, runtime);
+				expect(config.teamAncestorIds).toBeUndefined();
+			});
+		});
 	});
 
 	describe('buildSystemPromptWithTeamContext (WIRE-2)', () => {

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -157,7 +157,30 @@ export function buildModuleConfigFromTeamMember(
 		teamQualityGate: team.qualityGate,
 		serviceContract: team.serviceContract,
 		teamOwnershipScope: team.ownershipScope,
+
+		// === Team-graph context (consumed by MissionContextModule) ===
+		// Slug derived from team name; matches the convention used elsewhere
+		// (e.g. template.controller.toSlug + sessionName composition).
+		// Used to resolve `<teamSlug>-team-sub-okr.md` under .crewly/goals/.
+		teamSlug: team.name ? toTeamSlug(team.name) : undefined,
+		// Single-level parent only — modules that need deeper ancestry
+		// should call a graph resolver. Walking the full parent chain
+		// here would require runtime team-graph access this builder
+		// intentionally does not have.
+		teamAncestorIds: team.parentTeamId ? [team.parentTeamId] : undefined,
 	};
+}
+
+/**
+ * Convert a team name to a URL-safe slug (lowercase, hyphens, alnum only).
+ * Mirrors `toSlug` in `controllers/template/template.controller.ts` so
+ * goal / OKR file naming stays consistent across the codebase.
+ *
+ * @param name - Human-readable team name
+ * @returns Lowercase slug suitable for file path segments
+ */
+function toTeamSlug(name: string): string {
+	return name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
 }
 
 /**

--- a/backend/src/services/ai/prompt-modules/index.ts
+++ b/backend/src/services/ai/prompt-modules/index.ts
@@ -26,6 +26,7 @@ export { TeamReferenceModule } from './team-reference.module.js';
 export { ProjectReferenceModule } from './project-reference.module.js';
 export { UserProfileReferenceModule } from './user-profile-reference.module.js';
 export { LearningReferenceModule } from './learning-reference.module.js';
+export { MissionContextModule } from './mission-context.module.js';
 export { CommunicationModule } from './communication.module.js';
 export { RecoveryModule } from './recovery.module.js';
 export { LifecycleModule } from './lifecycle.module.js';

--- a/backend/src/services/ai/prompt-modules/mission-context.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/mission-context.module.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for MissionContextModule — the live wire-in for mission/OKR
+ * auto-injection (fix #415, replaces the dead PromptGeneratorService
+ * hook).
+ *
+ * @module services/ai/prompt-modules/mission-context.module.test
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { MissionContextModule } from './mission-context.module.js';
+import type { ModuleConfig } from './prompt-module.interface.js';
+import { MissionContextService } from '../../memory/mission-context.service.js';
+
+/**
+ * Build a minimal MissionContextService stub that records every call
+ * and returns whatever the test sets up.
+ */
+function makeStubService(returnValue: string | Error): {
+	service: MissionContextService;
+	calls: Array<Parameters<MissionContextService['getContextForAgent']>[0]>;
+} {
+	const calls: Array<Parameters<MissionContextService['getContextForAgent']>[0]> = [];
+	const service = {
+		getContextForAgent: jest.fn(async (req: Parameters<MissionContextService['getContextForAgent']>[0]) => {
+			calls.push(req);
+			if (returnValue instanceof Error) throw returnValue;
+			return returnValue;
+		}),
+	} as unknown as MissionContextService;
+	return { service, calls };
+}
+
+const baseConfig: ModuleConfig = {
+	sessionName: 'crewly-product-leo-21a5477e',
+	memberId: '21a5477e-ec10-4e45-8cae-8b55e232e04e',
+	role: 'developer',
+	teamId: '28a4ac10-f37f-4286-ad8c-6926a0e177f5',
+	projectPath: '/Users/me/projects/crewly',
+	agentSkillsPath: '/path/to/skills/agent',
+	tlSkillsPath: '/path/to/skills/team-leader',
+	projectRoot: '/path/to/project',
+};
+
+describe('MissionContextModule', () => {
+	beforeEach(() => {
+		MissionContextService.clearInstance();
+	});
+
+	describe('metadata', () => {
+		it('declares name=mission_context, priority=7, max=600, compactable=true', () => {
+			const m = new MissionContextModule();
+			expect(m.name).toBe('mission_context');
+			expect(m.priority).toBe(7);
+			expect(m.maxTokens).toBe(600);
+			expect(m.compactable).toBe(true);
+		});
+	});
+
+	describe('shouldInclude', () => {
+		const m = new MissionContextModule();
+
+		it('includes when teamId is set and not in eval mode', () => {
+			expect(m.shouldInclude(baseConfig)).toBe(true);
+		});
+
+		it('skips when teamId is missing', () => {
+			expect(m.shouldInclude({ ...baseConfig, teamId: undefined })).toBe(false);
+		});
+
+		it('skips in eval mode (token saving)', () => {
+			expect(m.shouldInclude({ ...baseConfig, evalMode: true })).toBe(false);
+		});
+	});
+
+	describe('build', () => {
+		it('forwards sessionName, projectPath, teamId, teamSlug, ancestorTeamIds to service', async () => {
+			const { service, calls } = makeStubService('## Current Mission Context\n\nActive Project OKR (90-day):\n- Cloud MVP launch by Q2');
+			const m = new MissionContextModule(service);
+
+			const result = await m.build({
+				...baseConfig,
+				teamSlug: 'product',
+				teamAncestorIds: ['parent-team-1', 'company-team'],
+			});
+
+			expect(calls).toHaveLength(1);
+			expect(calls[0]).toEqual({
+				agentId: baseConfig.sessionName,
+				projectPath: baseConfig.projectPath,
+				teamId: baseConfig.teamId,
+				ancestorTeamIds: ['parent-team-1', 'company-team'],
+				teamSlug: 'product',
+			});
+			expect(result).toContain('## Current Mission Context');
+		});
+
+		it('does NOT use process.cwd() — uses config.projectPath verbatim', async () => {
+			const { service, calls } = makeStubService('card');
+			const m = new MissionContextModule(service);
+
+			await m.build({ ...baseConfig, projectPath: '/explicit/project/path' });
+
+			expect(calls[0].projectPath).toBe('/explicit/project/path');
+			expect(calls[0].projectPath).not.toBe(process.cwd());
+		});
+
+		it('returns empty string when projectPath is missing (defensive guard)', async () => {
+			const { service } = makeStubService('card');
+			const m = new MissionContextModule(service);
+
+			const result = await m.build({ ...baseConfig, projectPath: undefined });
+
+			expect(result).toBe('');
+		});
+
+		it('returns empty string when teamId is missing (defensive guard)', async () => {
+			const { service } = makeStubService('card');
+			const m = new MissionContextModule(service);
+
+			const result = await m.build({ ...baseConfig, teamId: undefined });
+
+			expect(result).toBe('');
+		});
+
+		it('returns trimmed card content from service', async () => {
+			const { service } = makeStubService('   \n## Card body\n   ');
+			const m = new MissionContextModule(service);
+
+			const result = await m.build(baseConfig);
+
+			expect(result).toBe('## Card body');
+		});
+
+		it('returns empty string when service returns empty string', async () => {
+			const { service } = makeStubService('');
+			const m = new MissionContextModule(service);
+
+			const result = await m.build(baseConfig);
+
+			expect(result).toBe('');
+		});
+
+		it('is fail-soft: returns empty string when service throws', async () => {
+			const { service } = makeStubService(new Error('mission file unparseable'));
+			const m = new MissionContextModule(service);
+
+			const result = await m.build(baseConfig);
+
+			expect(result).toBe('');
+		});
+
+		it('passes undefined teamSlug through unchanged when caller did not supply one', async () => {
+			const { service, calls } = makeStubService('card');
+			const m = new MissionContextModule(service);
+
+			await m.build(baseConfig);
+
+			expect(calls[0].teamSlug).toBeUndefined();
+		});
+
+		it('passes undefined ancestorTeamIds when none configured', async () => {
+			const { service, calls } = makeStubService('card');
+			const m = new MissionContextModule(service);
+
+			await m.build(baseConfig);
+
+			expect(calls[0].ancestorTeamIds).toBeUndefined();
+		});
+	});
+});

--- a/backend/src/services/ai/prompt-modules/mission-context.module.ts
+++ b/backend/src/services/ai/prompt-modules/mission-context.module.ts
@@ -1,0 +1,112 @@
+/**
+ * Mission Context module — auto-injects the agent's current mission /
+ * OKR context into the assembled prompt.
+ *
+ * Wraps `MissionContextService.getContextForAgent` and registers
+ * cleanly inside the live `PromptAssemblyService` pipeline. This is the
+ * production wire-in for Memory Phase 1 / fix #415; the older hook in
+ * `PromptGeneratorService.generateMemberPrompt` was on a dead code path.
+ *
+ * Behavior:
+ *   - Skipped when `teamId` is missing or `evalMode` is true.
+ *   - `build()` is fail-soft: any service error logs a warn and returns
+ *     `''` so the assembler never breaks because of a missing missions
+ *     directory or a malformed mission file.
+ *   - Uses `config.projectPath` as the source of truth — no `process.cwd()`.
+ *   - Forwards `teamSlug` for sub-OKR slug lookup and `teamAncestorIds`
+ *     so missions owned by parent teams in the OKR hierarchy are also
+ *     surfaced.
+ *
+ * @module services/ai/prompt-modules/mission-context.module
+ */
+
+import { LoggerService, type ComponentLogger } from '../../core/logger.service.js';
+import { MissionContextService } from '../../memory/mission-context.service.js';
+import { PromptModule, ModuleConfig } from './prompt-module.interface.js';
+
+/**
+ * Priority slot for the mission card. Sits after team references
+ * (priority 6) and before learning references (priority 10) so the
+ * agent first sees who they work with, then what mission they are
+ * serving, then how to learn from past work.
+ */
+const MISSION_CONTEXT_PRIORITY = 7;
+
+/**
+ * Soft token budget. The service caps the rendered card at 2KB hard
+ * cap (~512 tokens at 4 chars/token); this gives the assembler some
+ * headroom for the markdown framing.
+ */
+const MISSION_CONTEXT_MAX_TOKENS = 600;
+
+/**
+ * Implements the PromptModule interface for the mission-context card.
+ */
+export class MissionContextModule implements PromptModule {
+	name = 'mission_context';
+	priority = MISSION_CONTEXT_PRIORITY;
+	maxTokens = MISSION_CONTEXT_MAX_TOKENS;
+	compactable = true;
+
+	private readonly logger: ComponentLogger;
+	private readonly service: MissionContextService;
+
+	/**
+	 * Construct the module. The service is resolved lazily through its
+	 * singleton — passing one in is supported for tests.
+	 *
+	 * @param service - Optional override for the mission-context service
+	 */
+	constructor(service?: MissionContextService) {
+		this.logger = LoggerService.getInstance().createComponentLogger('MissionContextModule');
+		this.service = service ?? MissionContextService.getInstance();
+	}
+
+	/**
+	 * Skip the card when the agent has no team (no scoping anchor) or
+	 * the assembler is in eval mode (token-saving).
+	 *
+	 * @param config - Module configuration
+	 * @returns true when the card should be built
+	 */
+	shouldInclude(config: ModuleConfig): boolean {
+		if (config.evalMode) return false;
+		if (!config.teamId) return false;
+		return true;
+	}
+
+	/**
+	 * Build the mission card by delegating to MissionContextService.
+	 * Returns the empty string on any error or when there is nothing to
+	 * surface.
+	 *
+	 * @param config - Module configuration with resolved project path,
+	 *   team id, optional team slug and optional ancestor team ids.
+	 * @returns Rendered mission card markdown or `''` to skip the section
+	 */
+	async build(config: ModuleConfig): Promise<string> {
+		// `shouldInclude` already guarded these; defensive for direct callers.
+		if (!config.teamId || !config.projectPath) return '';
+
+		try {
+			const card = await this.service.getContextForAgent({
+				agentId: config.sessionName,
+				projectPath: config.projectPath,
+				teamId: config.teamId,
+				ancestorTeamIds: config.teamAncestorIds,
+				teamSlug: config.teamSlug,
+			});
+			return card ? card.trim() : '';
+		} catch (err) {
+			this.logger.warn(
+				'MissionContextService threw — skipping mission card for this assembly',
+				{
+					sessionName: config.sessionName,
+					teamId: config.teamId,
+					error: err instanceof Error ? err.message : String(err),
+				}
+			);
+			return '';
+		}
+	}
+}

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
@@ -74,7 +74,9 @@ describe('PromptAssemblyService', () => {
 			expect(names).toContain('domain-sop');
 			expect(names).toContain('risk-policy');
 			expect(names).toContain('team-norms');
-			expect(names.length).toBe(17);
+			// Mission/OKR card (fix #415 — replaces dead PromptGenerator hook)
+			expect(names).toContain('mission_context');
+			expect(names.length).toBe(18);
 		});
 
 		it('should use default token budget of 28000', () => {

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
@@ -16,6 +16,7 @@ import { TeamReferenceModule } from './team-reference.module.js';
 import { ProjectReferenceModule } from './project-reference.module.js';
 import { UserProfileReferenceModule } from './user-profile-reference.module.js';
 import { LearningReferenceModule } from './learning-reference.module.js';
+import { MissionContextModule } from './mission-context.module.js';
 import { CommunicationModule } from './communication.module.js';
 import { RecoveryModule } from './recovery.module.js';
 import { LifecycleModule } from './lifecycle.module.js';
@@ -114,6 +115,11 @@ export class PromptAssemblyService {
 			new MemoryReferenceModule(),
 			new SkillsReferenceModule(),
 			new TeamReferenceModule(),
+			// Mission/OKR card — sits right after team references so the
+			// agent first sees who they work with, then the mission they
+			// are serving. Live wire-in for fix #415; replaces the dead
+			// PromptGeneratorService hook.
+			new MissionContextModule(),
 			new CapabilityOverlayModule(),
 			new ProjectReferenceModule(),
 			new CommunicationModule(),

--- a/backend/src/services/ai/prompt-modules/prompt-module.interface.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-module.interface.ts
@@ -90,6 +90,22 @@ export interface ModuleConfig {
 	teamQualityGate?: { reviewerId?: string; autoApprove?: boolean; minQualityScore?: number };
 	/** Absolute path to team norms directory (from template application) */
 	teamNormsPath?: string;
+	/**
+	 * Human-readable team slug used for resolving slug-named team files
+	 * (e.g. `<teamSlug>-team-sub-okr.md` under `.crewly/goals/`).
+	 * Populated by PromptBuilderService from team metadata when available.
+	 * Optional — modules MUST tolerate undefined and skip slug-dependent
+	 * sections silently.
+	 */
+	teamSlug?: string;
+	/**
+	 * Team-graph ancestor IDs (parent, grandparent, ...) used by modules
+	 * that need to surface inherited org context such as parent-team
+	 * missions / OKRs. Caller resolves the chain; modules consume it
+	 * read-only. Empty / undefined means "no ancestors" — modules MUST
+	 * default to a single-team view rather than error.
+	 */
+	teamAncestorIds?: string[];
 
 	// === Eval mode ===
 

--- a/backend/src/services/memory/mission-context.service.test.ts
+++ b/backend/src/services/memory/mission-context.service.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Tests for `MissionContextService`.
+ *
+ * Uses a per-test temp project root so file-system reads exercise the
+ * real `.crewly/...` layout the production service consumes.
+ *
+ * @module services/memory/mission-context.service.test
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import {
+  MissionContextService,
+  MISSION_CONTEXT_HARD_CAP_BYTES,
+  collectRecentStatusUpdates,
+  enforceHardCap,
+  extractMeaningfulLines,
+  renderMissionCard,
+} from './mission-context.service.js';
+import { GoalTrackingService } from './goal-tracking.service.js';
+import type { Mission } from '../../types/v2/mission.types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal valid Mission for tests. Pass overrides for any field
+ * the test cares about.
+ */
+function makeMission(overrides: Partial<Mission> = {}): Mission {
+  return {
+    id: overrides.id ?? `mission-${Math.random().toString(36).slice(2)}`,
+    objective: overrides.objective ?? 'Ship feature X',
+    ownerTeamId: overrides.ownerTeamId ?? 'team-A',
+    successCriteria: overrides.successCriteria ?? ['done by Friday'],
+    currentStrategy: overrides.currentStrategy ?? 'incremental',
+    activeProjectTaskIds: overrides.activeProjectTaskIds ?? [],
+    cadence: overrides.cadence ?? 'weekly',
+    // policy is required by the type but not exercised here — cast through
+    policy: overrides.policy ?? ({} as Mission['policy']),
+    status: overrides.status ?? 'active',
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
+    updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00Z',
+    learnings: overrides.learnings ?? [],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a temp project root with `.crewly/` skeleton for a test.
+ * Returns the absolute path. Caller is responsible for `fs.rm`.
+ */
+async function makeTempProject(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'mission-ctx-'));
+  await fs.mkdir(path.join(root, '.crewly', 'goals'), { recursive: true });
+  await fs.mkdir(path.join(root, '.crewly', 'missions'), { recursive: true });
+  return root;
+}
+
+/** Write `goals.md` for a temp project. */
+async function writeGoals(projectPath: string, body: string): Promise<void> {
+  await fs.writeFile(
+    path.join(projectPath, '.crewly', 'goals', 'goals.md'),
+    body,
+    'utf-8',
+  );
+}
+
+/** Write a team sub-OKR md file for a temp project. */
+async function writeTeamSubOkr(
+  projectPath: string,
+  teamSlug: string,
+  body: string,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(
+      projectPath,
+      '.crewly',
+      'goals',
+      `${teamSlug}-team-sub-okr.md`,
+    ),
+    body,
+    'utf-8',
+  );
+}
+
+/** Persist a Mission as `<id>.json` under `.crewly/missions/`. */
+async function writeMission(
+  projectPath: string,
+  mission: Mission,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(projectPath, '.crewly', 'missions', `${mission.id}.json`),
+    JSON.stringify(mission, null, 2),
+    'utf-8',
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pure-helper tests (no IO)
+// ---------------------------------------------------------------------------
+
+describe('extractMeaningfulLines', () => {
+  it('skips blank lines and HTML comments', () => {
+    const md = `# Heading\n\n<!-- TODO drop this -->\nLine A\n   \nLine B`;
+    expect(extractMeaningfulLines(md, 10)).toEqual([
+      '# Heading',
+      'Line A',
+      'Line B',
+    ]);
+  });
+
+  it('caps at maxLines', () => {
+    const md = ['a', 'b', 'c', 'd', 'e'].join('\n');
+    expect(extractMeaningfulLines(md, 3)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('de-duplicates consecutive identical lines', () => {
+    expect(extractMeaningfulLines('x\nx\ny', 10)).toEqual(['x', 'y']);
+  });
+});
+
+describe('collectRecentStatusUpdates', () => {
+  it('returns empty when no missions have a lastReviewSummary', () => {
+    expect(collectRecentStatusUpdates([makeMission()])).toEqual([]);
+  });
+
+  it('orders by lastReviewAt descending; missing dates sort last', () => {
+    const m1 = makeMission({
+      id: 'm1',
+      objective: 'A',
+      lastReviewSummary: 'sum-A',
+      lastReviewAt: '2026-04-01T00:00:00Z',
+    });
+    const m2 = makeMission({
+      id: 'm2',
+      objective: 'B',
+      lastReviewSummary: 'sum-B',
+      lastReviewAt: '2026-04-15T00:00:00Z',
+    });
+    const m3 = makeMission({
+      id: 'm3',
+      objective: 'C',
+      lastReviewSummary: 'sum-C',
+      // no lastReviewAt
+    });
+    const out = collectRecentStatusUpdates([m1, m2, m3]);
+    expect(out.map((u) => u.missionId)).toEqual(['m2', 'm1', 'm3']);
+  });
+});
+
+describe('renderMissionCard', () => {
+  it('emits headings only for sections with data', () => {
+    const card = renderMissionCard({
+      goalsLines: ['Goal A'],
+      missions: [],
+      teamSubOkrLines: [],
+      statusUpdates: [],
+    });
+    expect(card).toContain('## Current Mission Context');
+    expect(card).toContain('Active Project OKR');
+    expect(card).not.toContain('Current Active Missions');
+    expect(card).not.toContain("Your Team's Sub-OKR");
+  });
+
+  it('renders all sections with the spec template ordering', () => {
+    const card = renderMissionCard({
+      goalsLines: ['Project OKR line'],
+      missions: [
+        makeMission({
+          objective: 'Mission Foo',
+          priority: 'high',
+          successCriteria: ['ship by EOQ'],
+        }),
+      ],
+      teamSubOkrLines: ['Team sub-OKR line'],
+      statusUpdates: [
+        {
+          missionId: 'm1',
+          objective: 'Mission Foo',
+          summary: 'on track',
+          reviewedAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    });
+    const idxOkr = card.indexOf('Active Project OKR');
+    const idxMissions = card.indexOf('Current Active Missions');
+    const idxSub = card.indexOf("Your Team's Sub-OKR");
+    const idxStatus = card.indexOf('Recent Mission Status');
+    expect(idxOkr).toBeGreaterThan(0);
+    expect(idxMissions).toBeGreaterThan(idxOkr);
+    expect(idxSub).toBeGreaterThan(idxMissions);
+    expect(idxStatus).toBeGreaterThan(idxSub);
+    expect(card).toContain('[high] Mission Foo — ship by EOQ');
+    expect(card).toContain('2026-04-01: Mission Foo — on track');
+  });
+});
+
+describe('enforceHardCap', () => {
+  it('passes through cards already under the cap', () => {
+    const small = '## tiny\nhello';
+    expect(enforceHardCap(small, 1024)).toBe(small);
+  });
+
+  it('truncates oversized cards and appends an ellipsis', () => {
+    const big = ['## hdr', ...Array.from({ length: 200 }).map((_, i) => `line-${i}`)].join('\n');
+    const out = enforceHardCap(big, 256);
+    expect(Buffer.byteLength(out, 'utf-8')).toBeLessThanOrEqual(256);
+    expect(out).toContain('… (truncated to fit 2KB cap)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service-level tests (real fs roundtrip)
+// ---------------------------------------------------------------------------
+
+describe('MissionContextService.getContextForAgent', () => {
+  let projectPath: string;
+  let svc: MissionContextService;
+
+  beforeEach(async () => {
+    GoalTrackingService.clearInstance();
+    MissionContextService.clearInstance();
+    projectPath = await makeTempProject();
+    svc = MissionContextService.getInstance();
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectPath, { recursive: true, force: true });
+    GoalTrackingService.clearInstance();
+    MissionContextService.clearInstance();
+  });
+
+  it('returns empty string when no signals are present', async () => {
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).toBe('');
+  });
+
+  it('emits only the goals slice when only goals.md exists', async () => {
+    await writeGoals(projectPath, '# Project OKR\n\nShip Crewly Pro alpha by 6/1');
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).toContain('## Current Mission Context');
+    expect(out).toContain('Active Project OKR');
+    expect(out).toContain('Ship Crewly Pro alpha');
+    expect(out).not.toContain('Current Active Missions');
+    expect(out).not.toContain("Your Team's Sub-OKR");
+  });
+
+  it('filters missions by teamId and active status', async () => {
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-mine-active',
+        objective: 'Mine, active',
+        ownerTeamId: 'team-A',
+        status: 'active',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-mine-paused',
+        objective: 'Mine, paused',
+        ownerTeamId: 'team-A',
+        status: 'paused',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-other-active',
+        objective: 'Other team, active',
+        ownerTeamId: 'team-B',
+        status: 'active',
+      }),
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).toContain('Mine, active');
+    expect(out).not.toContain('Mine, paused');
+    expect(out).not.toContain('Other team, active');
+  });
+
+  it('also includes missions owned by ancestor teams when ancestorTeamIds is provided', async () => {
+    // Critical-priority missions sort first so both expected entries
+    // survive the MAX_MISSIONS=2 cap deterministically.
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-team',
+        objective: 'My team mission',
+        ownerTeamId: 'team-A',
+        status: 'active',
+        priority: 'critical',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-parent',
+        objective: 'Parent team OKR',
+        ownerTeamId: 'parent-team',
+        status: 'active',
+        priority: 'critical',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-other',
+        objective: 'Unrelated team mission',
+        ownerTeamId: 'team-Z',
+        status: 'active',
+        priority: 'critical',
+      }),
+    );
+
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+      ancestorTeamIds: ['parent-team'],
+    });
+
+    expect(out).toContain('My team mission');
+    expect(out).toContain('Parent team OKR');
+    expect(out).not.toContain('Unrelated team mission');
+  });
+
+  it('de-duplicates ancestor team ids that overlap with primary teamId', async () => {
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-only',
+        objective: 'Only mission',
+        ownerTeamId: 'team-A',
+        status: 'active',
+      }),
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+      // Same id repeated should not break the filter or duplicate output.
+      ancestorTeamIds: ['team-A', 'team-A'],
+    });
+    // Mission appears exactly once.
+    expect(out.match(/Only mission/g)?.length).toBe(1);
+  });
+
+  it('caps the surfaced mission count at 2 and respects priority order', async () => {
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-low',
+        objective: 'Low-priority mission',
+        ownerTeamId: 'team-A',
+        priority: 'low',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-crit',
+        objective: 'Critical mission',
+        ownerTeamId: 'team-A',
+        priority: 'critical',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-high',
+        objective: 'High-priority mission',
+        ownerTeamId: 'team-A',
+        priority: 'high',
+      }),
+    );
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-med',
+        objective: 'Medium-priority mission',
+        ownerTeamId: 'team-A',
+        priority: 'medium',
+      }),
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    // Top two priorities should appear; bottom two should not.
+    expect(out).toContain('Critical mission');
+    expect(out).toContain('High-priority mission');
+    expect(out).not.toContain('Medium-priority mission');
+    expect(out).not.toContain('Low-priority mission');
+  });
+
+  it('includes the team sub-OKR slice when teamSlug + file are present', async () => {
+    await writeTeamSubOkr(
+      projectPath,
+      'product',
+      '## Product Sub-OKR\nDeliver 3 design reviews per sprint',
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+      teamSlug: 'product',
+    });
+    expect(out).toContain("Your Team's Sub-OKR");
+    expect(out).toContain('Deliver 3 design reviews per sprint');
+  });
+
+  it('skips the team sub-OKR slice when no teamSlug is provided', async () => {
+    await writeTeamSubOkr(projectPath, 'product', 'Should not appear');
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).not.toContain('Should not appear');
+    expect(out).not.toContain("Your Team's Sub-OKR");
+  });
+
+  it('renders the recent-status section from mission.lastReviewSummary', async () => {
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm1',
+        objective: 'Mission Alpha',
+        ownerTeamId: 'team-A',
+        priority: 'high',
+        lastReviewSummary: 'KR-2 trending green',
+        lastReviewAt: '2026-05-01T00:00:00Z',
+      }),
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).toContain('Recent Mission Status');
+    expect(out).toContain('2026-05-01: Mission Alpha — KR-2 trending green');
+  });
+
+  it('respects the 2KB hard cap', async () => {
+    // Stuff goals.md with a very large body so the renderer wants to overflow.
+    const huge = Array.from({ length: 1000 })
+      .map((_, i) => `Goal-line-${i}-${'x'.repeat(50)}`)
+      .join('\n');
+    await writeGoals(projectPath, huge);
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(Buffer.byteLength(out, 'utf-8')).toBeLessThanOrEqual(
+      MISSION_CONTEXT_HARD_CAP_BYTES,
+    );
+  });
+
+  it('treats corrupt mission JSON as a missing mission, not a failure', async () => {
+    // Valid mission alongside a corrupt sibling.
+    await writeMission(
+      projectPath,
+      makeMission({
+        id: 'm-good',
+        objective: 'Healthy mission',
+        ownerTeamId: 'team-A',
+      }),
+    );
+    await fs.writeFile(
+      path.join(projectPath, '.crewly', 'missions', 'broken.json'),
+      '{not valid json',
+      'utf-8',
+    );
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath,
+      teamId: 'team-A',
+    });
+    expect(out).toContain('Healthy mission');
+  });
+
+  it('returns empty when projectPath does not exist', async () => {
+    const ghost = path.join(os.tmpdir(), 'definitely-not-a-project-' + Date.now());
+    const out = await svc.getContextForAgent({
+      agentId: 'leo',
+      projectPath: ghost,
+      teamId: 'team-A',
+    });
+    expect(out).toBe('');
+  });
+});

--- a/backend/src/services/memory/mission-context.service.ts
+++ b/backend/src/services/memory/mission-context.service.ts
@@ -1,0 +1,470 @@
+/**
+ * Mission Context Service — auto-injectable mission card for agent prompts.
+ *
+ * Builds a compact (≤2KB) markdown card that summarizes the active
+ * project OKR, the team's most-relevant active missions, and the team
+ * sub-OKR (if any) so every agent wakes with the answer to "what
+ * mission am I serving right now?".
+ *
+ * Per Memory Phase 1 / Fix M1: today, agents must call `recall` or
+ * `get_goals` explicitly to find the mission they're serving — and per
+ * the architecture audit, an agent can finish a sprint without ever
+ * reading it. This service closes that gap by feeding a tiny mission
+ * card into prompt assembly automatically.
+ *
+ * Out of scope for Phase 1 (deferred to later phases):
+ *   - Narrative summarization of mission state (no LLM round-trip here)
+ *   - Vector embedding / semantic recall
+ *   - Memory review queue / supersession
+ *
+ * @module services/memory/mission-context.service
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { GoalTrackingService } from './goal-tracking.service.js';
+import {
+  type Mission,
+  sortMissionsByPriority,
+} from '../../types/v2/mission.types.js';
+import { MEMORY_CONSTANTS } from '../../constants.js';
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard upper bound on the rendered mission card. The spec calls for
+ * 1-2KB; we cap at 2KB and truncate by section priority (most-recent
+ * status → oldest first) when over budget.
+ */
+export const MISSION_CONTEXT_HARD_CAP_BYTES = 2048;
+
+/** Maximum lines extracted from `goals.md` for the project-OKR slice. */
+const GOALS_MAX_LINES = 4;
+
+/** Maximum active missions to surface per call (sorted by priority + recency). */
+const MAX_MISSIONS = 2;
+
+/** Maximum status updates surfaced under "Recent Mission Status". */
+const MAX_STATUS_UPDATES = 3;
+
+/** Maximum lines extracted from the team sub-OKR file. */
+const TEAM_SUB_OKR_MAX_LINES = 4;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs accepted by `getContextForAgent`.
+ *
+ * `projectPath` is the absolute path to the project root (the directory
+ * containing `.crewly/`). `teamSlug` is the human-readable team slug
+ * used to resolve `<slug>-team-sub-okr.md`; if omitted, the team-sub-OKR
+ * section is skipped.
+ */
+export interface MissionContextRequest {
+  /** Agent session id, used for logging only. */
+  agentId: string;
+  /** Absolute path to the project root that owns `.crewly/`. */
+  projectPath: string;
+  /** Team id whose missions should be surfaced (matches `Mission.ownerTeamId`). */
+  teamId: string;
+  /**
+   * Optional ancestor team ids whose missions should ALSO be surfaced
+   * to the agent — covers the OKR hierarchy case where a sub-team agent
+   * needs to see the parent team / company-level mission they ladder up
+   * to. Supplied by the caller (PromptBuilderService) which has team-
+   * graph access; the service does no graph traversal of its own.
+   */
+  ancestorTeamIds?: string[];
+  /**
+   * Human-readable team slug used to find `<slug>-team-sub-okr.md`
+   * under `.crewly/goals/`. If omitted, the team-sub-OKR section
+   * is skipped.
+   */
+  teamSlug?: string;
+  /** Optional id (informational, not used for filtering today). */
+  projectId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a small markdown card describing the agent's mission context.
+ *
+ * Singleton, side-effect-free reads. All file IO is fail-soft: any
+ * read or parse error skips the affected section but never throws into
+ * the prompt-assembly path.
+ *
+ * @example
+ * ```ts
+ * const svc = MissionContextService.getInstance();
+ * const card = await svc.getContextForAgent({
+ *   agentId: 'crewly-product-leo-21a5477e',
+ *   projectPath: '/Users/me/projects/crewly',
+ *   teamId: '28a4ac10-...',
+ *   teamSlug: 'product',
+ * });
+ * if (card) prompt += `\n${card}`;
+ * ```
+ */
+export class MissionContextService {
+  private static instance: MissionContextService | null = null;
+  private readonly logger: ComponentLogger;
+  private readonly goalService: GoalTrackingService;
+
+  private constructor() {
+    this.logger = LoggerService.getInstance().createComponentLogger(
+      'MissionContextService',
+    );
+    this.goalService = GoalTrackingService.getInstance();
+  }
+
+  /** Get the shared singleton instance. */
+  public static getInstance(): MissionContextService {
+    if (!MissionContextService.instance) {
+      MissionContextService.instance = new MissionContextService();
+    }
+    return MissionContextService.instance;
+  }
+
+  /** Reset for tests. */
+  public static clearInstance(): void {
+    MissionContextService.instance = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build the mission-context card for an agent.
+   *
+   * Returns the empty string when no signals are available — callers
+   * should treat empty output as "skip the section entirely" rather
+   * than rendering an empty heading.
+   *
+   * @param req - Request inputs
+   * @returns A ≤2KB markdown card, or `''` when nothing is worth showing
+   */
+  public async getContextForAgent(req: MissionContextRequest): Promise<string> {
+    const goalsLines = await this.loadProjectGoalsSlice(req.projectPath);
+    // Filter accepts the agent's own team plus any ancestors (parent OKRs).
+    // De-duped at the call site; service treats the resulting set as the
+    // authoritative match list.
+    const teamScope = uniqueNonEmpty([req.teamId, ...(req.ancestorTeamIds ?? [])]);
+    const missions = await this.loadActiveTeamMissions(
+      req.projectPath,
+      teamScope,
+    );
+    const teamSubOkrLines = await this.loadTeamSubOkrSlice(
+      req.projectPath,
+      req.teamSlug,
+    );
+    const statusUpdates = collectRecentStatusUpdates(missions);
+
+    if (
+      goalsLines.length === 0 &&
+      missions.length === 0 &&
+      teamSubOkrLines.length === 0 &&
+      statusUpdates.length === 0
+    ) {
+      this.logger.debug('No mission signals — emitting empty card', {
+        agentId: req.agentId,
+        teamId: req.teamId,
+      });
+      return '';
+    }
+
+    const card = renderMissionCard({
+      goalsLines,
+      missions: missions.slice(0, MAX_MISSIONS),
+      teamSubOkrLines,
+      statusUpdates: statusUpdates.slice(0, MAX_STATUS_UPDATES),
+    });
+
+    const capped = enforceHardCap(card, MISSION_CONTEXT_HARD_CAP_BYTES);
+    this.logger.debug('Mission card built', {
+      agentId: req.agentId,
+      teamId: req.teamId,
+      bytes: Buffer.byteLength(capped, 'utf-8'),
+      missionCount: missions.length,
+    });
+    return capped;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal readers (each one fail-soft — never throws)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Read up to `GOALS_MAX_LINES` non-empty, non-comment lines from
+   * the project's `goals.md`. Returns `[]` when the file is missing.
+   */
+  private async loadProjectGoalsSlice(projectPath: string): Promise<string[]> {
+    try {
+      const raw = await this.goalService.getGoals(projectPath);
+      if (!raw) return [];
+      return extractMeaningfulLines(raw, GOALS_MAX_LINES);
+    } catch (err) {
+      this.logger.warn('Failed to load project goals.md', {
+        projectPath,
+        error: errMsg(err),
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Read all `*.json` files under `<projectPath>/.crewly/missions/`,
+   * filter to active missions whose `ownerTeamId` is in the supplied
+   * `teamScope` (own team + any ancestor teams the caller passed in),
+   * and sort by priority + recency. Returns `[]` on any error.
+   */
+  private async loadActiveTeamMissions(
+    projectPath: string,
+    teamScope: string[],
+  ): Promise<Mission[]> {
+    if (teamScope.length === 0) return [];
+    const dir = path.join(projectPath, '.crewly', 'missions');
+    let files: string[];
+    try {
+      files = await fs.readdir(dir);
+    } catch {
+      // Directory missing == no missions == empty section. Not an error.
+      return [];
+    }
+
+    const scope = new Set(teamScope);
+    const missions: Mission[] = [];
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      try {
+        const raw = await fs.readFile(path.join(dir, file), 'utf-8');
+        const parsed = JSON.parse(raw) as Mission;
+        if (parsed.status === 'active' && scope.has(parsed.ownerTeamId)) {
+          missions.push(parsed);
+        }
+      } catch (err) {
+        this.logger.debug('Skipping unreadable mission file', {
+          file,
+          error: errMsg(err),
+        });
+      }
+    }
+    return sortMissionsByPriority(missions);
+  }
+
+  /**
+   * Read the team sub-OKR file at
+   * `<projectPath>/.crewly/goals/<teamSlug>-team-sub-okr.md`. Returns
+   * `[]` when no slug, no file, or any read error.
+   */
+  private async loadTeamSubOkrSlice(
+    projectPath: string,
+    teamSlug: string | undefined,
+  ): Promise<string[]> {
+    if (!teamSlug) return [];
+    const filePath = path.join(
+      projectPath,
+      '.crewly',
+      MEMORY_CONSTANTS.PATHS.GOALS_DIR,
+      `${teamSlug}-team-sub-okr.md`,
+    );
+    try {
+      const raw = await fs.readFile(filePath, 'utf-8');
+      return extractMeaningfulLines(raw, TEAM_SUB_OKR_MAX_LINES);
+    } catch {
+      // Missing file is the common case — skip silently.
+      return [];
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Recent mission status entry — pulled from `mission.lastReviewSummary`,
+ * ordered by `lastReviewAt` desc.
+ */
+export interface RecentMissionStatus {
+  missionId: string;
+  objective: string;
+  summary: string;
+  reviewedAt?: string;
+}
+
+/**
+ * Collect the most recent status updates across the supplied missions.
+ * A mission contributes at most one entry. Missions with no
+ * `lastReviewSummary` are skipped. Result is sorted by `lastReviewAt`
+ * descending; missions with no `lastReviewAt` sort last.
+ */
+export function collectRecentStatusUpdates(
+  missions: Mission[],
+): RecentMissionStatus[] {
+  const updates: RecentMissionStatus[] = [];
+  for (const m of missions) {
+    if (!m.lastReviewSummary) continue;
+    updates.push({
+      missionId: m.id,
+      objective: m.objective,
+      summary: m.lastReviewSummary,
+      reviewedAt: m.lastReviewAt,
+    });
+  }
+  updates.sort((a, b) => {
+    const ta = a.reviewedAt ? Date.parse(a.reviewedAt) : 0;
+    const tb = b.reviewedAt ? Date.parse(b.reviewedAt) : 0;
+    return tb - ta;
+  });
+  return updates;
+}
+
+/**
+ * Extract up to `maxLines` "meaningful" lines from a markdown blob.
+ *
+ * Rules:
+ *   - skip empty lines
+ *   - skip standalone HTML/MD comments
+ *   - keep headings, prose, list items
+ *   - trim trailing whitespace
+ *   - de-duplicate consecutive identical lines
+ */
+export function extractMeaningfulLines(
+  raw: string,
+  maxLines: number,
+): string[] {
+  const out: string[] = [];
+  let lastPushed = '';
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) continue;
+    if (/^\s*<!--.*-->\s*$/.test(line)) continue;
+    if (line === lastPushed) continue;
+    out.push(line);
+    lastPushed = line;
+    if (out.length >= maxLines) break;
+  }
+  return out;
+}
+
+/**
+ * Render the final mission card as markdown using the spec template.
+ * Sections with no data are omitted entirely (no empty headings).
+ */
+export function renderMissionCard(args: {
+  goalsLines: string[];
+  missions: Mission[];
+  teamSubOkrLines: string[];
+  statusUpdates: RecentMissionStatus[];
+}): string {
+  const { goalsLines, missions, teamSubOkrLines, statusUpdates } = args;
+  const sections: string[] = ['## Current Mission Context', ''];
+
+  if (goalsLines.length > 0) {
+    sections.push('Active Project OKR (90-day):');
+    for (const line of goalsLines) sections.push(line);
+    sections.push('');
+  }
+
+  if (missions.length > 0) {
+    sections.push('Current Active Missions:');
+    for (const m of missions) {
+      sections.push(`- ${formatMissionLine(m)}`);
+    }
+    sections.push('');
+  }
+
+  if (teamSubOkrLines.length > 0) {
+    sections.push("Your Team's Sub-OKR:");
+    for (const line of teamSubOkrLines) sections.push(line);
+    sections.push('');
+  }
+
+  if (statusUpdates.length > 0) {
+    sections.push('Recent Mission Status:');
+    for (const u of statusUpdates) {
+      sections.push(`- ${formatStatusLine(u)}`);
+    }
+    sections.push('');
+  }
+
+  // Trim trailing blank line for tidiness
+  while (sections.length > 0 && sections[sections.length - 1] === '') {
+    sections.pop();
+  }
+  return sections.join('\n');
+}
+
+/**
+ * Format one mission as a single line: priority + objective +
+ * top-of-success-criteria summary.
+ */
+function formatMissionLine(m: Mission): string {
+  const priority = m.priority ?? 'medium';
+  const tail =
+    m.successCriteria?.length > 0 ? ` — ${m.successCriteria[0]}` : '';
+  return `[${priority}] ${m.objective}${tail}`;
+}
+
+/** Format one status update as a single bullet. */
+function formatStatusLine(u: RecentMissionStatus): string {
+  const date = u.reviewedAt ? u.reviewedAt.slice(0, 10) : '—';
+  return `${date}: ${u.objective} — ${u.summary}`;
+}
+
+/**
+ * Enforce the hard byte cap. If `card` already fits, returns it
+ * unchanged. Otherwise truncates line-by-line from the bottom until
+ * it fits, then appends a single ellipsis line so the card is
+ * obviously truncated.
+ */
+export function enforceHardCap(card: string, maxBytes: number): string {
+  if (Buffer.byteLength(card, 'utf-8') <= maxBytes) return card;
+  const lines = card.split('\n');
+  const ellipsis = '… (truncated to fit 2KB cap)';
+  while (lines.length > 0) {
+    lines.pop();
+    const candidate = `${lines.join('\n')}\n${ellipsis}`;
+    if (Buffer.byteLength(candidate, 'utf-8') <= maxBytes) {
+      return candidate;
+    }
+  }
+  // Even the heading didn't fit — return just the ellipsis.
+  return ellipsis;
+}
+
+/** Stringify an unknown error for log fields. */
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Return the input array de-duplicated and stripped of empty / falsy
+ * entries while preserving first-seen order.
+ */
+function uniqueNonEmpty(values: ReadonlyArray<string | undefined | null>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const v of values) {
+    if (!v) continue;
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Module-level convenience: get the singleton in one call.
+ */
+export const getMissionContextService = (): MissionContextService =>
+  MissionContextService.getInstance();


### PR DESCRIPTION
## Summary

Closes the dead-code-path bug Arch flagged on PR #415. The original M1 implementation hooked `PromptGeneratorService.generateMemberPrompt`, which is no longer in the agent boot path — the live path is `PromptBuilderService` → `PromptAssemblyService.modules[]` (the prompt-modules pattern Sam landed in P0-1 Phase 2). Result: the mission card was never reaching production prompts.

This PR brings M1 back via the correct mechanism and addresses Arch's three secondary findings.

## What changed

- **`MissionContextModule`** (NEW, `backend/src/services/ai/prompt-modules/`) implementing the standard `PromptModule` interface. Sits at priority 7 — after team references, before learning references — so the agent first sees who they work with, then which mission they serve. `compactable=true`, `maxTokens=600`. Build is fail-soft: any service error logs a warn and returns `''`.
- **Registered** the module in `PromptAssemblyService.registerDefaultModules()`.
- **`MissionContextService`** migrated from #415 with the `ownerTeamId === teamId` filter widened — accepts `ancestorTeamIds[]` and matches missions whose owner is anywhere in the team-graph scope (own team ∪ ancestors). Caller resolves the chain; the service does no graph traversal of its own.
- **`ModuleConfig`** gains `teamSlug` and `teamAncestorIds`. `PromptBuilderService.buildModuleConfigFromTeamMember` now populates both — `teamSlug` via local `toTeamSlug` (mirrors `template.controller.toSlug` convention), `teamAncestorIds` via `team.parentTeamId` (single-level today; deeper ancestry deferred to the runtime team-graph resolver).
- **No `process.cwd()`** — module consumes `config.projectPath` the assembler already plumbs.
- **Did NOT** bring over the `prompt-generator.service.ts` hook from #415 — that file stays untouched on this branch (it's the dead path).

## Arch finding mapping

| Finding | Resolution |
|---|---|
| Wired to dead path (PromptGeneratorService) | Replaced with PromptModule registered in PromptAssemblyService (live path) |
| Missing teamSlug pass-through | `teamSlug` now in `ModuleConfig`; populated from `team.name` via `toTeamSlug` |
| Hardcoded `process.cwd()` | Module reads `config.projectPath` exclusively; tested |
| `ownerTeamId`-only filter | Service accepts `ancestorTeamIds[]`, scope-set lookup includes parents |

## Test plan

- [x] `mission-context.module.test.ts` (NEW, 13) — metadata, shouldInclude (teamId / evalMode), payload forwarding, no process.cwd usage, trim/empty/throw handling
- [x] `mission-context.service.test.ts` (21) — original 19 + 2 new (ancestor inclusion, de-dup overlap)
- [x] `prompt-builder.service.test.ts` (+4) — slug + ancestor population in `buildModuleConfigFromTeamMember`
- [x] `prompt-assembly.service.test.ts` (updated) — module count 17 → 18, `mission_context` registered
- [x] **All 173 affected tests pass** in 4 suites
- [x] `tsc --noEmit -p backend` clean
- [ ] Manual smoke: spawn an agent with a populated `.crewly/missions/` directory and verify the mission card lands in the assembled system prompt

## Coordination

Ping sent to Max (`crewly-product-max-358c7cb7`) to follow the same pattern for #416 (M2 working-memory wake card). Plumbing added here (`teamSlug`, `teamAncestorIds`) lands first; M2's module should rebase on this branch and consume the same `ModuleConfig` fields.

## Spec / issue refs

- #415 — M1 dead-path issue (this PR replaces)
- `.crewly/specs/2026-05-03-state-persistence-fix-spec.md` — unrelated; just to confirm we're following the same pattern as Sam's P0-1 Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
