### PR TITLE
feat(memory): M3 — RoleKnowledgeEntry v3 schema (importance/confidence/evidence/ttl/supersededBy)

### DIFF
--- a/backend/src/services/memory/agent-memory.service.test.ts
+++ b/backend/src/services/memory/agent-memory.service.test.ts
@@ -395,6 +395,79 @@ describe('AgentMemoryService', () => {
       expect(context).toContain('Common error');
       expect(context).toContain('Fix it this way');
     });
+
+    // ---------------------------------------------------------------------
+    // M3 — recall-eligibility filter wire (spec §183-187)
+    // Proves the live agent self-context path honors the new filter.
+    // ---------------------------------------------------------------------
+
+    it('M3 hides entries with supersededBy set even when superseded boolean is absent', async () => {
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'OUTDATED via supersededBy',
+        confidence: 0.9,
+        // Note: superseded boolean intentionally NOT set — only the
+        // supersededBy reference. The pre-M3 filter would have shown
+        // this entry; the M3 wire must hide it.
+        supersededBy: 'rk-newer-id',
+      });
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'CURRENT entry',
+        confidence: 0.9,
+      });
+
+      const context = await service.generateAgentContext(testAgentId);
+      expect(context).not.toContain('OUTDATED via supersededBy');
+      expect(context).toContain('CURRENT entry');
+    });
+
+    it('M3 hides expired entries (ttl < now)', async () => {
+      const pastTtl = new Date(Date.now() - 86_400_000).toISOString(); // yesterday
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'EXPIRED tactical fact',
+        confidence: 0.9,
+        ttl: pastTtl,
+      });
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'EVERGREEN fact',
+        confidence: 0.9,
+      });
+
+      const context = await service.generateAgentContext(testAgentId);
+      expect(context).not.toContain('EXPIRED tactical fact');
+      expect(context).toContain('EVERGREEN fact');
+    });
+
+    it('M3 keeps entries whose ttl is in the future', async () => {
+      const futureTtl = new Date(Date.now() + 86_400_000).toISOString(); // tomorrow
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'NOT-YET-EXPIRED fact',
+        confidence: 0.9,
+        ttl: futureTtl,
+      });
+
+      const context = await service.generateAgentContext(testAgentId);
+      expect(context).toContain('NOT-YET-EXPIRED fact');
+    });
+
+    it('M3 hides entries with malformed ttl gracefully (fail-soft: keeps them visible)', async () => {
+      // Per role-knowledge-eligibility.isExpired: malformed TTL must not
+      // silently disappear an entry. Confirms that a bogus ttl does not
+      // accidentally hide a real fact.
+      await service.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'KEEP malformed-ttl fact',
+        confidence: 0.9,
+        ttl: 'not-a-real-date',
+      });
+
+      const context = await service.generateAgentContext(testAgentId);
+      expect(context).toContain('KEEP malformed-ttl fact');
+    });
   });
 
   describe('pruneStaleEntries', () => {

--- a/backend/src/services/memory/agent-memory.service.ts
+++ b/backend/src/services/memory/agent-memory.service.ts
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync } from 'fs';
 import * as os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import { atomicWriteJson, safeReadJson } from '../../utils/file-io.utils.js';
+import { isHiddenFromDefaultRecall } from './role-knowledge-eligibility.js';
 
 /** Constants for memory scoring and decay (v2) */
 const DECAY_CONSTANTS = {
@@ -597,8 +598,12 @@ export class AgentMemoryService implements IAgentMemoryService {
 
     // v2: Filter using effective score (confidence × recency × verification)
     // Exclude performance memories — those are for TL/orchestrator scheduling, not self-use
+    // M3 (spec §183-187): isHiddenFromDefaultRecall catches superseded
+    // entries (both `superseded` flag AND `supersededBy` reference) plus
+    // expired entries (ttl < now). Replaces the old `!k.superseded` check
+    // which only saw the boolean flag.
     const scored = roleKnowledge
-      .filter(k => !k.superseded && k.memoryType !== 'performance')
+      .filter(k => !isHiddenFromDefaultRecall(k) && k.memoryType !== 'performance')
       .map(k => ({ entry: k, score: this.calculateEffectiveScore(k) }))
       .filter(s => s.score >= DECAY_CONSTANTS.MIN_EFFECTIVE_SCORE)
       .sort((a, b) => b.score - a.score)
@@ -693,7 +698,10 @@ ${performance.commonErrors.slice(0, 5).map(e => `- ${e.pattern} → ${e.resoluti
     }
 
     const performanceMemories = memory.roleKnowledge
-      .filter(k => !k.superseded && k.memoryType === 'performance')
+      // M3 (spec §183-187): hide superseded + expired entries from
+      // scheduling context too — TL/orc must not schedule against stale
+      // performance signals.
+      .filter(k => !isHiddenFromDefaultRecall(k) && k.memoryType === 'performance')
       .map(k => ({ entry: k, score: this.calculateEffectiveScore(k) }))
       .filter(s => s.score >= DECAY_CONSTANTS.MIN_EFFECTIVE_SCORE)
       .sort((a, b) => b.score - a.score)

--- a/backend/src/services/memory/memory.service.test.ts
+++ b/backend/src/services/memory/memory.service.test.ts
@@ -590,4 +590,93 @@ describe('MemoryService', () => {
       expect(result.agentMemories).toHaveLength(0);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // M3 — recall-eligibility filtering (spec §183-187).
+  //
+  // These wire tests prove that filterRelevant() — the LIVE recall path called
+  // by service.recall() at memory.service.ts:757 — correctly drops entries
+  // that are superseded or expired (TTL in the past). They use the agent
+  // memory service's addRoleKnowledge() API to seed entries with the v3
+  // fields (supersededBy / ttl) that service.remember() does not yet expose
+  // through the high-level API.
+  // ---------------------------------------------------------------------------
+  describe('M3 recall filtering', () => {
+    beforeEach(async () => {
+      await service.initializeForSession(testAgentId, testRole, testProjectPath);
+    });
+
+    it('hides entries with supersededBy set from recall results', async () => {
+      const agentService = service.getAgentMemoryService();
+      // Seed a healthy + a superseded entry that both match the same context.
+      await agentService.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'Always validate user input thoroughly',
+        confidence: 0.9,
+      });
+      await agentService.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'Stale validation guidance from older spec',
+        confidence: 0.9,
+        supersededBy: 'rk-newer',
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        context: 'validation user input',
+        scope: 'agent',
+      });
+
+      const joined = result.agentMemories.join('\n');
+      expect(joined).toContain('validate user input thoroughly');
+      expect(joined).not.toContain('Stale validation guidance');
+    });
+
+    it('hides expired entries (ttl < now) from recall results', async () => {
+      const agentService = service.getAgentMemoryService();
+      const PAST_TTL = '2000-01-01T00:00:00Z';
+      await agentService.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'Active testing convention',
+        confidence: 0.9,
+      });
+      await agentService.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'Expired testing convention from old framework',
+        confidence: 0.9,
+        ttl: PAST_TTL,
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        context: 'testing convention',
+        scope: 'agent',
+      });
+
+      const joined = result.agentMemories.join('\n');
+      expect(joined).toContain('Active testing convention');
+      expect(joined).not.toContain('Expired testing convention');
+    });
+
+    it('surfaces healthy entries on recall (positive control)', async () => {
+      const agentService = service.getAgentMemoryService();
+      const FUTURE_TTL = '2099-01-01T00:00:00Z';
+      await agentService.addRoleKnowledge(testAgentId, {
+        category: 'best-practice',
+        content: 'Healthy long-lived pattern about retries',
+        confidence: 0.8,
+        ttl: FUTURE_TTL,
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        context: 'retries pattern',
+        scope: 'agent',
+      });
+
+      expect(result.agentMemories.join('\n')).toContain(
+        'Healthy long-lived pattern about retries',
+      );
+    });
+  });
 });

--- a/backend/src/services/memory/memory.service.ts
+++ b/backend/src/services/memory/memory.service.ts
@@ -15,6 +15,7 @@ import { KnowledgeSearchService } from '../knowledge/knowledge-search.service.js
 import { VectorStoreService, type VectorSearchResult } from '../knowledge/vector-store.service.js';
 import { createEmbeddingProvider, type EmbeddingProvider } from '../knowledge/embedding-provider.js';
 import { safeReadJson } from '../../utils/file-io.utils.js';
+import { isHiddenFromDefaultRecall } from './role-knowledge-eligibility.js';
 import { CREWLY_CONSTANTS, MEMORY_CONSTANTS } from '../../constants.js';
 import type { KnowledgeDocumentSummary } from '../../types/knowledge.types.js';
 import type {
@@ -368,21 +369,28 @@ export class MemoryService implements IMemoryService {
   }
 
   /**
-   * Filters memories by relevance to a context
+   * Filters memories by relevance to a context.
+   *
+   * **M3 (spec §183-187):** Default recall hides superseded and expired
+   * entries via {@link isHiddenFromDefaultRecall}. They remain in the raw
+   * store for audit / explicit recall, but they no longer pollute the
+   * agent's recall path.
    */
   private filterRelevant(knowledge: RoleKnowledgeEntry[], context: string, limit?: number): string[] {
     const contextWords = context.toLowerCase().split(/\s+/);
 
-    const scored = knowledge.map(entry => {
-      const contentWords = entry.content.toLowerCase().split(/\s+/);
-      const matchCount = contextWords.filter(word =>
-        contentWords.some(cw => cw.includes(word) || word.includes(cw))
-      ).length;
-      return {
-        entry,
-        score: matchCount * entry.confidence,
-      };
-    });
+    const scored = knowledge
+      .filter(entry => !isHiddenFromDefaultRecall(entry))
+      .map(entry => {
+        const contentWords = entry.content.toLowerCase().split(/\s+/);
+        const matchCount = contextWords.filter(word =>
+          contentWords.some(cw => cw.includes(word) || word.includes(cw))
+        ).length;
+        return {
+          entry,
+          score: matchCount * (entry.confidence ?? 0.7),
+        };
+      });
 
     return scored
       .filter(s => s.score > 0)

--- a/backend/src/services/memory/role-knowledge-eligibility.test.ts
+++ b/backend/src/services/memory/role-knowledge-eligibility.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for role-knowledge recall-eligibility helpers.
+ *
+ * Coverage:
+ * - lazyMigrateEntry: legacy → v3 defaults; learnedFrom → evidence
+ *   coercion; idempotence on already-migrated entries.
+ * - isExpired: present/absent/invalid TTL.
+ * - isAutoInjectEligible: every branch of the spec §183-187 rule table,
+ *   including the confidence-floor override.
+ * - isHiddenFromDefaultRecall: superseded + expired + happy path.
+ *
+ * @module services/memory/role-knowledge-eligibility.test
+ */
+
+import {
+  AUTO_INJECT_CONFIDENCE_MIN,
+  AUTO_INJECT_IMPORTANCE_MIN,
+  DEFAULT_CONFIDENCE,
+  DEFAULT_IMPORTANCE,
+  NEVER_AUTO_INJECT_CONFIDENCE,
+  isAutoInjectEligible,
+  isExpired,
+  isHiddenFromDefaultRecall,
+  lazyMigrateEntry,
+} from './role-knowledge-eligibility.js';
+import type { RoleKnowledgeEntry } from '../../types/memory.types.js';
+
+const NOW = new Date('2026-05-04T12:00:00Z');
+const PAST = '2026-04-01T00:00:00Z';
+const FUTURE = '2026-06-01T00:00:00Z';
+
+/**
+ * Construct a baseline v3 entry for tests.
+ */
+function makeEntry(overrides: Partial<RoleKnowledgeEntry> = {}): RoleKnowledgeEntry {
+  return {
+    id: 'rk-test',
+    category: 'best-practice',
+    content: 'test content',
+    confidence: 0.7,
+    importance: 0.5,
+    evidence: [],
+    createdAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants — guard against accidental drift from the spec values
+// ---------------------------------------------------------------------------
+
+describe('eligibility constants', () => {
+  it('exports the spec-defined defaults', () => {
+    expect(DEFAULT_IMPORTANCE).toBe(0.5);
+    expect(DEFAULT_CONFIDENCE).toBe(0.7);
+  });
+
+  it('exports the spec-defined gates', () => {
+    expect(AUTO_INJECT_IMPORTANCE_MIN).toBe(0.85);
+    expect(AUTO_INJECT_CONFIDENCE_MIN).toBe(0.7);
+    expect(NEVER_AUTO_INJECT_CONFIDENCE).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isExpired
+// ---------------------------------------------------------------------------
+
+describe('isExpired', () => {
+  it('returns false when ttl is undefined', () => {
+    expect(isExpired({ ttl: undefined }, NOW)).toBe(false);
+  });
+
+  it('returns true when ttl is in the past', () => {
+    expect(isExpired({ ttl: PAST }, NOW)).toBe(true);
+  });
+
+  it('returns false when ttl is in the future', () => {
+    expect(isExpired({ ttl: FUTURE }, NOW)).toBe(false);
+  });
+
+  it('returns false (fail-soft) when ttl is malformed', () => {
+    // Malformed TTL must not silently disappear an entry.
+    expect(isExpired({ ttl: 'not-a-date' }, NOW)).toBe(false);
+  });
+
+  it('uses Date.now() as the default reference', () => {
+    // Use a far-past TTL so the assertion is robust regardless of when the
+    // test runs.
+    expect(isExpired({ ttl: '1970-01-01T00:00:00Z' })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lazyMigrateEntry
+// ---------------------------------------------------------------------------
+
+describe('lazyMigrateEntry', () => {
+  it('fills importance + confidence defaults on a legacy entry', () => {
+    const legacy = {
+      id: 'rk-legacy',
+      category: 'best-practice',
+      content: 'Always run tests before committing',
+      learnedFrom: 'TICKET-123',
+      // pre-M3 entries always carried `confidence` per the existing
+      // schema, but exercise the explicit-undefined path too.
+    } as RoleKnowledgeEntry;
+
+    const v = lazyMigrateEntry(legacy);
+    expect(v.importance).toBe(DEFAULT_IMPORTANCE);
+    expect(v.confidence).toBe(DEFAULT_CONFIDENCE);
+  });
+
+  it('coerces learnedFrom into evidence when evidence is missing', () => {
+    const legacy = makeEntry({
+      evidence: undefined,
+      learnedFrom: 'TICKET-123',
+    });
+    const v = lazyMigrateEntry(legacy);
+    expect(v.evidence).toEqual(['TICKET-123']);
+  });
+
+  it('returns evidence=[] when neither evidence nor learnedFrom is set', () => {
+    const legacy = makeEntry({ evidence: undefined, learnedFrom: undefined });
+    const v = lazyMigrateEntry(legacy);
+    expect(v.evidence).toEqual([]);
+  });
+
+  it('preserves an explicit evidence array even when learnedFrom is also set', () => {
+    const e = makeEntry({
+      evidence: ['req-1', 'wi-2'],
+      learnedFrom: 'TICKET-OLD',
+    });
+    expect(lazyMigrateEntry(e).evidence).toEqual(['req-1', 'wi-2']);
+  });
+
+  it('is idempotent on an already-migrated entry', () => {
+    const e = makeEntry({
+      importance: 0.9,
+      confidence: 0.8,
+      evidence: ['req-1'],
+    });
+    const v1 = lazyMigrateEntry(e);
+    const v2 = lazyMigrateEntry(v1);
+    expect(v2).toEqual(v1);
+  });
+
+  it('does not mutate the input', () => {
+    const e = makeEntry({ evidence: undefined, learnedFrom: 'TICKET' });
+    const before = JSON.parse(JSON.stringify(e));
+    lazyMigrateEntry(e);
+    expect(e).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAutoInjectEligible
+// ---------------------------------------------------------------------------
+
+describe('isAutoInjectEligible', () => {
+  it('hides superseded entries (superseded boolean flag)', () => {
+    const e = makeEntry({
+      superseded: true,
+      importance: 1,
+      confidence: 1,
+    });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('hides entries with supersededBy set even when superseded flag is absent', () => {
+    const e = makeEntry({
+      supersededBy: 'rk-newer',
+      importance: 1,
+      confidence: 1,
+    });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('hides expired entries', () => {
+    const e = makeEntry({ ttl: PAST, importance: 1, confidence: 1 });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('shows an entry that meets both score gates', () => {
+    const e = makeEntry({ importance: 0.9, confidence: 0.8 });
+    expect(isAutoInjectEligible(e, NOW)).toBe(true);
+  });
+
+  it('hides an entry below the importance gate even with high confidence', () => {
+    const e = makeEntry({ importance: 0.6, confidence: 1 });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('hides an entry below the confidence gate even with high importance', () => {
+    const e = makeEntry({ importance: 1, confidence: 0.6 });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('honors shouldInjectByDefault=false even when scores would qualify', () => {
+    const e = makeEntry({
+      importance: 1,
+      confidence: 1,
+      shouldInjectByDefault: false,
+    });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('honors shouldInjectByDefault=true even when scores fall below derived gates', () => {
+    const e = makeEntry({
+      importance: 0.6,
+      confidence: 0.6,
+      shouldInjectByDefault: true,
+    });
+    expect(isAutoInjectEligible(e, NOW)).toBe(true);
+  });
+
+  it('rejects shouldInjectByDefault=true when confidence is below the hard floor', () => {
+    // §185: confidence < 0.5 → NEVER auto-inject regardless.
+    const e = makeEntry({
+      importance: 1,
+      confidence: 0.4,
+      shouldInjectByDefault: true,
+    });
+    expect(isAutoInjectEligible(e, NOW)).toBe(false);
+  });
+
+  it('uses defaults when importance is missing on a legacy entry', () => {
+    // confidence default = 0.7 (gate met), importance default = 0.5 (gate
+    // missed) → not eligible.
+    const legacy = makeEntry({ importance: undefined });
+    expect(isAutoInjectEligible(legacy, NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isHiddenFromDefaultRecall
+// ---------------------------------------------------------------------------
+
+describe('isHiddenFromDefaultRecall', () => {
+  it('hides superseded entries', () => {
+    const e = makeEntry({ superseded: true });
+    expect(isHiddenFromDefaultRecall(e, NOW)).toBe(true);
+  });
+
+  it('hides entries with a supersededBy reference', () => {
+    const e = makeEntry({ supersededBy: 'rk-newer' });
+    expect(isHiddenFromDefaultRecall(e, NOW)).toBe(true);
+  });
+
+  it('hides expired entries', () => {
+    const e = makeEntry({ ttl: PAST });
+    expect(isHiddenFromDefaultRecall(e, NOW)).toBe(true);
+  });
+
+  it('does NOT hide an entry merely because it falls below the auto-inject gate', () => {
+    // This is the strict-superset rule: low-score entries still surface
+    // on default recall, they just are not auto-injected.
+    const e = makeEntry({ importance: 0.1, confidence: 0.1 });
+    expect(isHiddenFromDefaultRecall(e, NOW)).toBe(false);
+  });
+
+  it('shows healthy entries by default', () => {
+    const e = makeEntry({ importance: 0.6, confidence: 0.6 });
+    expect(isHiddenFromDefaultRecall(e, NOW)).toBe(false);
+  });
+});

--- a/backend/src/services/memory/role-knowledge-eligibility.ts
+++ b/backend/src/services/memory/role-knowledge-eligibility.ts
@@ -1,0 +1,184 @@
+/**
+ * Role-knowledge recall-eligibility helpers (M3 — Memory Importance,
+ * Confidence, Evidence + lifecycle filtering).
+ *
+ * Implements the recall-eligibility rules from
+ * `.crewly/specs/2026-05-03-memory-codebase-improvement-plan.md` §183-187:
+ *
+ * | Rule                                              | Effect                                  |
+ * | ------------------------------------------------- | --------------------------------------- |
+ * | importance ≥ 0.85 AND confidence ≥ 0.7            | Eligible for auto-inject into context   |
+ * | confidence < 0.5                                  | NEVER auto-inject (explicit recall only)|
+ * | supersededBy != null                              | Hidden from default recall (audit-only) |
+ * | ttl < now                                         | Archived, hidden from recall            |
+ * | shouldInjectByDefault === false                   | Hidden from default recall              |
+ * | shouldInjectByDefault === true                    | Auto-inject (overrides derivation)      |
+ *
+ * The helpers are split from `memory.service.ts` so the live (singleton)
+ * service and the agent-memory service can share one implementation.
+ *
+ * @module services/memory/role-knowledge-eligibility
+ */
+
+import type { RoleKnowledgeEntry } from '../../types/memory.types.js';
+
+/**
+ * Default importance value for legacy entries that pre-date M3.
+ * Per spec §191: "existing entries get default importance=0.5".
+ */
+export const DEFAULT_IMPORTANCE = 0.5;
+
+/**
+ * Default confidence value for legacy entries that omit the field.
+ * Per spec §191: default confidence=0.7.
+ */
+export const DEFAULT_CONFIDENCE = 0.7;
+
+/**
+ * Lower bound for "auto-inject eligible" entries.
+ */
+export const AUTO_INJECT_IMPORTANCE_MIN = 0.85;
+
+/**
+ * Confidence floor for auto-inject (cannot auto-inject below this).
+ */
+export const AUTO_INJECT_CONFIDENCE_MIN = 0.7;
+
+/**
+ * Hard cut-off — entries below this confidence are NEVER auto-injected,
+ * regardless of importance or `shouldInjectByDefault` overrides.
+ *
+ * Per spec §185: "confidence < 0.5 → NEVER auto-inject (only show on
+ * explicit recall)".
+ */
+export const NEVER_AUTO_INJECT_CONFIDENCE = 0.5;
+
+/**
+ * Check whether an entry has expired against the supplied "now".
+ *
+ * @param entry - Knowledge entry under evaluation
+ * @param now - Reference instant (ISO string or Date). Defaults to Date.now().
+ * @returns true when the entry's TTL has passed
+ */
+export function isExpired(
+  entry: Pick<RoleKnowledgeEntry, 'ttl'>,
+  now: Date = new Date(),
+): boolean {
+  if (!entry.ttl) return false;
+  const ttlMs = Date.parse(entry.ttl);
+  // Invalid ISO → treat as not expired (fail-soft) so a malformed entry
+  // doesn't get silently disappeared.
+  if (Number.isNaN(ttlMs)) return false;
+  return ttlMs < now.getTime();
+}
+
+/**
+ * Lazy-migrate a possibly-legacy entry to v3 shape **for read**.
+ *
+ * The migration is non-destructive — it returns a copy with M3 defaults
+ * filled in:
+ *
+ * - `importance` → `DEFAULT_IMPORTANCE` when missing
+ * - `confidence` → `DEFAULT_CONFIDENCE` when missing
+ * - `evidence`   → `[learnedFrom]` when learnedFrom present, else `[]`
+ * - `shouldInjectByDefault` left **undefined** so the eligibility
+ *   predicate can fall back to the derived rule
+ *
+ * Callers that **persist** entries should write the v3 fields explicitly;
+ * this helper deliberately does not write back.
+ *
+ * @param entry - Legacy or v3 entry to normalize for read
+ * @returns Entry with v3 fields guaranteed (importance + confidence
+ *          + evidence)
+ *
+ * @example
+ * ```typescript
+ * const view = lazyMigrateEntry(rawEntry);
+ * if (isAutoInjectEligible(view)) prompt += view.content;
+ * ```
+ */
+export function lazyMigrateEntry(entry: RoleKnowledgeEntry): RoleKnowledgeEntry {
+  const evidence: string[] | undefined =
+    entry.evidence !== undefined
+      ? entry.evidence
+      : entry.learnedFrom
+        ? [entry.learnedFrom]
+        : [];
+  return {
+    ...entry,
+    importance: entry.importance ?? DEFAULT_IMPORTANCE,
+    confidence: entry.confidence ?? DEFAULT_CONFIDENCE,
+    evidence,
+  };
+}
+
+/**
+ * Check whether an entry is eligible to be auto-injected into agent
+ * context by default.
+ *
+ * **Rule order (per spec §183-187):**
+ * 1. Hidden if `superseded === true` or `supersededBy != null` — audit-only.
+ * 2. Hidden if expired (`ttl < now`).
+ * 3. Honored if `shouldInjectByDefault` is explicitly set:
+ *    - `false` → NEVER auto-inject regardless of scores.
+ *    - `true`  → auto-inject UNLESS confidence < 0.5 (the hard floor
+ *               from §185).
+ * 4. Otherwise derived: `importance >= 0.85 AND confidence >= 0.7`.
+ *
+ * @param entry - Knowledge entry under evaluation (does not need to be pre-migrated)
+ * @param now - Reference instant for TTL evaluation. Defaults to Date.now().
+ * @returns true when this entry should appear in default-recall results
+ *
+ * @example
+ * ```typescript
+ * const visible = entries.filter((e) => isAutoInjectEligible(e));
+ * ```
+ */
+export function isAutoInjectEligible(
+  entry: RoleKnowledgeEntry,
+  now: Date = new Date(),
+): boolean {
+  // Step 1 — supersession.
+  if (entry.superseded === true || entry.supersededBy) return false;
+
+  // Step 2 — TTL.
+  if (isExpired(entry, now)) return false;
+
+  // Read-time normalization for the score gates below.
+  const importance = entry.importance ?? DEFAULT_IMPORTANCE;
+  const confidence = entry.confidence ?? DEFAULT_CONFIDENCE;
+
+  // Step 3 — explicit override, but the < 0.5 confidence floor always wins.
+  if (entry.shouldInjectByDefault === false) return false;
+  if (entry.shouldInjectByDefault === true) {
+    return confidence >= NEVER_AUTO_INJECT_CONFIDENCE;
+  }
+
+  // Step 4 — derived gate.
+  return (
+    importance >= AUTO_INJECT_IMPORTANCE_MIN &&
+    confidence >= AUTO_INJECT_CONFIDENCE_MIN
+  );
+}
+
+/**
+ * Should this entry be **completely hidden** from default-recall?
+ *
+ * This is a strict superset of "not eligible for auto-inject" — entries
+ * that are merely below the auto-inject score gate are still surfaced on
+ * default recall (just not auto-injected into prompts), but entries that
+ * are superseded or expired are not surfaced at all unless the caller
+ * explicitly opts in.
+ *
+ * @param entry - Knowledge entry under evaluation
+ * @param now - Reference instant for TTL evaluation. Defaults to Date.now().
+ * @returns true when default recall should drop this entry
+ */
+export function isHiddenFromDefaultRecall(
+  entry: RoleKnowledgeEntry,
+  now: Date = new Date(),
+): boolean {
+  if (entry.superseded === true || entry.supersededBy) return true;
+  if (isExpired(entry, now)) return true;
+  return false;
+}

--- a/backend/src/services/memory/role-knowledge-eligibility.ts
+++ b/backend/src/services/memory/role-knowledge-eligibility.ts
@@ -125,6 +125,24 @@ export function lazyMigrateEntry(entry: RoleKnowledgeEntry): RoleKnowledgeEntry 
  *               from §185).
  * 4. Otherwise derived: `importance >= 0.85 AND confidence >= 0.7`.
  *
+ * @remarks
+ * **Phase-2 priority filter — DO NOT wire into the prompt path until M5.**
+ *
+ * This helper is forward-declared and intentionally NOT called from any
+ * production prompt-build path in M3. M5 wires it into
+ * `generateRoleKnowledgeContext` and `generateSchedulingContext` AFTER
+ * the legacy-entry backfill lands.
+ *
+ * Wiring it into M3's prompt path would be a P0 regression: pre-migration
+ * entries default to `importance=0.5` and `shouldInjectByDefault=false`
+ * (per spec §191), so the derived gate `importance >= 0.85` would cull
+ * every pre-migration knowledge entry on day one. The backfill in M5 lifts
+ * `importance`/`shouldInjectByDefault` for the entries that actually
+ * deserve auto-injection, then this helper becomes safe to wire.
+ *
+ * See `.crewly/specs/2026-05-03-memory-codebase-improvement-plan.md` M5
+ * for the wiring instruction.
+ *
  * @param entry - Knowledge entry under evaluation (does not need to be pre-migrated)
  * @param now - Reference instant for TTL evaluation. Defaults to Date.now().
  * @returns true when this entry should appear in default-recall results

--- a/backend/src/types/memory.types.test.ts
+++ b/backend/src/types/memory.types.test.ts
@@ -323,4 +323,77 @@ describe('Memory Types', () => {
       });
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // M3 — v3 schema fields on RoleKnowledgeEntry
+  // (spec §158-216: importance, evidence, ttl, shouldInjectByDefault).
+  //
+  // These tests assert the v3 fields are part of the type contract so that
+  // accidental removal/rename produces a compile-time signal in addition to
+  // the runtime eligibility tests in role-knowledge-eligibility.test.ts.
+  // ---------------------------------------------------------------------------
+  describe('RoleKnowledgeEntry v3 fields (M3)', () => {
+    it('accepts an entry with all v3 lifecycle fields', () => {
+      const entry: RoleKnowledgeEntry = {
+        id: 'rk-v3-001',
+        category: 'best-practice',
+        content: 'Use parameterized queries to prevent SQL injection',
+        confidence: 0.95,
+        importance: 0.9,
+        evidence: ['REQ-101', 'wi-202', 'TICKET-303'],
+        ttl: '2099-12-31T23:59:59Z',
+        shouldInjectByDefault: true,
+        createdAt: '2026-05-04T10:00:00Z',
+      };
+
+      expect(entry.importance).toBe(0.9);
+      expect(entry.evidence).toEqual(['REQ-101', 'wi-202', 'TICKET-303']);
+      expect(entry.ttl).toBe('2099-12-31T23:59:59Z');
+      expect(entry.shouldInjectByDefault).toBe(true);
+    });
+
+    it('accepts an entry with supersededBy reference (audit pointer)', () => {
+      const entry: RoleKnowledgeEntry = {
+        id: 'rk-old',
+        category: 'workflow',
+        content: 'Stale workflow note',
+        confidence: 0.7,
+        supersededBy: 'rk-newer',
+        createdAt: '2026-04-01T00:00:00Z',
+      };
+
+      expect(entry.supersededBy).toBe('rk-newer');
+    });
+
+    it('treats v3 fields as optional (legacy entries remain valid)', () => {
+      // A legacy entry without any v3 fields must still compile and behave
+      // correctly — backward compatibility is non-negotiable.
+      const legacy: RoleKnowledgeEntry = {
+        id: 'rk-legacy',
+        category: 'tool-usage',
+        content: 'Legacy entry from pre-M3 schema',
+        confidence: 0.8,
+        createdAt: '2026-04-01T00:00:00Z',
+      };
+
+      expect(legacy.importance).toBeUndefined();
+      expect(legacy.evidence).toBeUndefined();
+      expect(legacy.ttl).toBeUndefined();
+      expect(legacy.shouldInjectByDefault).toBeUndefined();
+    });
+
+    it('accepts shouldInjectByDefault=false for explicit opt-out entries', () => {
+      const entry: RoleKnowledgeEntry = {
+        id: 'rk-opt-out',
+        category: 'anti-pattern',
+        content: 'Niche guidance, only on explicit recall',
+        confidence: 0.9,
+        importance: 0.95,
+        shouldInjectByDefault: false,
+        createdAt: '2026-05-04T10:00:00Z',
+      };
+
+      expect(entry.shouldInjectByDefault).toBe(false);
+    });
+  });
 });

--- a/backend/src/types/memory.types.ts
+++ b/backend/src/types/memory.types.ts
@@ -90,6 +90,69 @@ export interface RoleKnowledgeEntry {
   superseded?: boolean;
   /** ID of the entry that supersedes this one */
   supersededBy?: string;
+
+  // === v3 (M3): Importance + evidence + lifecycle ===
+  // Per spec 2026-05-03-memory-codebase-improvement-plan.md §158-197:
+  // separates "Steve's strategic preference (high importance, persistent)"
+  // from "agent's tactical guess yesterday (low confidence, expires)" so
+  // recall can stop drowning agents in stale low-signal entries.
+
+  /**
+   * Strategic importance score 0-1.
+   *
+   * Distinct from {@link confidence}:
+   * - importance = how much this should weight in injection decisions
+   *   (a strategic preference is high-importance even when only 0.6
+   *   confident);
+   * - confidence = how reliably true this entry is.
+   *
+   * Default for legacy entries (lazy-migrated on read): 0.5.
+   *
+   * Recall-eligibility (per spec §183-187):
+   * - importance >= 0.85 AND confidence >= 0.7 → eligible for auto-inject
+   *   into context.
+   */
+  importance?: number;
+
+  /**
+   * Provenance refs that back this entry — requestId, workItemId,
+   * slackMessageTs, file paths, etc. Distinct from the legacy
+   * {@link learnedFrom} single-string field which is preserved for
+   * backward compatibility (lazy-migration: when evidence is absent and
+   * learnedFrom is present, evidence resolves to [learnedFrom]).
+   *
+   * Default for legacy entries: [] (or [learnedFrom] when available).
+   */
+  evidence?: string[];
+
+  /**
+   * Optional ISO8601 timestamp at which this entry expires.
+   *
+   * Recall behavior (per spec §187): when {@link ttl} < now, the entry
+   * is hidden from default recall (kept in raw store for audit). Used
+   * for tactical / time-bound facts (e.g., "the staging API key
+   * rotates Friday").
+   */
+  ttl?: string;
+
+  /**
+   * Should this entry be auto-injected into the agent's context by
+   * default?
+   *
+   * Allows the writer to override the derived default. The derivation
+   * (used when this field is undefined) is:
+   *
+   *   importance >= 0.85
+   *   AND confidence >= 0.7
+   *   AND !superseded
+   *   AND (!ttl || ttl > now)
+   *
+   * Setting `false` explicitly forces "show only on explicit recall"
+   * even when the derivation would auto-inject. Setting `true`
+   * explicitly forces auto-inject even if importance/confidence fall
+   * below the gate.
+   */
+  shouldInjectByDefault?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements M3 of the memory codebase improvement plan ([spec §158-216](.crewly/specs/2026-05-03-memory-codebase-improvement-plan.md)).

Adds the v3 lifecycle fields to `RoleKnowledgeEntry` — `importance`, `confidence` (already existed), `evidence`, `ttl`, `supersededBy`, and `shouldInjectByDefault` — and wires them into the live recall path so superseded and expired entries are filtered before reaching the prompt.

## What changed

- **Schema** (`backend/src/types/memory.types.ts`): 4 new optional v3 fields on `RoleKnowledgeEntry`. Legacy entries remain valid (all fields optional).
- **Eligibility helpers** (`backend/src/services/memory/role-knowledge-eligibility.ts`): new module — `isExpired`, `lazyMigrateEntry`, `isAutoInjectEligible`, `isHiddenFromDefaultRecall` per spec §183-187 rule table. Includes the confidence<0.5 hard floor that overrides explicit `shouldInjectByDefault=true`.
- **Live recall paths wired**: `MemoryService.filterRelevant()` and `AgentMemoryService.generateRoleKnowledgeContext` / `generateSchedulingContext` now call `isHiddenFromDefaultRecall()` so superseded + expired entries do not surface on default recall.
- **Lazy migration on read**: legacy entries get `importance=0.5`, `confidence=0.7`, and `evidence=[learnedFrom]` filled in non-destructively. No write-back, no schema migration script needed.

## Recall-eligibility rules (spec §183-187)

| Rule | Effect |
|---|---|
| `importance >= 0.85 AND confidence >= 0.7` | Auto-inject eligible |
| `confidence < 0.5` | NEVER auto-inject (hard floor) |
| `supersededBy != null` | Hidden from default recall (audit-only) |
| `ttl < now` | Hidden from default recall (archived) |
| `shouldInjectByDefault === false` | Hidden from auto-inject |
| `shouldInjectByDefault === true` | Auto-inject UNLESS confidence<0.5 |

## Tests

All M3-touched files green:
- `role-knowledge-eligibility.test.ts`: **28/28** (constants + every branch of the rule table + lazy migration + idempotence + non-mutation)
- `memory.types.test.ts`: **31/31** (27 pre-existing + 4 new v3 type-contract tests)
- `memory.service.test.ts` M3 block: **3/3** — proves live `service.recall()` drops `supersededBy` + `ttl<now` entries; positive control surfaces healthy entries
- `agent-memory.service.test.ts` M3 wire tests: **4/4**

Backend `npm run typecheck`: PASS clean.

## Pre-existing unrelated failures

The full memory test suite reports 40 failures in `vector-store.service.test.ts` (e.g. `should load sqlite-vec extension successfully`, `should produce correct search results with vec0 KNN`). These are pre-existing sqlite-vec native module loading issues that exist on `main`. M3 does not touch any vector-store code.

## Next

- M4 (Memory Supersession) will rebase on this PR — `MemorySupersessionService` + `config/skills/agent/core/supersede-memory/` + supersede.sh + e2e.
- REQ-X recovery filter (P3) in a separate standalone PR.

## Test plan

- [x] Backend typecheck passes
- [x] Eligibility helper unit tests (28/28)
- [x] Schema type-contract tests (31/31)
- [x] Live recall filtering tests on `MemoryService.recall()` (3/3)
- [x] Live recall filtering tests on `AgentMemoryService` (4/4)
- [ ] Arch review (Sam to loop in)