### PR TITLE
fix(reconciler): per-type stuck timeout + gate cascade-cancel on permanent failure

### DIFF
--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -93,7 +93,15 @@ describe('detectStuckWorkItems', () => {
 
   it('should detect timed-out WorkItems even with active agents', () => {
     const oldStart = new Date(Date.now() - 700_000).toISOString(); // 11+ min ago
-    const wi = makeWorkItem({ status: 'running', target: 'agent-1', startedAt: oldStart });
+    // type='project_task' falls back to the default 600_000ms timeout;
+    // 'delegate' / 'review' / 'confirm' have per-type overrides that would
+    // skip this case (see DEFAULT_PER_TYPE_TIMEOUT_MS).
+    const wi = makeWorkItem({
+      type: 'project_task',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: oldStart,
+    });
     const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
 
     const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000);
@@ -137,6 +145,83 @@ describe('detectStuckWorkItems', () => {
 
     const { stuckIds } = detectStuckWorkItems([wi], agentMap);
     expect(stuckIds).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Per-type timeout (2026-05-06 dogfood regression — see DEFAULT_PER_TYPE_TIMEOUT_MS)
+  // -------------------------------------------------------------------------
+  it('should NOT timeout delegate-type WIs at the default 10min threshold', () => {
+    // 11 minutes of running — past the legacy 10min default but well within
+    // the 4h delegate-type override. A TL umbrella WI must not flip to failed
+    // here, otherwise the cascade-cancel rules will wipe its children.
+    const oldStart = new Date(Date.now() - 11 * 60 * 1000).toISOString();
+    const wi = makeWorkItem({
+      type: 'delegate',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: oldStart,
+    });
+    const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
+
+    const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000);
+    expect(stuckIds).toHaveLength(0);
+  });
+
+  it('should NOT timeout review-type WIs at the default 10min threshold', () => {
+    const oldStart = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const wi = makeWorkItem({
+      type: 'review',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: oldStart,
+    });
+    const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
+
+    const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000);
+    expect(stuckIds).toHaveLength(0);
+  });
+
+  it('should still timeout delegate WIs once the 4h ceiling is exceeded', () => {
+    const oldStart = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(); // 5h
+    const wi = makeWorkItem({
+      type: 'delegate',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: oldStart,
+    });
+    const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
+
+    const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000);
+    expect(stuckIds).toContain(wi.id);
+  });
+
+  it('should NEVER timeout confirm-type WIs (waiting on user)', () => {
+    const ancientStart = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(); // 24h
+    const wi = makeWorkItem({
+      type: 'confirm',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: ancientStart,
+    });
+    const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
+
+    const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000);
+    expect(stuckIds).toHaveLength(0);
+  });
+
+  it('should honor caller-provided per-type timeout overrides', () => {
+    const oldStart = new Date(Date.now() - 30_000).toISOString(); // 30s
+    const wi = makeWorkItem({
+      type: 'project_task',
+      status: 'running',
+      target: 'agent-1',
+      startedAt: oldStart,
+    });
+    const agentMap = makeAgentMap([['agent-1', { status: 'active' }]]);
+
+    // Override default 10min → 10s for project_task; the 30s-old WI should now timeout.
+    const { stuckIds } = detectStuckWorkItems([wi], agentMap, 600_000, { project_task: 10_000 });
+    expect(stuckIds).toContain(wi.id);
   });
 });
 
@@ -283,13 +368,37 @@ describe('detectOrphanWorkItems', () => {
     expect(orphanIds).toContain('child-1');
   });
 
