### PR TITLE
feat(v3): WorkItemDispatchSubscriber — push WI dispatch to active target sessions

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1699,6 +1699,21 @@ export class CrewlyServer {
 				});
 			}
 
+			// Start WorkItemDispatchSubscriber FIRST — AgentAutoClaim's recovery
+			// path delegates to its dispatchTo() for the "active target session"
+			// branch, so the singleton must be reachable when recovery fires.
+			try {
+				const { WorkItemDispatchSubscriber } = await import('./services/v3/workitem-dispatch.subscriber.js');
+				const dispatchSubscriber = WorkItemDispatchSubscriber.getInstance();
+				dispatchSubscriber.initialize(this.eventBusService);
+				dispatchSubscriber.start();
+				this.logger.info('WorkItemDispatchSubscriber started — workitem:queued events push to target sessions');
+			} catch (dispatchErr) {
+				this.logger.warn('WorkItemDispatchSubscriber initialization failed (non-critical)', {
+					error: dispatchErr instanceof Error ? dispatchErr.message : String(dispatchErr),
+				});
+			}
+
 			// Start AgentAutoClaimService — auto-assign work to idle agents
 			try {
 				const { AgentAutoClaimService } = await import('./services/v3/agent-auto-claim.service.js');

--- a/backend/src/services/v3/agent-auto-claim.service.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.ts
@@ -323,12 +323,21 @@ export class AgentAutoClaimService {
 
     const agentsToWake = new Set<string>();
     const orphanedItems: typeof targetedItems = [];
+    const activeTargetedItems: typeof targetedItems = [];
 
     for (const wi of targetedItems) {
       if (!wi.target) continue;
 
       if (activeSessions.has(wi.target)) {
-        // Agent is active — it should claim the task normally
+        // Agent is active — historically we skipped here on the assumption
+        // that "an active agent will claim the task on its own". Empirically
+        // (2026-05-06 dogfood) that assumption is broken: an agent that
+        // returned from a session-history reload, or that is mid-thought
+        // when the WI lands, never emits `agent:idle` and therefore never
+        // triggers AutoClaim's pull path. Hand off to the dispatch
+        // subscriber instead — it pushes a [CREWLY-DISPATCH] prompt to the
+        // target session telling them to run poll-tasks.
+        activeTargetedItems.push(wi);
         continue;
       }
 
@@ -338,6 +347,29 @@ export class AgentAutoClaimService {
       } else {
         // Agent doesn't exist in any team → orphaned task
         orphanedItems.push(wi);
+      }
+    }
+
+    // Dispatch to active targets. Best-effort, non-fatal — the
+    // WorkItemDispatchSubscriber will also rerun via its own startup
+    // backfill ~10s after this returns, so a transient failure here
+    // doesn't strand the WI.
+    if (activeTargetedItems.length > 0) {
+      try {
+        const { WorkItemDispatchSubscriber } = await import('./workitem-dispatch.subscriber.js');
+        const dispatcher = WorkItemDispatchSubscriber.getInstance();
+        let dispatched = 0;
+        for (const wi of activeTargetedItems) {
+          if (await dispatcher.dispatchTo(wi)) dispatched += 1;
+        }
+        this.logger.info('Dispatched queued WIs to active target sessions', {
+          attempted: activeTargetedItems.length,
+          dispatched,
+        });
+      } catch (err) {
+        this.logger.warn('Active-target dispatch failed (non-fatal)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 
@@ -435,10 +467,11 @@ export class AgentAutoClaimService {
       }
     }
 
-    if (agentsToWake.size > 0 || orphanedItems.length > 0) {
+    if (agentsToWake.size > 0 || orphanedItems.length > 0 || activeTargetedItems.length > 0) {
       this.logger.info('Startup task recovery complete', {
         agentsWoken: agentsToWake.size,
         orphanedEscalated: orphanedItems.length,
+        activeTargetsDispatched: activeTargetedItems.length,
         totalTargetedQueued: targetedItems.length,
       });
     }

--- a/backend/src/services/v3/workitem-dispatch.subscriber.test.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for WorkItemDispatchSubscriber.
+ *
+ * Covers the runtime path (workitem:queued event listener) and the dispatch
+ * primitive used by both the subscriber and AgentAutoClaim's recovery.
+ *
+ * @module services/v3/workitem-dispatch.subscriber.test
+ */
+
+import axios from 'axios';
+import { WorkItemDispatchSubscriber } from './workitem-dispatch.subscriber.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
+import { createWorkItem } from '../../types/v2/index.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+/**
+ * Builds a minimal WorkItem fixture. Spec-required fields only — tests
+ * override what they care about.
+ */
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    ...createWorkItem({
+      type: 'project_task',
+      owner: 'agent',
+      title: 'default title',
+      target: 'crewly-product-leo-21a5477e',
+    }),
+    ...overrides,
+  };
+}
+
+describe('WorkItemDispatchSubscriber', () => {
+  beforeEach(() => {
+    WorkItemDispatchSubscriber.resetInstance();
+    jest.clearAllMocks();
+    mockedAxios.post.mockResolvedValue({ status: 200, data: { success: true } });
+  });
+
+  describe('singleton', () => {
+    it('returns the same instance', () => {
+      const a = WorkItemDispatchSubscriber.getInstance();
+      const b = WorkItemDispatchSubscriber.getInstance();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('dispatchTo', () => {
+    it('POSTs a [CREWLY-DISPATCH] message to the target session', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-1', target: 'crewly-product-max-358c7cb7' });
+
+      const ok = await svc.dispatchTo(wi);
+      expect(ok).toBe(true);
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+
+      const [url, body, config] = mockedAxios.post.mock.calls[0];
+      expect(url).toContain('/api/terminal/crewly-product-max-358c7cb7/write');
+      expect((body as { mode: string }).mode).toBe('message');
+      expect((body as { data: string }).data).toContain('[CREWLY-DISPATCH]');
+      expect((body as { data: string }).data).toContain('wi-1');
+      expect((body as { data: string }).data).toContain('poll-tasks');
+      expect((config as { headers: { 'X-Agent-Session': string } }).headers['X-Agent-Session']).toBe('WorkItemDispatch');
+    });
+
+    it('skips WIs without a target', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-no-target', target: undefined });
+
+      const ok = await svc.dispatchTo(wi);
+      expect(ok).toBe(false);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('skips SLA tracker WIs (respond_to_user pattern)', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({
+        id: 'request:abc-123:respond_to_user',
+        target: 'crewly-orc',
+      });
+
+      const ok = await svc.dispatchTo(wi);
+      expect(ok).toBe(false);
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: a second call for the same WI is a no-op', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-dup' });
+
+      const first = await svc.dispatchTo(wi);
+      const second = await svc.dispatchTo(wi);
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not mark dispatched on HTTP failure (allows retry)', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-failing' });
+
+      mockedAxios.post.mockRejectedValueOnce(new Error('connection refused'));
+      const first = await svc.dispatchTo(wi);
+      expect(first).toBe(false);
+
+      // Now succeeds — should still be allowed (not blocked by dedup set)
+      mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { success: true } });
+      const retry = await svc.dispatchTo(wi);
+      expect(retry).toBe(true);
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    });
+
+    it('encodes session names with special characters into the URL', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-encode', target: 'agent name with space' });
+
+      await svc.dispatchTo(wi);
+      const [url] = mockedAxios.post.mock.calls[0];
+      expect(url).toContain(encodeURIComponent('agent name with space'));
+    });
+  });
+
+  describe('event subscription', () => {
+    it('warns when started without initialization', () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      expect(() => svc.start()).not.toThrow();
+    });
+
+    it('subscribes to event_published', () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const mockEventBus = { on: jest.fn() };
+      svc.initialize(mockEventBus);
+      svc.start();
+      expect(mockEventBus.on).toHaveBeenCalledWith('event_published', expect.any(Function));
+    });
+
+    it('dispatches on workitem:queued, ignores other event types', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const mockEventBus = { on: jest.fn() };
+      svc.initialize(mockEventBus);
+      svc.start();
+
+      const wi = makeWorkItem({ id: 'wi-from-event' });
+      jest.spyOn(TaskPoolService, 'getInstance').mockReturnValue({
+        findWorkItem: jest.fn().mockResolvedValue(wi),
+      } as unknown as TaskPoolService);
+
+      // Pull the registered handler
+      const handler = mockEventBus.on.mock.calls[0][1];
+
+      // Wrong event type — no dispatch
+      await handler({ eventType: 'task:done', workItemId: 'wi-from-event' });
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+
+      // Right event type — dispatch
+      handler({ eventType: 'workitem:queued', workItemId: 'wi-from-event' });
+      // handler is fire-and-forget; allow async settle
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips event dispatch when WI has already moved past queued', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const mockEventBus = { on: jest.fn() };
+      svc.initialize(mockEventBus);
+      svc.start();
+
+      const movedWi = makeWorkItem({ id: 'wi-moved', status: 'running' });
+      jest.spyOn(TaskPoolService, 'getInstance').mockReturnValue({
+        findWorkItem: jest.fn().mockResolvedValue(movedWi),
+      } as unknown as TaskPoolService);
+
+      const handler = mockEventBus.on.mock.calls[0][1];
+      handler({ eventType: 'workitem:queued', workItemId: 'wi-moved' });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('message format', () => {
+    it('truncates long titles to keep terminal lines bounded', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const longTitle = 'A'.repeat(200);
+      const wi = makeWorkItem({ id: 'wi-long', title: longTitle });
+
+      await svc.dispatchTo(wi);
+      const body = mockedAxios.post.mock.calls[0][1] as { data: string };
+      expect(body.data).toContain('A'.repeat(77));
+      expect(body.data).toContain('...');
+      expect(body.data).not.toContain('A'.repeat(81));
+    });
+
+    it('embeds the runnable poll-tasks command for the target', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-cmd', target: 'crewly-product-quinn-47ce967d' });
+
+      await svc.dispatchTo(wi);
+      const body = mockedAxios.post.mock.calls[0][1] as { data: string };
+      expect(body.data).toContain('bash $AGENT_SKILLS_PATH/core/poll-tasks/execute.sh');
+      expect(body.data).toContain('"sessionName":"crewly-product-quinn-47ce967d"');
+    });
+  });
+});

