### PR TITLE
fix(compact): SI A+B follow-up — close 3 gaps from PR #444 audit

### DIFF
--- a/backend/src/services/agent/context-window-monitor.service.test.ts
+++ b/backend/src/services/agent/context-window-monitor.service.test.ts
@@ -171,6 +171,18 @@ describe('ContextWindowMonitorService', () => {
 		jest.clearAllMocks();
 		jest.useFakeTimers();
 		ContextWindowMonitorService.resetInstance();
+
+		// Per spec 2026-05-05-compact-fix-AB-followup §A.2 + §B the production
+		// defaults for both compact gates flipped to `false` (fail-safe CLOSED).
+		// Existing behavior-tests in this suite were written when the gates were
+		// effectively `true` and they assert that compact fires at the threshold.
+		// Re-open both gates here so those behavior assertions still hold without
+		// rewriting every test. The new `compact gating (Option A+B)` describe
+		// block intentionally OVERRIDES these to `false` to verify the gating
+		// contract (defaults closed, RED/CRITICAL paths blocked when off, etc).
+		const service = ContextWindowMonitorService.getInstance();
+		(service as unknown as { proactiveCompactEnabled: boolean; thresholdCompactEnabled: boolean }).proactiveCompactEnabled = true;
+		(service as unknown as { proactiveCompactEnabled: boolean; thresholdCompactEnabled: boolean }).thresholdCompactEnabled = true;
 	});
 
 	afterEach(() => {
@@ -1737,6 +1749,219 @@ describe('ContextWindowMonitorService', () => {
 
 			// Verify state is fully cleaned up
 			expect(service.getContextState('test-agent')).toBeUndefined();
+		});
+	});
+
+	// =========================================================================
+	// Compact gating (Option A+B per spec 2026-05-05-compact-fix-AB-followup)
+	//
+	// Verifies the fail-safe-CLOSED contract for both compact gates:
+	//   - `proactiveCompactEnabled` defaults to `false` (initial cached value)
+	//   - `thresholdCompactEnabled` defaults to `false` (initial cached value)
+	//   - When `thresholdCompactEnabled === false`:
+	//       * RED-level (≥85%) /compact emission is blocked
+	//       * CRITICAL-level (≥95%) /compact emission is blocked
+	//       * CRITICAL auto-recovery still runs (when AUTO_RECOVERY_ENABLED)
+	//   - Refresh paths fail-safe to `false` on undefined settings
+	// =========================================================================
+
+	describe('compact gating (Option A+B)', () => {
+		/**
+		 * Build a service WITHOUT touching the gate fields, so the production
+		 * fail-safe defaults are preserved for the assertion. The outer
+		 * describe's `beforeEach` re-opens both gates by default; we override
+		 * back to `false` here to verify the closed-by-default contract.
+		 */
+		function setupWithGatesClosed() {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { proactiveCompactEnabled: boolean; thresholdCompactEnabled: boolean }).proactiveCompactEnabled = false;
+			(service as unknown as { proactiveCompactEnabled: boolean; thresholdCompactEnabled: boolean }).thresholdCompactEnabled = false;
+
+			const mockSession = createMockSession();
+			const sessions = new Map([['test-agent', mockSession.session]]);
+			const backend = createMockSessionBackend(sessions as any);
+			const eventBus = createMockEventBus();
+			const regService = createMockAgentRegistrationService();
+
+			service.setDependencies(
+				backend as any,
+				regService as any,
+				{} as any,
+				createMockTaskTrackingService() as any,
+				eventBus as any
+			);
+			service.startSessionMonitoring('test-agent', 'member-1', 'team-1', 'developer');
+			return { service, mockSession, eventBus, regService };
+		}
+
+		// -------------------------------------------------------------------
+		// Initial state — fail-safe CLOSED defaults
+		// -------------------------------------------------------------------
+
+		it('initial cached proactiveCompactEnabled defaults to false (fail-safe CLOSED)', () => {
+			ContextWindowMonitorService.resetInstance();
+			const service = ContextWindowMonitorService.getInstance();
+
+			// Read the private field via cast — verifying the production default.
+			const value = (service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled;
+			expect(value).toBe(false);
+		});
+
+		it('initial cached thresholdCompactEnabled defaults to false (fail-safe CLOSED)', () => {
+			ContextWindowMonitorService.resetInstance();
+			const service = ContextWindowMonitorService.getInstance();
+
+			const value = (service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled;
+			expect(value).toBe(false);
+		});
+
+		// -------------------------------------------------------------------
+		// Threshold-compact gating — RED level
+		// -------------------------------------------------------------------
+
+		it('RED-level compact is BLOCKED when thresholdCompactEnabled=false', async () => {
+			const { service, mockSession } = setupWithGatesClosed();
+
+			service.updateContextUsage('test-agent', 86); // red
+			await jest.advanceTimersByTimeAsync(300);
+
+			const writeCalls = mockSession.session.write.mock.calls.map((c: string[]) => c[0]);
+			expect(writeCalls).not.toContain('/compact\r');
+
+			const state = service.getContextState('test-agent');
+			expect(state!.compactInProgress).toBe(false);
+			expect(state!.compactAttempts).toBe(0);
+		});
+
+		it('RED-level compact FIRES when thresholdCompactEnabled=true', async () => {
+			const { service, mockSession } = setupWithGatesClosed();
+			(service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled = true;
+
+			service.updateContextUsage('test-agent', 86); // red
+			await jest.advanceTimersByTimeAsync(300);
+
+			const writeCalls = mockSession.session.write.mock.calls.map((c: string[]) => c[0]);
+			expect(writeCalls).toContain('/compact\r');
+		});
+
+		// -------------------------------------------------------------------
+		// Threshold-compact gating — CRITICAL level
+		// -------------------------------------------------------------------
+
+		it('CRITICAL-level compact attempt is BLOCKED when thresholdCompactEnabled=false', async () => {
+			const { service, mockSession } = setupWithGatesClosed();
+
+			// Go straight to critical
+			service.updateContextUsage('test-agent', 96);
+			await jest.advanceTimersByTimeAsync(300);
+
+			const writeCalls = mockSession.session.write.mock.calls.map((c: string[]) => c[0]);
+			expect(writeCalls).not.toContain('/compact\r');
+
+			const state = service.getContextState('test-agent');
+			expect(state!.compactInProgress).toBe(false);
+		});
+
+		it('CRITICAL still publishes agent:context_critical event regardless of gate (informational)', () => {
+			const { service, eventBus } = setupWithGatesClosed();
+
+			service.updateContextUsage('test-agent', 96);
+
+			// The critical event publish happens before the gated compact attempt,
+			// so it must fire even when the wrapper-driven compact is suppressed.
+			expect(eventBus.publish).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'agent:context_critical' })
+			);
+		});
+
+		// -------------------------------------------------------------------
+		// Refresh paths — settings hydration fail-safe semantics
+		// -------------------------------------------------------------------
+
+		it('refreshProactiveCompactSetting falls back to false when getSettings returns undefined.general', async () => {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled = true; // pre-existing value
+
+			const settingsService = require('../settings/settings.service.js');
+			const spy = jest.spyOn(settingsService, 'getSettingsService').mockReturnValue({
+				getSettings: jest.fn().mockResolvedValue({}), // no `general`
+			} as any);
+
+			await (service as unknown as { refreshProactiveCompactSetting: () => Promise<void> }).refreshProactiveCompactSetting();
+
+			const value = (service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled;
+			expect(value).toBe(false);
+
+			spy.mockRestore();
+		});
+
+		it('refreshThresholdCompactSetting falls back to false when getSettings returns undefined.general', async () => {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled = true; // pre-existing value
+
+			const settingsService = require('../settings/settings.service.js');
+			const spy = jest.spyOn(settingsService, 'getSettingsService').mockReturnValue({
+				getSettings: jest.fn().mockResolvedValue({}), // no `general`
+			} as any);
+
+			await (service as unknown as { refreshThresholdCompactSetting: () => Promise<void> }).refreshThresholdCompactSetting();
+
+			const value = (service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled;
+			expect(value).toBe(false);
+
+			spy.mockRestore();
+		});
+
+		it('refreshProactiveCompactSetting reads enableProactiveCompact=true when persisted', async () => {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled = false;
+
+			const settingsService = require('../settings/settings.service.js');
+			const spy = jest.spyOn(settingsService, 'getSettingsService').mockReturnValue({
+				getSettings: jest.fn().mockResolvedValue({ general: { enableProactiveCompact: true } }),
+			} as any);
+
+			await (service as unknown as { refreshProactiveCompactSetting: () => Promise<void> }).refreshProactiveCompactSetting();
+
+			const value = (service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled;
+			expect(value).toBe(true);
+
+			spy.mockRestore();
+		});
+
+		it('refreshThresholdCompactSetting reads enableThresholdCompact=true when persisted', async () => {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled = false;
+
+			const settingsService = require('../settings/settings.service.js');
+			const spy = jest.spyOn(settingsService, 'getSettingsService').mockReturnValue({
+				getSettings: jest.fn().mockResolvedValue({ general: { enableThresholdCompact: true } }),
+			} as any);
+
+			await (service as unknown as { refreshThresholdCompactSetting: () => Promise<void> }).refreshThresholdCompactSetting();
+
+			const value = (service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled;
+			expect(value).toBe(true);
+
+			spy.mockRestore();
+		});
+
+		it('refreshThresholdCompactSetting keeps last-known value on read failure (non-fatal)', async () => {
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled = true; // last known
+
+			const settingsService = require('../settings/settings.service.js');
+			const spy = jest.spyOn(settingsService, 'getSettingsService').mockReturnValue({
+				getSettings: jest.fn().mockRejectedValue(new Error('disk error')),
+			} as any);
+
+			await (service as unknown as { refreshThresholdCompactSetting: () => Promise<void> }).refreshThresholdCompactSetting();
+
+			// Last known value preserved on transient read failure.
+			const value = (service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled;
+			expect(value).toBe(true);
+
+			spy.mockRestore();
 		});
 	});
 

--- a/backend/src/services/agent/context-window-monitor.service.test.ts
+++ b/backend/src/services/agent/context-window-monitor.service.test.ts
@@ -1963,6 +1963,53 @@ describe('ContextWindowMonitorService', () => {
 
 			spy.mockRestore();
 		});
+
+		// -------------------------------------------------------------------
+		// Proactive-path gating (negative case) — per Arch review obs 3
+		// -------------------------------------------------------------------
+
+		it('proactive compact is BLOCKED when proactiveCompactEnabled=false even if cumulative output exceeds threshold', () => {
+			// Mirror of `should trigger proactive compact when cumulative output
+			// exceeds threshold` (in `proactive compact` describe), but with the
+			// gate explicitly closed. Confirms the L1091 single-boolean gate
+			// covers the path end-to-end so resetCumulativeOutput is NOT called.
+			const service = ContextWindowMonitorService.getInstance();
+			(service as unknown as { proactiveCompactEnabled: boolean }).proactiveCompactEnabled = false;
+			// The outer beforeEach also re-opened threshold; close it too so
+			// nothing else fires for this test.
+			(service as unknown as { thresholdCompactEnabled: boolean }).thresholdCompactEnabled = false;
+
+			const mockSession = createMockSession();
+			const sessions = new Map([['test-agent', mockSession.session]]);
+			const mockGetCumulativeOutputBytes = jest.fn().mockReturnValue(
+				CONTEXT_WINDOW_MONITOR_CONSTANTS.PROACTIVE_COMPACT_THRESHOLD_BYTES + 1
+			);
+			const mockResetCumulativeOutput = jest.fn();
+			const backend = {
+				...createMockSessionBackend(sessions as any),
+				getCumulativeOutputBytes: mockGetCumulativeOutputBytes,
+				resetCumulativeOutput: mockResetCumulativeOutput,
+			};
+
+			service.setDependencies(
+				backend as any,
+				createMockAgentRegistrationService() as any,
+				{} as any,
+				createMockTaskTrackingService() as any,
+				createMockEventBus() as any
+			);
+			service.startSessionMonitoring('test-agent', 'member-1', 'team-1', 'developer');
+
+			service.start();
+			jest.advanceTimersByTime(CONTEXT_WINDOW_MONITOR_CONSTANTS.CHECK_INTERVAL_MS);
+
+			// Gate closed → proactive path short-circuits at L1091 → reset NOT called
+			expect(mockResetCumulativeOutput).not.toHaveBeenCalled();
+
+			const state = service.getContextState('test-agent');
+			expect(state!.compactInProgress).toBe(false);
+			expect(state!.compactAttempts).toBe(0);
+		});
 	});
 
 	// =========================================================================

--- a/backend/src/services/agent/context-window-monitor.service.ts
+++ b/backend/src/services/agent/context-window-monitor.service.ts
@@ -249,6 +249,7 @@ export class ContextWindowMonitorService {
 			criticalThreshold: CONTEXT_WINDOW_MONITOR_CONSTANTS.CRITICAL_THRESHOLD_PERCENT,
 		});
 		void this.refreshProactiveCompactSetting();
+		void this.refreshThresholdCompactSetting();
 
 		this.checkTimer = setInterval(() => {
 			this.performCheck();
@@ -535,7 +536,11 @@ export class ContextWindowMonitorService {
 		}
 
 		// At red level: flush memory before compacting (#166)
-		if (state.level === 'red' && !state.compactInProgress) {
+		// Gated by enableThresholdCompact (default false per spec
+		// 2026-05-05-compact-fix-AB-followup §B). When disabled, the wrapper
+		// does NOT trigger /compact at the red threshold; the runtime handles
+		// its own compaction internally.
+		if (this.thresholdCompactEnabled && state.level === 'red' && !state.compactInProgress) {
 			if (state.compactAttempts < CONTEXT_WINDOW_MONITOR_CONSTANTS.MAX_COMPACT_ATTEMPTS) {
 				// #166: Pre-compaction memory flush — send a silent message asking the agent
 				// to save critical context before compaction clears conversation history.
@@ -561,8 +566,12 @@ export class ContextWindowMonitorService {
 		if (state.level === 'critical') {
 			this.publishContextEvent(state, 'agent:context_critical');
 
-			// Try compact if we haven't hit the limit yet
+			// Try compact if we haven't hit the limit yet — gated by
+			// enableThresholdCompact (default false per spec
+			// 2026-05-05-compact-fix-AB-followup §B). When the gate is closed,
+			// auto-recovery still runs as the safety net for runaway sessions.
 			if (
+				this.thresholdCompactEnabled &&
 				!state.compactInProgress &&
 				state.compactAttempts < CONTEXT_WINDOW_MONITOR_CONSTANTS.MAX_COMPACT_ATTEMPTS
 			) {
@@ -1091,8 +1100,9 @@ This is automated — do not ask questions, just save and respond NO_REPLY.`;
 		if (this.proactiveCompactEnabled) {
 			this.checkProactiveCompact(now);
 		}
-		// Refresh cached setting in background so runtime config changes are picked up.
+		// Refresh cached settings in background so runtime config changes are picked up.
 		void this.refreshProactiveCompactSetting();
+		void this.refreshThresholdCompactSetting();
 
 		for (const [sessionName, state] of this.contextStates) {
 			const timeSinceLastDetection = now - state.lastDetectedAt;
@@ -1149,17 +1159,50 @@ This is automated — do not ask questions, just save and respond NO_REPLY.`;
 
 	/** Timestamp of last proactive compact per session for cooldown tracking */
 	private proactiveCompactLastTriggered: Map<string, number> = new Map();
-	/** Cached toggle for proactive compact behavior (loaded from settings) */
-	private proactiveCompactEnabled: boolean = true;
+	/**
+	 * Cached toggle for proactive compact behavior (loaded from settings).
+	 *
+	 * Default: `false` (fail-safe CLOSED). Per spec 2026-05-05-compact-fix-AB-followup §A.2 —
+	 * before the first refresh from settings, the wrapper does NOT proactively compact.
+	 * The runtime (Claude Code) handles its own compaction internally.
+	 */
+	private proactiveCompactEnabled: boolean = false;
+	/**
+	 * Cached toggle for threshold-driven compact at RED (85%) / CRITICAL (95%).
+	 *
+	 * Default: `false` (fail-safe CLOSED). Per spec 2026-05-05-compact-fix-AB-followup §B —
+	 * threshold-driven external compaction is opt-in. Auto-recovery (kill+restart) still
+	 * runs at CRITICAL when AUTO_RECOVERY_ENABLED, regardless of this flag.
+	 */
+	private thresholdCompactEnabled: boolean = false;
 
 	/**
 	 * Refresh the cached proactive compact toggle from persisted settings.
 	 * Non-fatal: any read failure keeps the previous cached value.
+	 *
+	 * Fail-safe semantics: when the persisted setting is undefined, default to
+	 * `false` so an absent configuration cannot enable external compaction.
 	 */
 	private async refreshProactiveCompactSetting(): Promise<void> {
 		try {
 			const settings = await getSettingsService().getSettings();
-			this.proactiveCompactEnabled = settings?.general?.enableProactiveCompact ?? true;
+			this.proactiveCompactEnabled = settings?.general?.enableProactiveCompact ?? false;
+		} catch {
+			// Keep last known value on read failures.
+		}
+	}
+
+	/**
+	 * Refresh the cached threshold compact toggle from persisted settings.
+	 * Non-fatal: any read failure keeps the previous cached value.
+	 *
+	 * Fail-safe semantics: when the persisted setting is undefined, default to
+	 * `false` so an absent configuration cannot enable threshold-driven compaction.
+	 */
+	private async refreshThresholdCompactSetting(): Promise<void> {
+		try {
+			const settings = await getSettingsService().getSettings();
+			this.thresholdCompactEnabled = settings?.general?.enableThresholdCompact ?? false;
 		} catch {
 			// Keep last known value on read failures.
 		}

--- a/backend/src/services/settings/settings.service.test.ts
+++ b/backend/src/services/settings/settings.service.test.ts
@@ -214,6 +214,100 @@ describe('SettingsService', () => {
 
       expect(settings.general.runtimeCommands['codex-cli']).toBe('codex -a never -s danger-full-access');
     });
+
+    // ----------------------------------------------------------------------
+    // enableProactiveCompact one-time flip migration
+    // Per spec 2026-05-05-compact-fix-AB-followup §A.1
+    // ----------------------------------------------------------------------
+
+    it('should flip persisted enableProactiveCompact=true → false on first load and set the migration marker', async () => {
+      // Existing user installed before PR #444 has the proactive trigger ON.
+      // The migration should flip it OFF and stamp `_proactiveCompactMigrated: true`
+      // so the load is observable as a one-time migration.
+      const legacyEnabled = {
+        general: {
+          enableProactiveCompact: true,
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(legacyEnabled, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.enableProactiveCompact).toBe(false);
+      // The marker is stored on the loaded JSON, not on the typed defaults shape;
+      // re-read the raw file to confirm the migration is durable.
+      // The first call already mutated the in-memory `loaded`, so the cached
+      // settings reflect the flip. Saving it back is a separate concern; this
+      // test asserts the user-observable runtime value, which is `false`.
+    });
+
+    it('should NOT re-flip enableProactiveCompact when the migration marker is already set (idempotent re-enable preserved)', async () => {
+      // User previously migrated (marker set), then deliberately re-enabled
+      // proactive compact via the Settings UI. The next load must NOT undo
+      // their choice — the marker gates the migration.
+      const reEnabledByUser = {
+        general: {
+          enableProactiveCompact: true,
+          _proactiveCompactMigrated: true,
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(reEnabledByUser, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.enableProactiveCompact).toBe(true);
+    });
+
+    it('should leave enableProactiveCompact=false alone (no-op when already disabled)', async () => {
+      // Fresh installs after PR #444 land with `false`. The migration must
+      // not toggle the marker for users who never had it on.
+      const freshDefault = {
+        general: {
+          enableProactiveCompact: false,
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(freshDefault, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.enableProactiveCompact).toBe(false);
+    });
+
+    it('should leave enableProactiveCompact alone when missing from persisted general (unset → falls back to current default via mergeSettings)', async () => {
+      // Settings file omits the field entirely. mergeSettings should fill
+      // from getDefaultSettings (now `false`). The migration block is a
+      // no-op because the typeof check excludes undefined.
+      const noCompactField = {
+        general: {
+          defaultRuntime: 'claude-code',
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(noCompactField, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.enableProactiveCompact).toBe(false);
+    });
   });
 
   describe('updateSettings', () => {

--- a/backend/src/services/settings/settings.service.test.ts
+++ b/backend/src/services/settings/settings.service.test.ts
@@ -239,11 +239,14 @@ describe('SettingsService', () => {
       const settings = await service.getSettings();
 
       expect(settings.general.enableProactiveCompact).toBe(false);
-      // The marker is stored on the loaded JSON, not on the typed defaults shape;
-      // re-read the raw file to confirm the migration is durable.
-      // The first call already mutated the in-memory `loaded`, so the cached
-      // settings reflect the flip. Saving it back is a separate concern; this
-      // test asserts the user-observable runtime value, which is `false`.
+      // Direct marker assertion (per Arch review observation 1 on PR #447):
+      // The `_proactiveCompactMigrated` marker is set in the cached general
+      // object after a successful flip. The marker is not part of the typed
+      // GeneralSettings shape (it's a private migration field), so we cast
+      // through Record<string, unknown> to read it.
+      expect(
+        (settings.general as unknown as Record<string, unknown>)._proactiveCompactMigrated
+      ).toBe(true);
     });
 
     it('should NOT re-flip enableProactiveCompact when the migration marker is already set (idempotent re-enable preserved)', async () => {

--- a/backend/src/services/settings/settings.service.ts
+++ b/backend/src/services/settings/settings.service.ts
@@ -319,6 +319,18 @@ export class SettingsService {
     // idempotent — a user who deliberately re-enables via Settings UI will not
     // be re-flipped on subsequent loads.
     //
+    // **Marker persistence note** (per Arch review observation 2 on PR #447):
+    // This migration mutates the in-memory `loaded` object only. The marker
+    // is not separately written to disk here — it lands on disk via the
+    // standard `saveSettings()` flow (e.g. when the user later updates ANY
+    // setting through the UI, or via `mergeSettings`/`updateSettings`).
+    // Until that next save, the marker exists transiently in memory; if the
+    // process restarts before any save, the migration runs again and is
+    // still safe (the same `true → false` flip happens, idempotent in
+    // user-visible outcome). Future maintainers: a missing-on-disk marker
+    // is NOT a bug — it just means the user has not saved settings since
+    // first load post-upgrade.
+    //
     // Per spec 2026-05-05-compact-fix-AB-followup §A.1
     if (
       typeof general['enableProactiveCompact'] === 'boolean' &&

--- a/backend/src/services/settings/settings.service.ts
+++ b/backend/src/services/settings/settings.service.ts
@@ -313,6 +313,22 @@ export class SettingsService {
       runtimeCommands['codex-cli'] = 'codex -a never -s danger-full-access';
     }
 
+    // One-time flip: existing users with proactive compact enabled get switched
+    // off per Steve user-position decision (2026-05-04). The Settings UI still
+    // allows users to opt back in. The `_proactiveCompactMigrated` marker is
+    // idempotent — a user who deliberately re-enables via Settings UI will not
+    // be re-flipped on subsequent loads.
+    //
+    // Per spec 2026-05-05-compact-fix-AB-followup §A.1
+    if (
+      typeof general['enableProactiveCompact'] === 'boolean' &&
+      general['enableProactiveCompact'] === true &&
+      !general['_proactiveCompactMigrated']
+    ) {
+      general['enableProactiveCompact'] = false;
+      general['_proactiveCompactMigrated'] = true;
+    }
+
     // Clean up legacy fields
     delete general['claudeCodeCommand'];
     delete general['claudeCodeInitScript'];

--- a/backend/src/types/settings.types.test.ts
+++ b/backend/src/types/settings.types.test.ts
@@ -72,6 +72,7 @@ describe('Settings Types', () => {
         },
         agentIdleTimeoutMinutes: 10,
         enableProactiveCompact: true,
+        enableThresholdCompact: false,
         enableSelfEvolution: false,
         tokenTracking: false,
         enableAuditor: false,
@@ -103,6 +104,7 @@ describe('Settings Types', () => {
         },
         agentIdleTimeoutMinutes: 15,
         enableProactiveCompact: true,
+        enableThresholdCompact: false,
         enableSelfEvolution: false,
         tokenTracking: false,
         enableAuditor: false,
@@ -166,6 +168,7 @@ describe('Settings Types', () => {
           },
           agentIdleTimeoutMinutes: 10,
           enableProactiveCompact: true,
+          enableThresholdCompact: false,
           enableSelfEvolution: false,
           tokenTracking: false,
           enableAuditor: false,
@@ -285,6 +288,16 @@ describe('Settings Types', () => {
       // disables only the proactive trigger; users can re-enable via settings UI.
       const defaults = getDefaultSettings();
       expect(defaults.general.enableProactiveCompact).toBe(false);
+    });
+
+    it('defaults enableThresholdCompact to false so threshold-compact is opt-in', () => {
+      // Per spec 2026-05-05-compact-fix-AB-followup §B: threshold-driven compact at
+      // RED (85%) / CRITICAL (95%) is gated behind this flag. Default `false` aligns
+      // wrapper behavior with Steve's user-position — "Claude Code self-compacts
+      // internally, external compact is unnecessary". Auto-recovery (kill+restart)
+      // still runs at CRITICAL when AUTO_RECOVERY_ENABLED, regardless of this flag.
+      const defaults = getDefaultSettings();
+      expect(defaults.general.enableThresholdCompact).toBe(false);
     });
 
     it('should have runtime commands defaults for all runtimes', () => {
@@ -453,6 +466,19 @@ describe('Settings Types', () => {
       const result = validateSettings(settings);
 
       expect(result.valid).toBe(true);
+    });
+
+    it('should detect non-boolean enableThresholdCompact', () => {
+      // Per spec 2026-05-05-compact-fix-AB-followup §B: validate the new field
+      // alongside enableProactiveCompact. Cast to bypass compile-time type check
+      // — the runtime validator is the contract.
+      const settings = getDefaultSettings();
+      (settings.general as unknown as Record<string, unknown>).enableThresholdCompact = 'yes';
+
+      const result = validateSettings(settings);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('enableThresholdCompact'))).toBe(true);
     });
   });
 

--- a/backend/src/types/settings.types.ts
+++ b/backend/src/types/settings.types.ts
@@ -53,6 +53,20 @@ export interface GeneralSettings {
   /** Enable proactive context compaction based on cumulative terminal output volume */
   enableProactiveCompact: boolean;
 
+  /**
+   * Enable threshold-driven context compaction at RED (85%) / CRITICAL (95%).
+   *
+   * When `false` (default), the wrapper does NOT trigger `/compact` based on
+   * context-percent thresholds — the runtime (Claude Code, etc.) handles its
+   * own internal compaction. The threshold path remains as opt-in safety net
+   * for users who want wrapper-driven compaction on top of native compaction.
+   *
+   * Per spec 2026-05-05-compact-fix-AB-followup: aligns wrapper behavior with
+   * Steve's user-position decision — "Claude Code self-compacts internally,
+   * external compact is unnecessary".
+   */
+  enableThresholdCompact: boolean;
+
   /** Enable Self Evolution mode — orchestrator monitors for errors and self-triages */
   enableSelfEvolution: boolean;
 
@@ -308,6 +322,7 @@ export function getDefaultSettings(): CrewlySettings {
       },
       agentIdleTimeoutMinutes: 30,
       enableProactiveCompact: false,
+      enableThresholdCompact: false,
       enableSelfEvolution: false,
       tokenTracking: false,
       enableAuditor: false,
@@ -383,6 +398,10 @@ export function validateSettings(settings: CrewlySettings): SettingsValidationRe
 
   if (typeof settings.general.enableProactiveCompact !== 'boolean') {
     errors.push('enableProactiveCompact must be a boolean');
+  }
+
+  if (typeof settings.general.enableThresholdCompact !== 'boolean') {
+    errors.push('enableThresholdCompact must be a boolean');
   }
 
   if (typeof settings.general.enableSelfEvolution !== 'undefined' && typeof settings.general.enableSelfEvolution !== 'boolean') {


### PR DESCRIPTION
## Why

PR #444 flipped the `GeneralSettings.enableProactiveCompact` default from `true` → `false`, but Arch's compact-code audit (`/tmp/compact_audit_verdict.md` — local file, distributed below) showed **PR #444 IS NECESSARY BUT INSUFFICIENT**. Three gaps left the proactive `/compact` trigger firing for every existing user in production:

1. **Persisted settings overrode the new default** — `mergeSettings(defaults, loaded)` overlays loaded values on top, so an existing `~/.crewly/settings.json` with `enableProactiveCompact: true` (Steve's, and every existing user's) wins over PR #444's new `false` default. PR #444 only affected fresh installs.
2. **Initial cached `proactiveCompactEnabled = true` + fallback `?? true` were fail-OPEN** — the very first `performCheck()` after process start ran with proactive ENABLED regardless of settings, and any settings-read failure kept proactive ON.
3. **No migration** — `migrateSettings()` had no code path to flip the persisted value for existing users.

Per Steve's user-position decision (2026-05-04): "Claude Code self-compacts internally, external compact is unnecessary." PR #444 alone could not enforce that; this PR does.

## What changes (Option A + B from Arch verdict, ~35 LOC across 3 source files)

### §A: Migration + cache fail-safe

- **A.1** — `SettingsService.migrateSettings()` adds an idempotent one-time flip: if persisted `enableProactiveCompact === true` and the new `_proactiveCompactMigrated` marker is absent, flip to `false` and stamp the marker. Users who deliberately re-enable via Settings UI are NOT re-flipped on subsequent loads.
- **A.2** — `context-window-monitor.service.ts` initial cached `proactiveCompactEnabled` flipped from `true` → `false`, and the settings-read fallback flipped from `?? true` → `?? false`. Fail-safe **CLOSED** — when uncertain, the wrapper does NOT compact.

### §B: Threshold-compact gating

- New `GeneralSettings.enableThresholdCompact: boolean` (default `false`) gates the RED (≥85%) and CRITICAL (≥95%) compact paths.
  - When closed: RED pre-compaction flush + `/compact` is skipped; CRITICAL `/compact` attempt is skipped.
  - **Auto-recovery still runs at CRITICAL** when `AUTO_RECOVERY_ENABLED` — the safety net is independent of the threshold-compact gate.
  - The `agent:context_critical` event is still published regardless of gate (informational).

## Test plan

All 1:1 source-to-test per CLAUDE.md.

- [x] `settings.types.test.ts` — 2 new tests (default + validation), 3 inline `GeneralSettings` literals updated. **85/85 pass**
- [x] `settings.service.test.ts` — 4 new tests covering: flip on first load, idempotent re-enable preserved, no-op when already `false`, no-op when missing. **58/58 pass**
- [x] `context-window-monitor.service.test.ts` — 11 new tests in `compact gating (Option A+B)` describe block:
  - initial cached defaults `false` for both gates
  - RED-level compact BLOCKED when `thresholdCompactEnabled=false`
  - RED-level compact FIRES when `thresholdCompactEnabled=true`
  - CRITICAL-level compact attempt BLOCKED when `thresholdCompactEnabled=false`
  - CRITICAL still publishes `agent:context_critical` regardless of gate
  - both refresh paths fall back to `false` on undefined settings
  - both refresh paths read `true` when persisted
  - threshold refresh keeps last-known on read failure
  
  Outer `beforeEach` re-opens both gates for behavior-style tests. **101/101 pass** (existing 90 + new 11).

## Rollback path

- Users opt back into proactive compact via Settings UI. The migration marker prevents re-flip.
- Users opt into threshold compact by setting `enableThresholdCompact: true` in `~/.crewly/settings.json`.

## Coordination

Surfaced for Arch deep-review. ORC + Steve aware via TL coord. Merge after Arch ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)