### PR TITLE
feat(v3): P1 Bug A v0 — intent classifier ZH parity + L3 tier (umbrella 72ca743a)

### DIFF
--- a/backend/src/services/intent-task/intent-classifier.fixture.test.ts
+++ b/backend/src/services/intent-task/intent-classifier.fixture.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Fixture-driven integration tests for the intent classifier.
+ *
+ * Runs the regression fixtures from `intent-classifier.fixture.ts`
+ * through the canonical classifier entry points
+ * (`classifyIntentLevel`/`classifyIntentCategory`/`isActionableIntent`).
+ *
+ * **Failure-message contract:** the test name embeds the input + expected
+ * level so a failing test points the engineer at the exact rule that
+ * broke. The fixture's `rationale` field is logged via console.error
+ * on failure so the spec section is one click away from the failure.
+ *
+ * @module services/intent-task/intent-classifier.fixture.test
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  classifyIntentLevel,
+  classifyIntentCategory,
+  isActionableIntent,
+} from '../../types/intent-task.types.js';
+import {
+  STEVE_DOGFOOD_FIXTURES,
+  NEGATIVE_L2_FIXTURES,
+  NON_ACTIONABLE_FIXTURES,
+  L3_FIXTURES,
+} from './intent-classifier.fixture.js';
+
+describe('Steve dogfood mis-labels — must classify L2 with correct category', () => {
+  it.each(STEVE_DOGFOOD_FIXTURES)(
+    'L2: $input',
+    ({ input, expectedLevel, expectedCategory, rationale }) => {
+      const level = classifyIntentLevel(input);
+      const category = classifyIntentCategory(input);
+      if (level !== expectedLevel) {
+        // eslint-disable-next-line no-console
+        console.error(`FIXTURE FAIL [level]: input='${input}' rationale='${rationale}'`);
+      }
+      if (category !== expectedCategory) {
+        // eslint-disable-next-line no-console
+        console.error(`FIXTURE FAIL [category]: input='${input}' rationale='${rationale}'`);
+      }
+      expect(level).toBe(expectedLevel);
+      expect(category).toBe(expectedCategory);
+    },
+  );
+});
+
+describe('Negative-L2 (Mia §3 anti-promotion guard)', () => {
+  it.each(NEGATIVE_L2_FIXTURES)(
+    '$expectedLevel: $input',
+    ({ input, expectedLevel, expectedCategory, rationale }) => {
+      const level = classifyIntentLevel(input);
+      const category = classifyIntentCategory(input);
+      if (level !== expectedLevel) {
+        // eslint-disable-next-line no-console
+        console.error(`FIXTURE FAIL [level]: input='${input}' rationale='${rationale}'`);
+      }
+      if (category !== expectedCategory) {
+        // eslint-disable-next-line no-console
+        console.error(`FIXTURE FAIL [category]: input='${input}' rationale='${rationale}'`);
+      }
+      expect(level).toBe(expectedLevel);
+      expect(category).toBe(expectedCategory);
+      // Critical: NEVER L2/L3 for these inputs.
+      expect(level).not.toBe('L2');
+      expect(level).not.toBe('L3');
+    },
+  );
+});
+
+describe('Non-actionable filter — must reject before classification', () => {
+  it.each(NON_ACTIONABLE_FIXTURES)('rejects: $input', ({ input, rationale }) => {
+    const actionable = isActionableIntent(input);
+    if (actionable) {
+      // eslint-disable-next-line no-console
+      console.error(`FIXTURE FAIL [actionable]: input='${input}' rationale='${rationale}'`);
+    }
+    expect(actionable).toBe(false);
+  });
+});
+
+describe('L3 fixtures — sprint/OKR markers + system-level scope', () => {
+  it.each(L3_FIXTURES)('L3: $input', ({ input, expectedLevel, rationale }) => {
+    const level = classifyIntentLevel(input);
+    if (level !== expectedLevel) {
+      // eslint-disable-next-line no-console
+      console.error(`FIXTURE FAIL [level]: input='${input}' rationale='${rationale}'`);
+    }
+    expect(level).toBe(expectedLevel);
+  });
+});

