### PR TITLE
fix(classifier): issue #472 — symmetric 做 negative lookahead (mistake-form parity with 搞)

### DIFF
--- a/backend/src/services/intent-task/intent-classifier.fixture.ts
+++ b/backend/src/services/intent-task/intent-classifier.fixture.ts
@@ -205,6 +205,12 @@ export const NON_ACTIONABLE_FIXTURES: { input: string; rationale: string; source
   { input: '搞砸了', rationale: 'Mia stricter 2026-05-06: ZH botched', source: 'Mia inline 2026-05-06' },
   // Completed action
   { input: '做完了', rationale: 'Mia stricter 2026-05-06: ZH completed (no imperative prefix)', source: 'Mia inline 2026-05-06' },
+  // Issue #472 — symmetry fix: 做 mistake-form coverage parallel to 搞 砸|错|乱|糊涂.
+  // Pre-fix the bare 做 token reached the L2 promoter on these forms because
+  // the negative lookahead omitted 错|坏|废.
+  { input: '做错了', rationale: 'Issue #472: ZH bare-做 mistake-form (做错) — parallel to 搞错', source: 'Arch nit on PR #471' },
+  { input: '做坏了', rationale: 'Issue #472: ZH bare-做 mistake-form (做坏) — parallel to 搞错', source: 'Arch nit on PR #471' },
+  { input: '做废了', rationale: 'Issue #472: ZH bare-做 mistake-form (做废) — parallel to 搞错', source: 'Arch nit on PR #471' },
 ];
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/intent-task/intent-classifier.rules.test.ts
+++ b/backend/src/services/intent-task/intent-classifier.rules.test.ts
@@ -220,6 +220,32 @@ describe('Action verbs (EN + ZH)', () => {
     expect(ACTION_VERB_ZH.test('搞错了')).toBe(false);
     expect(ACTION_VERB_ZH.test('搞不定')).toBe(false);
   });
