### PR TITLE
feat(prompt): pipeline dogfood §3 — per-role amendments to surface Request/WorkItem pipeline

### DIFF
--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -2369,4 +2369,266 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			}
 		});
 	});
+
+	// =============================================================================
+	// §3.0 Universal Delegator Closure (Mia spec patch fold-in):
+	//
+	// §3.0 is the dual of §3.5 — delegator-side closure (subscribe via
+	// watch-for-event + schedule-followup fallback at ~2x ETA + cancel-on-verify).
+	// It MUST land in ALL FOUR role souls (ORC/TL/PM/Worker) plus the kickoff
+	// prompt at buildOrchestratorPrompt, with role-specific ETA tuning per
+	// §3.1/§3.2/§3.3/§3.4 closure paragraphs.
+	//
+	// These tests verify:
+	// 1. Each role's rendered prompt names all three skill-paths (watch-for-event,
+	//    schedule-followup, cancel-followup) so agents can find them.
+	// 2. Each role's rendered prompt contains its role-specific ETA-tuning
+	//    numbers — proves the spec ETA framing actually made it through to the
+	//    runtime prompt, not just an abstract "schedule a fallback" mention.
+	// 3. The watch-for-event invocations parse cleanly (same flag-parse smoke
+	//    convention as the idle-self-ping tests above).
+	// =============================================================================
+	describe('§3.0 Universal Delegator Closure (Mia spec patch fold-in)', () => {
+		/**
+		 * Extract the watch-for-event bash invocation from a rendered prompt.
+		 * Mirrors `extractScheduleFollowupInvocation` above — finds the line
+		 * containing `watch-for-event/execute.sh` and walks forward across
+		 * line continuations.
+		 */
+		function extractWatchForEventInvocation(rendered: string): string {
+			const lines = rendered.split('\n');
+			const startIdx = lines.findIndex((l) => /watch-for-event\/execute\.sh/.test(l));
+			if (startIdx < 0) return '';
+			const collected: string[] = [];
+			for (let i = startIdx; i < lines.length; i++) {
+				collected.push(lines[i] ?? '');
+				if (!/\\\s*$/.test(lines[i] ?? '')) break;
+			}
+			return collected.join('\n');
+		}
+
+		/**
+		 * Assert flag-parse correctness for a watch-for-event invocation per
+		 * `config/skills/agent/core/watch-for-event/execute.sh` argument grammar.
+		 */
+		function assertWatchForEventFlagsValid(invocation: string): void {
+			expect(invocation.length).toBeGreaterThan(0);
+			// Required: --event-type <value>
+			expect(invocation).toMatch(/--event-type\s+/);
+			// Required: --title <value>
+			expect(invocation).toMatch(/--title\s+/);
+			// Best-practice: --filter-session (narrows to specific delegatee per §3.0)
+			expect(invocation).toMatch(/--filter-session\s+/);
+			// Best-practice: bound the watcher (--max-fires) so it can't flap forever
+			expect(invocation).toMatch(/--max-fires\s+/);
+			// Forbidden: --target-self is NOT a valid flag (same as schedule-followup)
+			expect(invocation).not.toMatch(/--target-self\b/);
+		}
+
+		describe('ORC §3.1 closure paragraph', () => {
+			it('ORC role prompt names all three §3.0 skills + ORC ETA tuning numbers', async () => {
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcContent = fs.readFileSync(orcPromptPath, 'utf8');
+				expect(orcContent).toContain('watch-for-event/execute.sh');
+				expect(orcContent).toContain('schedule-followup/execute.sh');
+				expect(orcContent).toContain('cancel-followup/execute.sh');
+				// ORC ETA tuning per §3.1 closure: TL milestone 30–90min → fallback 120,
+				// cross-team 2–8h → 12h (~720 min).
+				expect(orcContent).toMatch(/30[–-]90\s*min/);
+				expect(orcContent).toMatch(/120/); // 120-min fallback
+				expect(orcContent).toMatch(/12\s*h|720/); // 12h fallback
+			});
+
+			it('ORC role prompt watch-for-event invocation parses cleanly', async () => {
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcContent = fs.readFileSync(orcPromptPath, 'utf8');
+				const invocation = extractWatchForEventInvocation(orcContent);
+				assertWatchForEventFlagsValid(invocation);
+			});
+
+			it('buildOrchestratorPrompt kickoff names all three §3.0 skills', () => {
+				const projectData = {
+					projectName: 'Dogfood Test',
+					projectPath: '/test/path',
+					teamDetails: { name: 'Crew', members: [{ name: 'Sam', role: 'TL' }] },
+					requirements: 'ship pipeline-first',
+				};
+				const result = service.buildOrchestratorPrompt(projectData);
+				expect(result).toContain('watch-for-event');
+				expect(result).toContain('schedule-followup');
+				expect(result).toContain('cancel-followup');
+				// Recursion clause naming
+				expect(result).toContain('Recursion clause');
+			});
+		});
+
+		describe('TL §3.2 closure paragraph', () => {
+			it('TL addon names all three §3.0 skills + TL ETA tuning numbers + verified-complete nuance', async () => {
+				const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+				const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(tlAddonContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'tl-session',
+					role: 'developer',
+					canDelegate: true,
+					teamId: 'team-x',
+					memberId: 'mem-x',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+					subordinates: [
+						{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+					],
+				};
+
+				const result = await service.buildTeamLeadSection(config);
+				expect(result).toContain('watch-for-event');
+				expect(result).toContain('schedule-followup');
+				expect(result).toContain('cancel-followup');
+				// TL ETA tuning per §3.2 closure: tactical Worker 20–60min → 90min,
+				// multi-step chains 1–3h → 5h (~300 min).
+				expect(result).toMatch(/20[–-]60\s*min/);
+				expect(result).toMatch(/90/); // 90-min fallback
+				expect(result).toMatch(/5\s*h|300/); // 5h fallback
+				// Nuance Sam called out: cancel on verified-complete, NOT raw complete-task.
+				expect(result).toMatch(/verified[\s-]complete/);
+			});
+
+			it('TL addon watch-for-event invocation parses cleanly', async () => {
+				const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+				const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(tlAddonContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'tl-session',
+					role: 'developer',
+					canDelegate: true,
+					teamId: 'team-x',
+					memberId: 'mem-x',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+					subordinates: [
+						{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+					],
+				};
+
+				const result = await service.buildTeamLeadSection(config);
+				const invocation = extractWatchForEventInvocation(result);
+				assertWatchForEventFlagsValid(invocation);
+			});
+		});
+
+		describe('PM §3.3 closure paragraph', () => {
+			it('PM prompt names all three §3.0 skills + PM ETA tuning numbers + upper-end discipline', async () => {
+				const pmPromptPath = path.join(repoRoot, 'config', 'roles', 'product-manager', 'prompt.md');
+				const pmContent = fs.readFileSync(pmPromptPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(pmContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'pm-session',
+					role: 'product-manager',
+					memberId: 'mem-pm',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+				};
+
+				const result = await service.buildSystemPrompt(config);
+				expect(result).toContain('watch-for-event');
+				expect(result).toContain('schedule-followup');
+				expect(result).toContain('cancel-followup');
+				// PM ETA tuning per §3.3 closure: PM→TL 1–4h → 6h (~360 min),
+				// PM→ORC 4–24h → 36h (~2160 min).
+				expect(result).toMatch(/1[–-]4\s*h/);
+				expect(result).toMatch(/6\s*h|360/);
+				expect(result).toMatch(/4[–-]24\s*h/);
+				expect(result).toMatch(/36\s*h|2160/);
+				// Sam-called-out discipline: err toward upper end of fallback window
+				expect(result).toMatch(/upper end/);
+			});
+
+			it('PM prompt watch-for-event invocation parses cleanly', async () => {
+				const pmPromptPath = path.join(repoRoot, 'config', 'roles', 'product-manager', 'prompt.md');
+				const pmContent = fs.readFileSync(pmPromptPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(pmContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'pm-session',
+					role: 'product-manager',
+					memberId: 'mem-pm',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+				};
+
+				const result = await service.buildSystemPrompt(config);
+				const invocation = extractWatchForEventInvocation(result);
+				assertWatchForEventFlagsValid(invocation);
+			});
+		});
+
+		describe('Worker §3.4 closure paragraph (recursion clause)', () => {
+			it('developer prompt names all three §3.0 skills + Worker ETA tuning + recursion-clause callout + canonical-failure-case naming', async () => {
+				const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+				const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(devContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'dev-session',
+					role: 'developer',
+					memberId: 'mem-dev',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+				};
+
+				const result = await service.buildSystemPrompt(config);
+				expect(result).toContain('watch-for-event');
+				expect(result).toContain('schedule-followup');
+				expect(result).toContain('cancel-followup');
+				// Worker ETA tuning per §3.4 closure: peer sub-WorkItems 10–30min → 45min,
+				// cross-role clarifications 15–60min → 90min.
+				expect(result).toMatch(/10[–-]30\s*min/);
+				expect(result).toMatch(/45/);
+				expect(result).toMatch(/15[–-]60\s*min/);
+				// Sam-called-out: name the canonical failure case explicitly
+				expect(result).toMatch(/Steve manually pinged/i);
+				// Recursion clause non-negotiable framing
+				expect(result).toMatch(/recursion clause.*non-negotiable/i);
+			});
+
+			it('developer prompt watch-for-event invocation parses cleanly', async () => {
+				const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+				const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(devContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'dev-session',
+					role: 'developer',
+					memberId: 'mem-dev',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+				};
+
+				const result = await service.buildSystemPrompt(config);
+				const invocation = extractWatchForEventInvocation(result);
+				assertWatchForEventFlagsValid(invocation);
+			});
+		});
+	});
 });

--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -1975,3 +1975,267 @@ describe('buildModuleConfigFromTeamMember — WIRE-1 wiring', () => {
 		expect(config.projectRoot).toBe('/another/root');
 	});
 });
