### PR TITLE
fix(v3): P1 Bug C — Request → done lifecycle gate refuses close while children open

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -370,6 +370,15 @@ export class CrewlyServer {
 		// so subscriber-driven linking stays as belt-and-suspenders.
 		TaskPoolService.getInstance().setRequestService(RequestService.getInstance());
 
+		// P1 Bug C (Pool umbrella WI 72ca743a, sub-WI Bug C): Wire the inverse
+		// dependency — RequestService → TaskPool — so RequestService.update
+		// can refuse `Request → done` when any child WorkItem is still in a
+		// non-terminal state. Bug B (above) makes Request.workItemIds[]
+		// authoritative on every addToPool; Bug C makes the closure honor
+		// that data. The setter is duck-typed on IWorkItemQueryable so
+		// neither side needs a static import of the other.
+		RequestService.getInstance().setTaskPoolService(TaskPoolService.getInstance());
+
 		// Wire Task Pool router so [TASK]-prefixed messages route through the pool
 		this.queueProcessorService.setTaskPoolRouter(async (messageContent: string, targetSession: string) => {
 			const { createWorkItem } = await import('./types/v2/work-item.types.js');

--- a/backend/src/services/v3/request-lifecycle-gate.integration.test.ts
+++ b/backend/src/services/v3/request-lifecycle-gate.integration.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Request → done lifecycle gate integration test (P1 Bug C).
+ *
+ * Drives a Request through the **real** services to verify two things:
+ *
+ *   AC5 (F9 repro): pool 1 WI in queued + parent Request, attempt to close
+ *   the Request to done → must REFUSE post-fix. Pre-fix this would have
+ *   succeeded — that was the auditor's exact F9 fixture symptom on
+ *   Request `ff54231a-02f3-4841-a74c-734a5aca9d09`.
+ *
+ *   AC6 (Bug B + Bug C composition): POST an L2 actionable Request → the
+ *   auto-decompose subscriber populates workItemIds[] via the live event
+ *   chain → attempt close-before-children-done → REFUSE → transition all
+ *   children to terminal state → close Request → SUCCESS.
+ *
+ * Bug B (#467 merged 8bf58a11) made `Request.workItemIds[]` authoritative
+ * on every addToPool. Bug C makes the closure honor that data. Without
+ * Bug B's invariant, Bug C's gate would be useless (always-empty arrays
+ * trivially bypass the gate). The composition test explicitly exercises
+ * both.
+ *
+ * Mirrors the fixture pattern from request-decompose-auto.integration.test
+ * (real services, fs-backed tmp CREWLY_HOME, isolated singletons) and
+ * adds the Bug C wiring step (requestService.setTaskPoolService).
+ *
+ * @module services/v3/request-lifecycle-gate.integration.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  RequestService,
+  setRequestServiceEventBus,
+  RequestStillHasOpenChildrenError,
+} from './request.service.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
+import { EventBusService } from '../event-bus/event-bus.service.js';
+import {
+  RequestSlaSubscriber,
+  setRequestSlaSubscriber,
+} from './request-sla.subscriber.js';
+import {
+  RequestDecomposeSubscriber,
+  setRequestDecomposeSubscriber,
+} from './request-decompose.subscriber.js';
+import { LoggerService } from '../core/logger.service.js';
+import { createWorkItem } from '../../types/v2/work-item.types.js';
+
+// Silence the global logger across the suite so failures stay readable.
+beforeEach(() => {
+  const noop = (..._args: unknown[]) => {};
+  const stub = {
+    info: noop,
+    debug: noop,
+    warn: noop,
+    error: noop,
+  };
+  jest
+    .spyOn(LoggerService.prototype as unknown as { createComponentLogger: () => unknown }, 'createComponentLogger')
+    .mockReturnValue(stub as unknown as ReturnType<LoggerService['createComponentLogger']>);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+interface IntegrationFixture {
+  tmpRoot: string;
+  bus: EventBusService;
+  requestService: RequestService;
+  taskPool: TaskPoolService;
+  slaSubscriber: RequestSlaSubscriber;
+  decomposeSubscriber: RequestDecomposeSubscriber;
+  cleanup: () => Promise<void>;
+}
+
+async function buildFixture(): Promise<IntegrationFixture> {
+  const tmpRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'pipeline-bug-c-int-'),
+  );
+  const crewlyHome = path.join(tmpRoot, '.crewly');
+  await fs.mkdir(crewlyHome, { recursive: true });
+  const previousCrewlyHome = process.env.CREWLY_HOME;
+  process.env.CREWLY_HOME = crewlyHome;
+
+  RequestService.resetInstance();
+  TaskPoolService.resetInstance();
+  setRequestSlaSubscriber(null);
+  setRequestDecomposeSubscriber(null);
+
+  const bus = new EventBusService();
+  const requestService = RequestService.getInstance(tmpRoot);
+  const taskPool = TaskPoolService.getInstance();
+
+  // Wire bus into producers.
+  setRequestServiceEventBus(bus);
+  taskPool.setEventBusService(bus);
+
+  // Bug B (#467): TaskPool → Request linker so addToPool intrinsically
+  // links new WIs into Request.workItemIds[].
+  taskPool.setRequestService(requestService);
+
+  // Bug C (this PR): Request → TaskPool queryable so the close-gate can
+  // verify child terminal state.
+  requestService.setTaskPoolService(taskPool);
+
+  // Live SLA + auto-decompose subscribers (mirror production wiring).
+  const slaSubscriber = new RequestSlaSubscriber({
+    eventBus: bus,
+    requestService,
+    taskPool,
+    orchestratorSession: 'test-orc',
+  });
+  slaSubscriber.start();
+  setRequestSlaSubscriber(slaSubscriber);
+
+  const decomposeSubscriber = new RequestDecomposeSubscriber({
+    eventBus: bus,
+    requestService,
+    taskPool,
+  });
+  decomposeSubscriber.start();
+  setRequestDecomposeSubscriber(decomposeSubscriber);
+
+  return {
+    tmpRoot,
+    bus,
+    requestService,
+    taskPool,
+    slaSubscriber,
+    decomposeSubscriber,
+    cleanup: async () => {
+      decomposeSubscriber.stop();
+      slaSubscriber.stop();
+      setRequestDecomposeSubscriber(null);
+      setRequestSlaSubscriber(null);
+      setRequestServiceEventBus(null);
+      taskPool.setEventBusService(null);
+      taskPool.setRequestService(null);
+      requestService.setTaskPoolService(null);
+      RequestService.resetInstance();
+      TaskPoolService.resetInstance();
+      if (previousCrewlyHome === undefined) {
+        delete process.env.CREWLY_HOME;
+      } else {
+        process.env.CREWLY_HOME = previousCrewlyHome;
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Async predicate spinner with bounded attempts (mirror existing patterns). */
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  attempts = 100,
+): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (await predicate()) return;
+    await new Promise<void>((res) => {
+      const t = setTimeout(res, 10);
+      t.unref?.();
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Request → done lifecycle gate (P1 Bug C, integration)', () => {
+  let fx: IntegrationFixture;
+
+  beforeEach(async () => {
+    fx = await buildFixture();
+  });
+
+  afterEach(async () => {
+    await fx.cleanup();
+  });
+
+  // -------------------------------------------------------------------------
+  // AC5 — F9 fixture repro: queued WI + close attempt → must REFUSE post-fix
+  // -------------------------------------------------------------------------
+
+  it('AC5 (F9 repro): refuses Request → done while child WI is still queued', async () => {
+    // Manually create a Request and addToPool a WI — this is the
+    // pre-decompose-subscriber path that originally produced the F9 symptom.
+    const created = await fx.requestService.create({
+      title: 'F9 fixture repro',
+      description: 'Request with a queued child WI in the pool',
+      sourceConversationItemId: 'slack-F9-repro-1',
+      priority: 'normal',
+      tags: ['bug-c-repro'],
+    });
+
+    const wi = createWorkItem({
+      type: 'delegate',
+      owner: 'agent',
+      target: 'agent-test',
+      title: 'Some queued unit of work',
+      requestId: created.id,
+    });
+    await fx.taskPool.addToPool(wi);
+
+    // Bug B's intrinsic link populates workItemIds[] (no subscriber needed).
+    // Wait for the link to settle in case the link runs after addToPool.
+    await waitFor(async () => {
+      const r = await fx.requestService.getById(created.id);
+      return (r?.workItemIds.length ?? 0) > 0;
+    });
+
+    const linked = await fx.requestService.getById(created.id);
+    expect(linked!.workItemIds).toContain(wi.id);
+
+    // Walk Request to running so 'done' is a valid transition target.
+    await fx.requestService.update(created.id, { status: 'ready' });
+    await fx.requestService.update(created.id, { status: 'running' });
+
+    // Attempt to close — pre-fix this would succeed (the F9 symptom).
+    // Post-fix the gate must refuse.
+    let caught: unknown;
+    try {
+      await fx.requestService.update(created.id, { status: 'done' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(RequestStillHasOpenChildrenError);
+    const e = caught as RequestStillHasOpenChildrenError;
+    expect(e.requestId).toBe(created.id);
+    expect(e.openChildIds).toContain(wi.id);
+
+    // Confirm the Request was NOT mutated by the refused transition.
+    const reloaded = await fx.requestService.getById(created.id);
+    expect(reloaded?.status).toBe('running');
+    expect(reloaded?.completedAt).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // AC6 — Bug B + Bug C composition: full chain
+  // -------------------------------------------------------------------------
+
+  it('AC6: POST L2 → decompose → close-before-done REFUSES → close-after-done SUCCEEDS', async () => {
+    const created = await fx.requestService.create({
+      title: 'Bug B+C composition test',
+      description: 'Build a comprehensive feature that handles user authentication, persists state, and ships with end-to-end tests',
+      sourceConversationItemId: 'slack-bug-c-composition-1',
+      priority: 'normal',
+      tags: ['bug-c-composition'],
+      intentLevel: 'L2',
+      intentCategory: 'code_change',
+    });
+
+    // Drain the auto-decompose + SLA subscribers.
+    await fx.decomposeSubscriber.flushPending();
+    await fx.slaSubscriber.flushPending();
+
+    // Wait for workItemIds[] to populate (Bug B's intrinsic link +
+    // SLA-subscriber's belt-and-suspenders link).
+    await waitFor(async () => {
+      const r = await fx.requestService.getById(created.id);
+      return (r?.workItemIds.length ?? 0) > 0;
+    });
+
+    const decomposed = await fx.requestService.getById(created.id);
+    expect(decomposed!.workItemIds.length).toBeGreaterThan(0);
+
+    // Walk Request to running.
+    await fx.requestService.update(created.id, { status: 'ready' });
+    await fx.requestService.update(created.id, { status: 'running' });
+
+    // Attempt close while children are in their initial (queued) state.
+    let blockingError: unknown;
+    try {
+      await fx.requestService.update(created.id, { status: 'done' });
+    } catch (err) {
+      blockingError = err;
+    }
+    expect(blockingError).toBeInstanceOf(RequestStillHasOpenChildrenError);
+    const blocking = blockingError as RequestStillHasOpenChildrenError;
+    expect(blocking.openChildCount).toBe(decomposed!.workItemIds.length);
+
+    // Now transition every child to a terminal state (done) via the pool's
+    // production transition path so the state-machine guard fires.
+    for (const wiId of decomposed!.workItemIds) {
+      // queued → running → done is the simplest legal path.
+      await fx.taskPool.transitionStatus(wiId, 'running', { actor: 'system' });
+      await fx.taskPool.transitionStatus(wiId, 'done', { actor: 'system' });
+    }
+
+    // Close should now succeed.
+    const done = await fx.requestService.update(created.id, { status: 'done' });
+    expect(done.status).toBe('done');
+    expect(done.completedAt).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Composition guard: Bug B's intrinsic link + Bug C's gate operate on the
+  // same authoritative workItemIds[] — no race between addToPool and close.
+  // -------------------------------------------------------------------------
+
+  it('intrinsic link (Bug B) + gate (Bug C) reject close immediately after addToPool', async () => {
+    const created = await fx.requestService.create({
+      title: 'Race-condition guard',
+      description: 'Closure attempted immediately after addToPool',
+      sourceConversationItemId: 'slack-bug-c-race-1',
+      priority: 'normal',
+    });
+
+    // Walk to running BEFORE adding the WI — verifies the gate fires on
+    // the post-add state, not on a pre-add snapshot.
+    await fx.requestService.update(created.id, { status: 'ready' });
+    await fx.requestService.update(created.id, { status: 'running' });
+
+    const wi = createWorkItem({
+      type: 'delegate',
+      owner: 'agent',
+      target: 'agent-test',
+      title: 'Late-bound child',
+      requestId: created.id,
+    });
+    await fx.taskPool.addToPool(wi);
+
+    // Bug B's intrinsic link is synchronous-after-addToPool; wait for it.
+    await waitFor(async () => {
+      const r = await fx.requestService.getById(created.id);
+      return r?.workItemIds.includes(wi.id) ?? false;
+    });
+
+    await expect(
+      fx.requestService.update(created.id, { status: 'done' }),
+    ).rejects.toBeInstanceOf(RequestStillHasOpenChildrenError);
+  });
+});

--- a/backend/src/services/v3/request-lifecycle-gate.integration.test.ts
+++ b/backend/src/services/v3/request-lifecycle-gate.integration.test.ts
@@ -291,8 +291,8 @@ describe('Request → done lifecycle gate (P1 Bug C, integration)', () => {
     // production transition path so the state-machine guard fires.
     for (const wiId of decomposed!.workItemIds) {
       // queued → running → done is the simplest legal path.
-      await fx.taskPool.transitionStatus(wiId, 'running', { actor: 'system' });
-      await fx.taskPool.transitionStatus(wiId, 'done', { actor: 'system' });
+      await fx.taskPool.transitionStatus(wiId, 'running', 'system');
+      await fx.taskPool.transitionStatus(wiId, 'done', 'system');
     }
 
     // Close should now succeed.

--- a/backend/src/services/v3/request.service.test.ts
+++ b/backend/src/services/v3/request.service.test.ts
@@ -4,9 +4,16 @@
  * @module services/v3/request.service.test
  */
 
-import { RequestService, setRequestServiceEventBus, type RequestPlan } from './request.service.js';
+import {
+  RequestService,
+  setRequestServiceEventBus,
+  RequestStillHasOpenChildrenError,
+  type RequestPlan,
+  type IWorkItemQueryable,
+} from './request.service.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
 import type { AgentEvent } from '../../types/event-bus.types.js';
+import { createWorkItem, type WorkItem, type WorkItemStatus } from '../../types/v2/work-item.types.js';
 
 // Mock file I/O
 const mockFiles = new Map<string, string>();
@@ -290,6 +297,324 @@ describe('RequestService', () => {
       await expect(
         service.update('nonexistent-id', { title: 'nope' }),
       ).rejects.toThrow('Request not found');
+    });
+  });
+
+  // ===========================================================================
+  // P1 Bug C — Request → done lifecycle gate (Pool umbrella WI 72ca743a)
+  // ===========================================================================
+
+  describe('update — Request → done lifecycle gate (P1 Bug C)', () => {
+    /**
+     * Build a fake IWorkItemQueryable backed by an in-memory map. Mirrors
+     * the production TaskPoolService.findWorkItem null-fallthrough idiom.
+     */
+    function buildFakePool(items: WorkItem[]): IWorkItemQueryable {
+      const byId = new Map(items.map((wi) => [wi.id, wi]));
+      return {
+        findWorkItem: jest.fn(async (id: string) => byId.get(id) ?? null),
+      };
+    }
+
+    /** Build a child WI with a specific status, linked to a Request. */
+    function makeChild(requestId: string, status: WorkItemStatus): WorkItem {
+      const wi = createWorkItem({
+        type: 'delegate',
+        owner: 'agent',
+        target: 'agent-test',
+        title: 'child WI',
+        requestId,
+      });
+      // createWorkItem chooses initial status from inputs; force the test
+      // status directly. Bypasses the production transition validator —
+      // intentional for unit-level setup so we can stage every state.
+      (wi as { status: WorkItemStatus }).status = status;
+      return wi;
+    }
+
+    /**
+     * Walk a Request from its initial `open` to `running`. Done lives only
+     * directly off `running` per isValidRequestTransition.
+     */
+    async function walkToRunning(service: RequestService, requestId: string): Promise<void> {
+      await service.update(requestId, { status: 'ready' });
+      await service.update(requestId, { status: 'running' });
+    }
+
+    // -----------------------------------------------------------------------
+    // AC1 — empty workItemIds: backward-compatible historical case
+    // -----------------------------------------------------------------------
+    it('AC1: should allow Request → done when workItemIds=[] (no children)', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      service.setTaskPoolService(buildFakePool([]));
+
+      const created = await service.create({
+        sourceConversationItemId: 'conv-ac1',
+        title: 'AC1 — no children',
+        description: 'Closing a Request with no children',
+      });
+
+      await walkToRunning(service, created.id);
+      const done = await service.update(created.id, { status: 'done' });
+      expect(done.status).toBe('done');
+      expect(done.completedAt).toBeDefined();
+    });
+
+    // -----------------------------------------------------------------------
+    // AC2 — all children terminal: should succeed
+    // -----------------------------------------------------------------------
+    it.each([
+      ['done'],
+      ['verified'],
+      ['cancelled'],
+    ])('AC2: should allow Request → done when all children are %s (terminal)', async (status) => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: `conv-ac2-${status}`,
+        title: `AC2 — ${status}`,
+        description: 'Closing with all-terminal children',
+      });
+
+      const child1 = makeChild(created.id, status as WorkItemStatus);
+      const child2 = makeChild(created.id, status as WorkItemStatus);
+      await service.linkWorkItem(created.id, child1.id);
+      await service.linkWorkItem(created.id, child2.id);
+      service.setTaskPoolService(buildFakePool([child1, child2]));
+
+      await walkToRunning(service, created.id);
+      const done = await service.update(created.id, { status: 'done' });
+      expect(done.status).toBe('done');
+    });
+
+    // -----------------------------------------------------------------------
+    // AC3 — non-terminal child blocks closure
+    // -----------------------------------------------------------------------
+    it.each([
+      ['queued'],
+      ['running'],
+      ['blocked'],
+      ['proposed'],
+      ['accepted'],
+      ['done_by_worker'],
+      ['escalated'],
+      ['scheduled'],
+      ['failed'],     // recoverable per WORK_ITEM_TRANSITIONS — must block
+      ['rejected'],   // recoverable per WORK_ITEM_TRANSITIONS — must block
+    ])('AC3: should refuse Request → done when child is %s (non-terminal)', async (status) => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: `conv-ac3-${status}`,
+        title: `AC3 — ${status}`,
+        description: 'Closing with non-terminal child',
+      });
+
+      const openChild = makeChild(created.id, status as WorkItemStatus);
+      await service.linkWorkItem(created.id, openChild.id);
+      service.setTaskPoolService(buildFakePool([openChild]));
+
+      await walkToRunning(service, created.id);
+
+      let caught: unknown;
+      try {
+        await service.update(created.id, { status: 'done' });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(RequestStillHasOpenChildrenError);
+      const err = caught as RequestStillHasOpenChildrenError;
+      expect(err.requestId).toBe(created.id);
+      expect(err.openChildIds).toEqual([openChild.id]);
+      expect(err.openChildCount).toBe(1);
+      expect(err.message).toContain(created.id);
+      expect(err.message).toContain(openChild.id);
+    });
+
+    // -----------------------------------------------------------------------
+    // AC4 — mixed terminal + non-terminal children: still blocks
+    // -----------------------------------------------------------------------
+    it('AC4: should refuse Request → done with mixed terminal/non-terminal children', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: 'conv-ac4',
+        title: 'AC4 — mixed',
+        description: 'Mixed-state children',
+      });
+
+      const doneChild = makeChild(created.id, 'done');
+      const verifiedChild = makeChild(created.id, 'verified');
+      const queuedChild = makeChild(created.id, 'queued');
+      const runningChild = makeChild(created.id, 'running');
+      for (const c of [doneChild, verifiedChild, queuedChild, runningChild]) {
+        await service.linkWorkItem(created.id, c.id);
+      }
+      service.setTaskPoolService(
+        buildFakePool([doneChild, verifiedChild, queuedChild, runningChild]),
+      );
+
+      await walkToRunning(service, created.id);
+
+      let caught: unknown;
+      try {
+        await service.update(created.id, { status: 'done' });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(RequestStillHasOpenChildrenError);
+      const e = caught as RequestStillHasOpenChildrenError;
+      expect(new Set(e.openChildIds)).toEqual(
+        new Set([queuedChild.id, runningChild.id]),
+      );
+      expect(e.openChildCount).toBe(2);
+    });
+
+    // -----------------------------------------------------------------------
+    // Edge: Request was NOT mutated when the gate refused
+    // -----------------------------------------------------------------------
+    it('should NOT mutate Request status when the gate refuses', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: 'conv-no-mutate',
+        title: 'No-mutation guarantee',
+        description: 'Verifying the gate is fail-fast pre-mutation',
+      });
+
+      const queuedChild = makeChild(created.id, 'queued');
+      await service.linkWorkItem(created.id, queuedChild.id);
+      service.setTaskPoolService(buildFakePool([queuedChild]));
+      await walkToRunning(service, created.id);
+
+      await expect(
+        service.update(created.id, { status: 'done' }),
+      ).rejects.toBeInstanceOf(RequestStillHasOpenChildrenError);
+
+      // Re-read from disk to confirm no partial mutation slipped through.
+      const reloaded = await service.getById(created.id);
+      expect(reloaded?.status).toBe('running');
+      expect(reloaded?.completedAt).toBeUndefined();
+    });
+
+    // -----------------------------------------------------------------------
+    // Edge: gate is `done`-only — `cancelled` may proceed with open children
+    // -----------------------------------------------------------------------
+    it('should NOT gate Request → cancelled (only done is gated)', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: 'conv-cancel',
+        title: 'Cancel with open child',
+        description: 'Cancellation may happen mid-flight',
+      });
+
+      const queuedChild = makeChild(created.id, 'queued');
+      await service.linkWorkItem(created.id, queuedChild.id);
+      service.setTaskPoolService(buildFakePool([queuedChild]));
+
+      const cancelled = await service.update(created.id, { status: 'cancelled' });
+      expect(cancelled.status).toBe('cancelled');
+      expect(cancelled.completedAt).toBeDefined();
+    });
+
+    // -----------------------------------------------------------------------
+    // Edge: deleted/orphaned children (findWorkItem returns null) treated
+    // as harmless — option-a graceful degrade ORC took on historical orphans.
+    // -----------------------------------------------------------------------
+    it('should treat findWorkItem→null (orphaned/purged child) as terminal', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: 'conv-orphan',
+        title: 'Orphan-handling',
+        description: 'Children purged from pool should not deadlock close',
+      });
+
+      // Link two ids; pool returns null for both (purged).
+      await service.linkWorkItem(created.id, 'orphan-1');
+      await service.linkWorkItem(created.id, 'orphan-2');
+      service.setTaskPoolService(buildFakePool([]));
+
+      await walkToRunning(service, created.id);
+      const done = await service.update(created.id, { status: 'done' });
+      expect(done.status).toBe('done');
+    });
+
+    // -----------------------------------------------------------------------
+    // Edge: graceful degrade when taskPoolService is not wired
+    // -----------------------------------------------------------------------
+    it('should degrade gracefully (close anyway, log warning) when pool not wired', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      // intentionally NOT calling setTaskPoolService — emulate a code path
+      // that runs before boot wiring (or a test scaffold).
+      const created = await service.create({
+        sourceConversationItemId: 'conv-unwired',
+        title: 'Unwired gate',
+        description: 'Pre-fix behavior preserved when pool unavailable',
+      });
+
+      const queuedChild = makeChild(created.id, 'queued');
+      await service.linkWorkItem(created.id, queuedChild.id);
+
+      await walkToRunning(service, created.id);
+      const done = await service.update(created.id, { status: 'done' });
+      // Pre-fix behavior: close succeeds even with non-terminal child,
+      // because the gate has no pool to query.
+      expect(done.status).toBe('done');
+    });
+
+    // -----------------------------------------------------------------------
+    // Edge: setTaskPoolService(null) clears the wiring (test isolation)
+    // -----------------------------------------------------------------------
+    it('should allow setTaskPoolService(null) to clear the wiring', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+      const created = await service.create({
+        sourceConversationItemId: 'conv-clear',
+        title: 'Clear-wire test',
+        description: 'null setter clears prior wiring',
+      });
+
+      const queuedChild = makeChild(created.id, 'queued');
+      await service.linkWorkItem(created.id, queuedChild.id);
+
+      // Wire then clear — should fall back to graceful-degrade path.
+      service.setTaskPoolService(buildFakePool([queuedChild]));
+      service.setTaskPoolService(null);
+
+      await walkToRunning(service, created.id);
+      const done = await service.update(created.id, { status: 'done' });
+      expect(done.status).toBe('done');
+    });
+  });
+
+  // ===========================================================================
+  // RequestStillHasOpenChildrenError — error class shape
+  // ===========================================================================
+
+  describe('RequestStillHasOpenChildrenError', () => {
+    it('should expose structured fields on the error instance', () => {
+      const err = new RequestStillHasOpenChildrenError({
+        requestId: 'req-1',
+        openChildIds: ['wi-1', 'wi-2', 'wi-3'],
+      });
+      expect(err.requestId).toBe('req-1');
+      expect(err.openChildIds).toEqual(['wi-1', 'wi-2', 'wi-3']);
+      expect(err.openChildCount).toBe(3);
+      expect(err.name).toBe('RequestStillHasOpenChildrenError');
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(RequestStillHasOpenChildrenError);
+    });
+
+    it('should singularize message when only one child is open', () => {
+      const err = new RequestStillHasOpenChildrenError({
+        requestId: 'req-1',
+        openChildIds: ['wi-1'],
+      });
+      expect(err.message).toContain('1 child WorkItem still in non-terminal');
+      expect(err.message).not.toContain('child WorkItems still');
+    });
+
+    it('should pluralize message when multiple children are open', () => {
+      const err = new RequestStillHasOpenChildrenError({
+        requestId: 'req-1',
+        openChildIds: ['wi-1', 'wi-2'],
+      });
+      expect(err.message).toContain('2 child WorkItems still in non-terminal');
     });
   });
 

