### PR TITLE
fix(memory): P2/F4 — allow remember(category=gotcha, scope=agent)

### DIFF
--- a/backend/src/controllers/memory/memory.controller.test.ts
+++ b/backend/src/controllers/memory/memory.controller.test.ts
@@ -258,18 +258,27 @@ describe('MemoryController', () => {
 
     // F4 fix (2026-05-06): controller surfaces alias hints for common
     // mistakes. Sam (TL) hit `category=workflow` earlier in the audit cycle.
+    // Arch nit (PR #468): 'best-practice' is produced by BOTH 'fact'
+    // (agent-only) and 'decision' (project-only) in the service-layer
+    // mapper, so the hint must be scope-aware to avoid sending project
+    // callers down a dead-end (fact rejects on project scope).
     it.each([
-      ['workflow', 'pattern'],
-      ['best-practice', 'fact'],
-      ['anti-pattern', 'gotcha'],
-    ])('should hint public-API alias when caller uses internal name %s', async (badCategory, expectedHint) => {
+      // [badCategory, scope, expectedHint]
+      ['workflow', 'agent', 'pattern'],
+      ['workflow', 'project', 'pattern'],
+      ['best-practice', 'agent', 'fact'],
+      ['best-practice', 'project', 'decision'], // <-- Arch nit fix
+      ['anti-pattern', 'agent', 'gotcha'],
+      ['anti-pattern', 'project', 'gotcha'],
+    ])('should hint public-API alias when caller uses internal name %s with scope=%s', async (badCategory, scope, expectedHint) => {
       await remember(
         {
           body: {
             agentId: 'dev-001',
             content: 'test',
             category: badCategory,
-            scope: 'agent',
+            scope,
+            ...(scope === 'project' ? { projectPath: '/tmp/test' } : {}),
           },
         } as any,
         mockRes as any,

--- a/backend/src/controllers/memory/memory.controller.test.ts
+++ b/backend/src/controllers/memory/memory.controller.test.ts
@@ -256,6 +256,36 @@ describe('MemoryController', () => {
       expect(mockRemember).not.toHaveBeenCalled();
     });
 
+    // F4 fix (2026-05-06): controller surfaces alias hints for common
+    // mistakes. Sam (TL) hit `category=workflow` earlier in the audit cycle.
+    it.each([
+      ['workflow', 'pattern'],
+      ['best-practice', 'fact'],
+      ['anti-pattern', 'gotcha'],
+    ])('should hint public-API alias when caller uses internal name %s', async (badCategory, expectedHint) => {
+      await remember(
+        {
+          body: {
+            agentId: 'dev-001',
+            content: 'test',
+            category: badCategory,
+            scope: 'agent',
+          },
+        } as any,
+        mockRes as any,
+        mockNext
+      );
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining(`did you mean '${expectedHint}'`),
+        })
+      );
+      expect(mockRemember).not.toHaveBeenCalled();
+    });
+
     it('should return 400 for invalid scope', async () => {
       await remember(
         {

--- a/backend/src/controllers/memory/memory.controller.ts
+++ b/backend/src/controllers/memory/memory.controller.ts
@@ -69,9 +69,16 @@ export async function remember(req: Request, res: Response, next: NextFunction):
     }
 
     if (!VALID_REMEMBER_CATEGORIES.has(category)) {
+      // F4 fix (2026-05-06): if caller used a known internal alias
+      // (e.g. 'workflow') hint the public-API equivalent.
+      const aliasHint =
+        category === 'workflow' ? " — did you mean 'pattern'?" :
+        category === 'best-practice' ? " — did you mean 'fact'?" :
+        category === 'anti-pattern' ? " — did you mean 'gotcha'?" :
+        '';
       res.status(400).json({
         success: false,
-        error: `Invalid category '${category}'. Must be one of: ${[...VALID_REMEMBER_CATEGORIES].join(', ')}`,
+        error: `Invalid category '${category}'. Must be one of: ${[...VALID_REMEMBER_CATEGORIES].join(', ')}${aliasHint}`,
       });
       return;
     }

--- a/backend/src/controllers/memory/memory.controller.ts
+++ b/backend/src/controllers/memory/memory.controller.ts
@@ -71,9 +71,15 @@ export async function remember(req: Request, res: Response, next: NextFunction):
     if (!VALID_REMEMBER_CATEGORIES.has(category)) {
       // F4 fix (2026-05-06): if caller used a known internal alias
       // (e.g. 'workflow') hint the public-API equivalent.
+      // Arch nit (PR #468): the 'best-practice' internal name is produced
+      // by both 'fact' (agent-only) and 'decision' (project-only) in the
+      // service-layer mapper, so the hint must be scope-aware to avoid
+      // sending project-scope callers down a dead-end.
       const aliasHint =
         category === 'workflow' ? " — did you mean 'pattern'?" :
-        category === 'best-practice' ? " — did you mean 'fact'?" :
+        category === 'best-practice'
+          ? (scope === 'project' ? " — did you mean 'decision'?" : " — did you mean 'fact'?")
+          :
         category === 'anti-pattern' ? " — did you mean 'gotcha'?" :
         '';
       res.status(400).json({

--- a/backend/src/services/memory/memory.service.test.ts
+++ b/backend/src/services/memory/memory.service.test.ts
@@ -136,6 +136,88 @@ describe('MemoryService', () => {
         scope: 'agent',
       })).rejects.toThrow('not valid for agent scope');
     });
+
+    // ===== F4 fix (2026-05-06): gotcha is now valid for agent scope =====
+    // ORC Audit Cycle 3 finding F4. Previously rejected with "not valid for
+    // agent scope" because rememberForAgent only accepted fact/pattern/preference,
+    // forcing callers to pollute project memory with personal gotchas.
+
+    it('should store gotcha in agent memory (F4 fix)', async () => {
+      const id = await service.remember({
+        agentId: testAgentId,
+        content: 'My grep -A audit pattern produced false positives — use yq instead',
+        category: 'gotcha',
+        scope: 'agent',
+      });
+
+      expect(id).toBeDefined();
+      expect(id).not.toBe('preference-updated');
+
+      const agentService = service.getAgentMemoryService();
+      const knowledge = await agentService.getRoleKnowledge(testAgentId);
+      const stored = knowledge.find(k => k.content.includes('grep -A audit'));
+      expect(stored).toBeDefined();
+      expect(stored?.category).toBe('anti-pattern');
+    });
+
+    it('should keep gotcha valid for project scope (no regression)', async () => {
+      const id = await service.remember({
+        agentId: testAgentId,
+        projectPath: testProjectPath,
+        content: 'Database connections leak without explicit cleanup',
+        category: 'gotcha',
+        scope: 'project',
+        metadata: {
+          title: 'Connection Pool Leak',
+          solution: 'Use try/finally with client.release()',
+          severity: 'high',
+        },
+      });
+
+      expect(id).toBeDefined();
+
+      const projectService = service.getProjectMemoryService();
+      const gotchas = await projectService.getGotchas(testProjectPath);
+      expect(gotchas.some(g => g.title === 'Connection Pool Leak')).toBe(true);
+    });
+
+    it('should make agent-scope gotcha recallable (F4 fix)', async () => {
+      await service.remember({
+        agentId: testAgentId,
+        content: 'Never run git checkout -- . without stashing first — destructive',
+        category: 'gotcha',
+        scope: 'agent',
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        context: 'git checkout destructive stash',
+        scope: 'agent',
+      });
+
+      expect(result.agentMemories.length).toBeGreaterThan(0);
+      expect(
+        result.agentMemories.some(m => m.includes('git checkout'))
+      ).toBe(true);
+    });
+
+    it('should reject relationship for agent scope (project-only by design)', async () => {
+      await expect(service.remember({
+        agentId: testAgentId,
+        content: 'UserController',
+        category: 'relationship',
+        scope: 'agent',
+      })).rejects.toThrow('not valid for agent scope');
+    });
+
+    it('should reject user_preference for agent scope (project-only by design)', async () => {
+      await expect(service.remember({
+        agentId: testAgentId,
+        content: 'User prefers concise replies',
+        category: 'user_preference',
+        scope: 'agent',
+      })).rejects.toThrow('not valid for agent scope');
+    });
   });
 
   describe('remember - project scope', () => {

--- a/backend/src/services/memory/memory.service.ts
+++ b/backend/src/services/memory/memory.service.ts
@@ -319,16 +319,27 @@ export class MemoryService implements IMemoryService {
   }
 
   /**
-   * Maps RememberCategory to RoleKnowledgeCategory for agent memory
+   * Maps RememberCategory to RoleKnowledgeCategory for agent memory.
+   *
+   * Public-API categories that map cleanly to internal storage:
+   * - `fact` / `decision` → `best-practice` (positive learnings the agent should follow)
+   * - `pattern` / `preference` → `workflow` (how-to / process knowledge)
+   * - `gotcha` → `anti-pattern` (things to avoid; F4 fix 2026-05-06)
+   *
+   * Categories that do NOT reach this mapper because `rememberForAgent`
+   * routes them differently or rejects them: `relationship` and
+   * `user_preference` are project-only by design.
    */
   private mapToKnowledgeCategory(category: RememberCategory): RoleKnowledgeCategory {
     switch (category) {
       case 'fact':
+      case 'decision':
         return 'best-practice';
       case 'pattern':
-        return 'workflow';
       case 'preference':
         return 'workflow';
+      case 'gotcha':
+        return 'anti-pattern';
       default:
         return 'best-practice';
     }
@@ -634,12 +645,24 @@ export class MemoryService implements IMemoryService {
   }
 
   /**
-   * Stores memory at agent level
+   * Stores memory at agent level.
+   *
+   * Valid public-API categories for agent scope:
+   * - `fact`, `pattern` → role knowledge (existing behavior)
+   * - `gotcha` → role knowledge with internal `anti-pattern` category
+   *   (F4 fix 2026-05-06: agents can now record personal gotchas without
+   *    polluting project memory).
+   * - `preference` → updates AgentPreferences struct
+   *
+   * Categories `relationship` and `user_preference` remain project-only
+   * by design (relationship describes codebase component edges;
+   * user_preference is scoped to a specific project's user).
    */
   private async rememberForAgent(params: RememberParams): Promise<string> {
     switch (params.category) {
       case 'fact':
       case 'pattern':
+      case 'gotcha':
         return this.agentMemory.addRoleKnowledge(params.agentId, {
           category: this.mapToKnowledgeCategory(params.category),
           content: params.content,
@@ -660,7 +683,11 @@ export class MemoryService implements IMemoryService {
         return 'preference-updated';
 
       default:
-        throw new Error(`Category '${params.category}' is not valid for agent scope. Use 'fact', 'pattern', or 'preference'.`);
+        throw new Error(
+          `Category '${params.category}' is not valid for agent scope. ` +
+          `Use 'fact', 'pattern', 'gotcha', or 'preference'. ` +
+          `('decision', 'relationship', and 'user_preference' are project-scope only.)`
+        );
     }
   }
 

--- a/config/skills/agent/core/remember/SKILL.md
+++ b/config/skills/agent/core/remember/SKILL.md
@@ -46,9 +46,25 @@ Store a memory entry for future recall. Use this to persist important context, d
 | `--agent` / `-a` | `agentId` | Yes | Your agent ID / session name |
 | `--content` / `-c` | `content` | Yes | Content to remember (or pipe via stdin) |
 | `--content-file` | — | No | Read content from a file path |
-| `--category` / `-C` | `category` | Yes | Category: `pattern`, `decision`, `gotcha`, `fact`, `preference`, `relationship`, `user_preference` |
+| `--category` / `-C` | `category` | Yes | See category × scope matrix below |
 | `--scope` / `-s` | `scope` | Yes | Scope: `agent` or `project` |
 | `--project` / `-p` | `projectPath` | No | Project path (required for `project` scope) |
+
+### Valid `category` × `scope` matrix
+
+| Category          | `scope=agent` | `scope=project` | Notes |
+|-------------------|:-------------:|:---------------:|-------|
+| `fact`            | ✅            | —               | Personal best-practice / "always do X". |
+| `pattern`         | ✅            | ✅              | Reusable workflow or code pattern. |
+| `gotcha`          | ✅ (F4 fix)   | ✅              | Things to avoid; agent-scope = personal, project-scope = team-wide. |
+| `preference`      | ✅            | —               | Updates your `AgentPreferences` (verbosity, breakdown size, etc.). |
+| `decision`        | —             | ✅              | Architectural / design decision (project-only). |
+| `relationship`    | —             | ✅              | Component-to-component edge in the codebase (project-only). |
+| `user_preference` | —             | ✅              | Project-scoped user preference (project-only). |
+
+> **Aliases / common mistakes:**
+> - `workflow` is **not** a public category — use `pattern` (it maps to internal `workflow` automatically).
+> - For "this approach failed for me last time" → use `category=gotcha scope=agent` (don't pollute project memory).
 
 ## Examples — CLI Flags (preferred)
 

--- a/config/skills/agent/core/remember/execute.sh
+++ b/config/skills/agent/core/remember/execute.sh
@@ -24,7 +24,11 @@ Options:
   --agent    | -a   Agent ID / session name (required)
   --content  | -c   Memory content text (required unless piped via stdin)
   --content-file    Read content from file path
-  --category | -C   Category: pattern, decision, gotcha, fact, preference (required)
+  --category | -C   Category (required) — valid values depend on scope:
+                      scope=agent   : fact, pattern, gotcha, preference
+                      scope=project : pattern, decision, gotcha, relationship, user_preference
+                    Aliases / common mistakes:
+                      'workflow' is NOT a public category — use 'pattern' instead.
   --scope    | -s   Scope: project or agent (required)
   --project  | -p   Project path (required for project scope)
   --json     | -j   Raw JSON payload


### PR DESCRIPTION
## Summary

ORC Audit Cycle 3 finding F4 (Pool WorkItem `2d1d15da-b2e6-4df9-9dc7-949c0e8770c8`). The `remember` skill rejected `category=gotcha + scope=agent` even though the controller's top-level enum accepted `gotcha`. Agents were forced to write personal gotchas to project memory, polluting team knowledge with single-agent learnings.

## Root cause

The asymmetry was inside `MemoryService.rememberForAgent`'s switch statement — it accepted only `fact`, `pattern`, and `preference`. The controller's `VALID_REMEMBER_CATEGORIES` set already included `gotcha`, `decision`, `relationship`, and `user_preference`, so requests for those categories survived controller validation only to fail at the service-layer dispatch with a confusing message.

## Shape (re: Sam's question — answer is **(a) ADDITIVE**)

This PR is **fully backward-compatible.** No rename. No migration.
- The public API category names are unchanged: `{fact, pattern, decision, gotcha, preference, user_preference, relationship}`.
- `gotcha` is now valid for **both** `scope=agent` (new) and `scope=project` (unchanged).
- Internally, `gotcha` agent-scope entries are stored with `RoleKnowledgeCategory = 'anti-pattern'`. This is an internal implementation detail of how `addRoleKnowledge` discriminates entries — callers never see it.
- Existing memory entries with `category=gotcha` (project scope) are untouched.
- New callers can write personal gotchas via `category=gotcha scope=agent` without any client-side change.

The internal mapping `gotcha → anti-pattern` and `decision → best-practice` lives entirely inside `mapToKnowledgeCategory()`. The internal `RoleKnowledgeCategory` enum (`'best-practice' | 'anti-pattern' | 'tool-usage' | 'workflow'`) is **not exposed** to the public API and is not part of the user-facing category set.

## On the `workflow` case (Sam's session-discovered gap)

`workflow` is **not added** to the public enum. It's an internal `RoleKnowledgeCategory` value that callers should never use directly. Two new defenses:

1. **Skill help text** (SKILL.md + execute.sh) now lists the valid `category × scope` matrix and documents \"`workflow` is **not** a public category — use `pattern` (it maps to internal `workflow` automatically).\"
2. **Controller alias hints** in error messages: passing `category=workflow` now returns `Invalid category 'workflow'. Must be one of: fact, pattern, ... — did you mean 'pattern'?` Same hint for `best-practice → fact` and `anti-pattern → gotcha`.

Rationale: adding `workflow` to the public enum would be a duplicate spelling for `pattern` and create call-site ambiguity. Hinting + docs is cleaner.

## Acceptance criteria (from brief)

- [x] **AC1:** `remember(category=gotcha, scope=agent)` succeeds and persists. (`memory.service.test.ts: should store gotcha in agent memory (F4 fix)`)
- [x] **AC2:** `remember(category=gotcha, scope=project)` continues to succeed. (`memory.service.test.ts: should keep gotcha valid for project scope (no regression)`)
- [x] **AC3:** `recall(...)` returns the agent-scope gotcha. (`memory.service.test.ts: should make agent-scope gotcha recallable (F4 fix)`)
- [x] **AC4:** `workflow` decision documented above + in PR + in skill help.
- [x] **AC5:** Skill help text updated with category × scope matrix.

Plus two regression-guard tests confirming `relationship` and `user_preference` remain project-only by design (and reject with the new improved error message).

## Out of scope (per brief)

- No storage format changes.
- No migration of existing memories.
- No NEW categories beyond the existing project-scope set.
- `decision`, `relationship`, `user_preference` remain project-only by design — documented as such in both SKILL.md and the agent-scope error message. Future work can revisit.

## Files changed

| File | Change |
|------|--------|
| `backend/src/services/memory/memory.service.ts` | Extend `rememberForAgent` to accept `gotcha`; map to internal `anti-pattern`. Improved error message. |
| `backend/src/services/memory/memory.service.test.ts` | +5 new tests (F4-tagged) |
| `backend/src/controllers/memory/memory.controller.ts` | Alias hints for known internal names |
| `backend/src/controllers/memory/memory.controller.test.ts` | +3 new tests via `it.each` |
| `config/skills/agent/core/remember/SKILL.md` | Category × scope matrix; workflow alias note |
| `config/skills/agent/core/remember/execute.sh` | Updated `print_usage` |

## Test plan

- [x] `npm run build:backend` — clean
- [x] `npx tsc --noEmit -p backend/tsconfig.json` — clean
- [x] `memory.service.test.ts` — 38/38 pass (5 new)
- [x] `memory.controller.test.ts` — 43/43 pass (3 new)
- [x] All other memory test suites — 21/21 pass
- [x] No existing tests modified except in semantically-preserving ways (the `'decision' rejected for agent scope` test still passes because `decision` is intentionally NOT added to agent scope; only the error message text is extended, the substring matched in the assertion is preserved)
- [ ] Smoke after merge: from any agent session, `bash config/skills/agent/core/remember/execute.sh --agent <self> --content "test gotcha" --category gotcha --scope agent` should return `{"success":true,"entryId":"..."}`

## Authority / cadence

Per dispatch: ship-with-Arch protocol same as B0/B1. Reply on PR-open (this), Arch-blocker, test-fail, spec-contradiction, or ETA-past-3h. ETA from claim → PR open: ~1.5h. Within budget.

Co-existence with parallel work confirmed:
- Max F8 (sops index regen) — orthogonal (sop.service.ts)
- Leo F9 dogfood subscriber — orthogonal

🤖 Generated with [Claude Code](https://claude.com/claude-code)