### PR TITLE
chore(skills): orc-namespace exclusion comments + skill-frontmatter cleanup (4-piece skill-mistake fix)

### DIFF
--- a/backend/src/controllers/monitoring/terminal.controller.test.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.test.ts
@@ -16,19 +16,33 @@ jest.mock('../../services/session/index.js', () => ({
 	getSessionBackend: jest.fn(),
 }));
 
-// Mock the logger service
-jest.mock('../../services/core/logger.service.js', () => ({
-	LoggerService: {
-		getInstance: jest.fn(() => ({
-			createComponentLogger: jest.fn(() => ({
-				info: jest.fn(),
-				debug: jest.fn(),
-				warn: jest.fn(),
-				error: jest.fn(),
+// Mock the logger service.
+// The factory creates a stable mockLogger inside its closure (avoids TDZ from
+// jest.mock hoisting) and exposes it via globalThis so tests can assert on
+// logger calls. This is the standard pattern when the controller captures the
+// logger at module load via `const logger = LoggerService.getInstance()...`.
+jest.mock('../../services/core/logger.service.js', () => {
+	const mockLogger = {
+		info: jest.fn(),
+		debug: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	};
+	(globalThis as any).__terminalControllerMockLogger = mockLogger;
+	return {
+		LoggerService: {
+			getInstance: jest.fn(() => ({
+				createComponentLogger: jest.fn(() => mockLogger),
 			})),
-		})),
-	},
-}));
+		},
+	};
+});
+
+// Stable handles to the logger mocks (resolved after jest.mock factory runs).
+const mockLoggerWarn = (globalThis as any).__terminalControllerMockLogger?.warn as jest.Mock;
+const mockLoggerInfo = (globalThis as any).__terminalControllerMockLogger?.info as jest.Mock;
+const mockLoggerDebug = (globalThis as any).__terminalControllerMockLogger?.debug as jest.Mock;
+const mockLoggerError = (globalThis as any).__terminalControllerMockLogger?.error as jest.Mock;
 
 // Mock the constants
 jest.mock('../../constants.js', () => ({
@@ -570,6 +584,127 @@ describe('TerminalController', () => {
 			// Default mode should not trigger the agent status check
 			expect(mockFindMemberBySessionName).not.toHaveBeenCalled();
 			expect(mockSession.write).toHaveBeenCalledWith('shell command\r');
+		});
+
+		// ===================================================================
+		// 4-piece skill-mistake fix — Piece #4: orc-namespace gate telemetry
+		//
+		// When an orc-role caller writes via the agent-side /terminal/{session}/write
+		// path (instead of the orc-namespaced /terminal/{session}/deliver via
+		// config/skills/orchestrator/send-message), emit a warn-log naming the
+		// namespace mistake. Caller is identified via X-Agent-Session header
+		// (set canonically by every agent skill via api_call() — see
+		// config/skills/_common/lib.sh:103). Caller role is resolved via
+		// StorageService.findMemberBySessionName.
+		//
+		// 3 cases covered:
+		// 1. orc-role caller → warn-log fires (positive)
+		// 2. worker-role caller → no log (negative — no false positive on legitimate use)
+		// 3. unknown caller (registration race / ad-hoc curl) → no log (no false positive)
+		// ===================================================================
+		describe('orc-namespace gate telemetry (piece #4)', () => {
+			it('emits warn-log when orc-role caller writes via agent-side path', async () => {
+				mockFindMemberBySessionName.mockResolvedValue({
+					team: { id: 'team-x', members: [] },
+					member: { sessionName: 'crewly-orc', role: 'orchestrator', agentStatus: 'active' },
+				});
+				mockReq = {
+					params: { sessionName: 'developer-session' } as any,
+					headers: { 'x-agent-session': 'crewly-orc' } as any,
+					body: { data: 'hello from orc' },
+				};
+
+				await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+				// Lookup must be called with the CALLER session (from header), not the target
+				expect(mockFindMemberBySessionName).toHaveBeenCalledWith('crewly-orc');
+
+				// warn-log must fire with the namespace-gate message
+				expect(mockLoggerWarn).toHaveBeenCalledWith(
+					expect.stringContaining('orc-namespace-gate'),
+					expect.objectContaining({
+						callerSession: 'crewly-orc',
+						targetSession: 'developer-session',
+						skillPath: 'config/skills/agent/core/send-message',
+						canonicalAlternative: 'config/skills/orchestrator/send-message',
+					}),
+				);
+
+				// The actual write must still proceed — telemetry does not block
+				expect(mockSession.write).toHaveBeenCalledWith('hello from orc\r');
+			});
+
+			it('does NOT emit warn-log when worker-role caller writes via agent-side path', async () => {
+				mockFindMemberBySessionName.mockResolvedValue({
+					team: { id: 'team-x', members: [] },
+					member: { sessionName: 'dev-1', role: 'developer', agentStatus: 'active' },
+				});
+				mockReq = {
+					params: { sessionName: 'peer-dev-session' } as any,
+					headers: { 'x-agent-session': 'dev-1' } as any,
+					body: { data: 'peer message' },
+				};
+
+				await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+				// Lookup is called (we resolve every caller) but role check excludes non-orc
+				expect(mockFindMemberBySessionName).toHaveBeenCalledWith('dev-1');
+
+				// No warn-log for worker — agent-side path is the canonical channel for them
+				const warnCalls = mockLoggerWarn.mock.calls.filter((args) =>
+					typeof args[0] === 'string' && args[0].includes('orc-namespace-gate'),
+				);
+				expect(warnCalls).toHaveLength(0);
+
+				// The actual write still succeeds
+				expect(mockSession.write).toHaveBeenCalledWith('peer message\r');
+			});
+
+			it('does NOT emit warn-log when caller session is unknown (registration race / ad-hoc curl)', async () => {
+				// findMemberBySessionName returns null when caller is not registered
+				mockFindMemberBySessionName.mockResolvedValue(null);
+				mockReq = {
+					params: { sessionName: 'some-session' } as any,
+					headers: { 'x-agent-session': 'unknown-caller' } as any,
+					body: { data: 'orphan write' },
+				};
+
+				await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+				// Lookup is called but returns null → no role check possible → no log
+				expect(mockFindMemberBySessionName).toHaveBeenCalledWith('unknown-caller');
+
+				// No warn-log fires (avoids false positives during registration race)
+				const warnCalls = mockLoggerWarn.mock.calls.filter((args) =>
+					typeof args[0] === 'string' && args[0].includes('orc-namespace-gate'),
+				);
+				expect(warnCalls).toHaveLength(0);
+
+				// Write still succeeds — telemetry is opt-in
+				expect(mockSession.write).toHaveBeenCalledWith('orphan write\r');
+			});
+
+			it('does NOT emit warn-log nor look up caller when X-Agent-Session header is absent', async () => {
+				mockReq = {
+					params: { sessionName: 'some-session' } as any,
+					headers: {} as any, // no X-Agent-Session
+					body: { data: 'no-header write' },
+				};
+
+				await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+				// Without the header, we don't even try to look up the caller (saves a storage hit)
+				expect(mockFindMemberBySessionName).not.toHaveBeenCalled();
+
+				// And no warn-log fires
+				const warnCalls = mockLoggerWarn.mock.calls.filter((args) =>
+					typeof args[0] === 'string' && args[0].includes('orc-namespace-gate'),
+				);
+				expect(warnCalls).toHaveLength(0);
+
+				// Write still succeeds
+				expect(mockSession.write).toHaveBeenCalledWith('no-header write\r');
+			});
 		});
 	});
 

--- a/backend/src/controllers/monitoring/terminal.controller.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.ts
@@ -282,6 +282,52 @@ export async function writeToSession(req: Request, res: Response): Promise<void>
 			return;
 		}
 
+		// =====================================================================
+		// Orc-namespace gate telemetry (4-piece skill-mistake fix piece #4).
+		// =====================================================================
+		// When an orc-role caller hits this raw /terminal/{session}/write path,
+		// emit a warn-log naming the namespace mistake. This is observability —
+		// the request still succeeds — so we can catch backsliding from the
+		// prompt-builder (piece #2) + soul (piece #3) + skill-frontmatter
+		// (piece #1) discipline.
+		//
+		// Caller is identified via X-Agent-Session header (set canonically by
+		// every agent skill that calls api_call() — see config/skills/_common/lib.sh:103).
+		// Caller role is resolved via StorageService.findMemberBySessionName.
+		// We deliberately skip the log when caller is unknown (registration
+		// race, ad-hoc curl) to avoid false positives.
+		//
+		// Spec provenance: 4-piece skill-mistake fix dispatch piece #4
+		// (Sam→Quinn, post-PR #446 merge). PR #449.
+		const callerSessionName = req.headers?.['x-agent-session'] as string | undefined;
+		if (callerSessionName) {
+			try {
+				const callerMember = await StorageService.getInstance().findMemberBySessionName(callerSessionName);
+				if (callerMember && callerMember.member.role === 'orchestrator') {
+					logger.warn(
+						'[orc-namespace-gate] orc-role caller wrote to terminal via agent-side /write — should use orc-namespaced wrapper',
+						{
+							callerSession: callerSessionName,
+							targetSession: sessionName,
+							skillPath: 'config/skills/agent/core/send-message',
+							canonicalAlternative: 'config/skills/orchestrator/send-message',
+							endpointHit: '/terminal/{session}/write',
+							canonicalEndpoint: '/terminal/{session}/deliver',
+							specProvenance: '4-piece skill-mistake fix piece #4 (PR #449)',
+						},
+					);
+				}
+			} catch (err) {
+				// Lookup failure is non-fatal — telemetry is best-effort, the actual
+				// write must proceed. Log at debug so noisy lookup errors don't
+				// pollute the warn channel.
+				logger.debug('orc-namespace-gate caller lookup failed (non-fatal)', {
+					callerSessionName,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+
 		if (data === undefined || data === null) {
 			res.status(400).json({
 				success: false,

--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -2631,4 +2631,210 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			});
 		});
 	});
+
+	// =============================================================================
+	// 4-Piece Skill-Mistake Fix — Piece #2: Communication template orc-branch
+	//
+	// Per orc-namespace convention (skill SKILL.md frontmatter excludes orchestrator
+	// from assignableRoles on send-message + recall + report-status etc.), the
+	// rendered Communication section in composePromptWithMemory() now branches on
+	// `parts.role === 'orchestrator'` to surface orc-namespaced wrapper invocations
+	// instead of the agent-side paths. Without this branch, an orc agent renders
+	// generic agent-skill paths and falls back to /terminal/{session}/write — the
+	// exact "ORC was using WRONG send-message skill" gotcha recorded in project
+	// knowledge on 2026-05-05.
+	//
+	// Tests verify:
+	// 1. Orc-role rendering surfaces ORCHESTRATOR_SKILLS_PATH/send-message in the
+	//    Communication section (positive branch).
+	// 2. Non-orc rendering still surfaces AGENT_SKILLS_PATH/core/send-message
+	//    (negative branch — guards against accidentally flattening the branch).
+	// 3. Orc rendering names the rationale (readiness-aware /deliver vs raw /write)
+	//    so future maintainers see WHY the namespace differs.
+	// 4. Path-resolution smoke (per pattern bank from PR #446 v2 commit 6ad0d250).
+	// =============================================================================
+	describe('4-piece skill-mistake fix — Piece #2: Communication template orc-branch', () => {
+		// Helper: render the full prompt for a given role on the LEGACY composition
+		// path (CREWLY_USE_MODULAR_PROMPTS=false). The legacy `composePromptWithMemory`
+		// runs only when at least one context block is non-empty, so we feed a stub
+		// memory string to trigger it.
+		async function renderLegacyPromptForRole(role: string): Promise<string> {
+			const syntheticRolePrompt = `# Synthetic ${role} prompt for piece #2 test`;
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(syntheticRolePrompt);
+			// Trigger composePromptWithMemory by making memory non-empty.
+			mockGetFullContext.mockResolvedValueOnce('stub memory content for piece #2 test');
+
+			const config: TeamMemberSessionConfig = {
+				name: `${role}-test-session`,
+				role: role as any, // Cast: orchestrator and developer are both valid TeamMemberRole values
+				memberId: `mem-${role}`,
+				projectPath: '/test/project',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			// Legacy path is forced via beforeEach (CREWLY_USE_MODULAR_PROMPTS='false').
+			return service.buildSystemPromptWithMemory(config, {
+				includeMemory: true,
+				includeSOPs: false,
+			});
+		}
+
+		// Helper: render via the MODULAR path (CREWLY_USE_MODULAR_PROMPTS not set
+		// or 'true' — production default). Each test overrides the env var
+		// individually then restores via the suite's afterEach.
+		async function renderModularPromptForRole(role: string): Promise<string> {
+			process.env.CREWLY_USE_MODULAR_PROMPTS = 'true';
+			const syntheticRolePrompt = `# Synthetic ${role} prompt for piece #2 modular test`;
+			mockAccess.mockResolvedValue(undefined);
+			mockReadFile.mockResolvedValue(syntheticRolePrompt);
+
+			const config: TeamMemberSessionConfig = {
+				name: `${role}-modular-session`,
+				role: role as any,
+				memberId: `mem-${role}`,
+				projectPath: '/test/project',
+				systemPrompt: '',
+				runtimeType: 'claude-code' as any,
+			};
+
+			return service.buildSystemPromptWithMemory(config, {});
+		}
+
+		it('orc-role rendered Communication section uses ORCHESTRATOR_SKILLS_PATH/send-message (positive branch)', async () => {
+			const result = await renderLegacyPromptForRole('orchestrator');
+
+			// Positive branch markers
+			expect(result).toContain('## Communication (orchestrator-namespaced)');
+			// The orc-namespaced send-message wrapper is the canonical path for orc
+			expect(result).toMatch(/config\/skills\/orchestrator\/send-message/);
+			// Rationale must be present so the namespace boundary is legible to
+			// future maintainers (the "WHY does the branch exist" provenance).
+			expect(result).toContain('readiness-aware');
+			expect(result).toMatch(/\/terminal\/\{session\}\/deliver/);
+			expect(result).toMatch(/\/terminal\/\{session\}\/write/);
+		});
+
+		it('non-orc rendered Communication section uses AGENT_SKILLS_PATH/core/send-message (negative branch)', async () => {
+			const result = await renderLegacyPromptForRole('developer');
+
+			// Negative branch markers — guards against accidentally flattening the branch
+			expect(result).toContain('## Communication');
+			expect(result).not.toContain('## Communication (orchestrator-namespaced)');
+			// Generic agent-skills path is canonical for non-orc roles
+			expect(result).toMatch(/config\/skills\/agent\//);
+			// Should NOT mention the orc-namespaced wrapper for non-orc roles
+			expect(result).not.toMatch(/config\/skills\/orchestrator\/send-message/);
+		});
+
+		it('orc-branch names the agent-side fallback as deprecated to suppress future flattening', async () => {
+			const result = await renderLegacyPromptForRole('orchestrator');
+
+			// The orc Communication section must name the agent-side path explicitly
+			// AND mark it as the wrong choice for orc — so future maintainers see why
+			// merging the two branches into one would be a regression.
+			expect(result).toContain('config/skills/agent/core/send-message');
+			// Discipline language: agent-side excludes orc, reaching for it bypasses orc-routing.
+			// (Match all common conjugations: exclude/excludes/excluded.)
+			expect(result).toMatch(/exclud(e|es|ed) orchestrator/i);
+			expect(result).toMatch(/bypass(es)?\s+the\s+orc-routing/i);
+		});
+
+		it('orc Communication section names other orc-namespaced equivalents (record-success, broadcast, reply-*)', async () => {
+			const result = await renderLegacyPromptForRole('orchestrator');
+
+			// Per piece #2 dispatch: enumerate the orc-namespaced equivalents so
+			// the orc agent has the complete surface visible at first contact.
+			expect(result).toContain('record-success');
+			expect(result).toContain('record-failure');
+			expect(result).toContain('broadcast');
+			expect(result).toContain('reply-chat');
+			expect(result).toMatch(/recallFromAllAgents/);
+		});
+
+		// Path-resolution smoke per pattern bank entry from §3.0 in PR #446 v2 commit
+		// 6ad0d250: when a literal skill-path surface gets added to a rendered prompt,
+		// we add a smoke assertion that the path token resolves to the right namespace.
+		// For piece #2 this is a path-resolution smoke (no flag list to parse since
+		// the Communication section uses bullet-list references rather than full
+		// bash invocations); the assertion mirrors the ORC §3.1 create-request path
+		// resolution smoke from the same v2 commit.
+		it('orc-branch send-message path token resolves to orc-namespace, NOT agent-namespace (path-resolution smoke)', async () => {
+			const result = await renderLegacyPromptForRole('orchestrator');
+
+			// Find every line that names a send-message reference in the Communication
+			// section; the FIRST canonical reference must use the orc-namespaced path.
+			const communicationSection = result.split('## Communication (orchestrator-namespaced)')[1] ?? '';
+			const sendMessageLines = communicationSection
+				.split('\n')
+				.filter((l) => /send-message/.test(l));
+			expect(sendMessageLines.length).toBeGreaterThan(0);
+
+			// At least one explicit orc-namespaced path reference must appear
+			const orcNamespacedRefs = sendMessageLines.filter((l) =>
+				/config\/skills\/orchestrator\/send-message/.test(l)
+			);
+			expect(orcNamespacedRefs.length).toBeGreaterThan(0);
+
+			// The first send-message bullet line must mark itself as orc-namespaced
+			// (so the orc reads the correct path before the agent-side fallback callout).
+			const firstSendMessageLine = sendMessageLines[0] ?? '';
+			expect(firstSendMessageLine).toMatch(/orc-namespaced/);
+		});
+
+		// Modular path coverage — CRITICAL because CREWLY_USE_MODULAR_PROMPTS defaults
+		// to 'true' in production. The legacy path tests above exercise
+		// composePromptWithMemory; these tests exercise CommunicationModule which is
+		// the live default surface. Without these, an orc agent in production would
+		// still render core/send-message even with the legacy fix in place.
+		it('MODULAR path: orc-role rendered Communication uses orc-namespaced send-message via /deliver', async () => {
+			const result = await renderModularPromptForRole('orchestrator');
+
+			// Orc loads the fragment file at config/roles/orchestrator/fragments/communication.md
+			// which contains the "Orc-Namespace Gate (MANDATORY)" section appended by piece #2.
+			expect(result).toContain('Orc-Namespace Gate');
+
+			// Narrow to the orc-namespace gate section to assert substitution worked.
+			// (Other parts of the rendered prompt may carry unsubstituted
+			// {{ORCHESTRATOR_SKILLS_PATH}} tokens — those leak from other modules
+			// reading orchestrator/prompt.md without calling the agent-registration
+			// substitution path. That is a known pre-existing issue, out of scope
+			// for piece #2 — file separately if it bites.)
+			const gateSectionStart = result.indexOf('Orc-Namespace Gate');
+			expect(gateSectionStart).toBeGreaterThan(-1);
+			// End the slice at the next module-section boundary (--- separator on its
+			// own line) after the gate header, so we don't pick up unsubstituted
+			// tokens from neighbouring modules.
+			const afterGateStart = result.slice(gateSectionStart);
+			const nextSeparatorIdx = afterGateStart.indexOf('\n---\n');
+			const gateSection = nextSeparatorIdx > 0
+				? afterGateStart.slice(0, nextSeparatorIdx)
+				: afterGateStart;
+
+			// Orc-namespaced send-message bash invocation must appear with substituted path
+			expect(gateSection).toMatch(/config\/skills\/orchestrator\/send-message\/execute\.sh/);
+			// Inside the gate section, the placeholders MUST be substituted (piece #2
+			// adds the substitution in CommunicationModule.build() for the fragment).
+			expect(gateSection).not.toContain('{{ORCHESTRATOR_SKILLS_PATH}}');
+			expect(gateSection).not.toContain('{{AGENT_SKILLS_PATH}}');
+			// Rationale must be present so the namespace boundary is legible
+			expect(gateSection).toMatch(/\/terminal\/\{session\}\/deliver/);
+			expect(gateSection).toMatch(/\/terminal\/\{session\}\/write/);
+			expect(gateSection).toMatch(/readiness-aware/);
+			// Negative pattern callout names the canonical failure case
+			expect(gateSection).toMatch(/ORC was using WRONG send-message/);
+		});
+
+		it('MODULAR path: non-orc rendered Communication uses agent-side core/send-message (negative branch)', async () => {
+			const result = await renderModularPromptForRole('developer');
+
+			// Worker comms section header
+			expect(result).toContain('## Communication');
+			// Agent-side path must appear
+			expect(result).toMatch(/config\/skills\/agent\/core\/send-message\/execute\.sh/);
+			// Orc-namespaced wrapper must NOT appear for non-orc
+			expect(result).not.toMatch(/config\/skills\/orchestrator\/send-message/);
+		});
+	});
 });

--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -2836,5 +2836,46 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			// Orc-namespaced wrapper must NOT appear for non-orc
 			expect(result).not.toMatch(/config\/skills\/orchestrator\/send-message/);
 		});
+
+		// =============================================================================
+		// Piece #3 — orc soul 1-line addition.
+		//
+		// Soul files are loaded directly by SoulModule via fs.readFileSync (no template
+		// substitution); the new bullet uses literal `config/skills/agent/core/` instead
+		// of {{AGENT_SKILLS_PATH}}. Reads the actual file from disk to assert the bullet
+		// is present at the top of the Communication Style section.
+		// =============================================================================
+		it('Piece #3: orc soul Communication Style section opens with the orc-namespace gate bullet', () => {
+			const orcSoulPath = path.join(repoRoot, 'config', 'souls', 'orchestrator.md');
+			const orcSoulContent = fs.readFileSync(orcSoulPath, 'utf8');
+
+			// Section must exist
+			expect(orcSoulContent).toContain('## Communication Style');
+			// New bullet must be present and reference the orc-namespace exclusion
+			expect(orcSoulContent).toMatch(
+				/I exclusively use orchestrator-namespaced skills for agent communication/i,
+			);
+			// Literal path (NOT {{AGENT_SKILLS_PATH}}, since soul files are not substituted).
+			// Narrow the placeholder-leak check to the bullet LINE only, since the
+			// HTML provenance comment legitimately mentions {{AGENT_SKILLS_PATH}} when
+			// explaining WHY the literal path is used instead.
+			expect(orcSoulContent).toContain('config/skills/agent/core/');
+			const bulletLine = orcSoulContent
+				.split('\n')
+				.find((l) => l.includes('I exclusively use orchestrator-namespaced skills'));
+			expect(bulletLine).toBeDefined();
+			expect(bulletLine!).not.toContain('{{AGENT_SKILLS_PATH}}');
+
+			// Placement gate: the new bullet must appear BEFORE the existing
+			// "Structured and organized" bullet so it sets the namespace discipline
+			// before any other style-shaping text.
+			const newBulletIdx = orcSoulContent.indexOf(
+				'I exclusively use orchestrator-namespaced skills',
+			);
+			const structuredBulletIdx = orcSoulContent.indexOf('Structured and organized');
+			expect(newBulletIdx).toBeGreaterThan(-1);
+			expect(structuredBulletIdx).toBeGreaterThan(-1);
+			expect(newBulletIdx).toBeLessThan(structuredBulletIdx);
+		});
 	});
 });