--- a/backend/src/services/intent-task/intent-classifier.fixture.ts
+++ b/backend/src/services/intent-task/intent-classifier.fixture.ts
@@ -1,0 +1,233 @@
+/**
+ * Intent classifier regression fixtures.
+ *
+ * **Source-of-truth contract (Mia §6):**
+ *
+ * - **L2-positive cases** — Steve dogfood mis-labels from 2026-05-06.
+ *   Pre-Bug-A these classified as L1/other (Steve's "ORC ignored half my
+ *   message" symptom). v0 ships with the 2 confirmed-by-name cases; Sam
+ *   is harvesting the remaining ~5 messages from Slack and will append.
+ * - **Negative-L2 cases** — at least one example per row of Mia §3 must
+ *   stay at the listed tier. This is the over-promotion guard: the
+ *   classifier must never promote these to L2 even if a future rule
+ *   tweak adds coverage we didn't anticipate.
+ * - **L3 cases** — sprint/OKR-shaped messages that should classify as L3
+ *   (label only; v0 routes L3=L2 internally per Mia §5 Q1 default).
+ *
+ * Each entry's `rationale` field links back to the spec section so a
+ * future regression points the engineer directly at the rule they broke.
+ *
+ * Spec: `specs/2026-05-06-intent-classifier-rules.md`.
+ *
+ * @module services/intent-task/intent-classifier.fixture
+ */
+
+import type { IntentLevel, IntentCategory } from '../../types/v2/request.types.js';
+
+/**
+ * One regression fixture entry. Every field is required so a failure
+ * message includes enough context for the engineer to triage without
+ * re-reading the spec.
+ */
+export interface ClassifierFixture {
+  /** The exact user input — verbatim where possible. */
+  input: string;
+  /** Expected `classifyIntentLevel` output. */
+  expectedLevel: IntentLevel;
+  /** Expected `classifyIntentCategory` output. */
+  expectedCategory: IntentCategory;
+  /**
+   * Free-form rationale linking back to the spec section. Format:
+   * "§N.M [language] [rule name]". Surfaces in test failure messages.
+   */
+  rationale: string;
+  /** Provenance of the case (Steve Slack / Mia spec / synthesised). */
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// L2-positive — Steve dogfood mis-labels (Mia §4)
+// ---------------------------------------------------------------------------
+
+/**
+ * Steve's mis-labeled messages from 2026-05-06. These MUST classify as
+ * L2 with the correct category. Pre-Bug-A all of these returned L1/other
+ * → 1 WorkItem instead of N → "ORC ignored half my message" symptom.
+ *
+ * Sam is harvesting cases #3-#7 from the Slack transcript; v0 ships
+ * with #1 + #2 (Mia-confirmed) + a placeholder bound to the planning
+ * Request (`ff54231a` from PR #461 F9).
+ */
+export const STEVE_DOGFOOD_FIXTURES: ClassifierFixture[] = [
+  {
+    input: '做这两份 md 文档',
+    expectedLevel: 'L2',
+    expectedCategory: 'code_change',
+    rationale: '§2.1 ZH quantifier trigram (这两份 + 做 + md 文档)',
+    source: 'Steve Slack 2026-05-06 (Mia spec §4 case #1)',
+  },
+  {
+    input: 'oss重启了 你现在再做这个',
+    expectedLevel: 'L2',
+    expectedCategory: 'code_change',
+    rationale: '§2.5 ZH cross-system pivot (重启了 + 现在 + 再做)',
+    source: 'Steve Slack 2026-05-06 (Mia spec §4 case #2)',
+  },
+  {
+    // Real-data case from PR #461 F9 fixture (request ff54231a). Pre-Bug-A
+    // this classified as L2/planning correctly thanks to "规划/计划/方案"
+    // matching the legacy planning regex — but only because the message
+    // happened to contain those words. The Mia §2 promoters now make this
+    // robust to phrasings that don't include those exact words.
+    input:
+      'Steve 2026-05-06 directive: 按这两份文档安排团队推进 P0 执行。请 plan() 拆解为 WorkItems：每个 P0 change 一个 WorkItem。',
+    expectedLevel: 'L2',
+    expectedCategory: 'planning',
+    rationale: '§2.1 ZH quantifier (这两份文档) + §2.4 ZH numbered planning + §2.7 charCount > 80',
+    source: 'Steve Slack 2026-05-06 (PR #461 F9 fixture, ff54231a)',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Negative-L2 — Mia §3 anti-promotion guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Cases that MUST NOT classify as L2 even after the promoters fire on
+ * adjacent text. At least one example per row of Mia §3.
+ *
+ * The most-load-bearing assertion is the "quantifier alone" guard: a
+ * quantified read query ("show me all 3 statuses") stays L0, not L2.
+ */
+export const NEGATIVE_L2_FIXTURES: ClassifierFixture[] = [
+  // Row 1 — pure status / read query (EN)
+  {
+    input: 'what is the deployment status',
+    expectedLevel: 'L0',
+    expectedCategory: 'query',
+    rationale: '§3 row 1 EN: pure read, no state change',
+    source: 'Mia spec §3 row 1',
+  },
+  // Row 1 — pure status / read query (ZH)
+  {
+    input: '现在的状态是什么',
+    expectedLevel: 'L0',
+    expectedCategory: 'query',
+    rationale: '§3 row 1 ZH: pure read, no state change',
+    source: 'Mia spec §3 row 1',
+  },
+  // Row 2 — quantified read (the canonical anti-pattern)
+  {
+    input: 'show me all 3 statuses',
+    expectedLevel: 'L0',
+    expectedCategory: 'query',
+    rationale: '§3 row 2 + last paragraph: quantifier + READ verb stays L0',
+    source: 'Mia spec §3 row 2 (anti-pattern guard)',
+  },
+  // Row 3 — single bounded directive (EN)
+  {
+    input: 'rename foo to bar',
+    expectedLevel: 'L1',
+    expectedCategory: 'code_change',
+    rationale: '§3 row 3 EN: single bounded directive',
+    source: 'Mia spec §3 row 3',
+  },
+  // Row 3 — single bounded directive (ZH)
+  {
+    input: '把 x 改成 y',
+    expectedLevel: 'L1',
+    expectedCategory: 'code_change',
+    rationale: '§3 row 3 ZH: single bounded directive',
+    source: 'Mia spec §3 row 3',
+  },
+  // Row 4 — single-arg ops
+  {
+    input: 'restart the api service',
+    expectedLevel: 'L1',
+    expectedCategory: 'code_change',
+    rationale: '§3 row 4: single-arg ops',
+    source: 'Mia spec §3 row 4',
+  },
+  // Row 5 — pure communication (EN)
+  {
+    input: 'tell Sam to review the PR',
+    expectedLevel: 'L1',
+    expectedCategory: 'review',
+    rationale: '§3 row 5 EN: pure communication, single Slack-side action',
+    source: 'Mia spec §3 row 5',
+  },
+  // Row 5 — pure communication (ZH)
+  {
+    input: '告诉 Sam 审查一下 PR',
+    expectedLevel: 'L1',
+    expectedCategory: 'review',
+    rationale: '§3 row 5 ZH: pure communication',
+    source: 'Mia spec §3 row 5',
+  },
+  // Row 6 — single test run. The classifier's category is 'other' for
+  // pure test-run commands (no authoring verb in the code_change set);
+  // the level — L1 — is what the spec asserts. Category stability is
+  // not load-bearing for the spec's anti-promotion guard.
+  {
+    input: 'run the tests',
+    expectedLevel: 'L1',
+    expectedCategory: 'other',
+    rationale: '§3 row 6: single test run, no authoring (level=L1 is the load-bearing assertion)',
+    source: 'Mia spec §3 row 6',
+  },
+];
+
+/**
+ * Filtered cases — should be rejected by `isActionableIntent` before
+ * classification. These never reach the L0/L1/L2/L3 classifier; the
+ * fixture asserts that fact.
+ */
+export const NON_ACTIONABLE_FIXTURES: { input: string; rationale: string; source: string }[] = [
+  // Acks
+  { input: 'ok', rationale: '§3 row 7 EN ack', source: 'Mia spec §3 row 7' },
+  { input: '好的', rationale: '§3 row 7 ZH ack', source: 'Mia spec §3 row 7' },
+  { input: '收到', rationale: '§3 row 7 ZH ack', source: 'Mia spec §3 row 7' },
+  // Discussion / opinion
+  { input: 'I think we should refactor', rationale: '§3 row 8 EN opinion', source: 'Mia spec §3 row 8' },
+  { input: '我觉得这个不太对', rationale: '§3 row 8 ZH opinion', source: 'Mia spec §3 row 8' },
+  // FYI / status-share
+  { input: 'I just merged PR 123', rationale: '§3 row 9 EN FYI', source: 'Mia spec §3 row 9' },
+  { input: '我刚 push 了', rationale: '§3 row 9 ZH FYI', source: 'Mia spec §3 row 9' },
+  // Apology / confirmation
+  { input: 'sorry about that', rationale: '§3 row 10 EN', source: 'Mia spec §3 row 10' },
+  { input: '抱歉', rationale: '§3 row 10 ZH', source: 'Mia spec §3 row 10' },
+  // Greeting
+  { input: 'hi', rationale: '§3 row 12 EN greeting', source: 'Mia spec §3 row 12' },
+  { input: '你好', rationale: '§3 row 12 ZH greeting', source: 'Mia spec §3 row 12' },
+  // Mia stricter-default — capability denial / botched
+  { input: '做不到', rationale: 'Mia stricter 2026-05-06: ZH capability denial', source: 'Mia inline 2026-05-06' },
+  { input: '搞不定', rationale: 'Mia stricter 2026-05-06: ZH capability denial', source: 'Mia inline 2026-05-06' },
+  { input: '搞砸了', rationale: 'Mia stricter 2026-05-06: ZH botched', source: 'Mia inline 2026-05-06' },
+  // Completed action
+  { input: '做完了', rationale: 'Mia stricter 2026-05-06: ZH completed (no imperative prefix)', source: 'Mia inline 2026-05-06' },
+];
+
+// ---------------------------------------------------------------------------
+// L3 cases — sprint / OKR initiative
+// ---------------------------------------------------------------------------
+
+/**
+ * Sprint/OKR-shaped messages that should classify as L3 (label only; v0
+ * routes L3=L2 internally). At least one ZH case asserts the parity.
+ */
+export const L3_FIXTURES: ClassifierFixture[] = [
+  {
+    input: '这周搞定 KR3 onboarding ≤ 5 分钟',
+    expectedLevel: 'L3',
+    expectedCategory: 'planning',
+    rationale: '§2.6 ZH (这周 + KR3 + 搞定) — sprint marker + deliver verb',
+    source: 'Mia spec §1.3 example',
+  },
+  {
+    input: 'ship Sprint 4 by Friday with the new auth feature',
+    expectedLevel: 'L3',
+    expectedCategory: 'planning',
+    rationale: '§2.6 EN (Sprint + Friday + ship) + §2.3 EN (feature)',
+    source: 'Mia spec §1.3 example',
+  },
+];

--- a/backend/src/services/intent-task/intent-classifier.rules.test.ts
+++ b/backend/src/services/intent-task/intent-classifier.rules.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Smoke tests for the rule-set exported by
+ * `intent-classifier.rules.ts`. The classifier consumer logic is tested
+ * end-to-end in `intent-task.types.test.ts` and the fixture suite —
+ * this file pins each individual rule so an inadvertent regex tweak
+ * lands as a localised failure rather than a multi-rule cascade.
+ *
+ * @module services/intent-task/intent-classifier.rules.test
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import {
+  L2_QUANTIFIER_TRIGRAM,
+  L2_TRIGRAM_STATE_CHANGE_VERB,
+  L2_TRIGRAM_DELIVERABLE,
+  L2_DOC_CREATION_TRIGGER,
+  L2_FILE_EXTENSION_TRIGGER,
+  L2_PR_ARTIFACT_TRIGGER,
+  L2_MIGRATION_TRIGGER,
+  L2_BUILD_SYSTEM_NOUN,
+  L2_DEPLOY_ENV_NOUN,
+  L2_E2E_SCOPE,
+  L2_COORDINATE,
+  L2_SEQUENCED_VERBS,
+  L2_NUMBERED_LIST,
+  L2_CROSS_SYSTEM_PIVOT,
+  L3_SPRINT_OKR_MARKERS,
+  L3_TIMEBOX_MARKERS,
+  L3_DELIVER_SHIP_VERBS,
+  L0_READ_VERB_PATTERN,
+  ACTION_VERB_EN,
+  ACTION_VERB_ZH,
+  NON_ACTIONABLE_PATTERNS_ZH,
+  CATEGORY_KEYWORDS,
+  L2_LENGTH_FLOORS,
+} from './intent-classifier.rules.js';
+
+describe('§2.1 — quantifier trigram (3-axis check)', () => {
+  // The trigram is the AND of three axes: quantifier + state-change verb +
+  // deliverable noun. The classifier checks all three; these tests pin
+  // each axis individually.
+  it('EN: all three axes fire for "create three reports about the issue"', () => {
+    const input = 'create three reports about the issue';
+    expect(L2_QUANTIFIER_TRIGRAM.en.test(input)).toBe(true);
+    expect(L2_TRIGRAM_STATE_CHANGE_VERB.en.test(input)).toBe(true);
+    expect(L2_TRIGRAM_DELIVERABLE.en.test(input)).toBe(true);
+  });
+
+  it('EN: all three axes fire for "build all five services"', () => {
+    const input = 'build all five services';
+    expect(L2_QUANTIFIER_TRIGRAM.en.test(input)).toBe(true);
+    expect(L2_TRIGRAM_STATE_CHANGE_VERB.en.test(input)).toBe(true);
+    expect(L2_TRIGRAM_DELIVERABLE.en.test(input)).toBe(true);
+  });
+
+  it('ZH: all three axes fire for the canonical Steve mis-label "做这两份 md 文档"', () => {
+    const input = '做这两份 md 文档';
+    expect(L2_QUANTIFIER_TRIGRAM.zh.test(input)).toBe(true);
+    expect(L2_TRIGRAM_STATE_CHANGE_VERB.zh.test(input)).toBe(true);
+    expect(L2_TRIGRAM_DELIVERABLE.zh.test(input)).toBe(true);
+  });
+
+  it('ZH: all three axes fire for "写三个 spec"', () => {
+    const input = '写三个 spec';
+    expect(L2_QUANTIFIER_TRIGRAM.zh.test(input)).toBe(true);
+    expect(L2_TRIGRAM_STATE_CHANGE_VERB.zh.test(input)).toBe(true);
+    expect(L2_TRIGRAM_DELIVERABLE.zh.test(input)).toBe(true);
+  });
+
+  it('"show me all 3 statuses" — quantifier fires but state-change verb does NOT', () => {
+    // Mia §3 anti-pattern: quantified read stays L0. The quantifier axis
+    // matches "all 3" but the state-change verb axis must NOT — "show"
+    // is read-only and not in the state-change set.
+    const input = 'show me all 3 statuses';
+    expect(L2_QUANTIFIER_TRIGRAM.en.test(input)).toBe(true);
+    expect(L2_TRIGRAM_STATE_CHANGE_VERB.en.test(input)).toBe(false);
+  });
+});
+
+describe('§2.2 — multi-artifact triggers', () => {
+  it('doc creation matches "spec" / "design doc" / "RFC"', () => {
+    expect(L2_DOC_CREATION_TRIGGER.en.test('write a design doc for X')).toBe(true);
+    expect(L2_DOC_CREATION_TRIGGER.en.test('draft an RFC')).toBe(true);
+    expect(L2_DOC_CREATION_TRIGGER.zh.test('写一份设计文档')).toBe(true);
+    expect(L2_DOC_CREATION_TRIGGER.zh.test('草稿一份 md 文档')).toBe(true);
+  });
+
+  it('file-with-extension matches paths ending in .ts/.md/.sql/.tf', () => {
+    expect(L2_FILE_EXTENSION_TRIGGER.test('update foo.ts and bar.md')).toBe(true);
+    expect(L2_FILE_EXTENSION_TRIGGER.test('migrate schema.sql')).toBe(true);
+    expect(L2_FILE_EXTENSION_TRIGGER.test('deploy main.tf')).toBe(true);
+  });
+
+  it('PR artifact matches "open a PR" / "create a branch" / "提交 PR"', () => {
+    expect(L2_PR_ARTIFACT_TRIGGER.en.test('open a PR for the fix')).toBe(true);
+    expect(L2_PR_ARTIFACT_TRIGGER.en.test('create a new branch')).toBe(true);
+    expect(L2_PR_ARTIFACT_TRIGGER.zh.test('提交一个 PR')).toBe(true);
+  });
+
+  it('migration matches "migration" / "schema" / "迁移"', () => {
+    expect(L2_MIGRATION_TRIGGER.en.test('add a migration for users table')).toBe(true);
+    expect(L2_MIGRATION_TRIGGER.zh.test('做数据迁移')).toBe(true);
+  });
+});
+
+describe('§2.3 — verb–noun pair signaling system-level work', () => {
+  it('build/system: EN + ZH parity', () => {
+    expect(L2_BUILD_SYSTEM_NOUN.en.test('implement a new feature')).toBe(true);
+    expect(L2_BUILD_SYSTEM_NOUN.zh.test('实现新功能')).toBe(true);
+    expect(L2_BUILD_SYSTEM_NOUN.zh.test('重构系统模块')).toBe(true);
+  });
+
+  it('deploy/env: EN + ZH parity', () => {
+    expect(L2_DEPLOY_ENV_NOUN.en.test('deploy to staging')).toBe(true);
+    expect(L2_DEPLOY_ENV_NOUN.zh.test('部署到生产环境')).toBe(true);
+  });
+
+  it('e2e/full-stack: EN + ZH parity', () => {
+    expect(L2_E2E_SCOPE.en.test('end-to-end test setup')).toBe(true);
+    expect(L2_E2E_SCOPE.zh.test('端到端测试搭建')).toBe(true);
+  });
+
+  it('coordinate/orchestrate: single-token signal in EN + ZH', () => {
+    expect(L2_COORDINATE.en.test('coordinate the team')).toBe(true);
+    expect(L2_COORDINATE.zh.test('协调一下')).toBe(true);
+    expect(L2_COORDINATE.zh.test('编排执行计划')).toBe(true);
+  });
+});
+
+describe('§2.4 — sequenced verbs / numbered list', () => {
+  it('sequenced verbs in EN + ZH', () => {
+    expect(L2_SEQUENCED_VERBS.en.test('build and then deploy')).toBe(true);
+    expect(L2_SEQUENCED_VERBS.zh.test('先实现 然后测试')).toBe(true);
+    expect(L2_SEQUENCED_VERBS.zh.test('先做 A 再做 B')).toBe(true);
+  });
+
+  it('numbered list with 1./2. or ①②', () => {
+    expect(L2_NUMBERED_LIST.test('1. fix bug 2. write test')).toBe(true);
+    expect(L2_NUMBERED_LIST.test('①修复 ②测试')).toBe(true);
+  });
+});
+
+describe('§2.5 — cross-system pivot ("oss重启了 你现在再做这个")', () => {
+  it('matches the canonical Steve mis-label', () => {
+    expect(L2_CROSS_SYSTEM_PIVOT.zh.test('oss重启了 你现在再做这个')).toBe(true);
+  });
+
+  it('matches restart + redirect in EN', () => {
+    expect(L2_CROSS_SYSTEM_PIVOT.en.test('server is back, now continue the work')).toBe(true);
+  });
+
+  it('matches "好了 现在开始做"', () => {
+    expect(L2_CROSS_SYSTEM_PIVOT.zh.test('好了 现在开始做')).toBe(true);
+  });
+});
+
+describe('§2.6 — sprint / OKR / timebox markers', () => {
+  it('sprint markers in EN + ZH', () => {
+    expect(L3_SPRINT_OKR_MARKERS.en.test('Sprint 4 planning')).toBe(true);
+    expect(L3_SPRINT_OKR_MARKERS.en.test('OKR for Q1')).toBe(true);
+    expect(L3_SPRINT_OKR_MARKERS.zh.test('这次冲刺')).toBe(true);
+    expect(L3_SPRINT_OKR_MARKERS.zh.test('KR3 onboarding')).toBe(true);
+  });
+
+  it('timebox markers in EN + ZH', () => {
+    expect(L3_TIMEBOX_MARKERS.en.test('this week')).toBe(true);
+    expect(L3_TIMEBOX_MARKERS.en.test('by Friday')).toBe(true);
+    expect(L3_TIMEBOX_MARKERS.zh.test('这周搞定')).toBe(true);
+    expect(L3_TIMEBOX_MARKERS.zh.test('下周交付')).toBe(true);
+  });
+
+  it('deliver / ship verbs in EN + ZH', () => {
+    expect(L3_DELIVER_SHIP_VERBS.en.test('ship by tonight')).toBe(true);
+    expect(L3_DELIVER_SHIP_VERBS.zh.test('上线发布')).toBe(true);
+    expect(L3_DELIVER_SHIP_VERBS.zh.test('交付落地')).toBe(true);
+  });
+});
+
+describe('§3 — read-verb anti-promotion guard', () => {
+  it('EN read verbs do NOT match the action-verb pattern as state-change', () => {
+    expect(L0_READ_VERB_PATTERN.en.test('show me the status')).toBe(true);
+    expect(L0_READ_VERB_PATTERN.en.test('how many agents are active')).toBe(true);
+  });
+
+  it('ZH read verbs match the read-only pattern', () => {
+    expect(L0_READ_VERB_PATTERN.zh.test('查看状态')).toBe(true);
+    expect(L0_READ_VERB_PATTERN.zh.test('多少个 agent')).toBe(true);
+  });
+});
+
+describe('Action verbs (EN + ZH)', () => {
+  it('EN action verbs fire on canonical imperatives', () => {
+    expect(ACTION_VERB_EN.test('fix the bug')).toBe(true);
+    expect(ACTION_VERB_EN.test('build a feature')).toBe(true);
+    expect(ACTION_VERB_EN.test('deploy to staging')).toBe(true);
+  });
+
+  it('ZH action verbs fire on canonical imperatives', () => {
+    expect(ACTION_VERB_ZH.test('修复登录 bug')).toBe(true);
+    expect(ACTION_VERB_ZH.test('部署到生产')).toBe(true);
+    expect(ACTION_VERB_ZH.test('实现登录功能')).toBe(true);
+  });
+
+  it('ZH stricter: bare 做 fires when imperative-shaped', () => {
+    expect(ACTION_VERB_ZH.test('做这件事')).toBe(true);
+    expect(ACTION_VERB_ZH.test('做完成')).toBe(true);
+  });
+
+  it('ZH stricter: 做了 / 做不到 / 搞砸 do NOT fire as actionable verbs', () => {
+    // Negative-lookahead removes the conversational-filler / capability-denial forms.
+    // Note: the verb pattern alone might still match other tokens in the sentence;
+    // these tests pin that the BARE-form forbidden suffixes are not the match anchor.
+    // We verify by matching a string that ONLY contains the forbidden form.
+    expect(ACTION_VERB_ZH.test('做了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做过了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做不到')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做不了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('搞砸了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('搞错了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('搞不定')).toBe(false);
+  });
+});
+
+describe('Non-actionable ZH patterns (Mia stricter-default)', () => {
+  it('greetings / pleasantries are filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('你好'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('多谢'))).toBe(true);
+  });
+
+  it('acknowledgements are filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('好的'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('收到'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('知道了'))).toBe(true);
+  });
+
+  it('opinion / discussion is filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('我觉得这个不太对'))).toBe(true);
+  });
+
+  it('completed-action FYI is filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('我刚 push 了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('做完了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('已经搞定了'))).toBe(true);
+  });
+
+  it('capability-denial is filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('做不到'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('搞不定'))).toBe(true);
+  });
+
+  it('botched-verb short messages are filtered', () => {
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('搞砸了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('搞错了'))).toBe(true);
+  });
+});
+
+describe('Category keywords (EN + ZH parity per Mia §2.3)', () => {
+  it.each<[keyof typeof CATEGORY_KEYWORDS, string, string]>([
+    ['debugging', 'fix the bug', '修复故障'],
+    ['deployment', 'deploy to production', '部署到生产'],
+    ['review', 'review the PR', '评审代码'],
+    ['research', 'investigate the issue', '调研一下'],
+    ['planning', 'plan the roadmap', '规划路线图'],
+    ['communication', 'notify the team', '通知团队'],
+    ['codeChange', 'implement the feature', '实现功能'],
+    ['query', 'what is the status', '查看状态'],
+  ])('%s — EN "%s" + ZH "%s"', (key, en, zh) => {
+    const set = CATEGORY_KEYWORDS[key];
+    expect(set.en.test(en.toLowerCase())).toBe(true);
+    expect(set.zh.test(zh)).toBe(true);
+  });
+});
+
+describe('L2_LENGTH_FLOORS', () => {
+  it('exposes EN word-count + ZH char-count floors', () => {
+    expect(L2_LENGTH_FLOORS.wordCount).toBe(35);
+    expect(L2_LENGTH_FLOORS.charCount).toBe(80);
+  });
+});

--- a/backend/src/services/intent-task/intent-classifier.rules.ts
+++ b/backend/src/services/intent-task/intent-classifier.rules.ts
@@ -1,0 +1,437 @@
+/**
+ * Intent classifier rules — code-of-record per Mia spec §5 Q4.
+ *
+ * **Purpose**
+ *
+ * Centralises every keyword set and structural pattern the L0/L1/L2/L3
+ * classifier consumes. Both production classifier paths
+ * (`backend/src/types/intent-task.types.ts:classifyIntentLevel/Category`
+ * and `backend/src/services/v3/v3-data.service.ts:classifyIntent`) read
+ * from this file so a rule update lands in exactly one place.
+ *
+ * **Why a separate file?**
+ *
+ * Per Mia: "Easier review than buried regex." A reviewer auditing rule
+ * coverage scans this file's exports rather than walking the classifier's
+ * inline regex. Adding ZH parity to a category is a single-edit operation
+ * here; in the inline shape it would be a ~10-line walk.
+ *
+ * **Spec source-of-truth**
+ *
+ * `specs/2026-05-06-intent-classifier-rules.md` (Mia, 2026-05-06).
+ * Section references (§2.1, §2.2, etc.) below correspond to that doc.
+ *
+ * @module services/intent-task/intent-classifier.rules
+ */
+
+// ---------------------------------------------------------------------------
+// §2.1 — Plurality / quantifier (HIGHEST PRECISION)
+// ---------------------------------------------------------------------------
+
+/**
+ * Quantifier tokens that, when paired with a state-changing verb AND a
+ * plural deliverable noun, force L1 → L2 promotion (§2.1).
+ *
+ * Anti-pattern guard (§3 last paragraph): quantifier alone is NOT enough.
+ * "Show me all 3 statuses" stays L0 because the verb is read-only.
+ * Promotion requires quantifier + state-changing verb + plural deliverable
+ * noun — see {@link L2_QUANTIFIER_PROMOTERS_TRIGRAM}.
+ */
+export const QUANTIFIER_TOKENS = {
+  /** EN: both/all/every/each + numeric + numeric-words. */
+  en: /\b(both|all|every|each|two|three|four|five|six|seven|eight|nine|ten|\d+)\b/i,
+  /** ZH: 这两/三/四/五/.../多个/所有/全部/每个/几个. */
+  zh: /(两|三|四|五|六|七|八|九|十|这两|这三|多个|所有|全部|每个|几个)/,
+} as const;
+
+/**
+ * Plural deliverable noun tokens that, paired with a quantifier + state-
+ * changing verb, force L2 promotion (§2.1).
+ *
+ * The ZH measure-words (份/个/张/篇/段/章/项/条) double as deliverable-noun
+ * proxies because Chinese uses measure-words in lieu of pluralisation.
+ */
+export const DELIVERABLE_NOUN_TOKENS = {
+  en: /\b(docs?|specs?|files?|reports?|tasks?|prs?|tickets?|issues?|services?|modules?|components?|features?|tests?|migrations?|scripts?)\b/i,
+  /**
+   * ZH: 文档/文件/规范 + measure-words (份/个/张/篇/段/章/项/条). Combined
+   * because Chinese parses noun + measure-word as the deliverable proxy.
+   */
+  zh: /(文档|文件|规范|份|个|张|篇|段|章|项|条|条目|笔记)/,
+} as const;
+
+/**
+ * Quantifier-trigram tokens (§2.1 + §3 anti-pattern guard).
+ *
+ * **Implementation note:** rather than constraining token order in a
+ * single regex, the classifier checks all three axes (quantifier +
+ * state-change verb + deliverable noun) for presence within the same
+ * input. This handles all natural orderings (VERB-QUANT-NOUN as in
+ * "create three reports" / "做这两份 md 文档"; QUANT-NOUN-VERB as in
+ * "three reports to make" / "三份报告要做"; QUANT-VERB-NOUN; etc.)
+ * without explosion of permutations.
+ *
+ * The anti-promotion guard in `classifyIntentLevel` ensures
+ * "Show me all 3 statuses" stays L0 by checking that the verb axis is
+ * NOT exclusively read-only ({@link L0_READ_VERB_PATTERN}) before
+ * promoting on this trigram.
+ */
+export const L2_QUANTIFIER_TRIGRAM = {
+  /**
+   * EN: requires all three axes — quantifier + state-change verb +
+   * deliverable noun — present in the input. Order-agnostic.
+   *
+   * The exposed regex matches the QUANTIFIER axis only; the consumer
+   * checks the other two axes via the helper below.
+   */
+  en: /\b(both|all|every|two|three|four|five|six|seven|eight|nine|ten|\d+)\b/i,
+  /** ZH quantifier axis. */
+  zh: /(两|三|四|五|六|七|八|九|十|这两|这三|多个|所有|全部|每个|几个)/,
+} as const;
+
+/**
+ * State-change verb axis for the quantifier-trigram. Distinct from
+ * {@link ACTION_VERB_EN}/{@link ACTION_VERB_ZH} because the trigram
+ * specifically excludes ambiguous-shape verbs (e.g. `run`, `check`)
+ * that are common in read-only contexts.
+ */
+export const L2_TRIGRAM_STATE_CHANGE_VERB = {
+  en: /\b(make|build|create|implement|add|write|update|delete|deploy|migrate|refactor|design|review|fix|configure|prepare|draft|publish|release|ship|launch|generate)\b/i,
+  zh: /(做(?!了|过|得|的|出|不到|不了|不下|不来|不出)|写|搞定|做完|完成|实现|添加|创建|构建|搭建|设计|部署|发布|上线|分析|审查|评审|编排|调研|规划|优化|重构|修复|改写|编写|起草|拆分|准备)/,
+} as const;
+
+/**
+ * Plural-deliverable axis for the quantifier-trigram. Mirrors
+ * {@link DELIVERABLE_NOUN_TOKENS} but kept distinct so a future tuning
+ * of "what counts as deliverable in a trigram context" doesn't drift.
+ */
+export const L2_TRIGRAM_DELIVERABLE = {
+  en: /\b(docs?|specs?|files?|reports?|tasks?|prs?|tickets?|issues?|services?|modules?|components?|features?|tests?|migrations?|scripts?)\b/i,
+  zh: /(份|个|张|篇|段|章|项|条|条目|文档|文件|规范|报告|任务|md|md\s*文档|计划|spec)/i,
+} as const;
+
+// ---------------------------------------------------------------------------
+// §2.2 — Multi-artifact / file-creation triggers
+// ---------------------------------------------------------------------------
+
+/**
+ * Doc/spec creation triggers (§2.2 row 1). These promote to L2 even with
+ * a tiny verb because authoring a doc is multi-step by nature.
+ */
+export const L2_DOC_CREATION_TRIGGER = {
+  en: /\b(spec|specification|design\s+doc|rfc|brief|writeup|whitepaper|markdown\s+doc|md\s+doc)\b/i,
+  zh: /(规范|设计文档|草稿|说明文档|md\s*文档|markdown\s*文档|笔记|白皮书|说明书)/,
+} as const;
+
+/**
+ * File-with-extension reference (§2.2 row 2). Any path with extension
+ * promotes to L2 unless the verb is read-only — the read-only guard is
+ * applied at the classifier level, not here, because read-only verbs are
+ * a separate axis (see {@link L0_READ_VERB_PATTERN}).
+ */
+export const L2_FILE_EXTENSION_TRIGGER = /\b\w+\.(md|markdown|ts|tsx|js|jsx|py|sql|json|yml|yaml|sh|tf|java|go|rb|rs|cpp|c|h|toml|ini|conf|css|scss|html|xml|csv)\b/i;
+
+/**
+ * PR / commit / branch artifact (§2.2 row 3). Order-agnostic — both
+ * "open a PR" (VERB-NOUN) and "PR to open" (NOUN-VERB) match, with the
+ * VERB-NOUN form being far more common.
+ */
+export const L2_PR_ARTIFACT_TRIGGER = {
+  en: /\b(?:(pr|pull\s+request|commit|branch|merge)\b.{0,30}?\b(open|create|raise|file|prepare|draft|push|cut|land)|(open|create|raise|file|prepare|draft|push|cut|land)\b.{0,30}?\b(pr|pull\s+request|commit|branch|merge))\b/i,
+  zh: /(pr|pull\s+request|提交|分支|合并|merge).{0,12}?(开|提|准备|起草|推送|落地|创建|发起)|(开|提|准备|起草|推送|落地|创建|发起).{0,12}?(pr|pull\s+request|提交|分支|合并|merge)/i,
+} as const;
+
+/**
+ * Migration / schema (§2.2 row 4).
+ */
+export const L2_MIGRATION_TRIGGER = {
+  en: /\b(migration|schema|seed|fixture|backfill)\b/i,
+  zh: /(迁移|建表|改表|回填|数据迁移|表结构)/,
+} as const;
+
+// ---------------------------------------------------------------------------
+// §2.3 — Verb–noun pair signaling system-level work
+// ---------------------------------------------------------------------------
+
+/**
+ * Build/implement + system-noun (§2.3 row 1). The canonical L2 shape —
+ * pre-existing in the EN classifier; ZH parity is the new contribution.
+ */
+export const L2_BUILD_SYSTEM_NOUN = {
+  en: /\b(implement|build|create|develop|design|architect|refactor)\b.{0,40}?\b(feature|system|service|module|component|pipeline|workflow|framework|infrastructure)\b/i,
+  zh: /(实现|构建|创建|搭建|设计|架构|重构|开发|编写|做).{0,15}?(功能|系统|服务|模块|组件|流水线|工作流|框架|基础设施|架构|平台|工具)/,
+} as const;
+
+/**
+ * Deploy/migrate + env-noun (§2.3 row 2).
+ */
+export const L2_DEPLOY_ENV_NOUN = {
+  en: /\b(deploy|migrate|upgrade|provision)\b.{0,40}?\b(to|from|environment|server|cluster|staging|production)\b/i,
+  zh: /(部署|迁移|升级|发布|上线).{0,15}?(到|从|环境|服务器|集群|预发|生产|测试环境|正式环境)/,
+} as const;
+
+/**
+ * End-to-end / full-stack scope (§2.3 row 3).
+ */
+export const L2_E2E_SCOPE = {
+  en: /\b(end[- ]?to[- ]?end|full[- ]?stack|e2e|integration)\b.{0,30}?\b(test|setup|implementation|implement)\b/i,
+  zh: /(端到端|全栈|完整|整套|完整链路).{0,12}?(测试|搭建|实现|实施|部署)/,
+} as const;
+
+/**
+ * Coordinate / orchestrate (§2.3 row 4). Single-token signal — by the
+ * time someone says "coordinate", the work is multi-agent by definition.
+ */
+export const L2_COORDINATE = {
+  en: /\b(coordinate|orchestrate|delegate|parallelize|fan\s*out)\b/i,
+  zh: /(协调|编排|分发|拆分|并行|分派|分配|统筹)/,
+} as const;
+
+// ---------------------------------------------------------------------------
+// §2.4 — Conjunction of distinct verbs / numbered list
+// ---------------------------------------------------------------------------
+
+/**
+ * Sequenced verbs (§2.4 row 1). "X then Y" / "X 然后 Y".
+ */
+export const L2_SEQUENCED_VERBS = {
+  en: /\b(then|and\s+then|after\s+that|next|followed\s+by|subsequently)\b/i,
+  zh: /(然后|接着|之后|再|随后|继而|紧接着)/,
+} as const;
+
+/**
+ * Numbered/bulleted list (§2.4 row 3). Two or more numbered items in the
+ * same input is structurally L2.
+ */
+/**
+ * Numbered list trigger. Matches "1. … 2. …" / "(1) … (2) …" / "① … ②".
+ * The `\s?` after the marker is OPTIONAL because Chinese-encoded numbered
+ * lists ("①修复 ②测试") have no whitespace between the marker and the
+ * content.
+ */
+export const L2_NUMBERED_LIST = /(?:^|\s)(?:1\.|\(1\)|①)\s?.{0,200}?(?:^|\s)(?:2\.|\(2\)|②)/s;
+
+// ---------------------------------------------------------------------------
+// §2.5 — Cross-system context-pivot (catches "oss重启了 你现在再做这个")
+// ---------------------------------------------------------------------------
+
+/**
+ * Restart/recovery + redirect (§2.5). Status-update clause followed by a
+ * directive that references prior multi-step context. The "this/这个"
+ * referent points to a prior plan the classifier can't resolve, but the
+ * SHAPE is reliable enough to promote.
+ */
+export const L2_CROSS_SYSTEM_PIVOT = {
+  en: /\b(restart(ed)?|back|up|live|running|recovered)\b.{0,40}?\b(now|then|so|please)?\s*(do|run|continue|resume|proceed|kick\s+off|pick\s+up)\b/i,
+  /**
+   * ZH: status-clause (重启/回来/上线/跑起来/好了/恢复) + ≤16-char gap +
+   * directive prefix (现在/那/你?) + (再/继续/接着/开始) + verb (做/搞/跑/继续).
+   */
+  zh: /(重启|回来|上线|跑起来|好了|恢复|恢复了|起来了|连上).{0,16}?(现在|那|你)?\s*(再|继续|接着|开始|重新).{0,8}?(做|搞|跑|继续|执行|开始|处理|完成)/,
+} as const;
+
+// ---------------------------------------------------------------------------
+// §2.6 — Sprint / OKR / time-budget markers (L3 candidates)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sprint / milestone / epic markers (§2.6 row 1). These are L3 CANDIDATES
+ * — combined with §2.3 they classify L3; alone they classify L2.
+ */
+export const L3_SPRINT_OKR_MARKERS = {
+  en: /\b(sprint|milestone|epic|okr|kr\d?)\b/i,
+  zh: /(冲刺|迭代|里程碑|目标|kr\d?|季度目标|年度目标)/i,
+} as const;
+
+/**
+ * Multi-day timebox (§2.6 row 2). Time markers like "this week" /
+ * "by Friday" / "这周" / "下周" combined with a verb suggest sprint-level
+ * scope.
+ */
+export const L3_TIMEBOX_MARKERS = {
+  en: /\b(this\s+week|by\s+(eod|friday|monday|tuesday|wednesday|thursday|sunday|saturday|tomorrow|tonight)|next\s+sprint|tonight|overnight|by\s+end\s+of\s+(day|week|sprint))\b/i,
+  zh: /(这周|本周|今天|今晚|过夜|周末|下周|明天前|月底|季度内|本季度|这个月|下个月)/,
+} as const;
+
+/**
+ * Deliver / ship verbs (§2.6 row 3). Distinct from §2.3 deploy axis —
+ * "ship" / "上线" carry a sprint-completion semantic.
+ */
+export const L3_DELIVER_SHIP_VERBS = {
+  en: /\b(ship|deliver|launch|release|land|execute)\b/i,
+  zh: /(发布|上线|交付|搞定|完成|拿下|落地|执行)/,
+} as const;
+
+// ---------------------------------------------------------------------------
+// §1.2 — Read verbs (anti-promotion guard for §2.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only / status-lookup verbs. If the only verb in the input is a
+ * read verb, do NOT promote even if a quantifier is present
+ * (§3 last paragraph: "Show me all 3 statuses" stays L0).
+ */
+export const L0_READ_VERB_PATTERN = {
+  en: /\b(show|list|get|check|find|count|describe|explain|view|see|look\s+at|what|where|when|who|which|how|is|are|does|do|status|version|health|uptime)\b/i,
+  zh: /(查看|查询|展示|列出|看一下|看看|多少|什么|哪|是否|有没有|状态|版本|健康|启动时间)/,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Action verb pattern (used by isActionableIntent)
+// ---------------------------------------------------------------------------
+
+/**
+ * EN action verb pattern. Used as a positive signal for actionability
+ * when no non-actionable pattern matches. Pre-existing — kept here to
+ * keep all classifier inputs in one file.
+ */
+export const ACTION_VERB_EN = /\b(fix|build|create|deploy|implement|add|update|delete|remove|write|read|check|test|run|make|send|set\s+up|configure|install|download|upload|convert|transform|generate|export|import|refactor|migrate|upgrade|optimize|search|find|move|copy|rename|clean\s*up|set|start|stop|restart|enable|disable|schedule|assign|delegate|review|audit|analyze|investigate|research|explore|design|plan|document|monitor|track|debug|trace|patch|revert|rollback|merge|push|pull|commit|release|publish|integrate|connect|disconnect|setup|tear\s*down|provision|scale|backup|restore)\b/i;
+
+/**
+ * ZH action verb pattern. Mirrors §2.3 + §2.6 verb sets plus the canonical
+ * Chinese imperatives Mia called out in the spec preamble (§0 root cause
+ * 1): 做/写/搞/搞定/重启/检查 etc.
+ *
+ * **Strictness on dual-use verbs (Mia 2026-05-06):** the bare imperatives
+ * 做 and 搞 are conversational-filler-ambiguous (做了 = "did already",
+ * 搞砸 = "messed up", 搞不定 = "can't do"). To follow Mia's
+ * stricter-promotion default ("false-negative is fixable; false-positive
+ * over-decomposes"), we use negative lookaheads on those two so the
+ * completed/denial forms don't match. Other actionable forms (做完, 搞定,
+ * 做+deliverable) are explicit fall-through tokens further in the pattern.
+ *
+ * The companion {@link NON_ACTIONABLE_PATTERNS_ZH} set includes
+ * sentence-shape filters for "I just did X" / "I can't do X" cases that
+ * the lookahead alone cannot catch — both layers together produce the
+ * stricter behaviour Mia asked for.
+ */
+export const ACTION_VERB_ZH = /(做(?!了|过|得|的|出|不到|不了|不下|不来|不出)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|搞定|做完|完成|重启|启动|停止|关闭|检查|查看|查询|修复|修\b|改|改写|编写|起草|添加|删除|移除|部署|上线|发布|创建|实现|构建|搭建|设计|分析|审查|评审|编排|调研|规划|计划|制定|优化|重构|拆分|分发|分派|协调|分配|统筹|集成|配置|安装|更新|升级|迁移|回填|监控|跟踪|追踪|调试|跑|执行|处理|准备|提交|合并|推送|拉取|发版|交付|落地|拿下|测试|审计|评估|排查|审核|审定)/;
+
+// ---------------------------------------------------------------------------
+// Non-actionable patterns — ZH parity additions
+// ---------------------------------------------------------------------------
+
+/**
+ * Non-actionable ZH patterns that should be filtered out by
+ * `isActionableIntent` before classification (§3 filtered rows).
+ *
+ * Exported as an array for composition with the existing EN
+ * NON_ACTIONABLE_PATTERNS in `intent-task.types.ts`.
+ */
+export const NON_ACTIONABLE_PATTERNS_ZH: RegExp[] = [
+  // Greetings / pleasantries (§3 row 12)
+  /^(你好|您好|嗨|早上好|下午好|晚上好|早|晚安|再见|拜拜|多谢|谢谢|感谢)\s*[。！!]?$/,
+  // Pure acknowledgements (§3 row 7)
+  /^(好的|好|知道了|收到|嗯|嗯嗯|哦|哦哦|明白|明白了|可以|行|对|没问题|稍等|马上|马上来|好啊|好哒)\s*[。！!]?$/,
+  // Opinion / discussion (§3 row 8: 我觉得 / 也许)
+  /^(我觉得|我认为|我感觉|也许|可能|可能我|或许|大概|应该|觉得)/,
+  // FYI / status-share (§3 row 9: 我刚 push 了)
+  // Allow optional whitespace between 我刚/已经 and the past-tense verb so
+  // "我刚 push 了" / "我已经 merge 完了" etc. all match.
+  /^我\s*(刚|已经|已|刚刚)\s*(做了|完成|搞定|push|merge|提交|推送|部署|更新|修复|发布)/i,
+  /^(做完了|完成了|已完成|刚完成|刚刚搞定)/,
+  // Apology / confirmation (§3 row 10)
+  /^(抱歉|不好意思|对不起|确认|确认了|没事|没关系|没什么)/,
+
+  // Mia stricter-default 2026-05-06: dual-use verb conversational-filler
+  // forms. These run BEFORE classification so a message like "做了" /
+  // "搞砸了" / "做不到" cannot reach the L2 promoter. Catches the cases
+  // the verb-level negative lookahead alone misses (e.g. when the
+  // problematic form is mid-sentence rather than verb-tail).
+  //
+  // (a) "I/we did X already" — completed action, not a directive.
+  /^(?:我们?\s*)?(?:刚|已经|已|刚刚|早就)?\s*(?:做了|搞了|做完了|搞完了|搞定了|完成了|弄完了|弄好了|做过了|搞过了)/,
+  // (b) "(I) can't do X" — capability denial, not a directive.
+  /^.{0,20}?(做不到|做不了|做不下来|做不出来|搞不定|搞不动|搞不了|完不成|弄不了|没做完|没搞定)/,
+  // (c) Short message ending in a botched/error verb (搞砸/搞错).
+  /^.{0,30}?(搞砸|搞错|搞乱|搞糊涂)(?:了|过)?\s*[。！？!?]?$/,
+];
+
+// ---------------------------------------------------------------------------
+// Length floors
+// ---------------------------------------------------------------------------
+
+/**
+ * Length floors for L2 promotion when no rule fires. ZH has no spaces, so
+ * word-count alone under-estimates message density — char-count is the
+ * complementary axis.
+ */
+export const L2_LENGTH_FLOORS = {
+  /** EN/space-tokenised word count above which the message is L2. */
+  wordCount: 35,
+  /** Total character count above which the message is L2 (catches ZH). */
+  charCount: 80,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Category — ZH parity extensions (§2.3 lookup tables)
+// ---------------------------------------------------------------------------
+
+/**
+ * Category-specific keyword sets. Each category combines an EN pattern
+ * with a ZH pattern; the classifier matches if EITHER fires.
+ *
+ * Exported as a structured object so the consumer code reads
+ * `CATEGORY_KEYWORDS.debugging.zh.test(input)` rather than digging into
+ * nested ternaries.
+ *
+ * Order is significant — see `classifyIntentCategory` in
+ * `intent-task.types.ts`. The most-specific categories run first.
+ */
+export const CATEGORY_KEYWORDS = {
+  debugging: {
+    en: /\b(fix|bug|error|crash|broken|issue|debug|trace|stack\s*trace|exception|segfault|panic|hang|leak|regression|flaky)\b/i,
+    zh: /(修复|修\b|改bug|bug|报错|崩溃|出错|故障|异常|挂了|内存泄漏|泄漏|不工作|有问题|错了|挂死|死循环|跑不起来)/i,
+  },
+  deployment: {
+    // Bug A v0 (2026-05-06): added `ship|publish` for backward
+    // compatibility with v3-data.service.test.ts which pins
+    // "Ship the new feature" → deployment. Pre-Bug-A the v3-data
+    // classifier had its own deploy regex with these tokens; the
+    // delegation rolls them in here so the pre-existing assertion
+    // still passes after consolidation.
+    en: /\b(deploy|ship|publish|staging|production|docker|kubernetes|k8s|helm|terraform|ansible|nginx|container|image|rollback|rollout)\b/i,
+    zh: /(部署|上线|发布|发版|预发|生产|生产环境|预发环境|镜像|容器|回滚|灰度|滚动发布)/,
+  },
+  release: {
+    en: /\b(release)\b/i,
+    zh: /(发版|release)/i,
+  },
+  ciCdContext: {
+    en: /\b(ci|cd)\b/i,
+    zh: /(持续集成|持续交付|流水线|ci|cd)/i,
+  },
+  ciCdAction: {
+    en: /\b(pipeline|build|run|trigger|fix)\b/i,
+    zh: /(流水线|构建|运行|触发|修复)/,
+  },
+  review: {
+    en: /\b(review|pr\b|pull\s+request|code\s+review|audit|approve|reject|lgtm)\b/i,
+    zh: /(审查|评审|审核|review|代码审查|代码评审|pr\b|拉取请求|批准|驳回|通过)/i,
+  },
+  research: {
+    en: /\b(research|investigate|explore|analyze|compare|evaluate|benchmark|measure|profile|survey|study)\b/i,
+    zh: /(研究|调查|分析|评估|对比|评测|基准测试|测量|画像|调研|考察|学习|探索)/,
+  },
+  planning: {
+    en: /\b(plan|roadmap|strategy|design|architect|spec|specification|rfc|proposal|estimate|prioritize|schedule|timeline|milestone)\b/i,
+    zh: /(规划|路线图|战略|策略|设计|架构|规范|提案|估算|优先级|时间表|时间线|里程碑|计划|方案|蓝图)/,
+  },
+  communication: {
+    en: /\b(message|notify|slack|email|communicate|tell\s|announce|broadcast|ping|alert|report\s+to|inform|update\s+the\s+team)\b/i,
+    zh: /(告诉|问|通知|发消息|转告|通报|告知|联系|沟通|喊一下|跟.{0,4}说|@|私信|群发)/,
+  },
+  codeChange: {
+    en: /\b(implement|code|write|add|update|modify|refactor|create|build|develop|rename|move|copy|delete|remove|clean\s*up|optimize|improve|enhance|extend|extract|inline|merge|split|convert|transform|generate|scaffold|bootstrap|set\s*up|configure|install|integrate|connect|wire|hook\s*up|enable|disable|restart|reboot)\b/i,
+    // CJK note: \b doesn't behave correctly between two CJK chars in JS,
+    // so the bare-verb tokens (做/写/改/加) use negative lookaheads to
+    // exclude their non-imperative suffixes rather than relying on \b.
+    // Mia stricter-default: 做(?!了|过|得|的|出) excludes 做了/做过/做得/
+    // 做的/做出 — the conversational/completed forms.
+    zh: /(实现|添加|创建|开发|编写|搭建|新增|修改|更新|更改|重构|删除|移除|优化|增强|扩展|抽取|内联|合并|拆分|转换|生成|脚手架|配置|安装|集成|连接|启用|禁用|改成|改名|改完|改造|改一下|改个|做(?!了|过|得|的|出|不到|不了)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|去掉|去除|加上|加入|加进|重启|启动)/,
+  },
+  query: {
+    en: /\b(what|where|when|who|which|how|show|list|get|status|check|find|search|look\s*up|count|describe|explain)\b/i,
+    zh: /(什么|哪里|哪|何时|谁|哪个|怎么|怎样|展示|列出|看|看看|查看|查询|状态|检查|查找|搜索|查阅|多少|描述|解释|说明)/,
+  },
+} as const;

--- a/backend/src/services/v3/v3-data.service.test.ts
+++ b/backend/src/services/v3/v3-data.service.test.ts
@@ -1078,9 +1078,14 @@ describe('classifyIntent', () => {
 
   it('should set correct intent levels', () => {
     expect(classifyIntent('Fix a bug').intentLevel).toBe('L1');           // debugging → L1
-    expect(classifyIntent('Deploy to prod').intentLevel).toBe('L2');      // deployment → L2
-    expect(classifyIntent('Build a feature').intentLevel).toBe('L2');     // code_change → L2
-    expect(classifyIntent('Tell the team').intentLevel).toBe('L0');       // communication → L0
+    expect(classifyIntent('Deploy to prod').intentLevel).toBe('L2');      // deployment → L2 (deploy/env trigger)
+    expect(classifyIntent('Build a feature').intentLevel).toBe('L2');     // code_change → L2 (build+system noun)
+    // Bug A v0 (Mia §3 row 5): a single bounded communication directive
+    // ("tell …") is L1, NOT L0. L0 is reserved for read-only / status /
+    // lookup with no state change. Pre-Bug-A v3-data.service.classifyIntent
+    // hard-coded communication → L0 — that's been corrected to align with
+    // Mia's canonical product brief.
+    expect(classifyIntent('Tell the team').intentLevel).toBe('L1');       // communication → L1
     expect(classifyIntent('Research options').intentLevel).toBe('L1');    // research → L1
   });
 });
@@ -1200,8 +1205,18 @@ describe('classifyIntent — Chinese keywords', () => {
   });
 
   it('should classify Chinese query keywords (查一下)', () => {
+    // Bug A v0 (canonical classifier from intent-task.types): "查一下 …
+    // 多少 团队" is structurally a lookup/status question, which Mia §1.2
+    // Q1 defines as L0/query. The pre-Bug-A v3-data.service heuristic
+    // bucketed it as 'research' via a Chinese-specific fallback that
+    // didn't distinguish lookup from investigation. The canonical
+    // classifier consolidates to 'query' which better fits Mia's
+    // category semantics (research = "investigate/explore/analyze";
+    // query = "what/where/count/lookup"). Both still result in the
+    // same SLA/decomposition behaviour because L1/query and L1/research
+    // route identically.
     const result = classifyIntent('帮我查一下现在有多少团队');
-    expect(result.intentCategory).toBe('research');
+    expect(result.intentCategory).toBe('query');
   });
 
   it('should classify Chinese debugging keywords (修复)', () => {

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -27,6 +27,14 @@ import { RequestTracker } from './request-tracker.service.js';
 import { createWorkItem, type WorkItem } from '../../types/v2/work-item.types.js';
 import { createMission, CONSERVATIVE_POLICY, type CreateMissionInput } from '../../types/v2/mission.types.js';
 import { isValidRequestTransition, type IntentCategory, type IntentLevel, type RequestStatus } from '../../types/v2/request.types.js';
+// Bug A v0 (2026-05-06): canonical intent classification — both
+// classifyIntentLevel + classifyIntentCategory consume the shared rule-set
+// at `services/intent-task/intent-classifier.rules.ts`, so this delegation
+// keeps the Request- and Mission-side classifiers in lock-step.
+import {
+  classifyIntentLevel,
+  classifyIntentCategory,
+} from '../../types/intent-task.types.js';
 import { ensureDir, atomicWriteJson } from '../../utils/file-io.utils.js';
 import { ProjectTaskWatcherService } from './project-task-watcher.service.js';
 import { TokenUsageService } from '../monitoring/token-usage.service.js';
@@ -928,52 +936,43 @@ export function isNonActionableMessage(content: string): boolean {
  * Auto-classify request intent from message content.
  * Runs synchronously — no AI call, just keyword matching.
  *
+ * Bug A v0 (2026-05-06): delegates to the canonical
+ * `classifyIntentLevel` + `classifyIntentCategory` from
+ * `backend/src/types/intent-task.types.ts` (which read from the
+ * code-of-record rules at
+ * `backend/src/services/intent-task/intent-classifier.rules.ts`).
+ *
+ * Why delegation rather than maintaining a parallel rule-set: prior to
+ * this PR, the two classifyIntent paths drifted. The Mission-side classifier
+ * had ~40 patterns + length floor; the Request-side classifier had ~7 patterns
+ * with no length floor. This caused classification skew across surfaces.
+ *
+ * The local pre-filter `isNonActionableMessage` is preserved because it's
+ * scoped to v3-data.service callers (Request creation flow) and short-
+ * circuits L0 for chit-chat without invoking the heavier classifier.
+ *
  * @param content - The user message text
  * @returns Object with intentCategory and intentLevel
  */
 export function classifyIntent(content: string): { intentCategory: IntentCategory; intentLevel: IntentLevel } {
-  const lower = content.toLowerCase();
-
-  // Non-actionable messages: acknowledgements, chit-chat, greetings
+  // Non-actionable messages: acknowledgements, chit-chat, greetings.
+  // Pre-filter at the Request boundary — short-circuit before invoking
+  // the canonical classifier so non-actionable input never lands as a
+  // Request-shaped row.
   if (isNonActionableMessage(content)) {
     return { intentCategory: 'other', intentLevel: 'L0' };
   }
 
-  // Debugging — English + Chinese keywords
-  if (/\b(fix|bug|error|crash|broken|issue)\b/.test(lower) || /修复|修|bug|报错|崩溃|出错|故障|异常/.test(content)) {
-    return { intentCategory: 'debugging', intentLevel: 'L1' };
-  }
-  // Deployment
-  if (/\b(deploy|release|publish|ship)\b/.test(lower) || /部署|发布|上线|发版/.test(content)) {
-    return { intentCategory: 'deployment', intentLevel: 'L2' };
-  }
-  // Review
-  if (/\b(review|pr|pull request|code review)\b/.test(lower) || /审查|评审|review|代码审查/.test(content)) {
-    return { intentCategory: 'review', intentLevel: 'L1' };
-  }
-  // Planning
-  if (/\b(plan|design|architect|spec)\b/.test(lower) || /规划|设计|架构|方案|计划/.test(content)) {
-    return { intentCategory: 'planning', intentLevel: 'L2' };
-  }
-  // Research / analysis
-  if (/\b(research|investigate|analyze|look into|evaluate|assess|audit)\b/.test(lower) || /研究|调查|分析|评估|排查|审计|检查/.test(content)) {
-    return { intentCategory: 'research', intentLevel: 'L1' };
-  }
-  // Communication
-  if (/\b(tell|ask|message|notify|send)\b/.test(lower) || /告诉|问|通知|发消息|转告/.test(content)) {
-    return { intentCategory: 'communication', intentLevel: 'L0' };
-  }
-  // Code change
-  if (/\b(add|implement|create|build|feature|write)\b/.test(lower) || /添加|实现|创建|开发|编写|搭建|新增/.test(content)) {
-    return { intentCategory: 'code_change', intentLevel: 'L2' };
-  }
-  // Query / lookup (Chinese-specific, lightweight tasks)
-  if (/查一下|查看|查询|看看|有多少|列出|统计/.test(content)) {
-    return { intentCategory: 'research', intentLevel: 'L1' };
-  }
-
-  return { intentCategory: 'other', intentLevel: 'L1' };
+  // Delegate to the canonical L0/L1/L2/L3 classifier + ZH-parity category
+  // matcher. Both functions read from the shared rule-set at
+  // `intent-classifier.rules.ts`, so any future tuning lands in exactly
+  // one place.
+  return {
+    intentLevel: classifyIntentLevel(content),
+    intentCategory: classifyIntentCategory(content),
+  };
 }
+
 
 // ---------------------------------------------------------------------------
 // Mission → Task Planning (keyword-based, no AI)

--- a/backend/src/types/intent-task.types.test.ts
+++ b/backend/src/types/intent-task.types.test.ts
@@ -141,7 +141,12 @@ describe('classifyIntentLevel', () => {
     expect(classifyIntentLevel('Implement a new authentication feature for the web service')).toBe('L2');
     expect(classifyIntentLevel('Build the user registration system with email verification')).toBe('L2');
     expect(classifyIntentLevel('Deploy the app to staging environment')).toBe('L2');
-    expect(classifyIntentLevel('Coordinate the team to deliver the sprint tasks')).toBe('L2');
+    // Bug A v0 (Mia §1.3 + §2.6): the sprint-marker + coordinate +
+    // deliver-verb combination promotes to L3 in the new framework.
+    // Pre-Bug-A this returned L2 because L3 didn't exist as a tier; v0
+    // routes L3 = L2 internally (Mia §5 Q1 default) so behavioural
+    // routing is unchanged — only the label moves up.
+    expect(classifyIntentLevel('Coordinate the team to deliver the sprint tasks')).toBe('L3');
     expect(classifyIntentLevel('Migrate the database from MySQL to PostgreSQL')).toBe('L2');
     expect(classifyIntentLevel('Design the API architecture for the new pipeline')).toBe('L2');
   });

--- a/backend/src/types/intent-task.types.ts
+++ b/backend/src/types/intent-task.types.ts
@@ -23,8 +23,12 @@
  * - L0: Simple query — single agent, no tool calls (e.g., "what time is it?")
  * - L1: Standard task — single agent, may use tools (e.g., "fix this bug")
  * - L2: Complex task — multi-agent, multi-step orchestration (e.g., "build a feature")
+ * - L3: OKR/sprint-scoped initiative — multi-day, multi-PR, multi-team. ORC owns
+ *   the plan personally; success measured against KR/sprint gate, not artifact.
+ *   Routed identically to L2 in v0 (Mia §5 Q1 default); the label is preserved so
+ *   the L3-specific routing-split can land without retro-classifying.
  */
-export type IntentLevel = 'L0' | 'L1' | 'L2';
+export type IntentLevel = 'L0' | 'L1' | 'L2' | 'L3';
 
 /**
  * Intent classification labels for categorizing user requests
@@ -403,9 +407,44 @@ export interface ProjectTaskStatus {
 // Actionability Detection
 // =============================================================================
 
+// Bug A v0 (2026-05-06): classifier rule-set externalised to
+// `backend/src/services/intent-task/intent-classifier.rules.ts` per Mia §5
+// Q4 (code-of-record). Re-importing the EN action-verb pattern + the new
+// ZH counterpart + the ZH non-actionable pre-filters keeps this file's
+// historical EN rules in place while extending coverage symmetrically.
+import {
+  ACTION_VERB_EN,
+  ACTION_VERB_ZH,
+  NON_ACTIONABLE_PATTERNS_ZH,
+  L2_QUANTIFIER_TRIGRAM,
+  L2_TRIGRAM_STATE_CHANGE_VERB,
+  L2_TRIGRAM_DELIVERABLE,
+  L2_DOC_CREATION_TRIGGER,
+  L2_FILE_EXTENSION_TRIGGER,
+  L2_PR_ARTIFACT_TRIGGER,
+  L2_MIGRATION_TRIGGER,
+  L2_BUILD_SYSTEM_NOUN,
+  L2_DEPLOY_ENV_NOUN,
+  L2_E2E_SCOPE,
+  L2_COORDINATE,
+  L2_SEQUENCED_VERBS,
+  L2_NUMBERED_LIST,
+  L2_CROSS_SYSTEM_PIVOT,
+  L3_SPRINT_OKR_MARKERS,
+  L3_TIMEBOX_MARKERS,
+  L3_DELIVER_SHIP_VERBS,
+  L0_READ_VERB_PATTERN,
+  L2_LENGTH_FLOORS,
+  CATEGORY_KEYWORDS,
+} from '../services/intent-task/intent-classifier.rules.js';
+
 /**
  * Patterns that indicate a message is NOT actionable (should not become a task).
  * These cover greetings, acknowledgments, questions, feedback, opinions, and filler.
+ *
+ * Bug A v0 (2026-05-06): the ZH-specific patterns live in
+ * {@link NON_ACTIONABLE_PATTERNS_ZH} (imported above) so the rule list is
+ * grouped by language. Both arrays are checked in `isActionableIntent`.
  */
 const NON_ACTIONABLE_PATTERNS: RegExp[] = [
   // Greetings / pleasantries
@@ -423,10 +462,16 @@ const NON_ACTIONABLE_PATTERNS: RegExp[] = [
 ];
 
 /**
- * Action verbs that indicate a message contains an actionable intent.
- * Used as a positive signal when non-actionable patterns don't match.
+ * Combined action-verb pattern (EN + ZH). A message must match ONE of
+ * these to be considered actionable when no non-actionable pattern fires.
+ *
+ * Note: a regex test against this composite is implemented as two checks
+ * in `isActionableIntent` rather than a single `|` union because the EN
+ * pattern uses `\b` word boundaries (which behave incorrectly across CJK
+ * codepoints) and the ZH pattern relies on negative lookaheads (kept
+ * separate so each is type-clean).
  */
-const ACTION_VERB_PATTERN = /\b(fix|build|create|deploy|implement|add|update|delete|remove|write|read|check|test|run|make|send|set\s+up|configure|install|download|upload|convert|transform|generate|export|import|refactor|migrate|upgrade|optimize|search|find|move|copy|rename|clean\s*up|set|start|stop|restart|enable|disable|schedule|assign|delegate|review|audit|analyze|investigate|research|explore|design|plan|document|monitor|track|debug|trace|patch|revert|rollback|merge|push|pull|commit|release|publish|integrate|connect|disconnect|setup|tear\s*down|provision|scale|backup|restore)\b/i;
+const ACTION_VERB_PATTERN = ACTION_VERB_EN;
 
 /**
  * Minimum character count for a segment to be a meaningful intent.
@@ -447,13 +492,22 @@ export function isActionableIntent(text: string): boolean {
   // Too short to be meaningful
   if (trimmed.length < MIN_ACTIONABLE_CHARS) return false;
 
-  // Check non-actionable patterns first (fast reject)
+  // Check EN non-actionable patterns first (fast reject).
   for (const pattern of NON_ACTIONABLE_PATTERNS) {
     if (pattern.test(trimmed)) return false;
   }
+  // Bug A v0 (Mia spec §3 + stricter-default 2026-05-06): ZH non-actionable
+  // patterns including conversational-filler forms of dual-use verbs
+  // (做了 / 搞砸 / 做不到) so the L2 promoter never sees a "completed" or
+  // "denial" sentence.
+  for (const pattern of NON_ACTIONABLE_PATTERNS_ZH) {
+    if (pattern.test(trimmed)) return false;
+  }
 
-  // Must contain at least one action verb to be considered a task
-  return ACTION_VERB_PATTERN.test(trimmed);
+  // Must contain at least one action verb to be considered a task. EN
+  // pattern uses \b word-boundaries (only meaningful in Latin); ZH pattern
+  // is checked separately because \b does not interpret CJK boundaries.
+  return ACTION_VERB_PATTERN.test(trimmed) || ACTION_VERB_ZH.test(trimmed);
 }
 
 // =============================================================================
@@ -461,51 +515,194 @@ export function isActionableIntent(text: string): boolean {
 // =============================================================================
 
 /**
- * Heuristic rules for auto-classifying intent level.
- * Returns L0 for simple queries/lookups, L1 for standard tasks, L2 for complex multi-step.
+ * Heuristic rules for auto-classifying intent level into L0/L1/L2/L3.
+ *
+ * Decision order (highest precision first):
+ *   1. **L0** — read-only / status / lookup; quantified read still L0.
+ *   2. **L3** — sprint/OKR markers + system-level scope (§2.6 + §2.3).
+ *   3. **L2** — quantifier-trigram (§2.1), doc/file/PR/migration triggers
+ *      (§2.2), build/system + deploy/env + e2e + coordinate (§2.3),
+ *      sequenced verbs / numbered list (§2.4), cross-system pivot (§2.5),
+ *      sprint markers alone (§2.6), or length floor (§2.7 — wordCount > 35
+ *      OR charCount > 80 for ZH parity).
+ *   4. **L1** — fallback (single bounded directive).
+ *
+ * Spec: `specs/2026-05-06-intent-classifier-rules.md` §1.2 + §2.
  *
  * @param intent - User intent text
  * @returns Classified intent level
  */
 export function classifyIntentLevel(intent: string): IntentLevel {
   const lower = intent.toLowerCase();
-  const wordCount = intent.split(/\s+/).length;
+  const wordCount = intent.split(/\s+/).filter(Boolean).length;
+  const charCount = intent.length;
 
-  // L0: Simple lookups, status checks, single-tool operations
-  const l0Patterns = [
+  // ---------------------------------------------------------------------
+  // L0 — read-only / status / lookup (no state change).
+  //
+  // Anti-promotion guard for §2.1 + §3 last paragraph: if the verb axis
+  // is read-only AND the message is short AND no §2.2-§2.6 promoter
+  // fires below, classify L0. We defer the L0 decision until AFTER §2
+  // promoter checks so a quantified state-change ("做这两份 md 文档")
+  // doesn't get squashed by the read-verb pattern when the read verb
+  // happens to also appear (e.g. "look at and fix").
+  // ---------------------------------------------------------------------
+  const isShortMessage = wordCount <= 12 && charCount <= 60;
+  const l0LegacyPatterns = [
     /^(what|where|when|who|how|is|are|can|does|do|show|list|get|check|find)\b/i,
     /\?$/,
     /\b(status|version|health|uptime|count|list)\b/i,
   ];
-  if (wordCount <= 12 && l0Patterns.some((p) => p.test(lower))) {
-    return 'L0';
+
+  // ---------------------------------------------------------------------
+  // L3 — sprint/OKR initiative.
+  //
+  // §2.6 + §2.3: when sprint/OKR markers AND a system-level verb-noun
+  // both fire, the message is a multi-day initiative. Routed identically
+  // to L2 in v0; the label preserves intent for future routing-split.
+  // ---------------------------------------------------------------------
+  const sprintMarkerFires =
+    L3_SPRINT_OKR_MARKERS.en.test(lower) ||
+    L3_SPRINT_OKR_MARKERS.zh.test(intent) ||
+    L3_TIMEBOX_MARKERS.en.test(lower) ||
+    L3_TIMEBOX_MARKERS.zh.test(intent);
+  // §2.3 — broad system-level verb-noun signal (build OR deploy OR e2e
+  // OR coordinate). Matches Mia's spec: "If 2.6 + 2.3 both fire → L3."
+  const l2_2_3_fires =
+    L2_BUILD_SYSTEM_NOUN.en.test(lower) ||
+    L2_BUILD_SYSTEM_NOUN.zh.test(intent) ||
+    L2_DEPLOY_ENV_NOUN.en.test(lower) ||
+    L2_DEPLOY_ENV_NOUN.zh.test(intent) ||
+    L2_E2E_SCOPE.en.test(lower) ||
+    L2_E2E_SCOPE.zh.test(intent) ||
+    L2_COORDINATE.en.test(lower) ||
+    L2_COORDINATE.zh.test(intent);
+  const deliverShipFires =
+    L3_DELIVER_SHIP_VERBS.en.test(lower) || L3_DELIVER_SHIP_VERBS.zh.test(intent);
+
+  if (sprintMarkerFires && (l2_2_3_fires || deliverShipFires)) {
+    return 'L3';
   }
 
-  // L2: Complex multi-agent, multi-step, or cross-system tasks
-  const l2Patterns = [
-    // Verb + complex noun = feature-level work
-    /\b(implement|build|create|develop|design|architect|refactor)\b.*\b(feature|system|service|module|component|pipeline|workflow|framework|infrastructure)\b/i,
-    // Deployment / migration / upgrade (multi-step by nature)
-    /\b(deploy|migrate|upgrade|provision)\b.*\b(to|from|environment|server|cluster|staging|production)\b/i,
-    // Explicit multi-step language
-    /\bmulti[- ]?(agent|step|phase|stage)\b/i,
-    /\b(coordinate|orchestrate|delegate|parallelize)\b/i,
-    // End-to-end or full-stack scope
-    /\b(end[- ]to[- ]end|full[- ]stack|e2e|integration)\b.*\b(test|setup|implementation)\b/i,
-    // Sprint / project level work
-    /\b(sprint|milestone|epic|project)\b.*\b(deliver|complete|implement|execute)\b/i,
-  ];
-  if (l2Patterns.some((p) => p.test(lower)) || wordCount > 35) {
+  // ---------------------------------------------------------------------
+  // L2 — multi-step / multi-artifact / multi-agent / cross-system / plural.
+  //
+  // Order within L2: highest-precision triggers first (§2.1 trigram), then
+  // structural cues (§2.2/§2.3/§2.4/§2.5), then sprint-marker-alone
+  // (§2.6), then the length floor.
+  // ---------------------------------------------------------------------
+
+  // §2.1 — quantifier + state-change verb + plural deliverable.
+  // Three-axis check (order-agnostic) so VERB-QUANT-NOUN, QUANT-VERB-NOUN,
+  // and QUANT-NOUN-VERB all promote. The §3 anti-pattern guard
+  // ("quantifier alone is not L2") is preserved by requiring the verb
+  // axis explicitly — a quantified read query like "show me all 3
+  // statuses" fails the verb-axis check and stays L0.
+  const quantifierFires =
+    L2_QUANTIFIER_TRIGRAM.en.test(intent) || L2_QUANTIFIER_TRIGRAM.zh.test(intent);
+  const stateChangeVerbFires =
+    L2_TRIGRAM_STATE_CHANGE_VERB.en.test(lower) ||
+    L2_TRIGRAM_STATE_CHANGE_VERB.zh.test(intent);
+  const deliverableFires =
+    L2_TRIGRAM_DELIVERABLE.en.test(lower) || L2_TRIGRAM_DELIVERABLE.zh.test(intent);
+  if (quantifierFires && stateChangeVerbFires && deliverableFires) {
     return 'L2';
   }
 
-  // L1: Standard single-agent tasks
+  // §2.2 — doc/spec creation, file-with-extension, PR/commit artifact,
+  // migration/schema. Each is a structural multi-artifact promoter.
+  // (file-extension respects the read-only verb guard: a request that
+  // ONLY references a file path with a read verb stays L0/L1.)
+  const fileExtensionFires = L2_FILE_EXTENSION_TRIGGER.test(intent);
+  const docCreationFires =
+    L2_DOC_CREATION_TRIGGER.en.test(lower) || L2_DOC_CREATION_TRIGGER.zh.test(intent);
+  const prArtifactFires =
+    L2_PR_ARTIFACT_TRIGGER.en.test(lower) || L2_PR_ARTIFACT_TRIGGER.zh.test(intent);
+  const migrationFires =
+    L2_MIGRATION_TRIGGER.en.test(lower) || L2_MIGRATION_TRIGGER.zh.test(intent);
+
+  if (docCreationFires || prArtifactFires || migrationFires) {
+    return 'L2';
+  }
+
+  // File-extension triggers only when paired with non-read verb. This is
+  // the §2.2 row 2 caveat: "any path with extension is L2 unless the verb
+  // is read-only".
+  if (fileExtensionFires) {
+    const readOnly =
+      L0_READ_VERB_PATTERN.en.test(lower) || L0_READ_VERB_PATTERN.zh.test(intent);
+    if (!readOnly) return 'L2';
+  }
+
+  // §2.3 — build/system, deploy/env, e2e, coordinate.
+  if (
+    L2_BUILD_SYSTEM_NOUN.en.test(lower) ||
+    L2_BUILD_SYSTEM_NOUN.zh.test(intent) ||
+    L2_DEPLOY_ENV_NOUN.en.test(lower) ||
+    L2_DEPLOY_ENV_NOUN.zh.test(intent) ||
+    L2_E2E_SCOPE.en.test(lower) ||
+    L2_E2E_SCOPE.zh.test(intent) ||
+    L2_COORDINATE.en.test(lower) ||
+    L2_COORDINATE.zh.test(intent) ||
+    /\bmulti[- ]?(agent|step|phase|stage)\b/i.test(intent) ||
+    /多.{0,4}(步|阶段|环节|轮)/.test(intent)
+  ) {
+    return 'L2';
+  }
+
+  // §2.4 — sequenced verbs / numbered list. Two distinct steps in a
+  // single sentence is structurally L2.
+  if (
+    L2_SEQUENCED_VERBS.en.test(lower) ||
+    L2_SEQUENCED_VERBS.zh.test(intent) ||
+    L2_NUMBERED_LIST.test(intent)
+  ) {
+    return 'L2';
+  }
+
+  // §2.5 — cross-system pivot ("oss重启了 你现在再做这个").
+  if (L2_CROSS_SYSTEM_PIVOT.en.test(lower) || L2_CROSS_SYSTEM_PIVOT.zh.test(intent)) {
+    return 'L2';
+  }
+
+  // §2.6 alone — sprint marker without system noun. Still L2 (multi-step
+  // by sprint definition); only combined with §2.3 does it become L3.
+  if (sprintMarkerFires) {
+    return 'L2';
+  }
+
+  // §2.7 — length floor. EN word-count OR ZH char-count.
+  if (wordCount > L2_LENGTH_FLOORS.wordCount || charCount > L2_LENGTH_FLOORS.charCount) {
+    return 'L2';
+  }
+
+  // ---------------------------------------------------------------------
+  // L0 fallback — short read-shaped message that did not promote.
+  // ---------------------------------------------------------------------
+  if (isShortMessage && l0LegacyPatterns.some((p) => p.test(lower))) {
+    return 'L0';
+  }
+
+  // ZH read-shaped: short query starting with what/which/how/where in ZH.
+  if (
+    isShortMessage &&
+    (/^(什么|哪|多少|怎么|怎样|是否|有没有)/.test(intent) ||
+      L0_READ_VERB_PATTERN.zh.test(intent))
+  ) {
+    return 'L0';
+  }
+
+  // L1 — standard single-agent task fallback.
   return 'L1';
 }
 
 /**
  * Heuristic rules for auto-classifying intent category.
  * Uses prioritized pattern matching — first match wins.
+ *
+ * Bug A v0 (2026-05-06): each category fires on EITHER the EN pattern OR
+ * the ZH parity pattern from {@link CATEGORY_KEYWORDS}. Order is preserved
+ * from the pre-existing EN classifier so historical EN cases stay green.
  *
  * @param intent - User intent text
  * @returns Classified intent category
@@ -514,30 +711,80 @@ export function classifyIntentCategory(intent: string): IntentCategory {
   const lower = intent.toLowerCase();
 
   // Debugging: bug fixes, error investigation, tracing
-  if (/\b(fix|bug|error|crash|broken|issue|debug|trace|stack\s*trace|exception|segfault|panic|hang|leak|regression|flaky)\b/.test(lower)) return 'debugging';
+  if (
+    CATEGORY_KEYWORDS.debugging.en.test(lower) ||
+    CATEGORY_KEYWORDS.debugging.zh.test(intent)
+  ) {
+    return 'debugging';
+  }
 
   // Deployment: releases, CI/CD, infrastructure (require deployment-specific context)
-  if (/\b(deploy|staging|production|docker|kubernetes|k8s|helm|terraform|ansible|nginx|container|image|rollback|rollout)\b/.test(lower)) return 'deployment';
-  if (/\b(release)\b/.test(lower) && !/\b(announce|notify|tell|inform|message|communicate)\b/.test(lower)) return 'deployment';
-  if (/\b(ci|cd)\b/.test(lower) && /\b(pipeline|build|run|trigger|fix)\b/.test(lower)) return 'deployment';
+  if (
+    CATEGORY_KEYWORDS.deployment.en.test(lower) ||
+    CATEGORY_KEYWORDS.deployment.zh.test(intent)
+  ) {
+    return 'deployment';
+  }
+  if (
+    (CATEGORY_KEYWORDS.release.en.test(lower) || CATEGORY_KEYWORDS.release.zh.test(intent)) &&
+    !(CATEGORY_KEYWORDS.communication.en.test(lower) || CATEGORY_KEYWORDS.communication.zh.test(intent))
+  ) {
+    return 'deployment';
+  }
+  if (
+    (CATEGORY_KEYWORDS.ciCdContext.en.test(lower) || CATEGORY_KEYWORDS.ciCdContext.zh.test(intent)) &&
+    (CATEGORY_KEYWORDS.ciCdAction.en.test(lower) || CATEGORY_KEYWORDS.ciCdAction.zh.test(intent))
+  ) {
+    return 'deployment';
+  }
 
   // Review: code review, PR, audit
-  if (/\b(review|pr\b|pull\s+request|code\s+review|audit|approve|reject|lgtm)\b/.test(lower)) return 'review';
+  if (
+    CATEGORY_KEYWORDS.review.en.test(lower) ||
+    CATEGORY_KEYWORDS.review.zh.test(intent)
+  ) {
+    return 'review';
+  }
 
   // Research: investigation, exploration, analysis, comparison
-  if (/\b(research|investigate|explore|analyze|compare|evaluate|benchmark|measure|profile|survey|study)\b/.test(lower)) return 'research';
+  if (
+    CATEGORY_KEYWORDS.research.en.test(lower) ||
+    CATEGORY_KEYWORDS.research.zh.test(intent)
+  ) {
+    return 'research';
+  }
 
   // Planning: strategy, design, architecture, roadmap
-  if (/\b(plan|roadmap|strategy|design|architect|spec|specification|rfc|proposal|estimate|prioritize|schedule|timeline|milestone)\b/.test(lower)) return 'planning';
+  if (
+    CATEGORY_KEYWORDS.planning.en.test(lower) ||
+    CATEGORY_KEYWORDS.planning.zh.test(intent)
+  ) {
+    return 'planning';
+  }
 
   // Communication: messaging, notifications, announcements
-  if (/\b(message|notify|slack|email|communicate|tell\s|announce|broadcast|ping|alert|report\s+to|inform|update\s+the\s+team)\b/.test(lower)) return 'communication';
+  if (
+    CATEGORY_KEYWORDS.communication.en.test(lower) ||
+    CATEGORY_KEYWORDS.communication.zh.test(intent)
+  ) {
+    return 'communication';
+  }
 
-  // Code change: implementation, modification, creation (broad — checked after more specific categories)
-  if (/\b(implement|code|write|add|update|modify|refactor|create|build|develop|rename|move|copy|delete|remove|clean\s*up|optimize|improve|enhance|extend|extract|inline|merge|split|convert|transform|generate|scaffold|bootstrap|set\s*up|configure|install|integrate|connect|wire|hook\s*up|enable|disable)\b/.test(lower)) return 'code_change';
+  // Code change: implementation, modification, creation (broad — last among actionables)
+  if (
+    CATEGORY_KEYWORDS.codeChange.en.test(lower) ||
+    CATEGORY_KEYWORDS.codeChange.zh.test(intent)
+  ) {
+    return 'code_change';
+  }
 
   // Query: information retrieval, status checks, lookups
-  if (/\b(what|where|when|who|which|how|show|list|get|status|check|find|search|look\s*up|count|describe|explain)\b/.test(lower)) return 'query';
+  if (
+    CATEGORY_KEYWORDS.query.en.test(lower) ||
+    CATEGORY_KEYWORDS.query.zh.test(intent)
+  ) {
+    return 'query';
+  }
 
   return 'other';
 }

--- a/backend/src/types/v2/request.types.ts
+++ b/backend/src/types/v2/request.types.ts
@@ -87,8 +87,12 @@ export const INTENT_CATEGORIES: readonly IntentCategory[] = [
  * - L0: trivial, no WorkItem needed (direct response)
  * - L1: single WorkItem sufficient
  * - L2: multiple WorkItems, potentially parallel
+ * - L3: OKR/sprint-scoped initiative — multi-day, multi-PR, ORC owns the
+ *   plan personally and recursively decomposes into L2 over time.
+ *   v0 routes L3 the same as L2 internally; the *label* is preserved so
+ *   future routing-split lands without retro-classifying.
  */
-export type IntentLevel = 'L0' | 'L1' | 'L2';
+export type IntentLevel = 'L0' | 'L1' | 'L2' | 'L3';
 
 // ---------------------------------------------------------------------------
 // Core Interface
@@ -291,8 +295,8 @@ export function validateCreateRequestInput(input: CreateRequestInput): string[] 
   if (input.intentCategory && !isValidIntentCategory(input.intentCategory)) {
     errors.push(`intentCategory must be one of: ${INTENT_CATEGORIES.join(', ')}`);
   }
-  if (input.intentLevel && !['L0', 'L1', 'L2'].includes(input.intentLevel)) {
-    errors.push('intentLevel must be one of: L0, L1, L2');
+  if (input.intentLevel && !['L0', 'L1', 'L2', 'L3'].includes(input.intentLevel)) {
+    errors.push('intentLevel must be one of: L0, L1, L2, L3');
   }
   return errors;
 }


### PR DESCRIPTION
## Summary

Closes the Bug A v0 scope of the umbrella `72ca743a`. Implements Mia's canonical intent-classifier brief at `specs/2026-05-06-intent-classifier-rules.md` — adds ZH parity to every keyword set, introduces the L3 tier, wires the §2.5 cross-system pivot promoter (catches "oss重启了 你现在再做这个"), and consolidates the two `classifyIntent` paths to share one rule-set.

## RCA

| Layer | Pre-Bug-A | Post-Bug-A |
|---|---|---|
| Action verbs | 100% English; 做/写/搞/重启 invisible → falls through to L1 | EN + ZH parity with `ACTION_VERB_ZH`; stricter lookaheads exclude 做了/搞砸/做不到 |
| Quantifier promotion (§2.1) | Not present | 3-axis check (quantifier + state-change verb + plural deliverable); EN + ZH; order-agnostic |
| Cross-system pivot (§2.5) | Not present | EN + ZH; catches "oss重启了 你现在再做这个" |
| L3 tier | Did not exist | `IntentLevel` extended; routes L3=L2 in v0 (Mia §5 Q1 default), label preserved |
| Length floor | wordCount > 35 only (under-counts ZH) | wordCount > 35 OR charCount > 80 |
| Category coverage | English only | EN + ZH for all 8 categories via `CATEGORY_KEYWORDS` |
| Rule code-of-record | Buried in classifier inline | New `intent-classifier.rules.ts` per Mia §5 Q4 |

## Reframes from brief (caught pre-code per dispatch discipline)

1. **`IntentLevel` is duplicated** — both `intent-task.types.ts:27` AND `types/v2/request.types.ts:91` define the type. Both extended to add `'L3'`.
2. **§2.1 trigram order-agnostic** — original spec regex had QUANT-VERB-NOUN order, but VERB-QUANT-NOUN ("做这两份 md 文档" / "create three reports") is the natural imperative. Replaced single regex with 3-axis presence check; anti-promotion guard preserved by requiring the verb axis explicitly (read verbs excluded from state-change set).
3. **L3 gate: ANY §2.3 axis OR deliver-ship verb + §2.6 sprint marker = L3** — Mia's spec §2.6 says "If 2.6 + 2.3 both fire → L3"; broadening §2.3 to include all four axes (build/deploy/e2e/coordinate) reclassified one pre-existing test case ("Coordinate the team to deliver the sprint tasks") L2 → L3. Routing unchanged in v0 so behaviour is preserved.
4. **v3-data.service consolidation** — pre-Bug-A maintained a parallel rule-set with ~7 patterns + no length floor; Mission-side had ~40 patterns + length floor. Now delegates to the canonical functions so a future tuning lands in one place.

## Mia stricter-default (2026-05-06 inline guidance)

Bare 做 / 搞 are dual-use (做了 = "did already", 搞砸 = "messed up", 做不到 = "can't do"). Per Mia: false-negative is fixable; false-positive over-decomposes WorkItems and hurts the orc planner. Two layers of strictness:

1. `ACTION_VERB_ZH` uses negative lookaheads: `做(?!了|过|得|的|出|不到|不了)` etc.
2. `NON_ACTIONABLE_PATTERNS_ZH` adds explicit sentence-shape filters for "I just did X" / "I can't do X" / "搞砸了" so the promoter never sees a completed-action input.

## Tests

**269/269 green across 6 directly-touched suites; 124 new tests:**

- `intent-classifier.rules.test.ts` (39 cases) — rule-by-rule unit pins (§2.1-§2.6, §3 negatives, EN+ZH parity per category)
- `intent-classifier.fixture.test.ts` (27 cases) — fixture-driven regression including:
  - Steve dogfood (2 bound + F9 ff54231a placeholder)
  - Mia §3 negative-L2 (anti-promotion guard, including "show me all 3 statuses" stays-L0)
  - Non-actionable filter coverage (EN + ZH, including stricter-default capability-denial forms)
  - L3 detection (这周搞定 KR3 onboarding + ship Sprint 4)
- `intent-task.types.test.ts` (38 cases) — pre-existing + 1 reclassification noted inline
- `v3-data.service.test.ts` (76 cases) — pre-existing + 3 reclassifications noted inline
- `request.types.test.ts` (54 cases) — pre-existing
- `request.service.test.ts` (35 cases) — pre-existing

**Verification:**
- ✅ `tsc -p backend/tsconfig.json --noEmit` clean
- ✅ `npm run build` green (backend + frontend + cli)
- ✅ Pre-existing unrelated test failures elsewhere (chokidar/jest infra, intent-task.controller toggle-status) verified unchanged from origin/main on each touched file

## Acceptance criteria (Mia §6)

| # | Criterion | Status |
|---|---|---|
| 1 | The 2 bound Steve mis-labels classify L2 with correct category | ✅ Pinned in fixture (做这两份 md 文档 → L2/code_change; oss重启了 你现在再做这个 → L2/code_change) |
| 2 | No regression of existing L0/L1 cases | ✅ `intent-task.types.test.ts` green; 1 reclassification (Coordinate→L3) explicitly documented |
| 3 | Chinese coverage parity per §2 keyword set | ✅ Every category + promoter has ZH parity in `CATEGORY_KEYWORDS` + rule files; ZH dogfood test asserts each |
| 4 | Negative-L2 fixture | ✅ At least one example per row of §3; "show me all 3 statuses" stays L0 (the canonical anti-pattern) |
| 5 | L3 detection — `IntentLevel` extended; label returned correctly | ✅ Both `IntentLevel` definitions extended; L3 fixture pins the label |

## Sequencing

- Bug B (Max) — orthogonal codepath. No file conflict.
- Bug C (Quinn post-F4) — depends on Bug B; doesn't touch classifier.
- Pool-claim umbrella `1ffffb84` — parked until `72ca743a` settles.

## Out of scope (deferred per dispatch)

- Remaining 5 Steve mis-label messages — Sam harvests separately + appends to fixture.
- Consolidate the duplicate `IntentLevel`/`IntentCategory` type definitions (intent-task.types vs v2/request.types) — separate cleanup PR.
- LLM fallback (Mia §5 Q3 default).
- L3-specific routing-split (Mia §5 Q5 + ORC follow-on ticket).

## Reviewer dispatch (per Sam's protocol)

- **Arch** — diff-piped-inline review same as B0/B1/Decompose.
- **Mia** — fixture review (concurrent with Arch). Specifically the §3 negative-L2 fixture (over-promotion guard) — that's the row Mia flagged as "most worried about under-testing".

## Test plan

- [x] `npm run build` green
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [x] 269/269 across 6 directly-touched test suites
- [x] Mia §6 acceptance criteria 1-5 verified
- [ ] Mia approves the §3 negative-L2 fixture
- [ ] Arch verdict clean
- [ ] Post-merge smoke: re-classify the bound Steve dogfood pair against running backend; assert workItemIds.length > 0 within 10s of POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)