-  it('should detect children of failed parents', () => {
-    const parent = makeWorkItem({ id: 'parent-1', status: 'failed' });
+  it('should detect children of permanently-failed parents (retries exhausted)', () => {
+    const parent = makeWorkItem({
+      id: 'parent-1',
+      status: 'failed',
+      retryCount: 3,
+      maxRetries: 3,
+    });
     const child = makeWorkItem({ id: 'child-1', status: 'queued', parentWorkItemId: 'parent-1' });
     const workItemMap = new Map([[parent.id, parent], [child.id, child]]);
 
     const { orphanIds } = detectOrphanWorkItems([child], workItemMap);
     expect(orphanIds).toContain('child-1');
+  });
+
+  it('should NOT cascade-cancel when parent is failed but retries remain', () => {
+    // Regression: 2026-05-06 dogfood — umbrella WI hit a 10min timeout, was
+    // marked failed, all 6 children got cancelled, then auto-retry resurrected
+    // the parent leaving it childless. The cascade must skip retry-eligible
+    // parents so the auto-retry pass can revive the whole subtree.
+    const parent = makeWorkItem({
+      id: 'parent-retryable',
+      status: 'failed',
+      retryCount: 0,
+      maxRetries: 3,
+    });
+    const child = makeWorkItem({ id: 'child-1', status: 'queued', parentWorkItemId: 'parent-retryable' });
+    const workItemMap = new Map([[parent.id, parent], [child.id, child]]);
+
+    const { orphanIds, corrections } = detectOrphanWorkItems([child], workItemMap);
+    expect(orphanIds).toHaveLength(0);
+    expect(corrections).toHaveLength(0);
   });
 
   it('should skip children with active parents', () => {
@@ -517,6 +626,45 @@ describe('runPruningPass', () => {
   it('should handle empty WorkItems array', () => {
     const result = runPruningPass([]);
     expect(result.totalCorrections).toHaveLength(0);
+  });
+
+  it('REGRESSION 2026-05-06: failed-but-retryable parent must NOT cascade-cancel its children', () => {
+    // Reproduces the dogfood data-loss: umbrella WI hits running-timeout →
+    // status='failed' (retryCount=0/max=3). Same reconciler pass runs the
+    // pruning loop; before the fix this cancelled all 6 P0 children. After
+    // the fix, the children stay queued so the auto-retry can revive the
+    // whole subtree.
+    const parent = makeWorkItem({
+      id: 'umbrella',
+      status: 'failed',
+      retryCount: 0,
+      maxRetries: 3,
+    });
+    const children = [
+      makeWorkItem({ id: 'p0-1', status: 'queued', parentWorkItemId: 'umbrella' }),
+      makeWorkItem({ id: 'p0-2', status: 'queued', parentWorkItemId: 'umbrella' }),
+      makeWorkItem({ id: 'p0-3', status: 'queued', parentWorkItemId: 'umbrella' }),
+      makeWorkItem({ id: 'p0-4', status: 'queued', parentWorkItemId: 'umbrella' }),
+      makeWorkItem({ id: 'p0-5', status: 'queued', parentWorkItemId: 'umbrella' }),
+      makeWorkItem({ id: 'p0-6', status: 'queued', parentWorkItemId: 'umbrella' }),
+    ];
+
+    const result = runPruningPass([parent, ...children]);
+    expect(result.orphanCancelledCount).toBe(0);
+    expect(result.cascadeCancelledCount).toBe(0);
+  });
+
+  it('should still cascade-cancel children when parent has exhausted retries', () => {
+    const parent = makeWorkItem({
+      id: 'umbrella-dead',
+      status: 'failed',
+      retryCount: 3,
+      maxRetries: 3,
+    });
+    const child = makeWorkItem({ id: 'c1', status: 'queued', parentWorkItemId: 'umbrella-dead' });
+
+    const result = runPruningPass([parent, child]);
+    expect(result.orphanCancelledCount).toBe(1);
   });
 });
 

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -58,18 +58,68 @@ export interface AgentHealth {
 // ---------------------------------------------------------------------------
 
 /**
+ * Per-WorkItemType timeout overrides for the stuck detector.
+ *
+ * **Why per-type:** the original single-value timeout (10 min) treated every
+ * WI the same — including `delegate`/`review` WIs that, by design, supervise
+ * multi-actor work spanning hours. A 10-min ceiling on a TL umbrella will
+ * always fire while the TL is still actively orchestrating, falsely marking
+ * it `failed` and (via cascade rules) cancelling its children. Workshop
+ * dogfood on 2026-05-06 lost 6 P0 child WIs to exactly this race.
+ *
+ * Defaults:
+ *   - `delegate`, `review` — 4h (these supervise long-running coordination)
+ *   - `confirm`            — Number.POSITIVE_INFINITY (waits for user; never timeout)
+ *   - everything else      — falls back to the caller-provided default
+ *
+ * Callers may pass a partial override map to tighten or loosen any entry.
+ */
+export const DEFAULT_PER_TYPE_TIMEOUT_MS: Partial<Record<WorkItem['type'], number>> = {
+  delegate: 4 * 60 * 60 * 1000,
+  review: 4 * 60 * 60 * 1000,
+  confirm: Number.POSITIVE_INFINITY,
+};
+
+/**
+ * Resolves the timeout for a given WorkItem type.
+ *
+ * @param type        - WorkItem.type value
+ * @param defaultMs   - Fallback when no per-type override exists
+ * @param overrides   - Optional caller-supplied per-type overrides (merged on top of defaults)
+ * @returns Timeout in ms, or Number.POSITIVE_INFINITY for "never timeout"
+ */
+function resolveTimeoutForType(
+  type: WorkItem['type'],
+  defaultMs: number,
+  overrides?: Partial<Record<WorkItem['type'], number>>,
+): number {
+  if (overrides && type in overrides) {
+    const v = overrides[type];
+    if (typeof v === 'number') return v;
+  }
+  if (type in DEFAULT_PER_TYPE_TIMEOUT_MS) {
+    const v = DEFAULT_PER_TYPE_TIMEOUT_MS[type];
+    if (typeof v === 'number') return v;
+  }
+  return defaultMs;
+}
+
+/**
  * Detects WorkItems that are 'running' but whose assigned agent is not alive.
  * Returns corrections to transition them to 'blocked' or 'failed'.
  *
  * @param workItems - All running WorkItems
  * @param agentHealthMap - Map of agent session → health info
- * @param timeoutMs - Max duration a WorkItem can be running (default: 10 min)
+ * @param timeoutMs - Default running timeout (default: 10 min); per-type overrides
+ *                   in {@link DEFAULT_PER_TYPE_TIMEOUT_MS} apply on top of this
+ * @param timeoutOverrides - Optional caller-supplied per-type overrides
  * @returns Array of corrections and affected WorkItem IDs
  */
 export function detectStuckWorkItems(
   workItems: WorkItem[],
   agentHealthMap: Map<string, AgentHealth>,
   timeoutMs: number = 600_000,
+  timeoutOverrides?: Partial<Record<WorkItem['type'], number>>,
 ): { corrections: ReconcileCorrection[]; stuckIds: string[] } {
   const corrections: ReconcileCorrection[] = [];
   const stuckIds: string[] = [];
@@ -82,7 +132,8 @@ export function detectStuckWorkItems(
     const agent = agentHealthMap.get(wi.target);
     const isAgentDead = !agent || agent.status === 'inactive' || agent.status === 'unknown';
     const startedAt = wi.startedAt ? new Date(wi.startedAt).getTime() : new Date(wi.createdAt).getTime();
-    const isTimedOut = (now - startedAt) > timeoutMs;
+    const effectiveTimeoutMs = resolveTimeoutForType(wi.type, timeoutMs, timeoutOverrides);
+    const isTimedOut = Number.isFinite(effectiveTimeoutMs) && (now - startedAt) > effectiveTimeoutMs;
 
     if (isAgentDead) {
       const newStatus: WorkItemStatus = wi.retryCount < wi.maxRetries ? 'blocked' : 'failed';
@@ -101,8 +152,8 @@ export function detectStuckWorkItems(
         entityId: wi.id,
         previousState: 'running',
         newState: 'failed',
-        reason: `WorkItem exceeded timeout of ${timeoutMs}ms`,
-        evidence: `Started at ${wi.startedAt ?? wi.createdAt}, running for ${now - startedAt}ms`,
+        reason: `WorkItem (type=${wi.type}) exceeded timeout of ${effectiveTimeoutMs}ms`,
+        evidence: `Started at ${wi.startedAt ?? wi.createdAt}, running for ${now - startedAt}ms (limit ${effectiveTimeoutMs}ms)`,
       }));
       stuckIds.push(wi.id);
     }
@@ -242,8 +293,35 @@ export function reconcileRequestStatus(
 // ---------------------------------------------------------------------------
 
 /**
- * Detects WorkItems whose parent has been cancelled/failed but are still active.
- * These should be cascade-cancelled.
+ * A parent WorkItem is treated as **permanently** terminal — and therefore
+ * eligible to cascade-cancel its children — only when:
+ *
+ *   - status === 'cancelled' (terminal by definition), OR
+ *   - status === 'failed' AND retryCount >= maxRetries (no more retries)
+ *
+ * A `failed` parent that still has retries left is **not** terminal: the
+ * Reconciler's auto-retry rule ({@link detectRetryableFailedWorkItems}) will
+ * re-queue it on the same pass. If we cascade-cancel the children at that
+ * moment, the parent gets revived but its children are already in the
+ * irreversible `cancelled` state — which is exactly the data-loss bug
+ * observed in the 2026-05-06 dogfood (umbrella WI 5bccc08d timed out, all 6
+ * P0 child WIs were cancelled, parent then auto-retried but was childless).
+ *
+ * @param parent - Parent WorkItem
+ * @returns True if cascade should fire on this parent
+ */
+function isParentPermanentlyTerminal(parent: WorkItem): boolean {
+  if (parent.status === 'cancelled') return true;
+  if (parent.status === 'failed' && parent.retryCount >= parent.maxRetries) return true;
+  return false;
+}
+
+/**
+ * Detects WorkItems whose parent has been permanently cancelled/failed but
+ * are still active. These should be cascade-cancelled.
+ *
+ * Children of `failed`-but-retryable parents are intentionally **skipped** —
+ * see {@link isParentPermanentlyTerminal} for the rationale.
  *
  * @param workItems - All WorkItems to check
  * @param workItemMap - Map of WorkItem ID → WorkItem for parent lookup
@@ -263,14 +341,14 @@ export function detectOrphanWorkItems(
     const parent = workItemMap.get(wi.parentWorkItemId);
     if (!parent) continue;
 
-    if (parent.status === 'cancelled' || parent.status === 'failed') {
+    if (isParentPermanentlyTerminal(parent)) {
       corrections.push(createCorrection({
         entityType: 'work_item',
         entityId: wi.id,
         previousState: wi.status,
         newState: 'cancelled',
-        reason: `Parent WorkItem ${parent.id} is ${parent.status}`,
-        evidence: `Cascade cancel: parent.status=${parent.status}, child.status=${wi.status}`,
+        reason: `Parent WorkItem ${parent.id} is ${parent.status} (permanent: retries ${parent.retryCount}/${parent.maxRetries})`,
+        evidence: `Cascade cancel: parent.status=${parent.status}, parent.retryCount=${parent.retryCount}/${parent.maxRetries}, child.status=${wi.status}`,
       }));
       orphanIds.push(wi.id);
     }
@@ -495,10 +573,12 @@ export function runPruningPass(
   // 2. Orphan detection
   const orphans = detectOrphanWorkItems(allWorkItems, workItemMap);
 
-  // 3. Build cancelled set for cascade
+  // 3. Build cancelled set for cascade — only include parents that are
+  //    *permanently* terminal. A `failed` parent with retries remaining is
+  //    excluded so its children are not cancelled mid-retry-window.
   const cancelledIds = new Set<string>();
   for (const wi of allWorkItems) {
-    if (wi.status === 'cancelled' || wi.status === 'failed') {
+    if (isParentPermanentlyTerminal(wi)) {
       cancelledIds.add(wi.id);
     }
   }


### PR DESCRIPTION
## Summary

Two reconciler bugs combined to delete 6 in-flight P0 child WorkItems during the 2026-05-06 dogfood. This patch fixes both.

- **Per-type stuck timeout** — `delegate` and `review` WIs (which supervise multi-actor work) get a 4h ceiling instead of the universal 10-min one. `confirm` never times out (waits for user). Default behavior unchanged for `project_task` / `check` / `notify` / `cron_run` / `reconcile`.
- **Cascade-cancel gated on permanent parent failure** — children are cancel-cascaded only when the parent is `cancelled` OR (`failed` AND `retryCount >= maxRetries`). Children of retry-eligible parents stay non-terminal so the auto-retry pass can revive the whole subtree.

## The dogfood timeline that motivated this

```
02:59:37  Request 0827cd1e created
03:00:42  Umbrella WI 5bccc08d (type=delegate) added to pool
03:00:46  Sam auto-claimed → running
03:00..   Sam decomposed into 6 P0 child WIs
03:10:47  ⚠ Reconciler: umbrella exceeded 10min timeout → status=failed
03:11:17  Same pass:
            • all 6 children: queued → cancelled (parent failed)
            • umbrella: failed → queued (auto-retry 1/3)
          Net: parent revived, children dead, irreversible.
```

After this PR, step 03:10:47 no longer fires for `delegate` (4h ceiling), and even if a future `delegate` does genuinely fail mid-retry-window, the children stay non-terminal until retries are truly exhausted.

## Test plan

- [x] `npx jest backend/src/services/reconciler/` — 125/125 pass (was 117 pre-patch, +8 new cases including a regression test that reproduces the 6-children scenario)
- [x] `tsc --noEmit -p backend/tsconfig.json` — clean
- [ ] Backend restart + manual verification: re-trigger an L1/L2 Slack request, confirm umbrella stays `running` past 10 min and children survive
- [ ] Observe one full reconciler pass (60s) post-restart to confirm no spurious cascade-cancel events in logs

## Out of scope (follow-ups)

- The `AgentAutoClaim` gap that left Leo / Max / Quinn / Mia unwoken on the original P0-3..P0-6 WIs is a separate concern; deferring until we observe behavior after this restart.
- Backfill of the 6 already-cancelled P0 children — `cancelled` is terminal by contract; recovery is to recreate fresh WIs after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)