### PR TITLE
chore(task-pool): Bug B Arch follow-up — OBS-1 comment + OBS-2 test type cleanup

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -4,7 +4,10 @@
  * @module services/task-pool/task-pool.service.test
  */
 
-import { TaskPoolService } from './task-pool.service.js';
+import {
+  TaskPoolService,
+  type IRequestWorkItemLinker,
+} from './task-pool.service.js';
 import { PoolStorage } from './pool-storage.js';
 import { createWorkItem } from '../../types/v2/work-item.types.js';
 import * as fs from 'fs/promises';
@@ -210,7 +213,12 @@ describe('TaskPoolService', () => {
     // belt-and-suspenders. These tests pin the contract.
     // ---------------------------------------------------------------------
     describe('intrinsic Request link (P1 Bug B)', () => {
-      function makeFakeLinker() {
+      function makeFakeLinker(): {
+        linker: IRequestWorkItemLinker & {
+          linkWorkItem: jest.Mock<Promise<unknown>, [string, string]>;
+        };
+        calls: Array<{ requestId: string; workItemId: string }>;
+      } {
         const calls: Array<{ requestId: string; workItemId: string }> = [];
         const linker = {
           linkWorkItem: jest.fn(async (requestId: string, workItemId: string) => {
@@ -223,7 +231,7 @@ describe('TaskPoolService', () => {
 
       it('calls linkWorkItem(requestId, workItemId) once when wi.requestId is set', async () => {
         const { linker, calls } = makeFakeLinker();
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         const wi = makeWorkItem({ requestId: 'req-bug-b-1' });
         await service.addToPool(wi);
@@ -234,7 +242,7 @@ describe('TaskPoolService', () => {
 
       it('does NOT call linkWorkItem when wi.requestId is NOT set', async () => {
         const { linker } = makeFakeLinker();
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         const wi = makeWorkItem(); // no requestId
         await service.addToPool(wi);
@@ -243,12 +251,12 @@ describe('TaskPoolService', () => {
       });
 
       it('isolates linkWorkItem failures (addToPool still succeeds, warn-logged)', async () => {
-        const linker = {
+        const linker: IRequestWorkItemLinker = {
           linkWorkItem: jest.fn(async () => {
             throw new Error('linker blew up — db down');
           }),
         };
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         const wi = makeWorkItem({ requestId: 'req-fail' });
 
@@ -265,7 +273,7 @@ describe('TaskPoolService', () => {
 
       it('does not double-link on duplicate addToPool calls (storage dedup short-circuits)', async () => {
         const { linker } = makeFakeLinker();
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         const wi = makeWorkItem({ requestId: 'req-dup-link' });
         await service.addToPool(wi);
@@ -303,7 +311,7 @@ describe('TaskPoolService', () => {
         const { linker } = makeFakeLinker();
 
         service.setEventBusService(fakeBus);
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         const wi = makeWorkItem({ requestId: 'req-coexist' });
         await service.addToPool(wi);
@@ -339,7 +347,7 @@ describe('TaskPoolService', () => {
           workItemIds: [], // empty — the bug condition
         });
 
-        const linker = {
+        const linker: IRequestWorkItemLinker = {
           linkWorkItem: jest.fn(async (requestId: string, workItemId: string) => {
             const req = fakeRequestStore.get(requestId);
             if (!req) return null;
@@ -351,7 +359,7 @@ describe('TaskPoolService', () => {
             return req;
           }),
         };
-        service.setRequestService(linker as any);
+        service.setRequestService(linker);
 
         // PRE-FIX assertion baseline
         expect(fakeRequestStore.get('req-322e7fd3')!.workItemIds).toEqual([]);

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -295,9 +295,15 @@ export class TaskPoolService {
     // so double-link is safe.
     //
     // Failure isolation: pool mutation is the source of truth. Link
-    // failures are warn-logged and swallowed; subscriber path remains
-    // as a backup, and a future addToPool of the same WI is a no-op
-    // (storage dedup) so retry comes via natural traffic.
+    // failures are warn-logged and swallowed. The recovery path is the
+    // immediately-following publishWorkItemQueued — it fires
+    // unconditionally even when the intrinsic link threw, so any wired
+    // subscriber (request-sla.subscriber on workitem:queued,
+    // V3DataService.onTaskDelegated downstream) re-links idempotently
+    // inside this same addToPool call. Storage dedup on a future
+    // re-enqueue is NOT the recovery mechanism — that path is only
+    // hit if the original publish also fails, which is independently
+    // isolated.
     await this.linkWorkItemToRequest(workItem);
 
     // INBOUND-1.f1: announce the queue mutation so subscribers (notably the


### PR DESCRIPTION
## Summary

Non-blocking observations from Arch's review of PR #467 (Bug B intrinsic Request.workItemIds[] backfill, merged at `8bf58a11`). No behaviour change — pure docs + test typing cleanup.

## OBS-1 (P4): retry-comment accuracy

**Before:** comment at `addToPool` implied recovery came via `re-enqueue + storage dedup` on a future call.

**After:** comment now correctly describes the actual recovery mechanism — `publishWorkItemQueued` fires unconditionally after the link failure, so any wired subscriber re-links idempotently inside the **same** `addToPool` call. Storage dedup on a future re-enqueue is **not** the recovery path; it only matters if the original publish also fails (independently isolated).

## OBS-2 (P5): drop unnecessary `as any` casts in tests

**Before:** 6 sites called `service.setRequestService(linker as any)`. The cast was unnecessary — `Promise<null>` is assignable to `Promise<unknown>`.

**After:**
- Type-only import added: `import { TaskPoolService, type IRequestWorkItemLinker } from './task-pool.service.js';`
- All 6 `as any` casts dropped.
- `makeFakeLinker` helper return-typed with `IRequestWorkItemLinker & { linkWorkItem: jest.Mock<...> }` so the fake is both contract-conformant AND retains the spy surface tests need.
- 2 inline `linker` objects (failure-isolation test + ORC 322e7fd3 integration repro) annotated with `: IRequestWorkItemLinker`.

## OBS-3 (P3): tracked memory-only

Test 7 (ORC 322e7fd3 integration repro) uses a `Map`-backed fake instead of the real `RequestService`. Per Arch verdict this is an acceptable trade-off; cache-staleness coverage falls under Bug C scope if it surfaces. **No code change here.** Recorded as a learning so we can revisit if Bug C surfaces a regression.

## Test results

```
PASS backend/src/services/task-pool/task-pool.service.test.ts — 100 passed
```

Full project build clean (`npm run build` — TS strict, frontend bundle, CLI all green).

## Authority

Standing rule per Bug B Arch verdict: non-blocking OBS items can ship without a fresh review. Self-merge candidate after CI green.

## Files changed

- `backend/src/services/task-pool/task-pool.service.ts` — comment-only at `addToPool` recovery-path docstring.
- `backend/src/services/task-pool/task-pool.service.test.ts` — type-only import + drop 6 casts + 2 inline annotations + helper return type.

## Test plan

- [ ] CI passes (TS strict, jest, lint)
- [ ] Self-merge on green per Arch standing-rule for non-blocking OBS items

🤖 Generated with [Claude Code](https://claude.com/claude-code)