--- a/backend/src/services/v3/workitem-dispatch.subscriber.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.ts
@@ -1,0 +1,290 @@
+/**
+ * WorkItem Dispatch Subscriber
+ *
+ * Pushes a `[CREWLY-DISPATCH]` system message to the **target session** every
+ * time a WorkItem is added to the pool with a specific target. Closes the
+ * "queued → claimed" gap that {@link AgentAutoClaimService} cannot cover:
+ * AutoClaim is *pull* (reacts to `agent:idle` / `task:done`); this subscriber
+ * is *push* (reacts to `workitem:queued`). The two compose:
+ *
+ *   - Fresh queued WI lands → this fires → target sees the prompt, runs
+ *     `poll-tasks`, claims the WI.
+ *   - Agent later goes idle → AutoClaim fires → it picks the next WI.
+ *
+ * **Why both are needed.** AutoClaim's startup recovery
+ * ({@link AgentAutoClaimService.recoverPendingTasks}) skips WIs whose
+ * target agent is already `active` on the assumption that "an active agent
+ * will claim it on its own". Empirically (2026-05-06 dogfood) that's false:
+ * an agent in the middle of a long thought stream never emits the
+ * `agent:idle` event AutoClaim listens to, so targeted WIs sit in the pool
+ * untouched. This subscriber covers exactly that case.
+ *
+ * **Integration with AgentAutoClaim.** The recovery path's `active` branch
+ * delegates here via {@link WorkItemDispatchSubscriber.dispatchTo}, so both
+ * paths emit the identical message. No double-fire because the dedup Set
+ * is shared across both call-sites.
+ *
+ * **Dedup contract.** Each WI is dispatched at most once per process
+ * lifetime (in-memory `Set<workItemId>`). Backend restart resets the set —
+ * which is the desired behavior since startup backfill needs to re-fire for
+ * the queued WIs that survived the restart.
+ *
+ * @module services/v3/workitem-dispatch.subscriber
+ */
+
+import axios from 'axios';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Service identifier for logs and the X-Agent-Session caller header. */
+const SERVICE_NAME = 'WorkItemDispatch';
+
+/** Loopback API used by {@link tl-auto-verify.service.ts} et al. */
+const API_BASE = 'http://localhost:8787';
+
+/**
+ * SLA tracker WIs use a deterministic id pattern `request:<rid>:respond_to_user`
+ * (see `request-sla.subscriber.ts`). They're internal bookkeeping items, not
+ * dispatchable work, so we always skip them.
+ */
+const SLA_TRACKER_ID_PATTERN = /^request:.+:respond_to_user$/;
+
+/** Per-WI delay between backfill pushes — keeps the burst polite. */
+const BACKFILL_THROTTLE_MS = 200;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Singleton subscriber that pushes dispatch prompts to target sessions.
+ */
+export class WorkItemDispatchSubscriber {
+  private static instance: WorkItemDispatchSubscriber | null = null;
+
+  private readonly logger: ComponentLogger;
+  private eventBusService: { on: (event: string, handler: (...args: unknown[]) => void) => void } | null = null;
+
+  /**
+   * WI ids already dispatched in this process lifetime. Reset on restart —
+   * which is intentional, the startup backfill re-reads the pool.
+   */
+  private readonly dispatched = new Set<string>();
+
+  private constructor() {
+    this.logger = LoggerService.getInstance().createComponentLogger(SERVICE_NAME);
+  }
+
+  public static getInstance(): WorkItemDispatchSubscriber {
+    if (!WorkItemDispatchSubscriber.instance) {
+      WorkItemDispatchSubscriber.instance = new WorkItemDispatchSubscriber();
+    }
+    return WorkItemDispatchSubscriber.instance;
+  }
+
+  public static resetInstance(): void {
+    WorkItemDispatchSubscriber.instance = null;
+  }
+
+  /**
+   * Wire the EventBus. Must be called before {@link start}.
+   *
+   * @param eventBusService - The shared EventBusService instance
+   */
+  initialize(
+    eventBusService: { on: (event: string, handler: (...args: unknown[]) => void) => void },
+  ): void {
+    this.eventBusService = eventBusService;
+  }
+
+  /**
+   * Begin listening for `workitem:queued` events and schedule the one-shot
+   * backfill that catches WIs that survived a backend restart.
+   */
+  start(): void {
+    if (!this.eventBusService) {
+      this.logger.warn('Cannot start — EventBusService not initialized');
+      return;
+    }
+
+    this.eventBusService.on('event_published', (payload: unknown) => {
+      const event = payload as { eventType?: string; workItemId?: string };
+      if (event?.eventType !== 'workitem:queued') return;
+      if (!event.workItemId) return;
+
+      // Fire-and-forget — dispatch must not block the bus.
+      this.handleQueuedEvent(event.workItemId).catch((err) => {
+        this.logger.debug('Dispatch on workitem:queued failed (non-fatal)', {
+          workItemId: event.workItemId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+
+    // Backfill runs after AgentAutoClaim's recoverPendingTasks (which uses a
+    // 15s setTimeout — see agent-auto-claim.service.ts:122). Wait a bit
+    // longer so the wake-then-dispatch ordering is deterministic: offline
+    // agents get woken first, then we push to the still-active ones.
+    const timer = setTimeout(() => {
+      this.runStartupBackfill().catch((err) => {
+        this.logger.warn('Startup backfill failed (non-fatal)', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }, 25_000);
+    // Don't keep the event loop alive in tests / one-shot scripts.
+    timer.unref?.();
+
+    this.logger.info('WorkItemDispatchSubscriber started');
+  }
+
+  // -------------------------------------------------------------------------
+  // Public dispatch (also called from AgentAutoClaim.recoverPendingTasks)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Push a dispatch message to the WI's target session. Idempotent within
+   * the process: a second call with the same WI id is a no-op.
+   *
+   * Returns true if a message was actually written, false if skipped.
+   *
+   * @param workItem - WorkItem to dispatch
+   * @returns Whether the dispatch was actually performed
+   */
+  async dispatchTo(workItem: WorkItem): Promise<boolean> {
+    if (!workItem.target) return false;
+    if (SLA_TRACKER_ID_PATTERN.test(workItem.id)) return false;
+    if (this.dispatched.has(workItem.id)) return false;
+
+    const message = this.buildDispatchMessage(workItem);
+
+    try {
+      await axios.post(
+        `${API_BASE}/api/terminal/${encodeURIComponent(workItem.target)}/write`,
+        { data: message, mode: 'message' },
+        {
+          headers: { 'X-Agent-Session': SERVICE_NAME },
+          timeout: 5_000,
+        },
+      );
+      this.dispatched.add(workItem.id);
+      this.logger.info('Dispatched WorkItem to target session', {
+        workItemId: workItem.id,
+        target: workItem.target,
+        type: workItem.type,
+      });
+      return true;
+    } catch (err) {
+      // Common non-fatal cases: 404 (session not found — agent gone),
+      // 503 (backend not ready), connection refused. We do NOT mark
+      // dispatched on failure so a later retry path can succeed.
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      this.logger.debug('Dispatch HTTP write failed (non-fatal)', {
+        workItemId: workItem.id,
+        target: workItem.target,
+        status: status ?? 'no-response',
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal — workitem:queued event path
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetch the WI by id and dispatch it. Called from the event listener.
+   *
+   * @param workItemId - The id from the workitem:queued event payload
+   */
+  private async handleQueuedEvent(workItemId: string): Promise<void> {
+    const taskPool = TaskPoolService.getInstance();
+    const wi = await taskPool.findWorkItem(workItemId);
+    if (!wi) return;
+    if (wi.status !== 'queued') return; // Race: already moved on
+    await this.dispatchTo(wi);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal — startup backfill
+  // -------------------------------------------------------------------------
+
+  /**
+   * Scan the pool once for queued+targeted WIs that lost their dispatch
+   * push to the previous backend instance, and re-fire each. Runs ~25s
+   * after start so AgentAutoClaim's recovery (which wakes offline agents)
+   * has a chance to settle first.
+   */
+  private async runStartupBackfill(): Promise<void> {
+    const taskPool = TaskPoolService.getInstance();
+    const items = await taskPool.getAvailableItems();
+    const targeted = items.filter(
+      (wi) => wi.target && wi.status === 'queued' && !SLA_TRACKER_ID_PATTERN.test(wi.id),
+    );
+
+    if (targeted.length === 0) {
+      this.logger.debug('Startup backfill: nothing to dispatch');
+      return;
+    }
+
+    this.logger.info('Startup backfill: dispatching pre-existing queued WIs', {
+      count: targeted.length,
+      targets: [...new Set(targeted.map((wi) => wi.target))],
+    });
+
+    let dispatched = 0;
+    for (const wi of targeted) {
+      const ok = await this.dispatchTo(wi);
+      if (ok) dispatched += 1;
+      // Polite pacing — terminal writes hit the same backend HTTP path.
+      await new Promise((resolve) => setTimeout(resolve, BACKFILL_THROTTLE_MS));
+    }
+
+    this.logger.info('Startup backfill complete', {
+      total: targeted.length,
+      dispatched,
+      skipped: targeted.length - dispatched,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal — message formatting
+  // -------------------------------------------------------------------------
+
+  /**
+   * Compose the prompt the worker sees in their terminal. Format choices:
+   *
+   *   - Tagged prefix `[CREWLY-DISPATCH]` so the line is grep-able and
+   *     visually distinguishable from natural-language ORC messages.
+   *   - Includes WI id + title + type so the worker can sanity-check before
+   *     running the claim command.
+   *   - Closes with a runnable `poll-tasks` command — the worker can
+   *     copy-paste or the harness can auto-execute. We deliberately do NOT
+   *     pass the WI id to poll-tasks; the skill is role-driven and will
+   *     pick whatever matches first, which preserves AutoClaim's scoring
+   *     contract.
+   *
+   * @param workItem - WI being dispatched
+   * @returns Multi-line message suitable for terminal write
+   */
+  private buildDispatchMessage(workItem: WorkItem): string {
+    const titleSnippet = workItem.title.length > 80
+      ? workItem.title.substring(0, 77) + '...'
+      : workItem.title;
+
+    return [
+      '',
+      `[CREWLY-DISPATCH] WorkItem ${workItem.id} queued for you (type=${workItem.type}).`,
+      `  Title: ${titleSnippet}`,
+      '  Run poll-tasks to claim:',
+      `    bash $AGENT_SKILLS_PATH/core/poll-tasks/execute.sh '{"sessionName":"${workItem.target}"}'`,
+      '',
+    ].join('\n');
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **queued→claimed gap** that `AgentAutoClaim` cannot cover.

- AutoClaim is **pull**: fires on `agent:idle` / `task:done` events to give the agent its next task.
- An agent that returns from a session-history reload, or that is mid-thought when a WI lands, never emits `agent:idle` — so targeted WIs sit in the pool untouched.
- Empirically (2026-05-06 post-restart dogfood): 14 queued WIs stranded across `leo` / `max` / `quinn` while all five workers were `active` but not claiming. AutoClaim's `recoverPendingTasks` even has explicit dead-code logic for this case (`active → skip`, line 330-333) on the assumption "an active agent will claim on its own" — which is wrong.

This PR adds the **push** counterpart so the two compose.

## What changed

- **New** `backend/src/services/v3/workitem-dispatch.subscriber.ts` — singleton listening to `workitem:queued`, fetches the WI by id, POSTs a tagged `[CREWLY-DISPATCH]` message to the target session via `/api/terminal/:name/write`. The message embeds the runnable `poll-tasks` command.
- **Changed** `agent-auto-claim.service.ts:recoverPendingTasks` — the `target active` branch now delegates to `dispatchTo()` instead of skipping. Both paths share the dispatch primitive and the in-process dedup `Set`, so each WI is pushed at most once per process lifetime.
- **Wired** in `index.ts` before AutoClaim (the singleton must be reachable when AutoClaim's recovery fires ~15s after start).

Skip rules: no `target`, SLA tracker pattern (`request:<rid>:respond_to_user`), already-dispatched in this process. HTTP failures do *not* mark dispatched, so a later retry path can succeed.

## Composition with existing services

```
new WI lands → workitem:queued → [subscriber] dispatchTo → POST /terminal/:tgt/write
                              ↘ [SLA] linkWorkItem
                              ↘ [decompose] (if Request L2)

backend restart with leftovers:
  +15s  AgentAutoClaim.recoverPendingTasks
        ├─ target offline → start-agent API (wake)
        ├─ target unknown → Slack escalation
        └─ target active  → dispatchTo()        ← this PR
  +25s  subscriber.runStartupBackfill           ← belt-and-suspenders, dedup'd
```

## Test plan

- [x] `npx jest backend/src/services/v3/workitem-dispatch.subscriber.test.ts` — 13/13 pass (happy path, all skip rules, dedup, HTTP-failure retry, event subscription, message format)
- [x] `npx jest backend/src/services/v3/agent-auto-claim.service.test.ts backend/src/services/reconciler/` — 133/133 pass (no regression in adjacent suites)
- [x] `tsc --noEmit -p backend/tsconfig.json` — clean
- [ ] Backend restart + observe: confirm 14 stranded queued WIs get dispatched within 25s and target sessions transition `queued → claimed → running`
- [ ] No `[CREWLY-DISPATCH]` lines hit Sam's session (he is the umbrella owner; his WI has `target=''`)

## Out of scope (deferred)

- Worker prompt does not yet special-case the `[CREWLY-DISPATCH]` prefix; agents currently parse it as a normal terminal message and decide whether to run the embedded command. If the parse rate is poor in observation, a small SOP addition to the worker prompt is the next step.
- The 99.5% memory pressure observed at restart is a separate operational issue (orthogonal to this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)