+
+// =============================================================================
+// Pipeline Dogfood Amendments — spec 2026-05-05-pipeline-dogfood-prompt-amendment
+// =============================================================================
+//
+// These tests cover the §5.1 "Prompt amendment landed" acceptance criteria.
+// Each amendment must surface in the rendered prompt; tests render via the
+// existing build* methods and assert that the §3 phrases appear.
+//
+// The prompt-builder service loads role files from disk; we mock fs/promises so
+// the tests are hermetic. For role-file-backed amendments (§3.2 TL, §3.3 PM,
+// §3.4 Worker session-start, §3.5 sweeps), the test reads the actual file from
+// the worktree using the unmocked Node fs and feeds the content through the
+// mock — this verifies BOTH that the prompt-builder pipeline renders the amendment
+// AND that the source role file contains the required phrases.
+// =============================================================================
+describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
+	let service: PromptBuilderService;
+	let mockReadFile: jest.Mock;
+	let mockAccess: jest.Mock;
+	const savedModularEnv = process.env.CREWLY_USE_MODULAR_PROMPTS;
+
+	// Resolve the actual repo root so we can read the real role files
+	// for assertion. __dirname under jest is something like
+	// `<repo>/backend/src/services/ai`; back up to repo root.
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const path = require('path') as typeof import('path');
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	const fs = require('fs') as typeof import('fs');
+	const repoRoot = path.resolve(__dirname, '../../../../');
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		process.env.CREWLY_USE_MODULAR_PROMPTS = 'false';
+		mockReadFile = jest.mocked(fsPromises.readFile);
+		mockAccess = jest.mocked(fsPromises.access);
+		service = new PromptBuilderService(repoRoot);
+	});
+
+	afterEach(() => {
+		if (savedModularEnv === undefined) {
+			delete process.env.CREWLY_USE_MODULAR_PROMPTS;
+		} else {
+			process.env.CREWLY_USE_MODULAR_PROMPTS = savedModularEnv;
+		}
+	});
+
+	describe('§3.1 — buildOrchestratorPrompt includes pipeline-first planning', () => {
+		it('rendered prompt contains "POST /api/requests" and "intentLevel"', () => {
+			const projectData = {
+				projectName: 'Dogfood Test',
+				projectPath: '/test/path',
+				teamDetails: { name: 'Crew', members: [{ name: 'Sam', role: 'TL' }] },
+				requirements: 'ship pipeline-first',
+			};
+
+			const result = service.buildOrchestratorPrompt(projectData);
+
+			// §5.1 line 1: assert both phrases appear in the rendered prompt
+			expect(result).toContain('POST /api/requests');
+			expect(result).toContain('intentLevel');
+			// Spec citation must remain so the amendment is traceable
+			expect(result).toContain('2026-05-05-pipeline-dogfood-prompt-amendment.md');
+		});
+	});
+
+	describe('§3.2 — buildTeamLeadSection includes pipeline-first delegation', () => {
+		it('rendered TL addon contains "claim from the pool" and "Request ID"', async () => {
+			// Read the actual tl-addon.md from disk and feed through mock
+			const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+			const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(tlAddonContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'tl-session',
+				role: 'developer',
+				canDelegate: true,
+				teamId: 'team-x',
+				memberId: 'mem-x',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+				subordinates: [
+					{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+				],
+			};
+
+			const result = await service.buildTeamLeadSection(config);
+
+			// §5.1 line 2: assert pipeline-first delegation phrases
+			expect(result).toContain('claim from the pool');
+			expect(result).toContain('Request ID');
+			// And the §3.5 cross-cutting amendments
+			expect(result).toContain('list-my-followups');
+			expect(result).toContain('idle-self-ping');
+		});
+	});
+
+	describe('§3.3 — PM role prompt template includes pipeline-first authoring', () => {
+		it('rendered PM prompt contains "POST a Request" and clarify-only/delivery framing', async () => {
+			const pmPromptPath = path.join(repoRoot, 'config', 'roles', 'product-manager', 'prompt.md');
+			const pmContent = fs.readFileSync(pmPromptPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(pmContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'pm-session',
+				role: 'product-manager',
+				memberId: 'mem-pm',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			const result = await service.buildSystemPrompt(config);
+
+			// §5.1 line 3: PM contains "POST a Request" and clarify-only framing
+			expect(result).toContain('POST a Request');
+			expect(result).toContain('Clarify-only is for interpretation, not for delivery');
+		});
+	});
+
+	describe('§3.4 — buildSystemPrompt (worker) includes session-start claim + decompose-on-claim', () => {
+		it('rendered developer prompt contains "POST /api/task-pool/claim" and "parentWorkItemId" near session-start', async () => {
+			const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+			const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(devContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'dev-session',
+				role: 'developer',
+				memberId: 'mem-dev',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			const result = await service.buildSystemPrompt(config);
+
+			// §5.1 line 4: claim endpoint and parentWorkItemId in session-start area
+			expect(result).toContain('POST /api/task-pool/claim');
+			expect(result).toContain('parentWorkItemId');
+
+			// "Near session-start protocol" — claim text should appear before
+			// the (later) post-completion sweep block to confirm placement.
+			const sessionStartIdx = result.indexOf('Session-Start Pipeline Claim');
+			const postCompletionIdx = result.indexOf('Post-Completion Inbox Sweep');
+			expect(sessionStartIdx).toBeGreaterThan(-1);
+			expect(postCompletionIdx).toBeGreaterThan(-1);
+			expect(sessionStartIdx).toBeLessThan(postCompletionIdx);
+		});
+	});
+
+	describe('§3.5.a — Post-completion inbox sweep present in Worker AND TL prompts', () => {
+		it('Worker (developer) prompt contains "list-my-followups" and "claim" in post-completion section', async () => {
+			const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+			const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(devContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'dev-session',
+				role: 'developer',
+				memberId: 'mem-dev',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			const result = await service.buildSystemPrompt(config);
+
+			expect(result).toContain('Post-Completion Inbox Sweep');
+			expect(result).toContain('list-my-followups');
+			expect(result).toContain('claim');
+		});
+
+		it('TL addon contains "list-my-followups" and "claim" in post-completion section', async () => {
+			const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+			const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(tlAddonContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'tl-session',
+				role: 'developer',
+				canDelegate: true,
+				teamId: 'team-x',
+				memberId: 'mem-x',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+				subordinates: [
+					{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+				],
+			};
+
+			const result = await service.buildTeamLeadSection(config);
+
+			expect(result).toContain('Post-Completion Inbox Sweep');
+			expect(result).toContain('list-my-followups');
+			expect(result).toContain('claim');
+		});
+	});
+
+	describe('§3.5.b — Idle-fallback schedule-followup present in Worker AND TL prompts', () => {
+		it('Worker (developer) prompt contains "idle-self-ping" and the 5–15 minute window', async () => {
+			const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+			const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(devContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'dev-session',
+				role: 'developer',
+				memberId: 'mem-dev',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			const result = await service.buildSystemPrompt(config);
+
+			expect(result).toContain('idle-self-ping');
+			// Window guidance: 5–15 minutes (en-dash per spec). Accept both en-dash
+			// and ASCII hyphen for robustness against editor normalization.
+			expect(result).toMatch(/5[–-]15\s*minute/);
+		});
+
+		it('TL addon contains "idle-self-ping" and the 5–15 minute window', async () => {
+			const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+			const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(tlAddonContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'tl-session',
+				role: 'developer',
+				canDelegate: true,
+				teamId: 'team-x',
+				memberId: 'mem-x',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+				subordinates: [
+					{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+				],
+			};
+
+			const result = await service.buildTeamLeadSection(config);
+
+			expect(result).toContain('idle-self-ping');
+			expect(result).toMatch(/5[–-]15\s*minute/);
+		});
+	});
+});

--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -2206,12 +2206,13 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			const result = await service.buildSystemPrompt(config);
 
 			expect(result).toContain('idle-self-ping');
-			// Window guidance: 5–15 minutes (en-dash per spec). Accept both en-dash
-			// and ASCII hyphen for robustness against editor normalization.
-			expect(result).toMatch(/5[–-]15\s*minute/);
+			// Window guidance: per Arch verdict polish #3, broken into 5/10/15-min
+			// bullets with stall-character justification. Accept either the legacy
+			// "5–15 minute" form OR the new bulleted form.
+			expect(result).toMatch(/(?:5[–-]15\s*minute)|(?:5\s*min[\s\S]{0,120}10\s*min[\s\S]{0,120}15\s*min)/);
 		});
 
-		it('TL addon contains "idle-self-ping" and the 5–15 minute window', async () => {
+		it('TL addon contains "idle-self-ping" and the 5/10/15-minute window guidance', async () => {
 			const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
 			const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
 
@@ -2235,7 +2236,137 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			const result = await service.buildTeamLeadSection(config);
 
 			expect(result).toContain('idle-self-ping');
-			expect(result).toMatch(/5[–-]15\s*minute/);
+			expect(result).toMatch(/(?:5[–-]15\s*minute)|(?:5\s*min[\s\S]{0,120}10\s*min[\s\S]{0,120}15\s*min)/);
+		});
+	});
+
+	// =============================================================================
+	// Block #1 / Arch verdict follow-up (PR #446 re-review):
+	// Flag-parse smoke test convention. Per Arch's observation #5, every literal
+	// `bash` invocation embedded in a rendered prompt must be flag-validated so
+	// future regressions in skill-CLI surface (e.g. invented `--target-self`,
+	// missing required `--title`) are caught at unit-test time, not at the agent
+	// runtime where the safety net silently fails.
+	//
+	// Going forward this is the prompt-builder test convention: every literal
+	// schedule-followup invocation in a role prompt gets a flag-parse smoke
+	// assertion — required flags present, invalid flags absent.
+	// =============================================================================
+	describe('Bash invocation flag-parse smoke (idle-self-ping safety net)', () => {
+		/**
+		 * Extract the schedule-followup bash invocation from a rendered prompt
+		 * by finding the `idle-self-ping` --name flag and walking forward across
+		 * line continuations (`\`-terminated lines).
+		 */
+		function extractScheduleFollowupInvocation(rendered: string): string {
+			// Find the line containing the `--name "idle-self-ping"` token. The
+			// invocation begins on the preceding `bash …/schedule-followup/…` line
+			// and ends on the first non-continuation line after it.
+			const lines = rendered.split('\n');
+			const startIdx = lines.findIndex((l) => /schedule-followup\/execute\.sh/.test(l));
+			if (startIdx < 0) return '';
+			const collected: string[] = [];
+			for (let i = startIdx; i < lines.length; i++) {
+				collected.push(lines[i] ?? '');
+				// Continuation: line ends with backslash (allowing trailing whitespace)
+				if (!/\\\s*$/.test(lines[i] ?? '')) break;
+			}
+			return collected.join('\n');
+		}
+
+		/**
+		 * Assert flag-parse correctness for an idle-self-ping invocation: the
+		 * required `--title` flag is present AND the invalid `--target-self`
+		 * flag is absent (per schedule-followup/execute.sh argument grammar).
+		 */
+		function assertIdleSelfPingFlagsValid(invocation: string): void {
+			expect(invocation.length).toBeGreaterThan(0);
+			// Required: --title (schedule-followup/execute.sh:109 hard-fails without it)
+			expect(invocation).toMatch(/--title\s+/);
+			// Required: --name (used for cancel-on-resolution + dedup)
+			expect(invocation).toMatch(/--name\s+/);
+			// Required: --in-minutes OR --fire-at OR --cron (one-of, schedule-followup script enforces)
+			expect(invocation).toMatch(/--(in-minutes|fire-at|cron)\s+/);
+			// Required: --max-fires (idle-self-ping must be bounded — cap-of-2 discipline)
+			expect(invocation).toMatch(/--max-fires\s+/);
+			// Forbidden: --target-self is NOT a valid flag in schedule-followup/execute.sh.
+			// To target self, OMIT --target entirely (defaults to CREWLY_SESSION_NAME).
+			expect(invocation).not.toMatch(/--target-self\b/);
+		}
+
+		it('Worker (developer) §3.5.b idle-self-ping invocation parses cleanly (--title present, --target-self absent)', async () => {
+			const devPromptPath = path.join(repoRoot, 'config', 'roles', 'developer', 'prompt.md');
+			const devContent = fs.readFileSync(devPromptPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(devContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'dev-session',
+				role: 'developer',
+				memberId: 'mem-dev',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			const result = await service.buildSystemPrompt(config);
+			const invocation = extractScheduleFollowupInvocation(result);
+			assertIdleSelfPingFlagsValid(invocation);
+		});
+
+		it('TL §3.5.b idle-self-ping invocation parses cleanly (--title present, --target-self absent)', async () => {
+			const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+			const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(tlAddonContent);
+
+			const config: TeamMemberSessionConfig = {
+				name: 'tl-session',
+				role: 'developer',
+				canDelegate: true,
+				teamId: 'team-x',
+				memberId: 'mem-x',
+				projectPath: '/proj',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+				subordinates: [
+					{ name: 'Worker1', sessionName: 'w1-session', role: 'developer', memberId: 'm-w1' },
+				],
+			};
+
+			const result = await service.buildTeamLeadSection(config);
+			const invocation = extractScheduleFollowupInvocation(result);
+			assertIdleSelfPingFlagsValid(invocation);
+		});
+
+		it('ORC §3.1 create-request bash path uses {{AGENT_SKILLS_PATH}} (path resolution smoke)', () => {
+			// §3.1 amendment lives in buildOrchestratorPrompt (kickoff prompt) AND
+			// in config/roles/orchestrator/prompt.md. The kickoff function
+			// renders the §3.1 paragraph; verify it does NOT reference the wrong
+			// {{ORCHESTRATOR_SKILLS_PATH}}/create-request path that would resolve
+			// to a non-existent file at config/skills/orchestrator/create-request/.
+			//
+			// (kickoff prompt only describes the discipline, not the bash invocation.
+			// The bash-invocation path correctness lives in the orchestrator role
+			// prompt file. The smoke test below checks the file-on-disk for the
+			// right path token.)
+			const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+			const orcContent = fs.readFileSync(orcPromptPath, 'utf8');
+
+			// Find the create-request invocation block; it must use AGENT_SKILLS_PATH
+			// (which substitutes to config/skills/agent/) — NOT ORCHESTRATOR_SKILLS_PATH
+			// (which substitutes to config/skills/orchestrator/, where create-request
+			// does not exist).
+			const createRequestLines = orcContent
+				.split('\n')
+				.filter((l) => /create-request\/execute\.sh/.test(l));
+			expect(createRequestLines.length).toBeGreaterThan(0);
+			for (const line of createRequestLines) {
+				expect(line).toContain('{{AGENT_SKILLS_PATH}}/core/create-request/execute.sh');
+				expect(line).not.toContain('{{ORCHESTRATOR_SKILLS_PATH}}/create-request');
+			}
 		});
 	});
 });

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -363,7 +363,18 @@ When you receive a planning-class intent from the owner (or any upstream source)
 2. If intentLevel ∈ {L1, L2}, call POST /api/requests/plan with the user message to receive a RequestPlan. Review it; if you accept, materialise WorkItems whose requestId is the new Request.
 3. Only after the Request exists and at least one WorkItem is in the pool may you send-message a teammate, and that message MUST reference the Request ID — it is a notification of an existing pipeline item, never a substitute for one.
 
-Markdown specs in .crewly/specs/ remain valid for durable design artefacts (architecture, post-mortems). They are NOT the channel for "tell the team what to build" — that is the Request. Negative pattern to suppress: "forward to TL via send-message" as the first step after parsing intent.`.trim();
+Markdown specs in .crewly/specs/ remain valid for durable design artefacts (architecture, post-mortems). They are NOT the channel for "tell the team what to build" — that is the Request. Negative pattern to suppress: "forward to TL via send-message" as the first step after parsing intent.
+
+## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
+
+> Source spec: .crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md §3.0. Dual of §3.5.
+
+Every dispatch (delegate-task, send-message-with-action, materialise WorkItem with target, POST Request handed off to a TL) MUST close the loop with BOTH:
+1. watch-for-event subscribed to the delegatee (--filter-session, --max-fires N, --max-idle-fires 3)
+2. schedule-followup fallback at ~2x expected ETA (TL milestone 30-90min → 120min; cross-team 2-8h → 12h)
+3. cancel-followup BOTH on verified completion (PR merged / Request done / acceptance met).
+
+Recursion clause: every delegator hop carries this rule — ORC→TL, TL→Worker, PM→TL, AND Worker→Worker. The pipeline does not exempt any hop. Failure mode it prevents: dispatcher forgets the work it dispatched and only checks status manually hours later because no event ever woke them.`.trim();
 
 		this.logger.debug('Built orchestrator prompt', {
 			projectName,

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -351,7 +351,19 @@ You are managing the "${projectName}" project. The team sessions have been creat
 
 The team is ready to start. Begin by reviewing the project specs and coordinating the team to start Phase 1 development.
 
-Start all teams on Phase 1 simultaneously.`.trim();
+Start all teams on Phase 1 simultaneously.
+
+## Pipeline-First Planning Discipline
+
+> Source spec: .crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md §3.1.
+
+When you receive a planning-class intent from the owner (or any upstream source), do NOT write a markdown spec or push tasks via send-message as your first move. The pipeline is the planner of record:
+
+1. POST /api/requests first — { sourceConversationItemId, title, description, intentLevel, intentCategory, priority }. Capture the returned id.
+2. If intentLevel ∈ {L1, L2}, call POST /api/requests/plan with the user message to receive a RequestPlan. Review it; if you accept, materialise WorkItems whose requestId is the new Request.
+3. Only after the Request exists and at least one WorkItem is in the pool may you send-message a teammate, and that message MUST reference the Request ID — it is a notification of an existing pipeline item, never a substitute for one.
+
+Markdown specs in .crewly/specs/ remain valid for durable design artefacts (architecture, post-mortems). They are NOT the channel for "tell the team what to build" — that is the Request. Negative pattern to suppress: "forward to TL via send-message" as the first step after parsing intent.`.trim();
 
 		this.logger.debug('Built orchestrator prompt', {
 			projectName,
@@ -781,6 +793,11 @@ ${fullContext}
 				MEMBER_ID: config.memberId || '',
 				PROJECT_PATH: config.projectPath || '',
 				AGENT_SKILLS_PATH: this.agentSkillsPath,
+				// Pipeline Dogfood Amendment §3.5 — TL prompt references {{SESSION_NAME}}
+				// in poll-tasks / schedule-followup invocations, so the addon now
+				// participates in session-name substitution alongside the worker prompts.
+				SESSION_NAME: config.name || 'unknown',
+				SESSION_ID: config.name || 'unknown',
 			});
 
 			this.logger.info('Loaded TL addon from file', {

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -80,6 +80,52 @@ Do **not** silently expand scope inside one WorkItem. The pipeline is how recurs
 
 **Negative pattern to suppress:** "Worker session starts → reads chat → decides what to do → opens editor → never touches the pool."
 
+## Universal Delegator Closure (§3.0 — MANDATORY for Worker→Worker dispatch)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.
+> **Dual of §3.5.** §3.5 is delegatee-side closure (your post-completion sweep + idle-self-ping). §3.0 is delegator-side closure. **Workers DO delegate** — see the L2 child-WorkItem path in §3.4 Step C, plus `send-message` for clarification, plus `delegate-task` for chained downstream work. **The recursion clause in §3.0 is non-negotiable: Worker→Worker dispatch is bound by §3.0 the same way ORC→TL or TL→Worker is.**
+
+When you create a child WorkItem for a peer Worker, hand off via `send-message` for clarification (e.g. dev→architect, dev→qa), or chain a downstream worker via `delegate-task`, you MUST close the loop with **both** signals:
+
+1. **Subscribe to the peer** via `watch-for-event` so you wake on their `agent:idle` (or `task:completed`):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
+     --event-type agent:idle \
+     --filter-session <peer-session> \
+     --title "Peer idle — child WorkItem check" \
+     --description "Per §3.0: <peer> went idle on <child workitem id / message ref>. Check whether their reply landed in your inbox or whether the child WorkItem flipped to done." \
+     --max-fires 3 \
+     --max-idle-fires 3
+   ```
+
+2. **Schedule a fallback** at roughly **2× expected ETA** via `schedule-followup` — `agent:idle` is best-effort, not a guarantee, and stalled peers never transition:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+     --name "fallback-<peer>-<short-task>" \
+     --title "Worker delegator fallback check on <peer>" \
+     --description "Per §3.0 fallback (~2× ETA): event-bus signal may be missed. Check whether the child WorkItem completed or peer replied. If still pending, escalate to TL." \
+     --in-minutes <2x ETA in minutes> \
+     --max-fires 1
+   ```
+
+3. **Cancel both** the moment the child's `complete-task` fires or the peer's reply lands in your inbox:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name <watch-or-fallback-name>
+   ```
+
+**Worker ETA tuning** (per §3.4 closure paragraph in the spec):
+- **Peer sub-WorkItems** (narrowly scoped, single-file, peer-developer pickup) typically resolve in **10–30 min** → set `--in-minutes 45` for the fallback.
+- **Cross-role clarifications** (dev→architect, dev→qa, dev→designer) typically resolve in **15–60 min** → set `--in-minutes 90` for the fallback.
+
+**Canonical failure case (the dogfood story this rule fixes):** A Worker dispatched a child WorkItem to a peer, then went idle without subscribing or scheduling a fallback. The peer was offline. The Worker sat silent until **Steve manually pinged** asking for status hours later. That's the exact failure mode §3.0 prevents — **a delegator without subscribe+fallback is a delegator that forgot the work it dispatched.**
+
+**Audit before adding a new watcher:**
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+```
+
+**Negative pattern to suppress:** "Worker decomposes L2 → creates child WorkItem → goes back to own work → never wakes when peer ships → child sits done in pool, parent stays `running` forever."
+
 ## What you'll be helping with
 
 - Implementing features according to specifications

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -24,6 +24,60 @@ bash {{AGENT_SKILLS_PATH}}/core/register-self/execute.sh '{"role":"{{ROLE}}","se
 ```
 All it does is update a local status flag so the web UI shows you as online - nothing more.
 
+## Session-Start Pipeline Claim (MANDATORY)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.4.
+
+**After register-self succeeds, claim work from the pool BEFORE responding to chat history.** This is the first action of the session, not the last.
+
+### Step A — Claim from the pool
+
+Call `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "<your-team>", role: "{{ROLE}}" } }`. The Crewly skill wrapper:
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"{{ROLE}}","projectPath":"{{PROJECT_PATH}}"}'
+```
+
+- If the pool returns a WorkItem → **that becomes your active task.**
+- If the pool returns nothing → wait for delegation or report idle. **Do NOT invent work from chat history.**
+
+### Step B — Worktree isolation (KR4 template-candidate pattern)
+
+If your task involves touching the repo (code edits, doc edits, prompt edits), **fork a private worktree off `origin/main`** before starting work. This avoids stepping on another agent who is mid-rebase or mid-merge in the main repo:
+
+```bash
+git fetch origin main
+git worktree add /tmp/crewly-worktrees/{{SESSION_NAME}}-<task-slug> -b <feat-branch> origin/main
+cd /tmp/crewly-worktrees/{{SESSION_NAME}}-<task-slug>
+```
+
+Why: Crewly is a multi-agent system, and the main repo's working tree may be in any state (rebase pending, conflict markers, another agent's WIP). A private worktree is your *own* clean copy off the latest origin/main; you can build, test, and commit there without colliding. When you're done, push your branch and open a PR — the worktree gets cleaned up after merge.
+
+This pattern *is* the dogfood — it's a KR4 template candidate, treat it as default for any code-touching task.
+
+### Step C — On-claim self-assessment (decompose-on-claim)
+
+Before executing a claimed WorkItem, run this **four-question check**:
+
+1. **Single-actor?** Can I, with my role's tools, finish this in one focused work block (≤2 hours of cognitive work, ≤1 codebase area)?
+2. **Atomic acceptance?** Is there one observable outcome that decides done vs not-done?
+3. **No new ownership lines?** Does completing this require zero coordination with another agent (no review-then-merge dependency, no spec-author handoff)?
+4. **Within my role boundary?** Does it stay inside what my role definition allows me to do without escalating?
+
+If **all four = yes** → treat as L0/L1, execute directly.
+
+If **any = no** → it is L2. **Decompose recursively:**
+1. Call the `decompose-intent` skill on the WorkItem description:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/decompose-intent/execute.sh '{"description":"<workitem description>","level":"L2"}'
+   ```
+2. For each returned sub-intent, create a child WorkItem via the WorkItem API with `parentWorkItemId = <your claimed WorkItem id>` and `requestId = <inherit from parent>`.
+3. Leave your own WorkItem in `status=running` until children resolve.
+4. When all children are `done`, mark yours `done` (with rollup notes summarising what each child shipped).
+
+Do **not** silently expand scope inside one WorkItem. The pipeline is how recursive structure becomes legible to ORC/TL/KR rollups.
+
+**Negative pattern to suppress:** "Worker session starts → reads chat → decides what to do → opens editor → never touches the pool."
+
 ## What you'll be helping with
 
 - Implementing features according to specifications
@@ -184,3 +238,50 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+## Post-Completion Inbox Sweep (MANDATORY)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.a.
+
+**After every task-completing action** — including any `send-message` reply, `report-status`, `complete-task`, opening a PR, or merging code — and **before transitioning to idle**, you MUST run this three-step sweep, in order:
+
+1. **`list-my-followups`** — surface any pending scheduled work owned by you. If a followup is due, address it.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+   ```
+2. **Claim from the pool** — `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "<team>", role: "{{ROLE}}" } }`. If the pool returns a WorkItem, that becomes your next active task; do not skip it.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"{{ROLE}}","projectPath":"{{PROJECT_PATH}}"}'
+   ```
+3. **Only after both come back empty** (or you have addressed what they returned) may you transition to idle / wait.
+
+This is non-optional. The system relies on Workers being self-pulling at completion boundaries; agents that stop pulling become invisible bottlenecks. Treat the sweep as part of the completion ritual, not a separate task.
+
+**Negative pattern to suppress:** "Worker sends reply → marks task done → goes idle → ORC's next delegation lands in inbox unread for 30 minutes."
+
+## Idle-Fallback Safety Net (`schedule-followup`)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.b.
+
+When you find yourself **stuck without action** — waiting on a downstream agent, polling a check that has not yet completed, or otherwise *stalled* (i.e. you are not strict-idle in the transition sense; you are mid-task but cannot make forward progress without external input) — schedule an **idle-self-ping** followup so the system can wake you if the stall persists:
+
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+  --name "idle-self-ping" \
+  --in-minutes 10 \
+  --max-fires 1 \
+  --target-self
+```
+
+Pick a window of **5–15 minutes** based on how time-sensitive the stall is.
+
+**When the followup fires, the WorkItem it creates instructs you to:**
+1. Re-run the post-completion inbox sweep above.
+2. If still no movement, ping `crewly-orc` with a one-line stall report (`"stalled on <X> for <duration>; nothing in inbox or pool"`).
+3. Schedule one more idle-self-ping if the stall is reasonable, OR escalate via TL if the stall is now blocking a Request.
+
+**Discipline:** Cap yourself at **at most 2 active idle-self-pings**. If you already have 2, `cancel-followup` on the older one before scheduling a new one.
+
+**Why this matters:** The `agent:idle` event is *transition-fire only* — it fires once when an agent goes from busy→idle and never again. An agent that "stalls" without ever flipping to strict-idle never gets pinged. Without the idle-self-ping safety net, a stalled worker is silently stuck.
+
+**Negative pattern to suppress:** "Worker is mid-task waiting on a downstream → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -32,13 +32,15 @@ All it does is update a local status flag so the web UI shows you as online - no
 
 ### Step A — Claim from the pool
 
-Call `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "<your-team>", role: "{{ROLE}}" } }`. The Crewly skill wrapper:
+Use the Crewly skill wrapper, which calls `POST /api/task-pool/claim` server-side and derives the right `types` filter from your role:
 ```bash
 bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"{{ROLE}}","projectPath":"{{PROJECT_PATH}}"}'
 ```
 
 - If the pool returns a WorkItem → **that becomes your active task.**
 - If the pool returns nothing → wait for delegation or report idle. **Do NOT invent work from chat history.**
+
+(If you ever need to call `/api/task-pool/claim` directly, the body shape is `{ agentId: string, filters?: { types?, owner?, target?, missionId? } }` — there is no `team` or `role` filter; the skill wrapper handles role-to-types mapping for you.)
 
 ### Step B — Worktree isolation (KR4 template-candidate pattern)
 
@@ -249,7 +251,7 @@ When you encounter an error and successfully resolve it:
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
    ```
-2. **Claim from the pool** — `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "<team>", role: "{{ROLE}}" } }`. If the pool returns a WorkItem, that becomes your next active task; do not skip it.
+2. **Claim from the pool** via the skill wrapper. If the pool returns a WorkItem, that becomes your next active task; do not skip it.
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"{{ROLE}}","projectPath":"{{PROJECT_PATH}}"}'
    ```
@@ -263,25 +265,37 @@ This is non-optional. The system relies on Workers being self-pulling at complet
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.b.
 
-When you find yourself **stuck without action** — waiting on a downstream agent, polling a check that has not yet completed, or otherwise *stalled* (i.e. you are not strict-idle in the transition sense; you are mid-task but cannot make forward progress without external input) — schedule an **idle-self-ping** followup so the system can wake you if the stall persists:
+When you find yourself **stuck without action** — *concrete triggers:* waiting on a TL review, monitoring a multi-minute build, polled an external API check that's not yet ready, downstream agent hasn't acked your message, mid-task but cannot make forward progress without external input — schedule an **idle-self-ping** followup so the system can wake you if the stall persists.
+
+You are not strict-idle in the transition sense (you are mid-task), so the `agent:idle` event will NOT fire. The idle-self-ping is your safety net.
+
+**Schedule the ping (default-self target — omit `--target` and the script defaults to your own session):**
 
 ```bash
 bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
   --name "idle-self-ping" \
+  --title "Idle self-ping — re-run inbox sweep" \
+  --description "Stall self-check: re-run §3.5.a sweep (list-my-followups + poll-tasks). If still no movement, ping crewly-orc with one-line stall report. Re-read §3.5.b in your role prompt for the full wake protocol." \
   --in-minutes 10 \
-  --max-fires 1 \
-  --target-self
+  --max-fires 1
 ```
 
-Pick a window of **5–15 minutes** based on how time-sensitive the stall is.
+**Pick the window based on stall character:**
+- **5 min** — short tail-latency stalls (waiting on a quick API check)
+- **10 min** — moderate stalls (waiting on a CI build, downstream agent step)
+- **15 min** — long stalls (waiting on cross-team review or a PR cycle)
 
-**When the followup fires, the WorkItem it creates instructs you to:**
-1. Re-run the post-completion inbox sweep above.
+**At wake-time, re-read this §3.5.b section** — the followup carries the title and description above as its WorkItem payload, but the detailed wake protocol lives in the prompt:
+1. Re-run the post-completion inbox sweep (§3.5.a) — `list-my-followups` then `poll-tasks`.
 2. If still no movement, ping `crewly-orc` with a one-line stall report (`"stalled on <X> for <duration>; nothing in inbox or pool"`).
 3. Schedule one more idle-self-ping if the stall is reasonable, OR escalate via TL if the stall is now blocking a Request.
 
-**Discipline:** Cap yourself at **at most 2 active idle-self-pings**. If you already have 2, `cancel-followup` on the older one before scheduling a new one.
+**Cleanup discipline (cancel-on-resolution):** If the stall resolves before the ping fires (review came through, build finished, downstream acked, you went strict-idle on your own), run:
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name idle-self-ping
+```
+**Don't leave stale pings in the queue** — they fire later, kick you into a sweep that finds nothing, and waste a wake cycle.
 
-**Why this matters:** The `agent:idle` event is *transition-fire only* — it fires once when an agent goes from busy→idle and never again. An agent that "stalls" without ever flipping to strict-idle never gets pinged. Without the idle-self-ping safety net, a stalled worker is silently stuck.
+**Cap discipline:** At most **2 active idle-self-pings** per agent. If you already have 2, cancel the older one before scheduling a new one.
 
 **Negative pattern to suppress:** "Worker is mid-task waiting on a downstream → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -233,9 +233,9 @@ When you receive a **planning-class intent** from Steve (or any upstream source)
 
 1. **POST the Request first.** Call `POST /api/requests` with `{ sourceConversationItemId, title, description, intentLevel, intentCategory, priority }`. This creates the Request of record. Capture the returned `id`.
    ```bash
-   bash {{ORCHESTRATOR_SKILLS_PATH}}/create-request/execute.sh '{"title":"<short title>","description":"<intent text>","intentLevel":"L1|L2","intentCategory":"planning|code_change|content|research","priority":"normal","sourceConversationItemId":"<msg-id>"}'
+   bash {{AGENT_SKILLS_PATH}}/core/create-request/execute.sh '{"title":"<short title>","description":"<intent text>","intentLevel":"L1|L2","intentCategory":"planning|code_change|content|research","priority":"normal","sourceConversationItemId":"<msg-id>"}'
    ```
-   (If a dedicated skill is not yet wired, call the REST endpoint directly via `curl $CREWLY_API_URL/api/requests`.)
+   (Note: `create-request` lives at `config/skills/agent/core/`, NOT under `config/skills/orchestrator/`. The orchestrator prompt template substitutes `{{AGENT_SKILLS_PATH}}` to point at the agent skill root. If a dedicated skill is not yet wired, call the REST endpoint directly via `curl $CREWLY_API_URL/api/requests`.)
 
 2. **If `intentLevel ∈ {L1, L2}`, plan it.** Call `POST /api/requests/plan` with the user message to receive a `RequestPlan`. Review it; if you accept, materialise WorkItems whose `requestId` is the new Request.
 

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -221,6 +221,34 @@ bash {{ORCHESTRATOR_SKILLS_PATH}}/recall/execute.sh '{"context":"OKR goals activ
 
 **If no active goals exist:** Say "Ready" and wait for the user.
 
+---
+
+## Pipeline-First Planning Discipline (MANDATORY for planning intent)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.1.
+
+When you receive a **planning-class intent** from Steve (or any upstream source), **do not write a markdown spec or push tasks via `send-message` as your first move**. The pipeline is the planner of record. Use it.
+
+**Required sequence:**
+
+1. **POST the Request first.** Call `POST /api/requests` with `{ sourceConversationItemId, title, description, intentLevel, intentCategory, priority }`. This creates the Request of record. Capture the returned `id`.
+   ```bash
+   bash {{ORCHESTRATOR_SKILLS_PATH}}/create-request/execute.sh '{"title":"<short title>","description":"<intent text>","intentLevel":"L1|L2","intentCategory":"planning|code_change|content|research","priority":"normal","sourceConversationItemId":"<msg-id>"}'
+   ```
+   (If a dedicated skill is not yet wired, call the REST endpoint directly via `curl $CREWLY_API_URL/api/requests`.)
+
+2. **If `intentLevel ∈ {L1, L2}`, plan it.** Call `POST /api/requests/plan` with the user message to receive a `RequestPlan`. Review it; if you accept, materialise WorkItems whose `requestId` is the new Request.
+
+3. **Only after the Request exists and at least one WorkItem is in the pool may you `send-message` a teammate** — and that message must reference the Request ID. The message is a *notification of an existing pipeline item*, never a substitute for one.
+
+**The negative pattern to suppress:** "Forward to <TL> via send-message" as the first step after parsing intent. If you find yourself drafting a spec to "tell Sam to do X", you should be POSTing a Request instead.
+
+**Spec-author exception (the recursive-dogfood loophole):** Markdown specs in `.crewly/specs/` remain valid for *durable design artefacts* — architecture decisions, post-mortems, this kind of behavioural spec. The rule: **a spec is legitimate iff its frontmatter cites a Request ID, OR it documents a decision whose existence pre-dates the Request entity (grandfathered).** Authoring a spec to "tell the team what to build" is pipeline-bypassing; authoring a spec that *follows from* a POSTed Request is fine.
+
+**Self-check before any planning action:** *Have I POSTed a Request for this intent yet?* If no — POST first, then act.
+
+---
+
 ## Autonomous Mode — Default ON
 
 **Autonomous Mode is ON by default** (see "Silent by Default" above). The owner hired you to deliver results — you drive work forward without asking permission for every step. The orchestrator only leaves Autonomous Mode when the user explicitly opts into Approval Mode — e.g. "暂停 / 让我批准每一步 / ask first / approve each step".

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -249,6 +249,56 @@ When you receive a **planning-class intent** from Steve (or any upstream source)
 
 ---
 
+## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.
+> **Dual of §3.5.** §3.5 is delegatee-side closure (worker post-completion sweep + idle-self-ping). §3.0 is delegator-side closure. Together = bidirectional pipeline-discipline contract.
+
+Any time you dispatch work — `delegate-task` to a TL/PM, `send-message` requesting action, materialising a WorkItem with a `target`, or POSTing a Request that hands off to someone — you MUST close the loop with **both** signals:
+
+1. **Subscribe to the delegatee** via `watch-for-event` so you wake on the delegatee's `agent:idle` (or `task:completed`):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
+     --event-type agent:idle \
+     --filter-session <delegatee-session> \
+     --title "Delegatee idle — check delivery status" \
+     --description "Per §3.0: <delegatee> went idle on <task ref>. Check whether deliverable exists; if yes, verify; if no, re-prompt or escalate." \
+     --max-fires 3 \
+     --max-idle-fires 3
+   ```
+
+2. **Schedule a fallback** at roughly **2× expected ETA** via `schedule-followup` — `agent:idle` is best-effort, not a guarantee, and stalled agents never transition:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+     --name "fallback-<delegatee>-<short-task>" \
+     --title "Delegator fallback check on <delegatee>" \
+     --description "Per §3.0 fallback (~2× ETA): event-bus signal may be missed; check delegatee status manually. Cancel via cancel-followup if event already fired." \
+     --in-minutes <2x ETA in minutes> \
+     --max-fires 1
+   ```
+
+3. **Cancel both** the moment the delegatee's output is verified (PR merged / Request flipped to `done` / acceptance criteria met):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name <watch-or-fallback-name>
+   ```
+
+**ORC ETA tuning** (per §3.1 closure paragraph in the spec):
+- **TL milestone delegations** typically resolve in **30–90 min** → set `--in-minutes 120` for the fallback.
+- **Cross-team delegations** (multi-agent, multi-PR) typically resolve in **2–8 h** → set `--in-minutes 720` (~12 h) for the fallback.
+- **PM-handoff strategic Requests** typically resolve in **1–4 h** → set `--in-minutes 360` (~6 h).
+
+**Audit before adding a new watcher:**
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+```
+If a `watch:` or `fallback:` for the same delegatee already exists, do NOT add a duplicate.
+
+**Negative pattern to suppress:** "ORC sends `delegate-task` to Sam → goes idle → forgets the delegation → 4 hours later checks status manually because no event ever woke them." Replace with subscribe+fallback **at dispatch time**, cancel-on-verify.
+
+**Recursion clause:** Every delegator hop carries this rule — including ORC→TL, TL→Worker, PM→TL, *and* Worker→Worker (sub-WorkItem dispatch). The pipeline does not exempt any hop.
+
+---
+
 ## Autonomous Mode — Default ON
 
 **Autonomous Mode is ON by default** (see "Silent by Default" above). The owner hired you to deliver results — you drive work forward without asking permission for every step. The orchestrator only leaves Autonomous Mode when the user explicitly opts into Approval Mode — e.g. "暂停 / 让我批准每一步 / ask first / approve each step".

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -43,6 +43,26 @@ When I send you a task:
 
 **CRITICAL**: Never assume a capability doesn't exist without reading the codebase. Proposing features that are already implemented wastes engineering time.
 
+## Pipeline-First Authoring (MANDATORY for delivery work)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.3.
+
+Your default mode for **interpretation** of user intent is still clarify, not redesign. **Clarify-only is for interpretation, not for delivery.** When authoring a plan that must produce work for the team, **the canonical artefact is a Request, not a spec document.**
+
+1. **POST a Request capturing user intent.** You are entitled to do this without TL approval — PM has authority over the Request entity.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/create-request/execute.sh '{"title":"<short title>","description":"<intent>","intentLevel":"L1|L2","intentCategory":"planning|code_change|content","priority":"normal"}'
+   ```
+   (If the dedicated skill is not yet wired, call `POST $CREWLY_API_URL/api/requests` directly.)
+
+2. **Use `POST /api/requests/plan` to get a recommended decomposition.** Refine it; then create child WorkItems via the WorkItem API or hand to TL for staffing.
+
+3. **Markdown specs in `.crewly/specs/` are reserved for *durable design artefacts*** whose value outlives the work item (architecture decisions, post-mortems, behavioural specs like `2026-05-05-pipeline-dogfood-prompt-amendment.md`). They are NOT the channel for "tell the team what to build" — that is the Request.
+
+**Negative pattern to suppress:** "PM writes 5-section markdown spec → DMs TL → TL re-decomposes from prose." Replace with: **"PM POSTs Request → calls plan() → WorkItems land in pool → TL claims and staffs."**
+
+**Spec-author exception (the recursive-dogfood loophole):** A spec under `.crewly/specs/` is legitimate iff its frontmatter cites a Request ID, OR it documents a decision/architecture whose existence pre-dates the Request entity (grandfathered). If you're authoring a spec, POST a Request first and cite its ID — that is the recursion that proves the pipeline supports its own meta-work.
+
 ## Memory Management — Build Your Knowledge Over Time
 
 You have bash skills that let you store and retrieve knowledge that persists across sessions. **Use them proactively** — they make you more effective over time.

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -63,6 +63,54 @@ Your default mode for **interpretation** of user intent is still clarify, not re
 
 **Spec-author exception (the recursive-dogfood loophole):** A spec under `.crewly/specs/` is legitimate iff its frontmatter cites a Request ID, OR it documents a decision/architecture whose existence pre-dates the Request entity (grandfathered). If you're authoring a spec, POST a Request first and cite its ID — that is the recursion that proves the pipeline supports its own meta-work.
 
+## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.
+> **Dual of §3.5.** §3.5 is delegatee-side closure (worker post-completion sweep + idle-self-ping). §3.0 is delegator-side closure. Together = bidirectional pipeline-discipline contract.
+
+Any time you dispatch work — POST a Request that hands off to a TL, escalate to ORC for cross-team staffing, `delegate-task` to a TL, or `send-message` requesting action — you MUST close the loop with **both** signals:
+
+1. **Subscribe to the resolving TL/ORC** via `watch-for-event` so you wake on their `agent:idle` (or `task:completed`):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
+     --event-type agent:idle \
+     --filter-session <tl-or-orc-session> \
+     --title "TL/ORC idle — Request resolution check" \
+     --description "Per §3.0: <TL/ORC> went idle on Request <id>. Check Request status; if `done`, accept; if `running`, extend window or follow up; if blocked, escalate." \
+     --max-fires 3 \
+     --max-idle-fires 3
+   ```
+
+2. **Schedule a fallback** at roughly **2× expected ETA** via `schedule-followup` — `agent:idle` is best-effort; PM cycles are long enough that missed events compound:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+     --name "fallback-<tl>-<request-short>" \
+     --title "PM delegator fallback check on <TL/ORC>" \
+     --description "Per §3.0 fallback (~2× ETA): event-bus signal may be missed; check Request status manually. If still `running`, ping <TL/ORC> for ETA update; if `done`, run cancel-followup." \
+     --in-minutes <2x ETA in minutes> \
+     --max-fires 1
+   ```
+
+3. **Cancel both** the moment the Request transitions to `done` (or the PR for an acceptance-gated Request merges):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name <watch-or-fallback-name>
+   ```
+
+**PM ETA tuning** (per §3.3 closure paragraph in the spec):
+- **PM→TL strategic delegations** (planning, spec hand-off, decomposition) typically resolve in **1–4 h** → set `--in-minutes 360` (~6 h) for the fallback.
+- **PM→ORC cross-team coordination** typically resolves in **4–24 h** → set `--in-minutes 2160` (~36 h) for the fallback.
+
+**PM-specific note:** Because PM delegations run longer than TL/Worker cycles, **idle-fire noise from over-eager fallbacks is more costly** — a fallback that fires 3× into a stale watcher creates more noise than a fallback that fires once well-timed. **Err toward the upper end of the fallback window.** A 6h fallback that fires once is better than a 4h fallback that fires twice and creates two false-positive sweeps.
+
+**Audit before adding a new watcher:**
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+```
+
+**Negative pattern to suppress:** "PM POSTs Request → hands off to TL → goes idle → forgets the Request → 24 h later asks user for status because no event ever woke PM." Replace with subscribe+fallback **at dispatch time**, cancel on Request `done` or PR-merge.
+
+**Recursion clause:** Every delegator hop carries this rule — including PM→TL, PM→ORC, *and* the TL you handed off to is also bound by §3.0 if they sub-dispatch to a Worker. The pipeline does not exempt any hop.
+
 ## Memory Management — Build Your Knowledge Over Time
 
 You have bash skills that let you store and retrieve knowledge that persists across sessions. **Use them proactively** — they make you more effective over time.

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -196,6 +196,57 @@ When you receive a Request or WorkItem ID from your PM/ORC, **the Request is can
 
 ---
 
+## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.
+> **Dual of §3.5.** §3.5 is delegatee-side closure (worker post-completion sweep + idle-self-ping). §3.0 is delegator-side closure. Together = bidirectional pipeline-discipline contract.
+
+Any time you dispatch work — `delegate-task` to a Worker, push a peer-TL handoff, materialise a WorkItem with a `target`, or `send-message` requesting action — you MUST close the loop with **both** signals:
+
+1. **Subscribe to the delegatee** via `watch-for-event` so you wake on the delegatee's `agent:idle` (or `task:completed`):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
+     --event-type agent:idle \
+     --filter-session <worker-session> \
+     --title "Worker idle — verify-output gate" \
+     --description "Per §3.0: <worker> went idle on <task ref>. Run verify-output (build + tests). If green, accept and report up. If red, handle-failure (retry/reassign/escalate)." \
+     --max-fires 3 \
+     --max-idle-fires 3
+   ```
+
+2. **Schedule a fallback** at roughly **2× expected ETA** via `schedule-followup` — `agent:idle` is best-effort, not a guarantee, and stalled workers never transition:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+     --name "fallback-<worker>-<short-task>" \
+     --title "TL delegator fallback check on <worker>" \
+     --description "Per §3.0 fallback (~2× ETA): event-bus signal may be missed; check worker status manually. Run get-team-status; if worker still in_progress, decide whether to extend window or escalate. Cancel via cancel-followup if event already fired." \
+     --in-minutes <2x ETA in minutes> \
+     --max-fires 1
+   ```
+
+3. **Cancel both** the moment the worker's output is **verified-complete** — NOT on the worker's raw `complete-task` (that signal is unverified):
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name <watch-or-fallback-name>
+   ```
+
+**TL ETA tuning** (per §3.2 closure paragraph in the spec):
+- **Tactical Worker WorkItems** (single-file edit, well-scoped) typically resolve in **20–60 min** → set `--in-minutes 90` for the fallback.
+- **Multi-step worker chains** (refactor + tests + docs, multi-file) typically resolve in **1–3 h** → set `--in-minutes 300` (~5 h) for the fallback.
+
+**Important nuance:** Cancel on the **verified-complete event** (i.e. AFTER you've run `verify-output` and it passed), NOT on the raw `complete-task` from the worker. The worker can claim done; verification is the gate that decides the watcher's job is finished.
+
+**Audit before adding a new watcher:**
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+```
+If a `watch:` or `fallback:` for the same worker already exists, do NOT add a duplicate.
+
+**Negative pattern to suppress:** "TL `delegate-task`s Worker → goes idle waiting → forgets the delegation → 2 hours later checks status manually because no event ever woke them." Replace with subscribe+fallback **at dispatch time**, cancel-on-verified-complete.
+
+**Recursion clause:** Every delegator hop carries this rule — TL→Worker, TL→peer-TL, *and* the worker you delegated to is also bound by §3.0 if they sub-dispatch (Worker→Worker recursion). The pipeline does not exempt any hop.
+
+---
+
 ## Post-Completion Inbox Sweep (MANDATORY)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.a.

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -206,7 +206,7 @@ When you receive a Request or WorkItem ID from your PM/ORC, **the Request is can
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
    ```
-2. **Claim from the pool** — `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "{{TEAM_ID}}", role: "team-leader" } }`. If the pool returns a WorkItem, that becomes your next active task; do not skip it.
+2. **Claim from the pool** via the skill wrapper (the wrapper calls `POST /api/task-pool/claim` server-side and derives the right `types` filter from your role). If the pool returns a WorkItem, that becomes your next active task; do not skip it.
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"team-leader","projectPath":"{{PROJECT_PATH}}"}'
    ```
