### PR TITLE
fix(frontend): complete DeepSeek Phase 1 — wire deepseek into ApiKeyProvider + Settings UI

### DIFF
--- a/frontend/src/components/Settings/ApiKeysTab.test.tsx
+++ b/frontend/src/components/Settings/ApiKeysTab.test.tsx
@@ -67,6 +67,7 @@ describe('ApiKeysTab', () => {
     expect(screen.getByText('Google Gemini')).toBeInTheDocument();
     expect(screen.getByText('Anthropic')).toBeInTheDocument();
     expect(screen.getByText('OpenAI')).toBeInTheDocument();
+    expect(screen.getByText('DeepSeek')).toBeInTheDocument();
   });
 
   it('should render runtime override sections', () => {
@@ -108,7 +109,7 @@ describe('ApiKeysTab', () => {
   it('should render test buttons for each provider', () => {
     render(<ApiKeysTab />);
     const testButtons = screen.getAllByText('Test');
-    expect(testButtons.length).toBe(3); // One per global provider
+    expect(testButtons.length).toBe(4); // One per global provider (gemini, anthropic, openai, deepseek)
   });
 
   it('should show env var hints', () => {
@@ -116,6 +117,7 @@ describe('ApiKeysTab', () => {
     expect(screen.getByText('GOOGLE_GENERATIVE_AI_API_KEY')).toBeInTheDocument();
     expect(screen.getByText('ANTHROPIC_API_KEY')).toBeInTheDocument();
     expect(screen.getByText('OPENAI_API_KEY')).toBeInTheDocument();
+    expect(screen.getByText('DEEPSEEK_API_KEY')).toBeInTheDocument();
   });
 
   it('should render with existing global keys', () => {
@@ -142,6 +144,38 @@ describe('ApiKeysTab', () => {
   it('should show "Not set" for unconfigured keys', () => {
     render(<ApiKeysTab />);
     const notSetElements = screen.getAllByText('Not set');
-    expect(notSetElements.length).toBe(3);
+    expect(notSetElements.length).toBe(4);
+  });
+
+  it('should accept input on the DeepSeek global key field', () => {
+    render(<ApiKeysTab />);
+    const input = screen.getByPlaceholderText('Enter DEEPSEEK_API_KEY') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: 'sk-deepseek-test-1234' } });
+    expect(input.value).toBe('sk-deepseek-test-1234');
+  });
+
+  it('should render saved DeepSeek global key', async () => {
+    mockUseSettings.mockReturnValue({
+      settings: {
+        general: { defaultRuntime: 'claude-code' as const },
+        chat: {},
+        skills: {},
+        apiKeys: {
+          global: { deepseek: '••••••••wxyz' },
+          runtimeOverrides: {},
+          skillOverrides: {},
+        },
+      },
+      updateSettings: mockUpdateSettings,
+      isLoading: false,
+      error: null,
+    });
+    render(<ApiKeysTab />);
+    // Three providers (gemini/anthropic/openai) report "Not set"; deepseek reports "Saved".
+    await waitFor(() => {
+      expect(screen.getByText('Saved')).toBeInTheDocument();
+      expect(screen.getAllByText('Not set').length).toBe(3);
+    });
   });
 });

--- a/frontend/src/components/Settings/ApiKeysTab.tsx
+++ b/frontend/src/components/Settings/ApiKeysTab.tsx
@@ -32,6 +32,7 @@ const PROVIDER_DISPLAY_NAMES: Record<ApiKeyProvider, string> = {
   gemini: 'Google Gemini',
   anthropic: 'Anthropic',
   openai: 'OpenAI',
+  deepseek: 'DeepSeek',
 };
 
 /**
@@ -41,6 +42,7 @@ const PROVIDER_ENV_HINTS: Record<ApiKeyProvider, string> = {
   gemini: 'GOOGLE_GENERATIVE_AI_API_KEY',
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
 };
 
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';

--- a/frontend/src/types/settings.types.test.ts
+++ b/frontend/src/types/settings.types.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect } from 'vitest';
 import {
   AI_RUNTIMES,
   AI_RUNTIME_DISPLAY_NAMES,
+  API_KEY_PROVIDERS,
+  ApiKeyProvider,
   getAIRuntimeDisplayName,
   isValidAIRuntime,
 } from './settings.types';
@@ -66,6 +68,31 @@ describe('Settings Types', () => {
       expect(isValidAIRuntime('')).toBe(false);
       expect(isValidAIRuntime('claude')).toBe(false);
       expect(isValidAIRuntime('CLAUDE-CODE')).toBe(false);
+    });
+  });
+
+  describe('API_KEY_PROVIDERS', () => {
+    it('should contain all supported API key providers', () => {
+      expect(API_KEY_PROVIDERS).toContain('gemini');
+      expect(API_KEY_PROVIDERS).toContain('anthropic');
+      expect(API_KEY_PROVIDERS).toContain('openai');
+      expect(API_KEY_PROVIDERS).toContain('deepseek');
+    });
+
+    it('should have exactly 4 providers (mirrors backend ApiKeyProvider union)', () => {
+      expect(API_KEY_PROVIDERS).toHaveLength(4);
+    });
+
+    it('should match the backend provider order so UI rows render consistently', () => {
+      // Order is part of the contract — UI iterates this array to render
+      // global key inputs and per-runtime override inputs.
+      expect([...API_KEY_PROVIDERS]).toEqual(['gemini', 'anthropic', 'openai', 'deepseek']);
+    });
+
+    it('should accept deepseek as a valid ApiKeyProvider value', () => {
+      // Compile-time check: assignment fails if the union excludes 'deepseek'.
+      const provider: ApiKeyProvider = 'deepseek';
+      expect(API_KEY_PROVIDERS).toContain(provider);
     });
   });
 });

--- a/frontend/src/types/settings.types.ts
+++ b/frontend/src/types/settings.types.ts
@@ -84,14 +84,24 @@ export interface SkillsSettings {
 // ============================================================================
 
 /**
- * Supported AI provider names for API key management
+ * Supported AI provider names for API key management.
+ *
+ * Note: 'deepseek' is served via the OpenAI-compatible endpoint at
+ * https://api.deepseek.com/v1, but is configured as a distinct provider
+ * so users can save a separate API key in Settings. Mirrors the backend
+ * `ApiKeyProvider` union (see backend/src/types/settings.types.ts).
  */
-export type ApiKeyProvider = 'gemini' | 'anthropic' | 'openai';
+export type ApiKeyProvider = 'gemini' | 'anthropic' | 'openai' | 'deepseek';
 
 /**
  * Array of all valid API key providers
  */
-export const API_KEY_PROVIDERS: readonly ApiKeyProvider[] = ['gemini', 'anthropic', 'openai'] as const;
+export const API_KEY_PROVIDERS: readonly ApiKeyProvider[] = [
+  'gemini',
+  'anthropic',
+  'openai',
+  'deepseek',
+] as const;
 
 /**
  * Configuration for an API key override at runtime or skill level
@@ -112,6 +122,7 @@ export interface ApiKeysSettings {
     gemini?: string;
     anthropic?: string;
     openai?: string;
+    deepseek?: string;
   };
   /** Per-runtime API key overrides */
   runtimeOverrides?: {
@@ -119,6 +130,7 @@ export interface ApiKeysSettings {
       gemini?: ApiKeyConfig;
       anthropic?: ApiKeyConfig;
       openai?: ApiKeyConfig;
+      deepseek?: ApiKeyConfig;
     };
   };
   /** Per-skill API key overrides */
@@ -127,6 +139,7 @@ export interface ApiKeysSettings {
       gemini?: ApiKeyConfig;
       anthropic?: ApiKeyConfig;
       openai?: ApiKeyConfig;
+      deepseek?: ApiKeyConfig;
     };
   };
 }


### PR DESCRIPTION
## Summary

Closes the DeepSeek Phase 1 frontend gap Sam's ralph-loop tick flagged. Backend already accepts `deepseek` as an `ApiKeyProvider` (see `backend/src/types/settings.types.ts:124,133` + `model-manager.ts`), but the frontend type union and Settings UI were still `gemini | anthropic | openai`-only — so end-users could **not** save a `DEEPSEEK_API_KEY` through Settings UI. They had to `export DEEPSEEK_API_KEY=...` manually. Phase 1 didn't actually reach the user.

This PR mirrors the backend types exactly and renders the DeepSeek key field + runtime override row in `ApiKeysTab`.

## What changed

- **`frontend/src/types/settings.types.ts`**
  - `ApiKeyProvider` union extended: `'gemini' | 'anthropic' | 'openai' | 'deepseek'`
  - `API_KEY_PROVIDERS` array gains `'deepseek'` (drives UI iteration)
  - `ApiKeysSettings.global` / `.runtimeOverrides[*]` / `.skillOverrides[*]` interfaces all gain optional `deepseek` slots
  - Provider order now matches backend (`gemini, anthropic, openai, deepseek`) so UI rows render in the same sequence as backend lookups
- **`frontend/src/components/Settings/ApiKeysTab.tsx`**
  - `PROVIDER_DISPLAY_NAMES`: `+ deepseek: 'DeepSeek'`
  - `PROVIDER_ENV_HINTS`: `+ deepseek: 'DEEPSEEK_API_KEY'`

## Tests

- **`settings.types.test.ts`** (+4): asserts `API_KEY_PROVIDERS` contains all 4 providers, exact length === 4, exact order matches backend, compile-time assignment of `'deepseek' as ApiKeyProvider`
- **`ApiKeysTab.test.tsx`** (+2 new, +4 updated):
  - NEW: input acceptance on DeepSeek field + saved-key rendering
  - UPDATED: provider-row count `3 → 4`, test-button count `3 → 4`, env-var hint count `3 → 4`, "Not set" indicator count `3 → 4`
- **All 25 affected tests pass** (`vitest run` on the two files)
- **Frontend TS clean** on changed files (preexisting unrelated chat-ui errors are not introduced by this PR)
- **Vite build clean**

## Manual smoke (deferred to staging)

- [ ] Open Settings → API Keys → enter DeepSeek key → Save → confirm `apiKeys.global.deepseek` persists
- [ ] Spawn a `crewly-agent` runtime with a DeepSeek model → confirm `model-manager.getApiKey('deepseek')` returns the saved key (already wired in backend)

## Why this matters

Backend type-drift was already done correctly here — the failure mode was the **frontend mirror missing**. Same lesson as PR #421's dead-path bug: in multi-layer systems, type-union drift between layers is a silent killer that only surfaces when a real user tries to use the feature. Worth a watcher / lint rule on next iteration.

## Coordination

Phase 1 ship-blocking work only; no shared module surface with Sam's Phase 2 I2 reasoning_content extraction (different files, different concerns). Phase 2 should proceed once this lands.

## Refs

- Backend canonical types: `backend/src/types/settings.types.ts:124,133,139,143`
- Backend runtime wiring: `backend/src/services/agent/crewly-agent/model-manager.ts:107-118` (DeepSeek via OpenAI-compat at `https://api.deepseek.com/v1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
