### PR TITLE
chore(crewly-agent): Object.freeze MODEL_TIMEOUT_MS — defensive guard against runtime mutation

### DIFF
--- a/backend/src/services/agent/crewly-agent/crewly-agent-runtime.service.test.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-runtime.service.test.ts
@@ -814,12 +814,17 @@ describe('CrewlyAgentRuntimeService', () => {
     it('uses MODEL_TIMEOUT_MS override when modelId matches', async () => {
       const originalTimeout = CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS;
       const originalWarning = CREWLY_AGENT_DEFAULTS.MESSAGE_SOFT_WARNING_MS;
-      const originalModelTimeouts = { ...CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS };
+      const originalModelTimeouts = CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS;
       // Default short so a non-override would fire fast and FAIL this test.
       // Override even shorter so the override timeout is what fires.
       (CREWLY_AGENT_DEFAULTS as any).MESSAGE_TIMEOUT_MS = 5_000;
       (CREWLY_AGENT_DEFAULTS as any).MESSAGE_SOFT_WARNING_MS = 4_000;
-      (CREWLY_AGENT_DEFAULTS as any).MODEL_TIMEOUT_MS['test-fast-model'] = 150;
+      // MODEL_TIMEOUT_MS is now frozen (defensive guard — see types.ts).
+      // Replace the whole reference instead of in-place mutation.
+      (CREWLY_AGENT_DEFAULTS as any).MODEL_TIMEOUT_MS = {
+        ...originalModelTimeouts,
+        'test-fast-model': 150,
+      };
 
       try {
         mockRun.mockImplementation((_msg: string, _convId: unknown, _meta: unknown, opts: Record<string, unknown>) => {

--- a/backend/src/services/agent/crewly-agent/types.test.ts
+++ b/backend/src/services/agent/crewly-agent/types.test.ts
@@ -67,6 +67,26 @@ describe('Crewly Agent Types', () => {
       expect(guardrails.promptGuardEnabled).toBe(true);
       expect(guardrails.explicitEnvVars).toEqual([]);
     });
+
+    /**
+     * P3 #7 — defensive guard: MODEL_TIMEOUT_MS must be Object.frozen at module
+     * load. `as const` is compile-time only and the `Record<string, number>` cast
+     * widens it back to mutable; without freeze, runtime writes like
+     * `MODEL_TIMEOUT_MS['x'] = 999` silently mutate global config table.
+     * Catches future regressions if anyone removes the freeze wrapper.
+     */
+    it('MODEL_TIMEOUT_MS is Object.frozen (defensive guard against runtime mutation)', () => {
+      expect(Object.isFrozen(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS)).toBe(true);
+      // In strict mode (which Node ESM modules use by default) writes to a
+      // frozen object throw TypeError. Without strict mode they would fail
+      // silently. Jest runs with strict mode under Node ESM.
+      expect(() => {
+        (CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS as Record<string, number>)['test-mutation'] = 999;
+      }).toThrow(TypeError);
+      // And the existing entry is untouched.
+      expect(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['deepseek-reasoner']).toBe(600_000);
+      expect(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['test-mutation']).toBeUndefined();
+    });
   });
 
   describe('isModelProvider', () => {

--- a/backend/src/services/agent/crewly-agent/types.ts
+++ b/backend/src/services/agent/crewly-agent/types.ts
@@ -477,10 +477,19 @@ export const CREWLY_AGENT_DEFAULTS = {
    *  agentic loops can accumulate 30+ steps. 5min default is tight; 10min gives
    *  safety margin without inviting runaway loops. See gap-list spec §I4 for
    *  measurement evidence. */
-  MODEL_TIMEOUT_MS: {
+  /**
+   * Frozen at module load via `Object.freeze` — defensive guard against
+   * runtime mutation. `as const` is compile-time only and the
+   * `Record<string, number>` cast widens it back to mutable, so freeze
+   * is the only line of defense against accidental writes like
+   * `CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['x'] = 999` from elsewhere
+   * in the codebase. Per-model overrides should be added by editing this
+   * file (treat as a config table, not runtime state).
+   */
+  MODEL_TIMEOUT_MS: Object.freeze({
     /** DeepSeek-R1: 2× default — reasoning chain-of-thought is slower per token. */
     'deepseek-reasoner': 600_000,
-  } as Record<string, number>,
+  }) as Readonly<Record<string, number>>,
   /** Soft warning threshold in milliseconds — logs a warning but does not kill the request.
    *  Override via CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS env var. */
   MESSAGE_SOFT_WARNING_MS: Number(process.env.CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS) || 240_000,


### PR DESCRIPTION
## Summary

P3 #7 from Arch's PR #441 review — defensive runtime-mutation guard on `MODEL_TIMEOUT_MS`. `as const` is compile-time only; the `Record<string, number>` cast widens it back to mutable, so writes like `CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['x'] = 999` would silently mutate the global config table. `Object.freeze` is the only line of runtime defense.

Cheapest defensive ROI per Sam's standby pick — catches future regression early.

## Changes (3 files, +38/-4)

1. **`backend/src/services/agent/crewly-agent/types.ts`** — wrap `MODEL_TIMEOUT_MS` literal in `Object.freeze`, recast as `Readonly<Record<string, number>>`. Read-only consumers (lookup-only) unaffected. JSDoc explains why freeze is needed despite `as const`.

2. **`backend/src/services/agent/crewly-agent/types.test.ts`** — new test:
   - `Object.isFrozen(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS) === true`
   - mutation `MODEL_TIMEOUT_MS['x'] = 999` throws `TypeError` (Node ESM strict mode)
   - existing `'deepseek-reasoner': 600_000` entry intact, mutation key undefined

3. **`backend/src/services/agent/crewly-agent/crewly-agent-runtime.service.test.ts`** — refactor existing I4 override test from in-place mutation (`MODEL_TIMEOUT_MS['test-fast-model'] = 150`, now blocked by freeze) to property replacement (clone + reassign on parent). Same test semantics, freeze-compatible. Falls-back test unchanged.

## Test plan

- [x] Backend `tsc --noEmit` clean for crewly-agent
- [x] `types.test.ts` — 28/28 PASS (new freeze test + existing 27)
- [x] `crewly-agent-runtime.service.test.ts` — 86/86 PASS (refactored I4 override + unchanged fallback + 84 others)
- [x] `agent-runner.service.test.ts` — 118/118 PASS (no changes; sanity)
- [x] `model-manager.test.ts` — 21/21 PASS (no changes; sanity)
- [x] `deepseek-sse-transform.test.ts` — 13/13 PASS (no changes; sanity)
- [x] **TOTAL: 266/266 PASS** across all touched + Phase 2 suites

## Risk

Near-zero. Single defensive freeze + companion test refactor (replacement pattern is the conventional way to do this; in-place mutation was a code smell). The only behavior change is that future contributors who write `MODEL_TIMEOUT_MS['x'] = ...` get an immediate `TypeError` instead of silent mutation — exactly the catch we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)