+
+  it('Issue #472 fix: 做错 / 做坏 / 做废 do NOT fire as actionable verbs', () => {
+    // Symmetry fix on the bare-做 negative-lookahead. Pre-fix the bare 做
+    // token matched these mistake-suffix forms because the lookahead only
+    // excluded completed/denial suffixes (了|过|得|的|出|不到|不了|...).
+    // 搞's lookahead already had the parallel exclusion (砸|错|乱|糊涂);
+    // 做 was the asymmetric case. This test pins the new symmetric
+    // behavior so a future tweak can't regress.
+    expect(ACTION_VERB_ZH.test('做错')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做错了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做坏')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做坏了')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做废')).toBe(false);
+    expect(ACTION_VERB_ZH.test('做废了')).toBe(false);
+  });
+
+  it('Issue #472 fix: NON_ACTIONABLE_PATTERNS_ZH row-c covers 做错|做坏|做废', () => {
+    // Parallel coverage for sentence-shape forms: even a longer message
+    // ending in 做错了 / 做坏了 / 做废了 should be filtered as non-actionable.
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('做错了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('做坏了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('做废了'))).toBe(true);
+    // Pre-existing parallel forms still covered.
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('搞砸了'))).toBe(true);
+    expect(NON_ACTIONABLE_PATTERNS_ZH.some((p) => p.test('搞错了'))).toBe(true);
+  });
 });
 
 describe('Non-actionable ZH patterns (Mia stricter-default)', () => {

--- a/backend/src/services/intent-task/intent-classifier.rules.ts
+++ b/backend/src/services/intent-task/intent-classifier.rules.ts
@@ -305,7 +305,14 @@ export const ACTION_VERB_EN = /\b(fix|build|create|deploy|implement|add|update|d
  * the lookahead alone cannot catch — both layers together produce the
  * stricter behaviour Mia asked for.
  */
-export const ACTION_VERB_ZH = /(做(?!了|过|得|的|出|不到|不了|不下|不来|不出)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|搞定|做完|完成|重启|启动|停止|关闭|检查|查看|查询|修复|修\b|改|改写|编写|起草|添加|删除|移除|部署|上线|发布|创建|实现|构建|搭建|设计|分析|审查|评审|编排|调研|规划|计划|制定|优化|重构|拆分|分发|分派|协调|分配|统筹|集成|配置|安装|更新|升级|迁移|回填|监控|跟踪|追踪|调试|跑|执行|处理|准备|提交|合并|推送|拉取|发版|交付|落地|拿下|测试|审计|评估|排查|审核|审定)/;
+// Issue #472 (Arch nit on PR #471): symmetry fix on the bare-做
+// negative-lookahead list. 搞 already excluded its mistake/botched
+// suffixes (砸|错|乱|糊涂); 做 only excluded completed/denial suffixes
+// (了|过|得|的|出|不到|不了|不下|不来|不出) and missed the parallel
+// mistake suffixes (错|坏|废). Operational risk: a user typing
+// "做错了" / "做坏了" / "做废了" matched the bare 做 token and reached
+// the L2 promoter. Symmetric coverage closes the gap.
+export const ACTION_VERB_ZH = /(做(?!了|过|得|的|出|错|坏|废|不到|不了|不下|不来|不出)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|搞定|做完|完成|重启|启动|停止|关闭|检查|查看|查询|修复|修\b|改|改写|编写|起草|添加|删除|移除|部署|上线|发布|创建|实现|构建|搭建|设计|分析|审查|评审|编排|调研|规划|计划|制定|优化|重构|拆分|分发|分派|协调|分配|统筹|集成|配置|安装|更新|升级|迁移|回填|监控|跟踪|追踪|调试|跑|执行|处理|准备|提交|合并|推送|拉取|发版|交付|落地|拿下|测试|审计|评估|排查|审核|审定)/;
 
 // ---------------------------------------------------------------------------
 // Non-actionable patterns — ZH parity additions
@@ -344,7 +351,10 @@ export const NON_ACTIONABLE_PATTERNS_ZH: RegExp[] = [
   // (b) "(I) can't do X" — capability denial, not a directive.
   /^.{0,20}?(做不到|做不了|做不下来|做不出来|搞不定|搞不动|搞不了|完不成|弄不了|没做完|没搞定)/,
   // (c) Short message ending in a botched/error verb (搞砸/搞错).
-  /^.{0,30}?(搞砸|搞错|搞乱|搞糊涂)(?:了|过)?\s*[。！？!?]?$/,
+  // Issue #472: parallel mistake-form coverage. 搞 had 砸|错|乱|糊涂;
+  // 做 needs the parallel 错|坏|废 forms so a user message like "做错了" /
+  // "做坏了" / "做废了" is filtered before the L2 promoter sees it.
+  /^.{0,30}?(搞砸|搞错|搞乱|搞糊涂|做错|做坏|做废|做糟)(?:了|过)?\s*[。！？!?]?$/,
 ];
 
 // ---------------------------------------------------------------------------
@@ -428,7 +438,9 @@ export const CATEGORY_KEYWORDS = {
     // exclude their non-imperative suffixes rather than relying on \b.
     // Mia stricter-default: 做(?!了|过|得|的|出) excludes 做了/做过/做得/
     // 做的/做出 — the conversational/completed forms.
-    zh: /(实现|添加|创建|开发|编写|搭建|新增|修改|更新|更改|重构|删除|移除|优化|增强|扩展|抽取|内联|合并|拆分|转换|生成|脚手架|配置|安装|集成|连接|启用|禁用|改成|改名|改完|改造|改一下|改个|做(?!了|过|得|的|出|不到|不了)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|去掉|去除|加上|加入|加进|重启|启动)/,
+    // Issue #472: parallel symmetry fix — 做(?!...|错|坏|废|...) so the
+    // codeChange category doesn't fire on "做错" / "做坏" / "做废" forms.
+    zh: /(实现|添加|创建|开发|编写|搭建|新增|修改|更新|更改|重构|删除|移除|优化|增强|扩展|抽取|内联|合并|拆分|转换|生成|脚手架|配置|安装|集成|连接|启用|禁用|改成|改名|改完|改造|改一下|改个|做(?!了|过|得|的|出|错|坏|废|不到|不了)|写(?!不出|不来)|搞(?!砸|错|不定|不动|不了|乱|糊涂)|去掉|去除|加上|加入|加进|重启|启动)/,
   },
   query: {
     en: /\b(what|where|when|who|which|how|show|list|get|status|check|find|search|look\s*up|count|describe|explain)\b/i,


### PR DESCRIPTION
## Summary

Closes #472 (Arch nit on PR #471). Symmetric fix on the bare-`做` negative-lookahead in `ACTION_VERB_ZH`: `搞` already excluded its mistake/botched suffixes (`砸|错|乱|糊涂`); `做` only excluded completed/denial suffixes and missed the parallel mistake suffixes (`错|坏|废`). A user typing `做错了` / `做坏了` / `做废了` previously matched the bare-做 token and reached the L2 promoter — symmetry closes the gap.

## What changed

| Site | Before | After |
|---|---|---|
| `ACTION_VERB_ZH` line 308 | `做(?!了|过|得|的|出|不到|不了|不下|不来|不出)` | `做(?!了|过|得|的|出|`**`错|坏|废`**`|不到|不了|不下|不来|不出)` |
| `CATEGORY_KEYWORDS.codeChange.zh` | bare-做 lookahead missing mistake forms | parallel symmetry fix |
| `NON_ACTIONABLE_PATTERNS_ZH` row-c | `(搞砸|搞错|搞乱|搞糊涂)` | `(搞砸|搞错|搞乱|搞糊涂|`**`做错|做坏|做废|做糟`**`)` |

## Tests

**129/129 across 3 directly-touched suites (+5 new pinning the symmetric behavior):**

- `intent-classifier.rules.test.ts`:
  - `Issue #472 fix: 做错 / 做坏 / 做废 do NOT fire as actionable verbs`
  - `Issue #472 fix: NON_ACTIONABLE_PATTERNS_ZH row-c covers 做错|做坏|做废`
- `intent-classifier.fixture.ts`:
  - 3 new entries in `NON_ACTIONABLE_FIXTURES` (`做错了` / `做坏了` / `做废了`)
  - Negation assertion via the existing `NON_ACTIONABLE_FIXTURES` runner — applies the Mia-flagged "negation-on-every-negative-fixture" pattern from PR #471 sign-off.

**Verification:**
- ✅ `tsc -p backend/tsconfig.json --noEmit` clean
- ✅ `npm run build` green (backend + frontend + cli)

## Operational risk closed

Pre-fix: if Steve sent a message like `做错了` or `做坏了` before the next session, the bare-做 token would match the verb axis. While the §3 anti-pattern guard typically caught the L2 promotion via missing other axes, the safety margin was thin. Symmetry restores it.

## Out of scope

- Issues #473 (charCount trim) and #474 (IntentLevel/IntentCategory duplication consolidation) — deferred per Sam's bundling guidance: pair them in a later cleanup PR to save a re-test cycle.

## Reviewer dispatch

Per Sam's protocol: ship-with-Arch, no PM gate (Mia green-lit standalone — impl hygiene, no product judgment).

## Test plan

- [x] `npm run build` green
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [x] 129/129 tests pass (5 new pinning the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)