--- a/backend/src/services/v3/request.service.ts
+++ b/backend/src/services/v3/request.service.ts
@@ -21,11 +21,89 @@ import {
   validateCreateRequestInput,
   createRequest,
 } from '../../types/v2/index.js';
+import {
+  type WorkItem,
+  TERMINAL_WORK_ITEM_STATUSES,
+} from '../../types/v2/work-item.types.js';
 import { planTasksFromObjective, type PlannedTask } from './v3-data.service.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
 
 /** Directory name under .crewly for request storage. */
 const REQUESTS_DIR = 'requests';
+
+// ---------------------------------------------------------------------------
+// P1 Bug C — Request → done lifecycle gate (Pool umbrella WI 72ca743a)
+// ---------------------------------------------------------------------------
+
+/**
+ * Duck-typed interface RequestService uses to query child WorkItem
+ * states for the {@link RequestService.update} → done gate.
+ *
+ * Defined as an interface (not a TaskPoolService import) so request.service
+ * does NOT acquire a static dependency on task-pool.service. The dependency
+ * direction stays one-way: TaskPool → Request (via Bug B's
+ * `IRequestWorkItemLinker`), Request → TaskPool only via this duck-typed
+ * setter (Bug C). This breaks the otherwise-circular type graph that would
+ * form if either side imported the other concretely.
+ *
+ * Tests pass a fake; production wires the real TaskPoolService instance via
+ * {@link RequestService.setTaskPoolService}.
+ *
+ * P1 Bug C (Pool umbrella WI 72ca743a-3a66-4d0e-a6cf-1a861f849dbd, sub-WI
+ *           72ca743a Bug C): the F9 fixture closed a Request to status=done
+ * with a non-terminal child WI in the pool. The gate fetches each child by
+ * id and refuses the transition if any child is in a non-terminal state.
+ */
+export interface IWorkItemQueryable {
+  /**
+   * Look up a WorkItem by id. Returns `null` if no item has that id —
+   * mirrors {@link TaskPoolService.findWorkItem}'s null-fallthrough idiom.
+   *
+   * @param workItemId - WorkItem id to look up
+   * @returns The WorkItem, or `null` if no item has that id
+   */
+  findWorkItem(workItemId: string): Promise<WorkItem | null>;
+}
+
+/**
+ * Structured error thrown when {@link RequestService.update} refuses to
+ * transition a Request to `done` because at least one of its child
+ * WorkItems is still in a non-terminal state.
+ *
+ * Distinct error class (not a generic `Error`) so callers can branch on
+ * `instanceof RequestStillHasOpenChildrenError` and surface a meaningful
+ * message — Slack bridge, REST consumers, audit, all want to differentiate
+ * "still has open children" from generic transition-validation errors.
+ *
+ * The structured payload exposes `requestId`, `openChildIds`, and
+ * `openChildCount` so consumers can render actionable messages without
+ * re-querying the pool.
+ */
+export class RequestStillHasOpenChildrenError extends Error {
+  /** The Request id that was refused. */
+  public readonly requestId: string;
+  /** WorkItem ids of children that are still in non-terminal status. */
+  public readonly openChildIds: readonly string[];
+  /** Convenience: openChildIds.length, included for log/format symmetry. */
+  public readonly openChildCount: number;
+
+  constructor(args: { requestId: string; openChildIds: readonly string[] }) {
+    const count = args.openChildIds.length;
+    super(
+      `Request '${args.requestId}' cannot transition to 'done': ` +
+      `${count} child WorkItem${count === 1 ? '' : 's'} still in non-terminal ` +
+      `state (${args.openChildIds.join(', ')}). Terminal WI statuses are: ` +
+      `${[...TERMINAL_WORK_ITEM_STATUSES].join(', ')}.`,
+    );
+    this.name = 'RequestStillHasOpenChildrenError';
+    this.requestId = args.requestId;
+    this.openChildIds = args.openChildIds;
+    this.openChildCount = count;
+    // Restore prototype chain — required when extending Error in TS targets
+    // older than ES2015 to keep `instanceof` working through transpilation.
+    Object.setPrototypeOf(this, RequestStillHasOpenChildrenError.prototype);
+  }
+}
 
 /**
  * Module-level event bus reference, wired from `backend/src/index.ts` via
@@ -67,6 +145,20 @@ export class RequestService {
   private readonly requestsDir: string;
 
   /**
+   * Optional TaskPool reference used by the {@link update} → done gate
+   * to verify that all child WorkItems are in terminal state before the
+   * Request itself can close. Wired via {@link setTaskPoolService} from
+   * the backend boot path (P1 Bug C — Pool umbrella WI 72ca743a).
+   *
+   * When `null`, the gate degrades gracefully — closure proceeds with a
+   * warning log. This preserves backward compatibility for tests and
+   * boot orderings that happen to call `update` before the wiring step.
+   * Production paths always wire the dependency before any user-facing
+   * Request close request can land.
+   */
+  private taskPoolService: IWorkItemQueryable | null = null;
+
+  /**
    * Creates a new RequestService.
    *
    * @param projectPath - Absolute path to the project root
@@ -94,6 +186,23 @@ export class RequestService {
    */
   public static resetInstance(): void {
     RequestService.instance = null;
+  }
+
+  /**
+   * Wire the TaskPool-queryable used by the Request → done gate
+   * (P1 Bug C — Pool umbrella WI 72ca743a).
+   *
+   * Called from the backend boot path after both services exist. Mirrors
+   * Bug B's {@link TaskPoolService.setRequestService} — same setter shape,
+   * idempotent, accepts `null` to clear in tests. Keeps the dependency
+   * direction Request → TaskPool one-way and duck-typed, so neither
+   * service needs a static import of the other.
+   *
+   * @param svc - The TaskPoolService instance (or any object satisfying
+   *   {@link IWorkItemQueryable}), or null to clear.
+   */
+  public setTaskPoolService(svc: IWorkItemQueryable | null): void {
+    this.taskPoolService = svc;
   }
 
   // ---------------------------------------------------------------------------
