### PR TITLE
chore(boot): wrap v3 subscriber boot in try/catch (closes #465)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -428,44 +428,80 @@ export class CrewlyServer {
 		this.autoLearningSubscriber = AutoLearningSubscriber.boot(this.eventBusService);
 		this.autoLearningSubscriber.start();
 
-		// INBOUND-1: wire RequestService → bus, then subscribe SLA tracker.
-		// Order matters: setRequestServiceEventBus must run BEFORE any code
-		// path can call RequestService.create() — the slack listener at
-		// line ~370 is the first hot caller, but the slack service hasn't
-		// been initialised yet at this point in boot, so we're safe.
-		setRequestServiceEventBus(this.eventBusService);
-		this.requestSlaSubscriber = RequestSlaSubscriber.boot(
-			this.eventBusService,
-			RequestService.getInstance(),
-			TaskPoolService.getInstance(),
-			async ({ channelId, threadTs, messageText }) => {
-				// Production wiring of the 10-min escalation hook: nudge the user
-				// in the same Slack thread so they're never blind to the miss.
-				const slack = getSlackService();
-				await slack.sendMessage({
-					channelId,
-					threadTs,
-					text: messageText,
-				});
-			},
-		);
-		this.requestSlaSubscriber.start();
-		setRequestSlaSubscriber(this.requestSlaSubscriber);
+		// INBOUND-1 + Pipeline-#4 follow-up: wire RequestService → bus, then
+		// boot both v3 subscribers (SLA tracker + auto-decompose). Order
+		// matters within the block: setRequestServiceEventBus must run
+		// BEFORE any code path can call RequestService.create() — the slack
+		// listener at line ~370 is the first hot caller, but the slack
+		// service hasn't been initialised yet at this point in boot, so
+		// we're safe.
+		//
+		// Failure-isolated (issue #465): the entire v3 subscriber boot is
+		// wrapped in try/catch so a wiring failure logs + continues rather
+		// than crashing the whole backend. Neither subscriber is essential
+		// to API liveness — degrading them is preferable to losing the
+		// process. A single catch block treats both as a unit because the
+		// failure mode is "wiring is broken, fix the deploy" not
+		// "intermittently flaky"; partial recovery would be unnecessary
+		// complexity for v1. B0 broadcast (line ~2336) and TriggerEngine
+		// boot (line ~1464) already have equivalent isolation; this brings
+		// the v3 subscriber block in line with that pattern.
+		try {
+			setRequestServiceEventBus(this.eventBusService);
+			this.requestSlaSubscriber = RequestSlaSubscriber.boot(
+				this.eventBusService,
+				RequestService.getInstance(),
+				TaskPoolService.getInstance(),
+				async ({ channelId, threadTs, messageText }) => {
+					// Production wiring of the 10-min escalation hook: nudge the user
+					// in the same Slack thread so they're never blind to the miss.
+					const slack = getSlackService();
+					await slack.sendMessage({
+						channelId,
+						threadTs,
+						text: messageText,
+					});
+				},
+			);
+			this.requestSlaSubscriber.start();
+			setRequestSlaSubscriber(this.requestSlaSubscriber);
 
-		// Pipeline-#4 follow-up: auto-decompose actionable L2 Requests on
-		// request:created. Sequenced AFTER the SLA subscriber so the
-		// respond_to_user WI seeding still runs first when both fire on the
-		// same event (deterministic listener-attach order; both run via the
-		// same in-process bus). Side note: order is semantically irrelevant —
-		// the linkWorkItem path keys on workitem:queued, not on relative
-		// listener position — but predictable startup ordering helps debug.
-		this.requestDecomposeSubscriber = RequestDecomposeSubscriber.boot(
-			this.eventBusService,
-			RequestService.getInstance(),
-			TaskPoolService.getInstance(),
-		);
-		this.requestDecomposeSubscriber.start();
-		setRequestDecomposeSubscriber(this.requestDecomposeSubscriber);
+			// Pipeline-#4 follow-up: auto-decompose actionable L2 Requests on
+			// request:created. Sequenced AFTER the SLA subscriber so the
+			// respond_to_user WI seeding still runs first when both fire on
+			// the same event (deterministic listener-attach order; both run
+			// via the same in-process bus). Side note: order is semantically
+			// irrelevant — the linkWorkItem path keys on workitem:queued, not
+			// on relative listener position — but predictable startup ordering
+			// helps debug.
+			this.requestDecomposeSubscriber = RequestDecomposeSubscriber.boot(
+				this.eventBusService,
+				RequestService.getInstance(),
+				TaskPoolService.getInstance(),
+			);
+			this.requestDecomposeSubscriber.start();
+			setRequestDecomposeSubscriber(this.requestDecomposeSubscriber);
+		} catch (subscriberBootErr) {
+			// Degraded mode: SLA tracking + auto-decompose are off, but the
+			// API surface and rest of the backend continue to serve. Ops can
+			// grep for `v3 subscriber boot failed` in logs to triage.
+			this.logger.error(
+				'v3 subscriber boot failed — degrading SLA + auto-decompose paths, continuing backend startup',
+				{
+					error:
+						subscriberBootErr instanceof Error
+							? subscriberBootErr.message
+							: String(subscriberBootErr),
+				},
+			);
+			// Best-effort cleanup of any partial wiring so a later restart
+			// doesn't see stale singletons. The setters are idempotent.
+			setRequestSlaSubscriber(null);
+			setRequestDecomposeSubscriber(null);
+			setRequestServiceEventBus(null);
+			this.requestSlaSubscriber = null;
+			this.requestDecomposeSubscriber = null;
+		}
 
 		// Initialize Slack thread store for persistent thread conversations
 		const slackThreadStore = new SlackThreadStoreService(this.config.crewlyHome);


### PR DESCRIPTION
## Summary

Wrap the v3 subscriber boot block (`RequestSlaSubscriber.boot+start` + `RequestDecomposeSubscriber.boot+start`) in a single try/catch so a wiring failure logs + continues rather than crashing backend startup. Brings the v3 subscriber block in line with the equivalent failure-isolation already in place for B0 (`system:backend_restarted` broadcast) and B1 (`TriggerEngine.start()`).

Closes #465 (Arch nit #4 from PR #461).

## Pre-implementation verification

Inspected actual boot paths in current main (commit d74d705a):

| Site | Status | Action |
|---|---|---|
| B0 `system:backend_restarted` publish (`index.ts:2336-2366`) | Already wrapped in try/catch | None — keep as-is |
| B1 `TriggerEngine.start()` (`index.ts:1464-1632`) | Already wrapped in try/catch | None — keep as-is |
| v3 subscribers (`index.ts:431-468`) | NOT wrapped | **Fix in this PR** |

Issue #465 originally claimed "same nit applies to B0/B1" — that was inaccurate; both already had the protection. Posted the verification on the issue before opening this PR.

## Failure mode

If either subscriber's `boot()+start()` throws during backend startup, the entire backend crashes — no API surface available, full restart required. Neither subscriber is essential to API liveness:
- SLA subscriber: degrades user-reply SLA tracking (5-min breach + 10-min escalation).
- Decompose subscriber: degrades to "orc must invoke break-down-request manually" (pre-PR-#461 behavior).

A degraded subscriber is strictly preferable to a crashed backend.

## Design choices

- **Single try/catch (both subscribers as a unit)** — the failure mode is "wiring is broken, fix the deploy" not "intermittently flaky". Partial recovery (per-subscriber try/catch) is unnecessary complexity for v1; split later if we ever want it.
- **Best-effort cleanup on catch** — null both module-level setters and the class fields so a later restart doesn't see stale singletons. Setters are idempotent.
- **Ops marker:** error-log line `v3 subscriber boot failed` is the grep target for triage. Same convention as B0/B1's warn-log markers.

## Tests

No new tests added. Rationale:
- Existing `backend/src/index.test.ts` uses route-replication (can't import `index.ts` in Jest due to `import.meta.url`), so a unit test of the boot path would require ~100 LOC of scaffold for ~10 LOC of failure-isolation.
- The failure-isolation pattern is identical to B0/B1 in-tree precedents that were never companion-tested either.
- Cost-benefit doesn't justify the test scaffold for a pure isolation wrapper that adds no new semantics.

Existing test coverage validates no regression:
- ✅ `backend/src/services/v3/(request-sla|request-decompose|request.service)` — **152/152 green** (5 suites, no regressions).
- ✅ `tsc -p backend/tsconfig.json --noEmit` clean.
- ✅ `npm run build` clean (backend + frontend + cli).

## Out of scope

- Health-check endpoint reporting subscriber-degraded state — separate observability ticket.
- Per-subscriber partial-recovery split — premature.

## Test plan

- [x] `npm run build` green
- [x] `npx jest --testPathPattern='backend/src/services/v3/(request-sla|request-decompose|request\.service)'` — 152/152 pass
- [x] `tsc --noEmit` clean
- [ ] Post-merge smoke: backend starts cleanly with both subscribers active (no behavior change in happy-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)