### PR TITLE
fix(task-pool): Bug B — intrinsic Request.workItemIds[] backfill (foundational for Bug C)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -360,6 +360,16 @@ export class CrewlyServer {
 		// depend on this for the auto-close path b chain. Idempotent.
 		TaskPoolService.getInstance().setEventBusService(this.eventBusService);
 
+		// P1 Bug B (Pool umbrella WI 72ca743a): Wire RequestService into the
+		// TaskPool singleton so addToPool intrinsically links new WIs into
+		// their parent Request.workItemIds[] — independent of the
+		// subscriber-driven path (request-sla.subscriber, V3DataService).
+		// Pre-fix, manual / programmatic / cron callers that bypassed the
+		// event chain left Requests with empty workItemIds[]. The linker is
+		// idempotent (request.service.ts:328 short-circuits on duplicate id)
+		// so subscriber-driven linking stays as belt-and-suspenders.
+		TaskPoolService.getInstance().setRequestService(RequestService.getInstance());
+
 		// Wire Task Pool router so [TASK]-prefixed messages route through the pool
 		this.queueProcessorService.setTaskPoolRouter(async (messageContent: string, targetSession: string) => {
 			const { createWorkItem } = await import('./types/v2/work-item.types.js');

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -190,6 +190,189 @@ describe('TaskPoolService', () => {
         expect(items[0].id).toBe(wi.id);
       });
     });
+
+    // ---------------------------------------------------------------------
+    // P1 Bug B: intrinsic Request.workItemIds[] backfill
+    //
+    // Pool umbrella WorkItem 72ca743a-3a66-4d0e-a6cf-1a861f849dbd.
+    //
+    // Pre-fix, addToPool stored requestId on the WI but did NOT push the
+    // WI id into Request.workItemIds[] — that link only happened via
+    // downstream subscribers (request-sla.subscriber on workitem:queued,
+    // V3DataService on task:delegated), both of which require the caller
+    // to have gone through the standard event chain. Manual / programmatic
+    // / cron / orchestrator-script callers bypassed those subscribers and
+    // left Requests with empty workItemIds[].
+    //
+    // The fix: addToPool now invokes a wired `linkWorkItem` on every
+    // successful enqueue. linkWorkItem is idempotent (short-circuits on
+    // duplicate id) so subscriber-driven linking remains as
+    // belt-and-suspenders. These tests pin the contract.
+    // ---------------------------------------------------------------------
+    describe('intrinsic Request link (P1 Bug B)', () => {
+      function makeFakeLinker() {
+        const calls: Array<{ requestId: string; workItemId: string }> = [];
+        const linker = {
+          linkWorkItem: jest.fn(async (requestId: string, workItemId: string) => {
+            calls.push({ requestId, workItemId });
+            return null;
+          }),
+        };
+        return { linker, calls };
+      }
+
+      it('calls linkWorkItem(requestId, workItemId) once when wi.requestId is set', async () => {
+        const { linker, calls } = makeFakeLinker();
+        service.setRequestService(linker as any);
+
+        const wi = makeWorkItem({ requestId: 'req-bug-b-1' });
+        await service.addToPool(wi);
+
+        expect(linker.linkWorkItem).toHaveBeenCalledTimes(1);
+        expect(calls[0]).toEqual({ requestId: 'req-bug-b-1', workItemId: wi.id });
+      });
+
+      it('does NOT call linkWorkItem when wi.requestId is NOT set', async () => {
+        const { linker } = makeFakeLinker();
+        service.setRequestService(linker as any);
+
+        const wi = makeWorkItem(); // no requestId
+        await service.addToPool(wi);
+
+        expect(linker.linkWorkItem).not.toHaveBeenCalled();
+      });
+
+      it('isolates linkWorkItem failures (addToPool still succeeds, warn-logged)', async () => {
+        const linker = {
+          linkWorkItem: jest.fn(async () => {
+            throw new Error('linker blew up — db down');
+          }),
+        };
+        service.setRequestService(linker as any);
+
+        const wi = makeWorkItem({ requestId: 'req-fail' });
+
+        // CRITICAL: addToPool must NOT re-throw — pool mutation is the
+        // source of truth, link is best-effort.
+        await expect(service.addToPool(wi)).resolves.toBeUndefined();
+
+        // Pool mutation committed even though link threw.
+        const items = await service.getAllItems();
+        expect(items).toHaveLength(1);
+        expect(items[0].id).toBe(wi.id);
+        expect(linker.linkWorkItem).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not double-link on duplicate addToPool calls (storage dedup short-circuits)', async () => {
+        const { linker } = makeFakeLinker();
+        service.setRequestService(linker as any);
+
+        const wi = makeWorkItem({ requestId: 'req-dup-link' });
+        await service.addToPool(wi);
+        await service.addToPool(wi); // duplicate id — storage short-circuits at line 206
+
+        // The duplicate addToPool returns early BEFORE the link call,
+        // so linkWorkItem is invoked exactly once. Even if it were called
+        // twice, the production linkWorkItem itself short-circuits on
+        // duplicate workItemId (request.service.ts:328) — pinned in a
+        // belt-and-suspenders test below.
+        expect(linker.linkWorkItem).toHaveBeenCalledTimes(1);
+      });
+
+      it('does NOT call linkWorkItem when no RequestService is wired (legacy/test path)', async () => {
+        // No setRequestService — requestService stays null, addToPool
+        // must not throw and the linker call must be skipped silently.
+        const wi = makeWorkItem({ requestId: 'req-no-linker' });
+        await expect(service.addToPool(wi)).resolves.toBeUndefined();
+
+        const items = await service.getAllItems();
+        expect(items).toHaveLength(1);
+      });
+
+      it('coexists with EventBus publish (both linker and bus invoked, in order)', async () => {
+        // Pin the belt-and-suspenders contract: a caller that goes
+        // through the request:created event chain still triggers BOTH
+        // the intrinsic link (this fix) AND the subscriber-driven link
+        // (downstream of workitem:queued). The downstream link is
+        // exercised in production via request-sla.subscriber.ts:1153,
+        // not invoked here, but we pin the publish ordering.
+        const publishCalls: any[] = [];
+        const fakeBus = {
+          publish: jest.fn((event: any) => publishCalls.push(event)),
+        } as any;
+        const { linker } = makeFakeLinker();
+
+        service.setEventBusService(fakeBus);
+        service.setRequestService(linker as any);
+
+        const wi = makeWorkItem({ requestId: 'req-coexist' });
+        await service.addToPool(wi);
+
+        // Both fired
+        expect(linker.linkWorkItem).toHaveBeenCalledTimes(1);
+        expect(publishCalls).toHaveLength(1);
+        expect(publishCalls[0].requestId).toBe('req-coexist');
+
+        // Ordering: linker BEFORE publish, so a subscriber that loads the
+        // Request synchronously after seeing workitem:queued will already
+        // observe the intrinsic link. (Subscribers re-link idempotently
+        // anyway, but ordering is documented.)
+        const linkOrder = (linker.linkWorkItem as jest.Mock).mock.invocationCallOrder[0];
+        const publishOrder = fakeBus.publish.mock.invocationCallOrder[0];
+        expect(linkOrder).toBeLessThan(publishOrder);
+      });
+
+      it('integration repro: ORC 322e7fd3 case — direct addToPool populates Request.workItemIds[]', async () => {
+        // Mimic the exact failure mode from ORC's bug report: a Request
+        // exists, then a caller directly invokes taskPool.addToPool
+        // outside the request:created event chain (no SLA subscriber, no
+        // V3DataService). PRE-FIX: workItemIds stays empty. POST-FIX:
+        // the intrinsic link populates it.
+        //
+        // We use a FAKE Request store keyed on requestId — simpler than
+        // standing up the full RequestService / persistence stack and
+        // pins the wire contract that matters: linkWorkItem produces the
+        // observed mutation on the Request side.
+        const fakeRequestStore = new Map<string, { id: string; workItemIds: string[] }>();
+        fakeRequestStore.set('req-322e7fd3', {
+          id: 'req-322e7fd3',
+          workItemIds: [], // empty — the bug condition
+        });
+
+        const linker = {
+          linkWorkItem: jest.fn(async (requestId: string, workItemId: string) => {
+            const req = fakeRequestStore.get(requestId);
+            if (!req) return null;
+            // Idempotency: short-circuit on duplicate id (mirrors
+            // request.service.ts:328).
+            if (!req.workItemIds.includes(workItemId)) {
+              req.workItemIds.push(workItemId);
+            }
+            return req;
+          }),
+        };
+        service.setRequestService(linker as any);
+
+        // PRE-FIX assertion baseline
+        expect(fakeRequestStore.get('req-322e7fd3')!.workItemIds).toEqual([]);
+
+        // Direct addToPool — bypasses any event subscribers
+        const wi = makeWorkItem({ requestId: 'req-322e7fd3' });
+        await service.addToPool(wi);
+
+        // POST-FIX: intrinsic link populated workItemIds
+        const after = fakeRequestStore.get('req-322e7fd3')!;
+        expect(after.workItemIds).toHaveLength(1);
+        expect(after.workItemIds).toContain(wi.id);
+
+        // Subscriber-driven re-link (simulated): calling linkWorkItem
+        // again with the same ids is a no-op due to the includes() guard.
+        // This pins the belt-and-suspenders idempotency contract.
+        await linker.linkWorkItem('req-322e7fd3', wi.id);
+        const afterSecondLink = fakeRequestStore.get('req-322e7fd3')!;
+        expect(afterSecondLink.workItemIds).toHaveLength(1); // still 1
+      });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -27,6 +27,32 @@ import {
 } from '../../types/v2/claim.types.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
 
+/**
+ * Narrow Request-link contract consumed by {@link TaskPoolService.addToPool}.
+ *
+ * Defined as a duck-typed interface (rather than importing the full
+ * `RequestService` class) so tests can supply fakes without depending on
+ * the RequestService transitive imports, and to keep the dependency
+ * direction one-way: TaskPool → Request, never the reverse.
+ *
+ * P1 Bug B (Pool umbrella WI 72ca743a-3a66-4d0e-a6cf-1a861f849dbd):
+ * the production `linkWorkItem` is idempotent — it short-circuits when
+ * `workItemId` is already in `request.workItemIds[]` — so the
+ * intrinsic-link path here is safe to coexist with downstream
+ * subscriber-driven linking (request-sla.subscriber, V3DataService).
+ */
+export interface IRequestWorkItemLinker {
+  /**
+   * Idempotently link a WorkItem id to a Request's workItemIds[].
+   *
+   * @param requestId - The parent Request id (already on the WI).
+   * @param workItemId - The WorkItem id to link.
+   * @returns The updated Request, or null if the Request was not found.
+   *   `addToPool` ignores the return value — link failure is best-effort.
+   */
+  linkWorkItem(requestId: string, workItemId: string): Promise<unknown>;
+}
+
 // ---------------------------------------------------------------------------
 // Filter / Snapshot Types
 // ---------------------------------------------------------------------------
@@ -118,6 +144,27 @@ export class TaskPoolService {
   private eventBus: EventBusService | null = null;
 
   /**
+   * Optional Request-linker reference — wired via {@link setRequestService}
+   * from the boot path. When set, {@link addToPool} pushes the new WI's id
+   * into the parent `Request.workItemIds[]` immediately after the storage
+   * flush, independent of any downstream subscriber.
+   *
+   * P1 Bug B (Pool umbrella WI 72ca743a) intrinsic-link contract:
+   *  - The pre-fix path relied on `workitem:queued` / `task:delegated`
+   *    subscribers (request-sla.subscriber, V3DataService) to backfill
+   *    `Request.workItemIds[]`. Manual / programmatic / cron callers that
+   *    bypass the standard event chain left Requests with
+   *    `workItemIds=[]` even though their WIs were in the pool.
+   *  - The intrinsic path here is the source-of-truth link and runs on
+   *    every `addToPool`. Subscriber-driven linking remains as
+   *    belt-and-suspenders (idempotent — see request.service.ts:328
+   *    short-circuit on duplicate id).
+   *  - Optional because singleton callers (tests, CLI) bring up the pool
+   *    before RequestService exists; missing linker is a no-op debug log.
+   */
+  private requestService: IRequestWorkItemLinker | null = null;
+
+  /**
    * Serializes claim operations to prevent the race where two concurrent
    * claimFromPool / claimSpecificItem calls both select the same queued
    * WorkItem between their read and write phases. In-process only — does
@@ -142,6 +189,23 @@ export class TaskPoolService {
    */
   setEventBusService(bus: EventBusService | null): void {
     this.eventBus = bus;
+  }
+
+  /**
+   * Wire the Request-linker reference used by {@link addToPool} to
+   * intrinsically link the new WI into its parent `Request.workItemIds[]`
+   * (P1 Bug B — Pool umbrella WI 72ca743a).
+   *
+   * Called from the backend boot path after both services exist.
+   * Idempotent and may be called with `null` to disable intrinsic
+   * linking (testing). Mirrors the {@link setEventBusService} setter
+   * pattern so the dependency wiring stays uniform and grep-able.
+   *
+   * @param svc - The RequestService instance (or any object satisfying
+   *   {@link IRequestWorkItemLinker}), or null to clear.
+   */
+  setRequestService(svc: IRequestWorkItemLinker | null): void {
+    this.requestService = svc;
   }
 
   /**
@@ -216,12 +280,72 @@ export class TaskPoolService {
       title: workItem.title,
     });
 
+    // P1 Bug B (Pool umbrella WI 72ca743a): intrinsically link the new
+    // WI into its parent `Request.workItemIds[]` if a linker is wired
+    // and the WI carries a requestId. This is the SOURCE-OF-TRUTH link
+    // and runs unconditionally on every successful addToPool, fixing
+    // the bug where manual / programmatic / cron / orchestrator-script
+    // callers that bypass the standard event chain left Requests with
+    // empty `workItemIds[]`.
+    //
+    // Subscriber-driven linking (request-sla.subscriber.ts on
+    // workitem:queued, V3DataService.onTaskDelegated on task:delegated)
+    // continues to run as belt-and-suspenders — `linkWorkItem` is
+    // idempotent (request.service.ts:328 short-circuits on duplicate id),
+    // so double-link is safe.
+    //
+    // Failure isolation: pool mutation is the source of truth. Link
+    // failures are warn-logged and swallowed; subscriber path remains
+    // as a backup, and a future addToPool of the same WI is a no-op
+    // (storage dedup) so retry comes via natural traffic.
+    await this.linkWorkItemToRequest(workItem);
+
     // INBOUND-1.f1: announce the queue mutation so subscribers (notably the
     // RequestSlaSubscriber) can react. We publish AFTER the storage flush
     // so any subscriber that re-reads via taskPool.findWorkItem sees the
     // committed item. Publish failures are logged-but-isolated — the pool
     // mutation is the source of truth, the event is informational.
     this.publishWorkItemQueued(workItem);
+  }
+
+  /**
+   * P1 Bug B helper: intrinsically link a freshly-added WI into its
+   * parent `Request.workItemIds[]`.
+   *
+   * Stays a separate method (vs inlining) so:
+   *   1. The dependency on RequestService stays explicit and grep-able,
+   *      mirroring {@link publishWorkItemQueued}.
+   *   2. Future enqueue paths (e.g. a batch addAll) can route through
+   *      the same linker for consistent behaviour.
+   *   3. Error handling stays in one place — a thrown linker must NOT
+   *      back out the pool mutation (the storage write already committed).
+   *
+   * @param workItem - The WI just persisted into the pool.
+   */
+  private async linkWorkItemToRequest(workItem: WorkItem): Promise<void> {
+    if (!workItem.requestId) {
+      // No parent Request — nothing to link.
+      return;
+    }
+    if (!this.requestService) {
+      this.logger.debug(
+        'No RequestService wired — skipping intrinsic Request link',
+        { workItemId: workItem.id, requestId: workItem.requestId },
+      );
+      return;
+    }
+    try {
+      await this.requestService.linkWorkItem(workItem.requestId, workItem.id);
+    } catch (linkError) {
+      this.logger.warn(
+        'Bug B intrinsic link failed (subscriber path remains as fallback)',
+        {
+          requestId: workItem.requestId,
+          workItemId: workItem.id,
+          error: formatError(linkError),
+        },
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Pre-fix, `taskPool.addToPool(wi)` stored `requestId` on the WorkItem but never pushed `wi.id` into the parent `Request.workItemIds[]`. The link only happened via downstream subscribers (`request-sla.subscriber.ts:1153` on `workitem:queued`, `V3DataService.onTaskDelegated` on `task:delegated`). Manual / programmatic / cron / orchestrator-script callers bypassed those subscribers, so Requests stayed with `workItemIds=[]` despite WIs existing in the pool.
- Fix adds the **intrinsic link** inside `addToPool` itself, immediately after `storage.flush()` and before `publishWorkItemQueued`. Subscriber-driven linking is preserved untouched as belt-and-suspenders (idempotent — `request.service.ts:328` short-circuits on duplicate id).
- Foundational for **Bug C** (close-on-WI-done gate) which depends on `workItemIds[]` being correctly populated.

## ORC repro pinned

ORC's Request `322e7fd3-b2c5-4f34-8c88-6cc490757d23` had 3 WIs in pool but `workItemIds=[]`. Test `integration repro: ORC 322e7fd3 case` reproduces the exact failure mode (direct `addToPool` outside the event chain) and pins the post-fix assertion: `request.workItemIds.length === 1 && includes(wi.id)`.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Unit test: `addToPool(wi)` with `wi.requestId` set → `linkWorkItem` called once with `(wi.requestId, wi.id)` | ✅ |
| 2 | Unit test: `addToPool(wi)` without `requestId` → `linkWorkItem` NOT called, no error | ✅ |
| 3 | Unit test: `linkWorkItem` throws → `addToPool` still succeeds, warn-log emitted | ✅ |
| 4 | Unit test: duplicate `addToPool(wi)` → `linkWorkItem` invoked at most once (storage dedup short-circuits before link) | ✅ |
| 5 | Integration test: ORC 322e7fd3 repro — direct addToPool populates `workItemIds[]` with `wi.id` | ✅ |
| 6 | Co-existence test: `addToPool` from inside the request:created chain → linker + bus both invoked, link BEFORE publish | ✅ |
| 7 | Smoke (manual post-merge): NEW Request created via direct addToPool gets workItemIds populated | _Pending merge_ |

## Files changed

- `backend/src/services/task-pool/task-pool.service.ts` — new `IRequestWorkItemLinker` interface, `setRequestService` setter, `linkWorkItemToRequest` private helper invoked from `addToPool` after `storage.flush()`.
- `backend/src/services/task-pool/task-pool.service.test.ts` — 7 new cases under `describe('intrinsic Request link (P1 Bug B)')`.
- `backend/src/index.ts` — boot-time wiring: `TaskPoolService.getInstance().setRequestService(RequestService.getInstance())` placed immediately after `setEventBusService`.

## Test results

```
PASS backend/src/services/task-pool/pool-storage.test.ts
PASS backend/src/services/task-pool/claim.service.test.ts
PASS backend/src/services/task-pool/task-pool.service.test.ts — 100 passed (incl. 7 new Bug B)
PASS backend/src/services/v3/request.service.test.ts

Tests: 180 passed, 180 total
```

Full project build clean (`npm run build` — TS strict, frontend bundle, CLI all green).

## Architectural notes for Arch review

1. **Failure isolation**: pool mutation is the source of truth. Link failures are warn-logged and swallowed so the storage write that already committed is never backed out. Subscriber path remains as a backup.
2. **No new circular import**: TaskPool consumes `IRequestWorkItemLinker` (a 1-method duck-typed interface); the concrete `RequestService` type is **not** imported. Wiring is one-way at boot time, mirroring the existing `setEventBusService` pattern.
3. **Idempotency belt-and-suspenders**: `linkWorkItem` short-circuits on duplicate id (`request.service.ts:328`), so existing subscriber-driven linking still runs safely. Test #4 + #6 pin this contract.
4. **Order pinned**: linker runs **before** `publishWorkItemQueued` so any subscriber that re-reads the Request synchronously after seeing `workitem:queued` already observes the intrinsic link. Test #6 pins this ordering.

## Out of scope (defer per task brief)

- Backfilling historical Requests with empty `workItemIds[]` (cosmetic; ORC accepted historical empty arrays on terminal cascade-closed threads).
- Removing the SLA-subscriber `linkWorkItem` call (idempotent; remove only after a separate hardening sweep).
- Bug A (intent classifier) and Bug C (close-on-WI-done gate) — separate sub-WIs in the same umbrella, NOT this PR.

## Authority

Ship-with-Arch protocol per task brief (same as B0/B1/F8/dogfood). Requesting Arch review before merge.

## Test plan

- [ ] CI passes (TS strict, jest, lint)
- [ ] Arch review confirms invariants: failure isolation, no circular import, ordering contract, idempotency belt-and-suspenders
- [ ] Post-merge smoke: a NEW Request created via the same direct-`addToPool` path Steve hit gets `workItemIds[]` populated (verify on next ORC delegation cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)