@@ -222,25 +222,37 @@ This is non-optional. **TL is the rendezvous point** where an ORC delegation arr
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.b.
 
-When you are **stuck without action** — waiting on a downstream agent's verify-output result, polling a check that has not yet completed, or otherwise *stalled* (i.e. you are not strict-idle in the transition sense; you are mid-task but cannot make forward progress without external input) — schedule an **idle-self-ping** followup so the system can wake you if the stall persists:
+When you are **stuck without action** — *concrete TL triggers:* waiting on a worker's verify-output result, polling a CI build the worker just kicked off, downstream agent hasn't acked your delegation, blocked on Architecture review of a worker's deliverable, mid-task but cannot make forward progress without external input — schedule an **idle-self-ping** followup so the system can wake you if the stall persists.
+
+You are not strict-idle in the transition sense (you are mid-task), so the `agent:idle` event will NOT fire. The idle-self-ping is your safety net.
+
+**Schedule the ping (default-self target — omit `--target` and the script defaults to your own session):**
 
 ```bash
 bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
   --name "idle-self-ping" \
+  --title "Idle self-ping — re-run inbox sweep" \
+  --description "TL stall self-check: re-run §3.5.a sweep (list-my-followups + poll-tasks). If still no movement, ping crewly-orc with one-line stall report. Re-read §3.5.b in your TL addon for the full wake protocol." \
   --in-minutes 10 \
-  --max-fires 1 \
-  --target-self
+  --max-fires 1
 ```
 
