### PR TITLE
chore(settings): default enableProactiveCompact to false

### DIFF
--- a/backend/src/types/settings.types.test.ts
+++ b/backend/src/types/settings.types.test.ts
@@ -278,6 +278,15 @@ describe('Settings Types', () => {
       expect(defaults.general.autoResumeOnRestart).toBe(true);
     });
 
+    it('defaults enableProactiveCompact to false to prevent proactive-compact state loss', () => {
+      // Per Steve user-position decision (2026-05-04): proactive cumulative-output-bytes
+      // compact trigger causes state loss + idle-after-compact issues. Threshold-driven
+      // compact at RED (85%) / CRITICAL (95%) is preserved separately. This default
+      // disables only the proactive trigger; users can re-enable via settings UI.
+      const defaults = getDefaultSettings();
+      expect(defaults.general.enableProactiveCompact).toBe(false);
+    });
+
     it('should have runtime commands defaults for all runtimes', () => {
       const defaults = getDefaultSettings();
 

--- a/backend/src/types/settings.types.ts
+++ b/backend/src/types/settings.types.ts
@@ -307,7 +307,7 @@ export function getDefaultSettings(): CrewlySettings {
         'crewly-agent': 'crewly-agent-in-process',
       },
       agentIdleTimeoutMinutes: 30,
-      enableProactiveCompact: true,
+      enableProactiveCompact: false,
       enableSelfEvolution: false,
       tokenTracking: false,
       enableAuditor: false,


### PR DESCRIPTION
## Why

Per Steve user-position decision (2026-05-04): the proactive cumulative-output-bytes compact trigger causes:
- **State loss** — sessions lose mid-task working memory when proactive compact fires
- **Idle-after-compact issues** — agents observed idle after triggered compaction
- Net effect: the proactive trigger does more harm than good in real ops.

This PR flips a single default. Existing user settings are not touched (UI still allows opt-in).

## What changed

`backend/src/types/settings.types.ts`:
- `getDefaultSettings().general.enableProactiveCompact`: `true` → `false`

`backend/src/types/settings.types.test.ts`:
- Added test pinning the new default + documenting rationale (Steve user-position decision link in comment).

Total diff: +10/-1.

## Existing threshold-driven compact PRESERVED

This change disables **only** the proactive (cumulative-output-bytes) trigger.
The threshold-driven compact at:
- **RED (85% of model context window)**
- **CRITICAL (95% of model context window)**

…is a **separate code path** (state-of-context monitor) and is **not affected** by this change. Agents will still auto-compact when context fills up — they just won't proactively compact based on raw output volume.

## Rollback path

Single-line revert. Either:
1. Revert this commit (`git revert a1d38e32`) — restores `enableProactiveCompact: true` default.
2. Users can opt back in via Settings UI on a per-install basis without a code change.

No migration, no data shape change, no API surface change. Safe to revert.

## Acceptance gates

- [x] TypeScript compiles
- [x] New test `defaults enableProactiveCompact to false` passes
- [x] Existing settings tests unchanged
- [x] No production code path touched outside `getDefaultSettings()`

## Test plan

- [x] Backend unit tests pass (`backend/src/types/settings.types.test.ts`)
- [ ] Reviewer confirms threshold-driven compact (RED/CRITICAL) still triggers in a fresh install
- [ ] Reviewer confirms existing user settings (DB-persisted) override the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)