### PR TITLE
P0-5: orc End-of-Turn Delivery Verification (pre-yield self-check)

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -421,6 +421,16 @@ bash {{ORCHESTRATOR_SKILLS_PATH}}/reply-slack/execute.sh '{"channelId":"D0AC7NF5
 5. **Use `reply-slack` skill for Slack delivery** — do NOT put `channelId` in `[NOTIFY]` headers. Instead, use the `reply-slack` bash skill to send messages directly to Slack via the backend API. This avoids PTY terminal artifacts that garble Slack messages. Use `[NOTIFY]` (with `conversationId`) for Chat UI only.
 6. **No JSON escaping needed** — write markdown naturally in the body after `---`
 
+## End-of-Turn Delivery Verification
+
+Before yielding the turn:
+1. Did I receive any `[CHAT:slack-...]` messages this turn?
+2. For EACH such message, did I make at least one Bash call to `reply-slack/execute.sh`?
+3. If no, the response was NOT delivered — `[NOTIFY]` alone is not sufficient.
+4. If the answer to (2) is "no," call `reply-slack` now BEFORE yielding the turn.
+
+This is a hard pre-yield check. Do not yield if any Slack message is unanswered.
+
 ## Your Capabilities
 
 > **Note:** You achieve these capabilities by **delegating to agents**. Do not perform these tasks yourself — assign them to the right team member.
@@ -755,8 +765,6 @@ Then for Slack:
 ```bash
 bash {{ORCHESTRATOR_SKILLS_PATH}}/reply-slack/execute.sh '{"channelId":"C0123","text":"*Emily (5-min check)*\nActively working on visa.careerengine.us:\n- Browsing circles, reviewing comments\n- 3 comments found\n- No blockers\n\nNext check in 5 min.","threadTs":"170743.001"}'
 ```
-
-**CRITICAL**: Plain text output (without markers) goes nowhere — the user won't see it in Chat or Slack. You MUST use `[NOTIFY]` markers for Chat UI updates and `reply-slack` skill for Slack messages.
 
 ### Proactive Behaviors You Should Always Do
 


### PR DESCRIPTION
## Summary

- Add a 4-step self-check the orchestrator runs **before yielding the turn**: verify every inbound `[CHAT:slack-...]` message produced at least one `reply-slack/execute.sh` call.
- Catches silent-fail Slack delivery — the bug Steve has had to ping "?" to surface.
- Net-zero offset: cut a redundant one-line `**CRITICAL**:` stub that restated the #1 notification rule.

## Spec reference

`.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` — **Fix P0-5** (lines 196–220).

Spec gives the exact prompt text; this PR places it as a top-level `## End-of-Turn Delivery Verification` section, positioned right after the existing `## CRITICAL: Notification Protocol — ALWAYS RESPOND TO THE USER` section so orc reads them as one coherent pre-yield checklist.

## What was added

```markdown
## End-of-Turn Delivery Verification

Before yielding the turn:
1. Did I receive any `[CHAT:slack-...]` messages this turn?
2. For EACH such message, did I make at least one Bash call to `reply-slack/execute.sh`?
3. If no, the response was NOT delivered — `[NOTIFY]` alone is not sufficient.
4. If the answer to (2) is "no," call `reply-slack` now BEFORE yielding the turn.

This is a hard pre-yield check. Do not yield if any Slack message is unanswered.
```

## What was cut (net-zero offset)

The redundant one-liner from the Smart Event Notification Protocol section:

```markdown
**CRITICAL**: Plain text output (without markers) goes nowhere — the user won't see it in Chat or Slack. You MUST use `[NOTIFY]` markers for Chat UI updates and `reply-slack` skill for Slack messages.
```

**Why this stub:** it was a one-line restatement of two existing rules:
- Line 263 (the **#1 rule** of the Notification Protocol): "Every `[CHAT:...]` message MUST produce at least one `[NOTIFY]` response."
- Line 784 (the CRITICAL ANTI-PATTERN): "Receiving a `[CHAT:...]` message, then running 3-5 bash scripts without ever outputting a `[NOTIFY]`."

The new End-of-Turn Delivery Verification section subsumes the same point with concrete steps, so the stub is true semantic redundancy — not a unique rule.

## Char budget proof

| Metric | Before | After | Δ |
|---|---|---|---|
| Chars | 81,460 | 81,715 | **+255 (+0.31%)** |
| Lines | 1,584 | 1,592 | +8 |
| Diff | — | — | +10 / -2 |

**Substantively net-zero** on an 81K-char prompt. New section adds ~510 chars (4-step protocol with rationale); cut stub freed ~255 chars. The +255 delta is the price of a structured 4-step check vs. a one-liner.

## Manual reasoning trace — does this catch yesterday's silent-fail?

Pre-yield check applied to the failure mode the spec calls out (orc writes Slack response in terminal text but never calls `reply-slack`):

1. **Step 1** — "Did I receive any `[CHAT:slack-...]` messages this turn?" → **YES** (the user pinged orc on Slack)
2. **Step 2** — "For EACH such message, did I make at least one Bash call to `reply-slack/execute.sh`?" → **NO** (terminal text only)
3. **Step 3** — "If no, the response was NOT delivered — `[NOTIFY]` alone is not sufficient." (orc recognizes the gap)
4. **Step 4** — "Call `reply-slack` now BEFORE yielding the turn." (orc self-corrects)

→ **Caught.** Owner does not need to ping "?" because orc self-corrects before yielding. ✅

## Files changed

- `config/roles/orchestrator/prompt.md` (+10 / -2)

Single file. Prompt-only change. No backend / messaging / skills code touched.

## Risk

- **Prompt budget:** +0.31% on an 81K prompt — negligible.
- **Behavior regression:** the cut stub is true semantic redundancy (verified via grep — no other prompt file references this exact phrasing); removing it does not weaken any unique behavior.
- **In-flight collisions:** branched from `origin/main` HEAD `ad817c3c` (post #418 Periodic Progress Check-In). No in-flight PRs touch the same lines.
- **Self-evolution loop:** confirmed — `self-evolution.md` does not reference the cut stub or the inserted lines.

## Test plan

- [x] `git diff --stat` shows single-file change (+10/-2)
- [x] `wc -c` baseline + post-edit captured (net +255 / +0.31%)
- [x] Manual reasoning trace: confirms the rule catches the silent-fail pattern the spec calls out
- [x] Self-evolution.md skim: no overlap with edited regions
- [x] grep for the cut phrasing across all orc prompt files: only one occurrence existed (the one I cut)
- [ ] Post-merge real-world verification: zero silent-fail Slack delivery incidents in week 1 (per spec success metric)

## Out of scope

- **P0-6** (Owner-Facing Communication Standard) — same spec, separate fix, separate PR.
- Any non-orchestrator prompt changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)