### PR TITLE
fix(typecheck): route baileys dynamic import through string var

### DIFF
--- a/backend/src/services/whatsapp/whatsapp.service.ts
+++ b/backend/src/services/whatsapp/whatsapp.service.ts
@@ -90,9 +90,18 @@ export class WhatsAppService extends EventEmitter {
     await fs.mkdir(authDir, { recursive: true });
 
     try {
-      // Dynamic import for Baileys (ESM/CJS compatibility)
+      // Dynamic import for Baileys (ESM/CJS compatibility).
+      //
+      // baileys is declared as an `optionalDependencies` in package.json and
+      // may legitimately be absent at install time (skipped optional, platform
+      // mismatch, or deliberate `--omit=optional`). We route the specifier
+      // through a string variable so TypeScript does not try to statically
+      // resolve the module — the typecheck passes whether `node_modules/
+      // @whiskeysockets/baileys` exists or not. Any actual missing-module
+      // failure surfaces at runtime via the surrounding try/catch.
+      const BAILEYS_MODULE = '@whiskeysockets/baileys';
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const baileys: any = await import('@whiskeysockets/baileys');
+      const baileys: any = await import(BAILEYS_MODULE);
       const makeWASocket = baileys.default?.default ?? baileys.default ?? baileys.makeWASocket;
       const useMultiFileAuthState = baileys.useMultiFileAuthState ?? baileys.default?.useMultiFileAuthState;
       const DisconnectReason = baileys.DisconnectReason ?? baileys.default?.DisconnectReason;


### PR DESCRIPTION
## Summary
- Fixes pre-existing TS2307 typecheck error on `backend/src/services/whatsapp/whatsapp.service.ts:95` when `@whiskeysockets/baileys` (an `optionalDependencies`) is absent locally — the literal `import('@whiskeysockets/baileys')` triggers static module resolution which fails when the optional dep is skipped.
- Routes the module specifier through a `const BAILEYS_MODULE` string variable so TypeScript skips static resolution. **Runtime semantics unchanged** — still `await import('@whiskeysockets/baileys')` with the existing `try/catch` handling missing-module at runtime.
- Single-file diff (+11 / -2). Adds a comment block documenting *why* the indirection exists.

## Why this fix and not the alternatives
| Option | Verdict |
|---|---|
| `// @ts-ignore` on the import | Adds a second eslint-disable on top of the existing `no-explicit-any` one. Loses signal if the package is added as a regular dep later. |
| `// @ts-nocheck` on the file | Throws away type checking for the entire 423-line service. Way too broad. |
| `tsconfig.exclude` for the file | Same problem — and silently skips coverage. |
| **String-indirection (chosen)** | Zero runtime change, no type safety lost elsewhere, no eslint-disable noise, self-documenting via comment. |

## Test plan
- [x] `npx tsc --noEmit -p backend/tsconfig.json` — **0 errors with baileys absent** (`rm -rf node_modules/@whiskeysockets`)
- [x] `npx tsc --noEmit -p backend/tsconfig.json` — **0 errors with baileys present** (no regression for CI/devs who get the optional dep)
- [x] `npm run build:backend` — clean
- [ ] Reviewer: confirm runtime behavior is unchanged (still does `await import('@whiskeysockets/baileys')`, still wrapped in `try/catch`)

## Out of scope
- The babel parser failure on `whatsapp.service.test.ts` (line 47 — TS syntax `(...args: unknown[])`) is **pre-existing on main**, not introduced by this PR. Filing separately if not already tracked.

## Context
- Discovered during PR #370 (onboarding-v3) review.
- baileys is intentionally `optionalDependencies` because the WhatsApp service is currently dormant in production runtime; we don't want to force the install on every contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)