--- a/backend/src/services/ai/prompt-builder.service.ts
+++ b/backend/src/services/ai/prompt-builder.service.ts
@@ -273,6 +273,16 @@ export class PromptBuilderService {
 	private readonly agentSkillsPath: string;
 	/** Absolute path to team-leader skill scripts (used in TL addon template variables) */
 	private readonly tlSkillsPath: string;
+	/**
+	 * Absolute path to orchestrator-namespaced skill scripts. Per orc-namespace
+	 * convention (see {@link composePromptWithMemory} role-branched Communication
+	 * section): orc has its own send-message wrapper that routes through
+	 * `/terminal/{session}/deliver` (readiness-aware, two-step delivery, retry)
+	 * instead of the agent-side `/terminal/{session}/write` (raw PTY buffer write,
+	 * no readiness, no Enter semantics). Spec provenance: 4-piece skill-mistake
+	 * fix dispatch piece #2 (Sam→Quinn, post-PR #446 merge).
+	 */
+	private readonly orchestratorSkillsPath: string;
 	private memoryService: MemoryService | null = null;
 	private sopService: SOPService | null = null;
 
@@ -282,6 +292,7 @@ export class PromptBuilderService {
 		this.rolesDirectory = path.join(projectRoot, 'config', 'roles');
 		this.agentSkillsPath = path.join(projectRoot, 'config', 'skills', 'agent');
 		this.tlSkillsPath = path.join(projectRoot, 'config', 'skills', 'team-leader');
+		this.orchestratorSkillsPath = path.join(projectRoot, 'config', 'skills', 'orchestrator');
 	}
 
 	/**
@@ -1050,9 +1061,40 @@ When you learn something worth remembering, store it in the **right place**:
 		sections.push('\n---\n');
 		sections.push(this.buildMemoryRoutingSection());
 
-		// Add communication instructions
+		// Add communication instructions — role-branched per orc-namespace convention.
+		// Per orc-namespace convention (skill SKILL.md frontmatter excludes orchestrator
+		// from assignableRoles on send-message + recall + report-status etc.): orc has
+		// its own send-message wrapper at config/skills/orchestrator/send-message/ that
+		// routes through /terminal/{session}/deliver (readiness-aware, two-step delivery,
+		// retry) instead of the agent-side /terminal/{session}/write (raw PTY buffer
+		// write, no readiness, no Enter semantics). Rendering the agent-skills path
+		// for orc would let orc fall back to /write and miss orc-specific routing —
+		// the exact "ORC was using WRONG send-message skill" gotcha recorded in the
+		// project knowledge base on 2026-05-05.
+		// See config/skills/agent/core/send-message/SKILL.md for the per-skill rationale.
+		// Spec provenance: 4-piece skill-mistake fix dispatch piece #2 (Sam→Quinn,
+		// post-PR #446 merge).
 		sections.push('\n---\n');
-		sections.push(`## Communication
+		if (parts.role === 'orchestrator') {
+			sections.push(`## Communication (orchestrator-namespaced)
+
+You are the orchestrator. Use **orchestrator-namespaced** bash skills at \`${this.orchestratorSkillsPath}/\` for all team communication — they route through the orc-specific message-routing layer (readiness-aware delivery via \`/terminal/{session}/deliver\`, jargon-hygiene gate, owner-vs-agent audience distinction). Read \`~/.crewly/skills/SKILLS_CATALOG.md\` for the full orc-namespaced reference (NOT \`AGENT_SKILLS_CATALOG.md\` — that lists worker-only skills).
+
+- \`send-message\` (orc-namespaced wrapper at \`${this.orchestratorSkillsPath}/send-message/execute.sh\`) — readiness-aware delivery to a teammate's terminal session; preferred over the agent-side \`send-message\` at \`${this.agentSkillsPath}/core/send-message/\` which uses raw PTY \`/write\` and lacks orc-specific routing
+- \`record-success\` / \`record-failure\` / \`report-bug\` (orc-namespaced) — orc-side status recording; do NOT use the agent-side \`report-status\` (that is for workers→orc, not orc→self)
+- \`broadcast\` / \`broadcast-to-org\` (orc-namespaced) — multi-agent fan-out
+- \`reply-chat\` / \`reply-slack\` / \`reply-gchat\` / \`reply-remote\` (orc-namespaced) — owner-facing replies on the channel the user wrote on
+- \`schedule-check\` / \`create-cron\` / \`cancel-schedule\` (orc-namespaced) — orc-side scheduling primitives
+- Memory access: orc reads cross-agent memory via the internal service-layer \`recallFromAllAgents()\` rather than the agent-side \`recall\` skill (which is gated to worker roles). Use \`query-knowledge\` (orc-namespaced) for SOP/runbook lookups.
+
+**IMPORTANT — namespace gate:** the agent-side skills under \`${this.agentSkillsPath}/core/\` exclude orchestrator from \`assignableRoles\` for a reason. Reaching for them from this orchestrator session bypasses the orc-routing layer:
+
+- agent-side \`send-message\` writes raw bytes to a peer's PTY via \`/terminal/{session}/write\` without readiness gating
+- orc-side \`send-message\` uses \`/terminal/{session}/deliver\` with the readiness-aware two-step delivery pattern + retry
+
+Always reach for \`${this.orchestratorSkillsPath}/<skill>/\` first.`);
+		} else {
+			sections.push(`## Communication
 
 Use bash skills at \`${this.agentSkillsPath}/\` for all team communication. Read \`~/.crewly/skills/AGENT_SKILLS_CATALOG.md\` for a full reference.
 - \`send-message\` to communicate with other agents
@@ -1068,6 +1110,7 @@ Use bash skills at \`${this.agentSkillsPath}/\` for all team communication. Read
 This ensures your knowledge is stored under your identity and in the correct project.
 
 **IMPORTANT for recall:** Before answering questions about the project, deployment, architecture, or past decisions, ALWAYS call \`recall\` first to check your stored knowledge.`);
+		}
 
 		// Add anti-deliberation instructions for Gemini CLI agents
 		if (parts.runtimeType === 'gemini-cli') {

--- a/backend/src/services/ai/prompt-modules/communication.module.ts
+++ b/backend/src/services/ai/prompt-modules/communication.module.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { PromptModule, ModuleConfig, loadRoleFragment } from './prompt-module.interface.js';
 
 /**
@@ -37,11 +38,20 @@ export class CommunicationModule implements PromptModule {
 		const isOrchestrator = config.role === 'orchestrator';
 		const isTL = config.canDelegate === true;
 
-		// Try loading role-specific fragment (orchestrator has the richest version)
+		// Try loading role-specific fragment (orchestrator has the richest version).
+		// Per piece #2 dispatch (4-piece skill-mistake fix, post-PR #446 merge):
+		// the orc fragment now references {{ORCHESTRATOR_SKILLS_PATH}} and
+		// {{AGENT_SKILLS_PATH}} placeholders that must be substituted to absolute
+		// paths before the orc sees the prompt. loadRoleFragment returns the file
+		// content as-is — substitution happens here so the orc-namespace gate
+		// table renders with real paths.
 		if (isOrchestrator) {
 			const fragment = loadRoleFragment(config.projectRoot, config.role, 'communication');
 			if (fragment) {
-				return fragment;
+				const orchestratorSkillsPath = path.join(config.projectRoot, 'config', 'skills', 'orchestrator');
+				return fragment
+					.replace(/\{\{ORCHESTRATOR_SKILLS_PATH\}\}/g, orchestratorSkillsPath)
+					.replace(/\{\{AGENT_SKILLS_PATH\}\}/g, config.agentSkillsPath);
 			}
 			return this.buildOrchestratorComms(config);
 		}
@@ -91,14 +101,78 @@ bash ${resolvedBase}/${skillPath}/execute.sh '${jsonExample}'
 	/**
 	 * Full orchestrator communication spec — Slack, Chat UI, NOTIFY markers,
 	 * thread management, message formatting, and notification protocol.
+	 *
+	 * Per orc-namespace convention (skill SKILL.md frontmatter excludes
+	 * orchestrator from `assignableRoles` on send-message + recall + etc.):
+	 * orc has its own send-message wrapper at `config/skills/orchestrator/send-message/`
+	 * that routes through `/terminal/{session}/deliver` (readiness-aware,
+	 * two-step delivery, retry) instead of the agent-side
+	 * `/terminal/{session}/write` (raw PTY buffer write, no readiness, no
+	 * Enter semantics). Rendering the agent-skills path here would let orc
+	 * fall back to `/write` and miss orc-specific routing — the exact
+	 * "ORC was using WRONG send-message skill" gotcha recorded in the
+	 * project knowledge base on 2026-05-05.
+	 *
+	 * Spec provenance: 4-piece skill-mistake fix dispatch piece #2
+	 * (Sam→Quinn, post-PR #446 merge).
 	 */
 	private buildOrchestratorComms(config: ModuleConfig): string {
 		const reportStatusJson = `{"sessionName":"${config.sessionName}","status":"<status>","summary":"<summary>","projectPath":"${config.projectPath || config.projectRoot}"}`;
 		const sendMessageJson = '{"to":"<session>","message":"<msg>"}';
 		const reportCliFlags = `--session "${config.sessionName}" --status "<status>" --summary "<summary>" --project "${config.projectPath || config.projectRoot}"`;
 		const sendCliFlags = '--to "<session>" --message "<msg>"';
+		// Derived from projectRoot to keep ModuleConfig surface small. If we ever
+		// need this in more modules, promote to `config.orchestratorSkillsPath`.
+		const orchestratorSkillsPath = path.join(config.projectRoot, 'config', 'skills', 'orchestrator');
+		// Orc uses the orc-namespaced send-message wrapper, NOT core/send-message.
+		// See class-level JSDoc above for the rationale.
+		const sendExample = this.buildOrcSkillExample(orchestratorSkillsPath, 'send-message', sendMessageJson, sendCliFlags, config.runtimeType);
 		const reportExample = this.buildSkillExample(config, 'core/report-status', reportStatusJson, reportCliFlags);
-		const sendExample = this.buildSkillExample(config, 'core/send-message', sendMessageJson, sendCliFlags);
+
+		return this.buildOrchestratorCommsBody(config, sendExample, reportExample);
+	}
+
+	/**
+	 * Build a bash example using an orc-namespaced skill path (vs the agent-side
+	 * `core/<skill>` path used by {@link buildSkillExample}). Mirrors
+	 * `buildSkillExample` for shape consistency but resolves the path under
+	 * `config/skills/orchestrator/<skill>/` and never falls back to a heredoc
+	 * since orc-namespaced skills are uniformly CLI-flag-friendly.
+	 *
+	 * Spec provenance: 4-piece skill-mistake fix dispatch piece #2.
+	 *
+	 * @param orchestratorSkillsPath - Absolute path to `config/skills/orchestrator/`
+	 * @param skillName - Skill directory name under the orc-namespace (e.g. `send-message`)
+	 * @param jsonExample - Inline JSON example for non-gemini runtimes
+	 * @param cliExample - CLI flags example for gemini-cli runtimes
+	 * @param runtimeType - Runtime type to choose JSON vs CLI rendering
+	 * @returns Formatted bash code block invoking the orc-namespaced skill
+	 */
+	private buildOrcSkillExample(
+		orchestratorSkillsPath: string,
+		skillName: string,
+		jsonExample: string,
+		cliExample: string,
+		runtimeType?: ModuleConfig['runtimeType'],
+	): string {
+		if (runtimeType === 'gemini-cli') {
+			return `\`\`\`bash
+bash ${orchestratorSkillsPath}/${skillName}/execute.sh ${cliExample}
+\`\`\``;
+		}
+		return `\`\`\`bash
+bash ${orchestratorSkillsPath}/${skillName}/execute.sh '${jsonExample}'
+\`\`\``;
+	}
+
+	/**
+	 * Build the body of the orchestrator Communication section. Split out from
+	 * {@link buildOrchestratorComms} so the per-piece example construction stays
+	 * isolated from the long Slack/Chat/NOTIFY markdown body.
+	 */
+	private buildOrchestratorCommsBody(config: ModuleConfig, sendExample: string, reportExample: string): string {
+		const orchestratorSkillsPath = path.join(config.projectRoot, 'config', 'skills', 'orchestrator');
+		void config; // reserved for future per-config formatting hooks
 
 		return `## Communication Protocol
 
@@ -163,6 +237,15 @@ When you receive a message from the user (via Slack, Chat UI, or Google Chat):
 This prevents the user from wondering if their message was received or if the agent is stuck.
 
 ### Communication Skills
+
+**Orc-namespace gate (MANDATORY):** the agent-side skills under \`config/skills/agent/core/\` excludes orchestrator from \`assignableRoles\` for a reason. Reaching for them from this orchestrator session bypasses the orc-routing layer (e.g. agent-side \`send-message\` writes raw bytes to a peer's PTY via \`/terminal/{session}/write\` without readiness gating; orc-side \`send-message\` uses \`/terminal/{session}/deliver\` with the readiness-aware two-step delivery pattern). Always reach for \`${orchestratorSkillsPath}/<skill>/\` first. Orc-namespaced equivalents you have:
+- \`send-message\` (orc-namespaced) — readiness-aware delivery via \`/terminal/{session}/deliver\` (NOT raw \`/write\`)
+- \`record-success\` / \`record-failure\` / \`report-bug\` (orc-namespaced) — orc-side status recording
+- \`broadcast\` / \`broadcast-to-org\` (orc-namespaced) — multi-agent fan-out
+- \`reply-chat\` / \`reply-slack\` / \`reply-gchat\` / \`reply-remote\` (orc-namespaced) — owner-facing replies routed back to the source channel
+- \`schedule-check\` / \`create-cron\` / \`cancel-schedule\` (orc-namespaced) — orc-side scheduling primitives
+- Memory access: orc reads cross-agent memory via the internal \`recallFromAllAgents()\` (memory.service.ts:1047), NOT via the agent-side \`recall\` skill which excludes orchestrator from assignableRoles.
+
 ${reportExample}
 ${sendExample}`;
 	}

--- a/config/roles/orchestrator/fragments/communication.md
+++ b/config/roles/orchestrator/fragments/communication.md
@@ -115,3 +115,30 @@ When you receive messages from Slack, they include a `[Thread context file: <pat
 | Slack    | Mobile updates   | Concise, scannable      |
 
 Adapt your communication style based on the channel being used.
+
+## Communication Protocol — Orc-Namespace Gate (MANDATORY)
+
+> Spec provenance: 4-piece skill-mistake fix dispatch piece #2 (Sam→Quinn, post-PR #446 merge).
+
+**The agent-side skills under `config/skills/agent/core/` exclude orchestrator from `assignableRoles` for a reason.** Reaching for them from this orchestrator session bypasses the orc-routing layer:
+
+- agent-side `send-message` writes raw bytes to a peer's PTY via `/terminal/{session}/write` without readiness gating
+- orc-side `send-message` uses `/terminal/{session}/deliver` with the readiness-aware two-step delivery pattern + retry
+
+Always reach for `{{ORCHESTRATOR_SKILLS_PATH}}/<skill>/` first. Orc-namespaced equivalents you have:
+
+| Need | Use orc-namespaced | NOT agent-side |
+|---|---|---|
+| Send a direct message to an agent | `{{ORCHESTRATOR_SKILLS_PATH}}/send-message/execute.sh` (readiness-aware, `/deliver`) | `{{AGENT_SKILLS_PATH}}/core/send-message/execute.sh` (raw `/write`) |
+| Record success / failure / bug | `{{ORCHESTRATOR_SKILLS_PATH}}/record-success/`, `/record-failure/`, `/report-bug/` | `{{AGENT_SKILLS_PATH}}/core/report-status/` (workers→orc, not orc→self) |
+| Multi-agent fan-out | `{{ORCHESTRATOR_SKILLS_PATH}}/broadcast/`, `/broadcast-to-org/` | n/a |
+| Reply to user on the source channel | `{{ORCHESTRATOR_SKILLS_PATH}}/reply-chat/`, `/reply-slack/`, `/reply-gchat/`, `/reply-remote/` | n/a |
+| Schedule recurring or one-off checks | `{{ORCHESTRATOR_SKILLS_PATH}}/schedule-check/`, `/create-cron/`, `/cancel-schedule/` | n/a |
+| Cross-agent memory access | internal `recallFromAllAgents()` in `memory.service.ts:1047` (service-layer, not skill) | `{{AGENT_SKILLS_PATH}}/core/recall/` (excludes orchestrator from assignableRoles) |
+
+**Negative pattern to suppress:** an orc agent reaching for `{{AGENT_SKILLS_PATH}}/core/send-message/` because it's "the obvious skill" — the result is messages written to peers' raw PTY buffers without readiness gating. The exact "ORC was using WRONG send-message skill" gotcha recorded in the project knowledge base on 2026-05-05.
+
+**Bash invocation example (orc-namespaced send-message):**
+```bash
+bash {{ORCHESTRATOR_SKILLS_PATH}}/send-message/execute.sh '{"to":"<session>","message":"<msg>"}'
+```

--- a/config/skills/agent/core/get-my-active-work/SKILL.md
+++ b/config/skills/agent/core/get-my-active-work/SKILL.md
@@ -19,8 +19,10 @@ assignableRoles:
   - generalist
   - sales
   - support
+  # Canonical convention is hyphenated (`team-lead`); the underscore variant
+  # (`team_lead`) was a duplicate-key typo discovered during the 4-piece skill-mistake
+  # audit (post-PR #446 merge). Removing it to keep the role-name surface single-shape.
   - team-lead
-  - team_lead
   - orchestrator
 triggers:
   - get my active work

--- a/config/skills/agent/core/recall/SKILL.md
+++ b/config/skills/agent/core/recall/SKILL.md
@@ -4,6 +4,13 @@ description: Retrieve stored memories relevant to a given context or query.
 version: 1.0.0
 category: memory
 skillType: claude-skill
+# Per orchestrator-namespace convention: orc accesses memory via a different
+# mechanism (internal `recallFromAllAgents()` in backend/src/services/memory/memory.service.ts:1047,
+# not surfaced as a skill — orc reads the cross-agent view directly through the
+# service layer when assembling team context). If a future PR adds an
+# orc-namespaced recall wrapper, update this comment to cross-ref. Until then,
+# keep orchestrator EXCLUDED here.
+# Spec provenance: 4-piece skill-mistake fix dispatch (Sam→Quinn, post-PR #446 merge).
 assignableRoles:
   - developer
   - qa

--- a/config/skills/agent/core/send-message/SKILL.md
+++ b/config/skills/agent/core/send-message/SKILL.md
@@ -4,6 +4,12 @@ description: "Send a direct message to another agent's terminal session."
 version: 1.0.0
 category: communication
 skillType: claude-skill
+# Per orchestrator-namespace convention: orc has its own send-message wrapper at
+# config/skills/orchestrator/send-message/ which routes through the orc-specific
+# message-routing layer (delivery framing, jargon-hygiene gate, owner-vs-agent
+# audience distinction). Listing orchestrator here would let orc fall back to the
+# generic agent-side path and miss orc-specific behaviors. Keep orchestrator EXCLUDED.
+# Spec provenance: 4-piece skill-mistake fix dispatch (Sam→Quinn, post-PR #446 merge).
 assignableRoles:
   - developer
   - qa

--- a/config/souls/orchestrator.md
+++ b/config/souls/orchestrator.md
@@ -5,6 +5,14 @@
 - **Core Values:** Clarity, coordination, accountability
 
 ## Communication Style
+<!-- Per orc-namespace convention (skill SKILL.md frontmatter excludes orchestrator
+     from assignableRoles on send-message + recall + report-status etc.): this line
+     shapes orc's identity-level discipline around the namespace gate. Soul files
+     are NOT template-substituted (verified in soul.module.ts:174-180), so literal
+     relative path `config/skills/agent/core/` is used here instead of {{AGENT_SKILLS_PATH}}.
+     Spec provenance: 4-piece skill-mistake fix dispatch piece #3 (Sam→Quinn,
+     post-PR #446 merge). -->
+- I exclusively use orchestrator-namespaced skills for agent communication — never the agent-side equivalents at `config/skills/agent/core/`.
 - Structured and organized
 - Uses bullet points, tables, and status summaries
 - Keeps messages actionable — every message has a clear next step


### PR DESCRIPTION
## Summary

4-piece skill-mistake fix dispatch (Sam→Quinn, post-PR #446 joint-surface merge of #447/#446/#445/#448 at `origin/main 2cd59e52`). Stacking pieces 1-4 on this branch per Sam's "single PR for clean review narrative" recommendation.

**Status: PIECE #1 ONLY committed so far. Pieces #2/#3/#4 incoming on same branch after Sam's per-piece verify gates.**

## Piece #1 — Skill catalog frontmatter (this commit, `1d9702e1`)

The orchestrator-namespace convention says: any agent-side communication or memory skill where `assignableRoles` includes worker/TL/PM/architect roles should explicitly EXCLUDE orchestrator with a comment naming the canonical orc-namespaced alternative. Without the comment, an editor passing through might "helpfully" add `orchestrator` to the list and silently break orc's routing.

| File | Change |
|---|---|
| `config/skills/agent/core/send-message/SKILL.md` | Add comment block above `assignableRoles:` naming orc-namespaced alternative at `config/skills/orchestrator/send-message/`. No behavior change (orc already absent). |
| `config/skills/agent/core/recall/SKILL.md` | Add comment block + cross-ref to internal `recallFromAllAgents()` at `backend/src/services/memory/memory.service.ts:1047`. Flag for future PR if orc-namespaced wrapper is added. No behavior change. |
| `config/skills/agent/core/get-my-active-work/SKILL.md` | **Audit-discovered duplicate-key typo:** `team-lead` AND `team_lead` both in `assignableRoles`. Drop `team_lead` (canonical convention is hyphenated). Inline 3-line comment explaining the cleanup. |

## Verification (piece #1)

Production parser (`backend/src/utils/skill-md-parser.ts`) round-trip:

| Skill | Roles count | hasOrc | hasTeamLeadUnderscore |
|---|---|---|---|
| send-message | 13 | false ✓ | n/a |
| recall | 13 | false ✓ | n/a |
| get-my-active-work | 15 (was 16) | true (intentional) | **false ✓** |

YAML comments inside frontmatter parse cleanly — they do NOT pollute the roles list. Verified by inspecting the round-tripped JSON role array.

`npm run typecheck` clean (`tsc -p backend/tsconfig.json --noEmit`).

No tests added — frontmatter-only changes; the production parser test suite (`skill-md-parser.test.ts`) already covers the comment-handling path.

## Pieces #2/#3/#4 (incoming on this branch)

- **#2** — Prompt-builder Communication template branch on `parts.role === 'orchestrator'` to render orc-namespaced wrapper invocations + 1-line provenance comment (target: `prompt-builder.service.ts:composePromptWithMemory()` ~L1027-1042)
- **#3** — Orc soul 1-line addition to `config/souls/orchestrator.md` Communication Style section: "I exclusively use orchestrator-namespaced skills for agent communication."
- **#4** — Backend telemetry warn-log in `terminal.controller.ts:writeToSession` (line 262) when orc-role caller hits raw `/write` instead of orc-namespaced delivery wrapper

Each piece will land as its own commit on this branch with its own per-piece eval gates met before pushing. Sam-Quinn per-piece verify cycle in effect.

## Test plan

- [x] Piece #1: Production SKILL.md parser round-trip + typecheck
- [ ] Piece #2: Prompt-builder branch test (orc renders orc-namespaced; non-orc renders agent-skills) + flag-parse smoke per pattern bank
- [ ] Piece #3: Orc soul rendered prompt assertion (line present in soul section)
- [ ] Piece #4: Backend telemetry test (warn-log fires when expected, doesn't fire otherwise)
- [ ] Final: combined Arch re-review on the stacked PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)