@@ -272,6 +381,27 @@ export class RequestService {
           `Invalid status transition: ${request.status} -> ${updates.status}`,
         );
       }
+
+      // P1 Bug C (Pool umbrella WI 72ca743a) — child WorkItem terminal-state
+      // gate. Refuse Request → done if any child WI in workItemIds[] is in a
+      // non-terminal state. F9 fixture symptom: Request closed to done with a
+      // queued child WI still in the pool. Bug B (#467, merged 8bf58a11) made
+      // workItemIds[] authoritative on every addToPool, so the gate operates
+      // on reliable data.
+      //
+      // Only `done` is gated. `cancelled` is intentionally NOT gated — a
+      // user / TL may cancel a Request while children are mid-flight; the
+      // cancellation cascade (orphaned children) is a separate concern owned
+      // by a future work item.
+      //
+      // The gate degrades gracefully when `taskPoolService` is null (test or
+      // unwired boot order): a warning is logged and the transition proceeds
+      // with the original (pre-fix) behavior. Production wiring runs before
+      // any user-facing close path.
+      if (updates.status === 'done' && request.workItemIds.length > 0) {
+        await this.assertAllChildrenTerminal(request);
+      }
+
       request.status = updates.status;
       if (updates.status === 'done' || updates.status === 'cancelled') {
         request.completedAt = new Date().toISOString();
@@ -297,6 +427,67 @@ export class RequestService {
     await this.save(request);
     this.logger.debug('Request updated', { id, status: request.status });
     return request;
+  }
+
+  /**
+   * P1 Bug C gate helper — verify that every WorkItem id in
+   * `request.workItemIds[]` resolves to a WorkItem in terminal state.
+   *
+   * Throws {@link RequestStillHasOpenChildrenError} when at least one child
+   * is non-terminal. Missing children (returned `null` by
+   * {@link IWorkItemQueryable.findWorkItem}) are treated as **terminal /
+   * harmless** — a deleted-or-purged WI does not block its parent's
+   * closure. This matches the option-a "graceful degrade" stance ORC took
+   * on historical orphan WIs and avoids a deadlock between data-cleanup
+   * jobs and lifecycle gates.
+   *
+   * Semantics: non-terminal = anything not in
+   * {@link TERMINAL_WORK_ITEM_STATUSES} (`done`, `verified`, `cancelled`).
+   * `failed` and `rejected` are treated as non-terminal because the WI
+   * state-machine in {@link WORK_ITEM_TRANSITIONS} explicitly allows them
+   * to re-enter `queued` — work the user requested is not actually
+   * complete.
+   *
+   * @param request - The Request whose children to verify
+   * @throws {@link RequestStillHasOpenChildrenError} when any child is
+   *   non-terminal.
+   */
+  private async assertAllChildrenTerminal(request: Request): Promise<void> {
+    if (!this.taskPoolService) {
+      // Graceful degrade — preserve pre-fix behavior when the gate hasn't
+      // been wired yet (test scaffold, unusual boot order). Production
+      // boot wires the dependency before any user-facing close path.
+      this.logger.warn(
+        'Request → done lifecycle gate skipped: taskPoolService not wired',
+        { requestId: request.id, childCount: request.workItemIds.length },
+      );
+      return;
+    }
+
+    const queryable = this.taskPoolService;
+    const children = await Promise.all(
+      request.workItemIds.map((id) => queryable.findWorkItem(id)),
+    );
+
+    const openChildIds: string[] = [];
+    for (let i = 0; i < children.length; i++) {
+      const wi = children[i];
+      if (wi !== null && !TERMINAL_WORK_ITEM_STATUSES.has(wi.status)) {
+        openChildIds.push(wi.id);
+      }
+    }
+
+    if (openChildIds.length > 0) {
+      this.logger.info('Request → done refused: open child WorkItems', {
+        requestId: request.id,
+        openChildCount: openChildIds.length,
+        openChildIds,
+      });
+      throw new RequestStillHasOpenChildrenError({
+        requestId: request.id,
+        openChildIds,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Pool umbrella WorkItem `72ca743a-3a66-4d0e-a6cf-1a861f849dbd` (Bug C sub-WI). Steve's P1 architectural concern (~01:00Z 2026-05-06) → ORC umbrella decomp → this PR.

The auditor's F9 fixture (Request `ff54231a-02f3-4841-a74c-734a5aca9d09`) was closed to status=done while child WorkItems were still in non-terminal state. Steve's exact ask: **"Request should only fulfill when all WorkItems done — why is it closing fast?"**

This PR adds the gate. Sequenced after Bug B (#467 merged 8bf58a11), which made `Request.workItemIds[]` authoritative on every `addToPool` — without that, this gate would always see empty arrays and trivially pass.

## Fix shape

`RequestService.update()` now refuses `Request → done` when any WI in `request.workItemIds[]` is in a non-terminal state. Throws a structured `RequestStillHasOpenChildrenError` with `requestId`, `openChildIds`, and `openChildCount`.

**Terminal set:** `TERMINAL_WORK_ITEM_STATUSES = {done, verified, cancelled}` per `work-item.types.ts` (canonical). `failed` and `rejected` are treated as **non-terminal** because `WORK_ITEM_TRANSITIONS` allows them to re-enter `queued` — work the user requested is not actually complete. (The brief suggested `{done, cancelled, failed}` but the canonical codebase definition supersedes — documented in commit body.)

**Gate scope:** `done` only. `cancelled` is intentionally **not** gated — a user/TL may cancel a Request while children are mid-flight; the cancellation cascade (orphaning children) is a separate concern owned by a future WI.

**Orphan handling:** `findWorkItem → null` (deleted/purged children) is treated as terminal/harmless to avoid deadlocking on data-cleanup jobs. Matches ORC's option-a stance on historical orphan WIs.

**Graceful degrade:** if `taskPoolService` is null (test scaffold or unusual boot order), the gate logs a warning and proceeds with the pre-fix behavior. Production wiring runs in `index.ts` before any user-facing close path.

## Architecture

Mirrors Bug B's duck-typed setter pattern:
- `IWorkItemQueryable` interface defined in `request.service.ts` — `findWorkItem(id): Promise<WorkItem | null>`.
- `RequestService.setTaskPoolService(svc | null)` setter — same shape as Bug B's `TaskPoolService.setRequestService`. Idempotent, accepts null to clear.
- Boot wiring in `backend/src/index.ts` runs the new line right after Bug B's wiring, comment cross-references Bug B.

Result: dependency direction is one-way duck-typed in both directions — neither `request.service.ts` nor `task-pool.service.ts` imports the other concretely. No static cycle.

## Acceptance criteria (from brief)

- [x] **AC1:** Request with `workItemIds=[]` → close to done succeeds. (Backward compat — historical case.)
- [x] **AC2:** Request with all children terminal → close to done succeeds. (Tested across `done`, `verified`, `cancelled`.)
- [x] **AC3:** Request with at least one non-terminal child → throws `RequestStillHasOpenChildrenError`. (Tested across all 10 non-terminal statuses including recoverable `failed`/`rejected`.)
- [x] **AC4:** Mixed terminal + non-terminal children → still throws.
- [x] **AC5 (integration):** F9 repro — pool 1 WI queued + parent Request, attempt close → REFUSES post-fix. Pre-fix would have succeeded.
- [x] **AC6 (integration):** Bug B+C composition — POST L2 Request → auto-decompose populates `workItemIds[]` via the live event chain → attempt close → REFUSES → walk children to done via `taskPool.transitionStatus` → close → SUCCEEDS.
- [ ] **AC7 (manual smoke):** Slack end-to-end. Deferred to post-merge — same protocol Bug B used.

## Files changed

| File | Change |
|------|--------|
| `backend/src/services/v3/request.service.ts` | + `IWorkItemQueryable`, + `RequestStillHasOpenChildrenError`, + `setTaskPoolService` setter, + `assertAllChildrenTerminal` gate helper, gate invocation in `update()` |
| `backend/src/services/v3/request.service.test.ts` | +23 unit tests (AC1, AC2 × 3 terminal, AC3 × 10 non-terminal, AC4, no-mutation, cancelled-not-gated, orphans, graceful-degrade, null-clear, error-class shape × 3) |
| `backend/src/services/v3/request-lifecycle-gate.integration.test.ts` | NEW — 3 integration tests (AC5, AC6, race-guard) using the same fixture pattern as `request-decompose-auto.integration.test` |
| `backend/src/index.ts` | Wire `RequestService.setTaskPoolService(TaskPoolService)` after Bug B's wiring |

## Test results

- `request.service.test.ts`: **48/48 pass** (was 25; +23 new Bug C tests)
- `request-lifecycle-gate.integration.test.ts`: **3/3 pass** (new)
- `npm run build:backend`: clean
- typecheck: clean
- v3 + task-pool broad sweep: 23 suites pass. 8 suites fail with **pre-existing** issues (vitest imports, missing `createMonthlyPeriod` export, plus 1 unrelated assertion in `request-notification.service.test`) — verified all 8 fail identically on `main` (commit `f914d32d`). Not introduced by Bug C.

## Out of scope (per brief)

- Backfilling historical Requests that closed prematurely (cosmetic; ORC option-a accept).
- Auto-cascade close (when last child closes, auto-close parent) — separate WI.
- Partial-write data bug `b7840fe8` — pool-claim umbrella `1ffffb84`, not Bug C.
- Bug A (intent classifier) — Leo on it parallel.

## Co-existence

- Leo on Bug A v0 — orthogonal codepath.
- Max post-Bug-B free.
- Pool-claim umbrella `1ffffb84` + `d5656813` parked.

## Authority / cadence

Per dispatch: ship-with-Arch protocol same as B0/B1/F8/dogfood/466/467/468. Reply on PR-open (this), Arch-blocker, test-fail, spec-contradiction, or ETA-past-3h. Within ETA budget (~2h actual including F4 fix-loop and one harness-induced re-apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)