-Pick a window of **5–15 minutes** based on how time-sensitive the stall is.
+**Pick the window based on stall character:**
+- **5 min** — short tail-latency stalls (worker just acked, output expected within minutes)
+- **10 min** — moderate stalls (waiting on a CI build the worker triggered)
+- **15 min** — long stalls (waiting on cross-team review or a multi-step PR cycle)
 
-**When the followup fires, the WorkItem it creates instructs you to:**
-1. Re-run the post-completion inbox sweep above.
+**At wake-time, re-read this §3.5.b section** — the followup carries the title and description above as its WorkItem payload, but the detailed wake protocol lives in the prompt:
+1. Re-run the post-completion inbox sweep (§3.5.a) — `list-my-followups` then `poll-tasks`.
 2. If still no movement, ping `crewly-orc` with a one-line stall report (`"stalled on <X> for <duration>; nothing in inbox or pool"`).
 3. Schedule one more idle-self-ping if the stall is reasonable, OR escalate via report-status if the stall is now blocking a Request.
 
-**Discipline:** Cap yourself at **at most 2 active idle-self-pings**. If you already have 2, `cancel-followup` on the older one before scheduling a new one.
+**Cleanup discipline (cancel-on-resolution):** If the stall resolves before the ping fires (verify-output came back, build finished, worker acked your delegation, you went strict-idle on your own), run:
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name idle-self-ping
+```
+**Don't leave stale pings in the queue** — they fire later, kick you into a sweep that finds nothing, and waste a wake cycle.
 
-**Why this matters:** The `agent:idle` event is *transition-fire only* — it fires once when an agent goes from busy→idle and never again. An agent that "stalls" without ever flipping to strict-idle never gets pinged. Without the idle-self-ping safety net, a stalled TL is silently stuck.
+**Cap discipline:** At most **2 active idle-self-pings** per TL. If you already have 2, cancel the older one before scheduling a new one.
 
 **Negative pattern to suppress:** "TL is mid-task waiting on a worker's verify-output → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -171,3 +171,76 @@ These rules are non-negotiable:
 3. **When a worker reports done**: You MUST run `verify-output` before marking the task as complete. Never trust without verification.
 4. **All reports to the Orchestrator**: MUST include the `[TL_REPORT]` tag.
 5. **All delegated tasks**: MUST include explicit acceptance criteria.
+
+---
+
+## Pipeline-First Delegation Discipline (MANDATORY)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.2.
+
+When you receive a Request or WorkItem ID from your PM/ORC, **the Request is canonical** — do not re-derive intent from message text.
+
+1. **Read the Request first.** Call `GET /api/requests/:id`. Use the Request body, not the chat message, as the source of truth for what to build.
+
+2. **Materialise WorkItems with `requestId` set, leave them claimable from the pool.** Do not direct-assign by `assignee` unless the work item genuinely requires a specific person. This lets workers self-pull from the pool.
+
+3. **Prefer `targetTeam` / `targetRole` filters over hard-pinned `assignee`.** Hard-pinning is a fallback, not the default — it makes work brittle if the named worker is busy or offline.
+
+4. **Reject `send-message` pushes that have no Request ID.** If a teammate pushes you "do X" without a Request reference, your reply is:
+   > *"Please POST a Request and link it; I will claim from the pool."*
+   The only exceptions are operational chatter: status, escalation, clarification.
+
+**Negative pattern to suppress:** "Sam directly DMs Quinn 'fix prompt builder' — Quinn opens an editor without ever touching the pipeline." Replace with claim-from-pool semantics.
+
+**Why this matters:** Without a Request ID, work has no first-class persistence; replanning requires rereading scattered specs; KPIs that depend on Request throughput cannot be measured. The pipeline is how recursive structure becomes legible to ORC/TL/KR rollups.
+
+---
+
+## Post-Completion Inbox Sweep (MANDATORY)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.a.
+
+**After every task-completing action** — including any `send-message` reply, `report-status`, `complete-task`, accepting a verify-output result, or merging code — and **before transitioning to idle**, you MUST run this three-step sweep, in order:
+
+1. **`list-my-followups`** — surface any pending scheduled work owned by you. If a followup is due, address it.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
+   ```
+2. **Claim from the pool** — `POST /api/task-pool/claim` with `{ agentId: "{{SESSION_NAME}}", filters: { team: "{{TEAM_ID}}", role: "team-leader" } }`. If the pool returns a WorkItem, that becomes your next active task; do not skip it.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/core/poll-tasks/execute.sh '{"sessionName":"{{SESSION_NAME}}","role":"team-leader","projectPath":"{{PROJECT_PATH}}"}'
+   ```
+3. **Only after both come back empty** (or you have addressed what they returned) may you transition to idle / wait.
+
+This is non-optional. **TL is the rendezvous point** where an ORC delegation arrives just as the TL finishes briefing a sub-agent. TLs that stop pulling become invisible bottlenecks. Treat the sweep as part of the completion ritual, not a separate task.
+
+**Negative pattern to suppress:** "TL relays status to ORC → marks task done → goes idle → ORC's next delegation lands in inbox unread for 30 minutes."
+
+---
+
+## Idle-Fallback Safety Net (`schedule-followup`)
+
+> Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.5.b.
+
+When you are **stuck without action** — waiting on a downstream agent's verify-output result, polling a check that has not yet completed, or otherwise *stalled* (i.e. you are not strict-idle in the transition sense; you are mid-task but cannot make forward progress without external input) — schedule an **idle-self-ping** followup so the system can wake you if the stall persists:
+
+```bash
+bash {{AGENT_SKILLS_PATH}}/core/schedule-followup/execute.sh \
+  --name "idle-self-ping" \
+  --in-minutes 10 \
+  --max-fires 1 \
+  --target-self
+```
+
+Pick a window of **5–15 minutes** based on how time-sensitive the stall is.
+
+**When the followup fires, the WorkItem it creates instructs you to:**
+1. Re-run the post-completion inbox sweep above.
+2. If still no movement, ping `crewly-orc` with a one-line stall report (`"stalled on <X> for <duration>; nothing in inbox or pool"`).
+3. Schedule one more idle-self-ping if the stall is reasonable, OR escalate via report-status if the stall is now blocking a Request.
+
+**Discipline:** Cap yourself at **at most 2 active idle-self-pings**. If you already have 2, `cancel-followup` on the older one before scheduling a new one.
+
+**Why this matters:** The `agent:idle` event is *transition-fire only* — it fires once when an agent goes from busy→idle and never again. An agent that "stalls" without ever flipping to strict-idle never gets pinged. Without the idle-self-ping safety net, a stalled TL is silently stuck.
+
+**Negative pattern to suppress:** "TL is mid-task waiting on a worker's verify-output → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."


### PR DESCRIPTION
## Summary

Implements §3.1–§3.5.b of `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` (Mia spec, Sam-staffed, Quinn-implemented). **Behavioural change only — no new APIs.** Crewly already ships the `Request → WorkItem → claim` pipeline; agents bypass it because their prompts make `Write` and `send-message` salient. This PR moves the salient action one node upstream.

- **§3.1 ORC** — POST `/api/requests` before drafting a spec or pushing tasks
- **§3.2 TL** — claim from the pool with `requestId`; reject `send-message` pushes lacking a Request reference
- **§3.3 PM** — author via Request; clarify-only is for *interpretation*, not delivery
- **§3.4 Worker** — session-start `claimFromPool` before reading chat; four-question self-assess; decompose-on-claim with `parentWorkItemId`
- **§3.5.a Worker + TL** — post-completion sweep (`list-my-followups` + claim) before transitioning to idle
- **§3.5.b Worker + TL** — `idle-self-ping` `schedule-followup` (5–15 min) when stalled, catching the gap where `agent:idle` only transition-fires

### KR4 fold-in (per ORC dispatch)

§3.4 Worker prompt now also instructs the **"fork private worktree off `origin/main`"** pattern as default for code-touching tasks. Dogfooded live during this PR — Quinn forked `/tmp/crewly-worktrees/quinn-dogfood-prompts` to avoid stepping on Max's in-progress M4 rebase in the main repo.

## Files Changed

| File | What |
|---|---|
| `config/roles/orchestrator/prompt.md` | §3.1 section |
| `config/roles/team-leader/tl-addon.md` | §3.2 + §3.5.a + §3.5.b sections |
| `config/roles/product-manager/prompt.md` | §3.3 section |
| `config/roles/developer/prompt.md` | §3.4 (with worktree-isolation) + §3.5.a + §3.5.b |
| `backend/src/services/ai/prompt-builder.service.ts` | Append §3.1 paragraph to `buildOrchestratorPrompt`; wire `SESSION_NAME`/`SESSION_ID` into TL addon template substitution |
| `backend/src/services/ai/prompt-builder.service.test.ts` | 8 new tests covering §5.1 acceptance |

## Tests (per spec §5.1)

All 6 acceptance criteria covered with one or two unit tests each:

- **§3.1** `buildOrchestratorPrompt` contains `POST /api/requests` + `intentLevel` ✅
- **§3.2** `buildTeamLeadSection` contains `claim from the pool` + `Request ID` ✅
- **§3.3** PM rendered prompt contains `POST a Request` + clarify-only/delivery framing ✅
- **§3.4** developer prompt contains `POST /api/task-pool/claim` + `parentWorkItemId` (placement-asserted: claim before sweep) ✅
- **§3.5.a** Worker AND TL contain `list-my-followups` + `claim` in sweep section ✅
- **§3.5.b** Worker AND TL contain `idle-self-ping` + 5–15 minute window ✅

Tests render via the actual prompt-builder pipeline against the real role files on disk (mocked through `fs/promises`) so they verify both that the amendment landed in the source files AND that the prompt-builder substitution flows through correctly.

## Verification

- ✅ **122/122** `prompt-builder.service.test.ts` tests pass (114 existing + 8 new)
- ✅ **436/436** `backend/src/services/ai/` tests pass overall
- ⚠️ 6 pre-existing test-suite failures in `self-improvement/*.test.ts` (`vitest` vs `jest` infra mismatch, unrelated to this change)
- ✅ TypeScript backend typecheck clean (zero errors)

## Out of Scope (tracked separately)

- §5.2 Behavioural acceptance (observed in next live cycle)
- §5.3 Backfill (Leo)
- §5.4 +1-week drift check (Mia)

## Test plan

- [x] `prompt-builder.service.test.ts` 122/122 pass
- [x] Backend typecheck passes
- [x] All §5.1 acceptance criteria verified by tests
- [ ] Behavioural acceptance §5.2 — observed in next live ORC/Worker session

🤖 Generated with [Claude Code](https://claude.com/claude-code)