### PR TITLE
feat(prompts): P0-4 Decision Rights + Escalation Chain across all agent roles

### DIFF
--- a/backend/src/services/ai/prompt-modules/decision-rights-role-coverage.test.ts
+++ b/backend/src/services/ai/prompt-modules/decision-rights-role-coverage.test.ts
@@ -1,0 +1,128 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Cross-role contract test for P0-4 Decision Rights + Escalation Chain.
+ *
+ * Eval criterion 1: ALL role prompts under `config/roles/` contain
+ * `## Decision Rights` AND `## Escalation Chain` headers.
+ * Eval criterion 5: Test asserts each role prompt contains the headers.
+ *
+ * This test discovers role prompts dynamically (no allowlist) so a new role
+ * dropped under `config/roles/{role}/prompt.md` is covered automatically.
+ * Adding a role without the authority block fails the test.
+ *
+ * Net-zero invariant: the spec-prohibited soft hints (`ask if unsure`,
+ * `escalate when needed`, `when in doubt`) MUST NOT appear under
+ * `config/roles/`. The DecisionRightsModule + per-role authority block are
+ * the canonical statement; vague hints around them re-introduce the bug.
+ *
+ * @see backend/src/services/ai/prompt-modules/decision-rights.module.ts
+ * @see .crewly/specs/2026-05-03-agent-improvement-p0-execution.md (Fix P0-4)
+ */
+describe('Decision Rights — role prompt coverage (P0-4 eval criteria)', () => {
+	// Walk up from this test file (backend/src/services/ai/prompt-modules/)
+	// to project root, then into config/roles/.
+	const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..');
+	const ROLES_DIR = path.join(PROJECT_ROOT, 'config', 'roles');
+
+	/**
+	 * Discover all role prompt files under config/roles/{role}/prompt.md.
+	 *
+	 * @returns Array of {role, absolutePath} for every prompt.md found
+	 */
+	function discoverRolePrompts(): Array<{ role: string; absolutePath: string }> {
+		if (!fs.existsSync(ROLES_DIR)) {
+			throw new Error(`config/roles/ not found at ${ROLES_DIR}`);
+		}
+		const entries = fs.readdirSync(ROLES_DIR, { withFileTypes: true });
+		const result: Array<{ role: string; absolutePath: string }> = [];
+		for (const e of entries) {
+			if (!e.isDirectory()) continue;
+			const promptPath = path.join(ROLES_DIR, e.name, 'prompt.md');
+			if (fs.existsSync(promptPath)) {
+				result.push({ role: e.name, absolutePath: promptPath });
+			}
+		}
+		return result.sort((a, b) => a.role.localeCompare(b.role));
+	}
+
+	const rolePrompts = discoverRolePrompts();
+
+	it('should discover at least one role prompt', () => {
+		// Sanity: if the test infrastructure breaks and finds zero role
+		// prompts the per-role assertions below would silently no-op.
+		expect(rolePrompts.length).toBeGreaterThan(0);
+	});
+
+	describe.each(rolePrompts)('role: $role', ({ absolutePath }) => {
+		const content = fs.readFileSync(absolutePath, 'utf-8');
+
+		it('contains "## Decision Rights" H2 header', () => {
+			expect(content).toMatch(/^## Decision Rights\b/m);
+		});
+
+		it('contains "## Escalation Chain" H2 header', () => {
+			expect(content).toMatch(/^## Escalation Chain\b/m);
+		});
+
+		it('encodes the four-link chain Worker → Team Lead → Orchestrator → Owner', () => {
+			expect(content).toContain('**Worker → Team Lead → Orchestrator → Owner**');
+		});
+
+		it('forbids worker-to-owner direct escalation', () => {
+			expect(content).toMatch(/Workers do \*\*not\*\* escalate directly to the owner/);
+		});
+
+		it('emits exactly five "Decide autonomously when" bullets', () => {
+			const m = content.match(/\*\*Decide autonomously when:\*\*\n([\s\S]*?)\n\n\*\*Escalate when:\*\*/);
+			expect(m).not.toBeNull();
+			const bullets = (m![1].match(/^- /gm) || []).length;
+			expect(bullets).toBe(5);
+		});
+
+		it('emits exactly five "Escalate when" bullets', () => {
+			const m = content.match(/\*\*Escalate when:\*\*\n([\s\S]*?)\n\n## Escalation Chain/);
+			expect(m).not.toBeNull();
+			const bullets = (m![1].match(/^- /gm) || []).length;
+			expect(bullets).toBe(5);
+		});
+	});
+
+	describe('net-zero spec invariant (criterion 4)', () => {
+		/**
+		 * Recursively collect every file under config/roles/.
+		 *
+		 * @param dir - Directory to walk
+		 * @returns Flat list of absolute file paths
+		 */
+		function walk(dir: string): string[] {
+			const out: string[] = [];
+			for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+				const full = path.join(dir, e.name);
+				if (e.isDirectory()) out.push(...walk(full));
+				else out.push(full);
+			}
+			return out;
+		}
+
+		const allFiles = walk(ROLES_DIR);
+		// Spec verbatim: `grep -rn "ask if unsure|escalate when needed|when in doubt" config/roles/`
+		// must return 0 hits.
+		const PROHIBITED = /\b(ask if unsure|escalate when needed|when in doubt)\b/i;
+
+		it('produces zero hits for spec-prohibited soft hints (case-insensitive)', () => {
+			const offenders: string[] = [];
+			for (const file of allFiles) {
+				const content = fs.readFileSync(file, 'utf-8');
+				const lines = content.split('\n');
+				lines.forEach((line, i) => {
+					if (PROHIBITED.test(line)) {
+						offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+					}
+				});
+			}
+			expect(offenders).toEqual([]);
+		});
+	});
+});

--- a/backend/src/services/ai/prompt-modules/decision-rights.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/decision-rights.module.test.ts
@@ -1,0 +1,163 @@
+import { DecisionRightsModule } from './decision-rights.module.js';
+import { ModuleConfig } from './prompt-module.interface.js';
+
+describe('DecisionRightsModule', () => {
+	let module: DecisionRightsModule;
+
+	const baseConfig: ModuleConfig = {
+		sessionName: 'crewly-product-sam-217bfbbf',
+		memberId: '217bfbbf-9c90-41ec-bf93-b7fca1b5934f',
+		role: 'developer',
+		teamId: '817a1aeb-b04e-45dd-bdbc-be5cbc4345f1',
+		projectPath: '/Users/user/projects/crewly',
+		agentSkillsPath: '/path/to/skills/agent',
+		tlSkillsPath: '/path/to/skills/team-leader',
+		projectRoot: '/path/to/project',
+	};
+
+	beforeEach(() => {
+		module = new DecisionRightsModule();
+	});
+
+	describe('metadata', () => {
+		it('should have name = decision-rights', () => {
+			expect(module.name).toBe('decision-rights');
+		});
+
+		it('should sit at priority 3.5 (between role-boundary=3 and memory-reference=4)', () => {
+			expect(module.priority).toBe(3.5);
+		});
+
+		it('should declare a token budget large enough for the static block', () => {
+			expect(module.maxTokens).toBeGreaterThanOrEqual(200);
+		});
+
+		it('should be non-compactable (authority text never truncates)', () => {
+			expect(module.compactable).toBe(false);
+		});
+	});
+
+	describe('shouldInclude', () => {
+		it('should always include regardless of role', () => {
+			expect(module.shouldInclude(baseConfig)).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'orchestrator' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'team-leader' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'developer' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'auditor' })).toBe(true);
+		});
+
+		it('should include when org-role fields are absent', () => {
+			expect(
+				module.shouldInclude({
+					sessionName: 'minimal',
+					memberId: 'm',
+					role: 'developer',
+					agentSkillsPath: '/a',
+					tlSkillsPath: '/t',
+					projectRoot: '/r',
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe('build — content contract (verbatim per spec)', () => {
+		it('should emit the ## Decision Rights H2 header', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toContain('## Decision Rights');
+		});
+
+		it('should emit the ## Escalation Chain H2 header', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toContain('## Escalation Chain');
+		});
+
+		it('should emit exactly five "Decide autonomously when" bullets', async () => {
+			const out = await module.build(baseConfig);
+			const decideBlockMatch = out.match(/\*\*Decide autonomously when:\*\*\n([\s\S]*?)\n\n\*\*Escalate when:\*\*/);
+			expect(decideBlockMatch).not.toBeNull();
+			const decideBullets = (decideBlockMatch![1].match(/^- /gm) || []).length;
+			expect(decideBullets).toBe(5);
+		});
+
+		it('should emit exactly five "Escalate when" bullets', async () => {
+			const out = await module.build(baseConfig);
+			const escalateBlockMatch = out.match(/\*\*Escalate when:\*\*\n([\s\S]*?)\n\n## Escalation Chain/);
+			expect(escalateBlockMatch).not.toBeNull();
+			const escalateBullets = (escalateBlockMatch![1].match(/^- /gm) || []).length;
+			expect(escalateBullets).toBe(5);
+		});
+
+		it('should encode the four-link chain Worker → Team Lead → Orchestrator → Owner', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toContain('**Worker → Team Lead → Orchestrator → Owner**');
+		});
+
+		it('should explicitly forbid worker-to-owner direct escalation', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toMatch(/Workers do \*\*not\*\* escalate directly to the owner/);
+		});
+
+		it('should describe TL escalation gate (scope / priority / acceptance criteria)', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toMatch(/Team Leads.*scope.*priority.*acceptance criteria/);
+		});
+
+		it('should describe orchestrator role (cross-team + owner-facing acceptance)', async () => {
+			const out = await module.build(baseConfig);
+			expect(out).toMatch(/Orchestrator owns cross-team and owner-facing acceptance/);
+		});
+
+		it('should pin the closed set of owner-consult triggers', async () => {
+			const out = await module.build(baseConfig);
+			// Spec verbatim: goal change, scope change, customer-facing commitment,
+			// irreversible expense, or strategic direction.
+			expect(out).toContain('goal change');
+			expect(out).toContain('scope change');
+			expect(out).toContain('customer-facing commitment');
+			expect(out).toContain('irreversible expense');
+			expect(out).toContain('strategic direction');
+		});
+	});
+
+	describe('build — role-invariance', () => {
+		it('should emit byte-identical content for every role', async () => {
+			const roles = [
+				'orchestrator',
+				'team-leader',
+				'developer',
+				'researcher',
+				'auditor',
+				'qa-engineer',
+				'designer',
+				'product-manager',
+				'sales',
+				'support',
+			];
+			const outputs = await Promise.all(
+				roles.map((role) => module.build({ ...baseConfig, role })),
+			);
+			const first = outputs[0];
+			for (const out of outputs) {
+				expect(out).toBe(first);
+			}
+		});
+
+		it('should emit byte-identical content regardless of org-role / autonomy', async () => {
+			const a = await module.build({ ...baseConfig, orgRole: 'orchestrator', autonomyLevel: 'domain_autonomous' });
+			const b = await module.build({ ...baseConfig, orgRole: 'executor', autonomyLevel: 'directed' });
+			const c = await module.build({ ...baseConfig, orgRole: 'team-lead', autonomyLevel: 'bounded' });
+			expect(a).toBe(b);
+			expect(b).toBe(c);
+		});
+	});
+
+	describe('build — token budget headroom', () => {
+		it('should fit comfortably under maxTokens (estimated)', async () => {
+			const out = await module.build(baseConfig);
+			// Rough token estimate: ~4 chars per token. We declare 320 tokens,
+			// the actual block should sit well under that.
+			const estimatedTokens = Math.ceil(out.length / 4);
+			expect(estimatedTokens).toBeLessThan(module.maxTokens);
+		});
+	});
+});

--- a/backend/src/services/ai/prompt-modules/decision-rights.module.ts
+++ b/backend/src/services/ai/prompt-modules/decision-rights.module.ts
@@ -1,0 +1,90 @@
+import { PromptModule, ModuleConfig } from './prompt-module.interface.js';
+
+/**
+ * Decision Rights + Escalation Chain block.
+ *
+ * P0-4 — Per spec
+ * `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-4",
+ * this module emits the canonical Decide-vs-Escalate criteria + the four-link
+ * Worker → Team Lead → Orchestrator → Owner chain.
+ *
+ * Why a module (not just per-role markdown)?
+ * - Authority text must be identical across every agent. A module guarantees
+ *   byte-identical output instead of relying on 20 role prompts staying in
+ *   sync over time.
+ * - The text is small (~25 lines) and authority-defining, so we cannot let it
+ *   be truncated under budget pressure → `compactable = false` (Trusted Zone).
+ * - Sits at priority 3.5 — immediately after RoleBoundary (priority 3),
+ *   immediately before MemoryReference (priority 4). This places Decision
+ *   Rights inside the authority cluster (Identity → Soul/Recovery →
+ *   RoleBoundary → DecisionRights) so an agent reads "who am I, what are
+ *   my limits, what can I decide" before any data context.
+ *
+ * Static role prompts under `config/roles/{role}/prompt.md` ALSO contain the
+ * same headers verbatim — this is intentional belt-and-suspenders coverage
+ * for the legacy `prompt-builder.service.ts` load path which does not run
+ * through `PromptAssemblyService`. The two paths produce different prompts
+ * for different runtimes; both must carry the contract.
+ *
+ * Net-zero offset: legacy "ask if unsure" / "escalate when needed" / "when
+ * in doubt" soft hints have been deleted from role prompts because this
+ * module + the role-prompt sections form the canonical statement.
+ */
+export class DecisionRightsModule implements PromptModule {
+	name = 'decision-rights';
+	priority = 3.5;
+	maxTokens = 320;
+	compactable = false;
+
+	/**
+	 * Always include — every agent makes decisions and every agent has a
+	 * point at which it must escalate. The block is identical across roles
+	 * because the meta-rule is universal; role-specific escalation
+	 * destinations are already encoded in the Escalation Chain text itself.
+	 *
+	 * @param _config - Unused; the inclusion rule is universal
+	 * @returns Always true
+	 */
+	shouldInclude(_config: ModuleConfig): boolean {
+		return true;
+	}
+
+	/**
+	 * Build the Decision Rights + Escalation Chain section.
+	 *
+	 * Output is byte-identical regardless of role — see the class JSDoc for
+	 * why universality is intentional.
+	 *
+	 * @param _config - Module configuration (unused; content is static)
+	 * @returns Formatted markdown block with two H2 sections:
+	 *   `## Decision Rights` and `## Escalation Chain`
+	 */
+	async build(_config: ModuleConfig): Promise<string> {
+		return [
+			'## Decision Rights',
+			'',
+			'**Decide autonomously when:**',
+			'- The decision is about implementation details (file naming, layout, internal API shape, test order).',
+			'- The decision does not change the user\'s stated goal.',
+			'- The decision does not reduce the expected outcome.',
+			'- The decision is reversible.',
+			'- The decision can be validated by tests, review, or demo.',
+			'',
+			'**Escalate when:**',
+			'- The goal is unclear.',
+			'- The expected outcome is unclear.',
+			'- Eval criteria are missing or conflicting.',
+			'- There are multiple materially different product directions.',
+			'- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.',
+			'',
+			'## Escalation Chain',
+			'',
+			'**Worker → Team Lead → Orchestrator → Owner**',
+			'',
+			'- Workers do **not** escalate directly to the owner unless explicitly instructed.',
+			'- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.',
+			'- The Orchestrator owns cross-team and owner-facing acceptance.',
+			'- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.',
+		].join('\n');
+	}
+}

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
@@ -76,7 +76,9 @@ describe('PromptAssemblyService', () => {
 			expect(names).toContain('team-norms');
 			// Mission/OKR card (fix #415 — replaces dead PromptGenerator hook)
 			expect(names).toContain('mission_context');
-			expect(names.length).toBe(18);
+			// Decision Rights + Escalation Chain (P0-4 — authority text, priority 3.5)
+			expect(names).toContain('decision-rights');
+			expect(names.length).toBe(19);
 		});
 
 		it('should use default token budget of 28000', () => {
@@ -485,12 +487,22 @@ describe('PromptAssemblyService', () => {
 			const evalConfig: ModuleConfig = { ...baseConfig, evalMode: true };
 			const { report } = await service.assemble(evalConfig);
 
-			// Core modules: identity, soul, role-boundary, recovery
+			// Core modules: identity, soul, role-boundary, recovery, decision-rights
 			const moduleNames = report.moduleBreakdown.map((m) => m.name);
-			const allowedCoreNames = new Set(['identity', 'soul', 'role-boundary', 'recovery']);
+			const allowedCoreNames = new Set(['identity', 'soul', 'role-boundary', 'recovery', 'decision-rights']);
 			for (const name of moduleNames) {
 				expect(allowedCoreNames.has(name)).toBe(true);
 			}
+		});
+
+		it('should include decision-rights authority text in evalMode', async () => {
+			const service = new PromptAssemblyService();
+			const evalConfig: ModuleConfig = { ...baseConfig, evalMode: true };
+			const { prompt, report } = await service.assemble(evalConfig);
+			const moduleNames = report.moduleBreakdown.map((m) => m.name);
+			expect(moduleNames).toContain('decision-rights');
+			expect(prompt).toContain('## Decision Rights');
+			expect(prompt).toContain('## Escalation Chain');
 		});
 
 		it('should include all modules when evalMode is false', async () => {

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
@@ -21,6 +21,7 @@ import { CommunicationModule } from './communication.module.js';
 import { RecoveryModule } from './recovery.module.js';
 import { LifecycleModule } from './lifecycle.module.js';
 import { RoleBoundaryModule } from './role-boundary.module.js';
+import { DecisionRightsModule } from './decision-rights.module.js';
 import { CapabilityOverlayModule } from './capability-overlay.module.js';
 import { DomainSOPModule } from './domain-sop.module.js';
 import { RiskPolicyModule } from './risk-policy.module.js';
@@ -54,6 +55,7 @@ const EVAL_MODE_CORE_MODULES: ReadonlySet<string> = new Set([
 	'soul',
 	'role-boundary',
 	'recovery',
+	'decision-rights',
 ]);
 
 /**
@@ -113,6 +115,10 @@ export class PromptAssemblyService {
 			new ExpertProfileModule(),
 			new RecoveryModule(),
 			new RoleBoundaryModule(),
+			// Decision Rights + Escalation Chain (P0-4) sits at priority 3.5,
+			// inside the authority cluster: identity → soul → recovery →
+			// role-boundary → decision-rights. Authority text is non-compactable.
+			new DecisionRightsModule(),
 			new MemoryReferenceModule(),
 			new SkillsReferenceModule(),
 			new TeamReferenceModule(),

--- a/config/roles/architect/prompt.md
+++ b/config/roles/architect/prompt.md
@@ -113,3 +113,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/auditor/prompt.md
+++ b/config/roles/auditor/prompt.md
@@ -82,3 +82,30 @@ When your message starts with `[SLACK_CONTEXT:channelId=xxx,threadTs=xxx]`, you 
 6. Always respond — never leave a user message unanswered
 
 When your message does NOT start with `[SLACK_CONTEXT:]`, you are in standard audit mode — follow the Audit Cycle steps above and write findings to the audit report.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/backend-developer/prompt.md
+++ b/config/roles/backend-developer/prompt.md
@@ -130,3 +130,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/content-strategist/prompt.md
+++ b/config/roles/content-strategist/prompt.md
@@ -81,3 +81,30 @@ Your team has a built-in cron system. The orchestrator or user can schedule recu
 - If you were offline, Crewly auto-started you to deliver the task
 
 You do not need to manage cron tasks yourself — the orchestrator handles creation and scheduling. If you need a recurring task set up, ask the orchestrator.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/designer/prompt.md
+++ b/config/roles/designer/prompt.md
@@ -112,3 +112,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -345,3 +345,30 @@ bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name idle-self-ping
 **Cap discipline:** At most **2 active idle-self-pings** per agent. If you already have 2, cancel the older one before scheduling a new one.
 
 **Negative pattern to suppress:** "Worker is mid-task waiting on a downstream → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/frontend-developer/prompt.md
+++ b/config/roles/frontend-developer/prompt.md
@@ -130,3 +130,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/fullstack-dev/prompt.md
+++ b/config/roles/fullstack-dev/prompt.md
@@ -130,3 +130,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/generalist/prompt.md
+++ b/config/roles/generalist/prompt.md
@@ -113,3 +113,30 @@ Your team has a built-in cron system. The orchestrator or user can schedule recu
 
 You do not need to manage cron tasks yourself — the orchestrator handles creation and scheduling. If you need a recurring task set up, ask the orchestrator.
 After checking in, just say "Ready for tasks" and wait for me to send you work.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/ops/prompt.md
+++ b/config/roles/ops/prompt.md
@@ -144,3 +144,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/orchestrator/fragments/role-boundary.md
+++ b/config/roles/orchestrator/fragments/role-boundary.md
@@ -55,5 +55,5 @@ If a team norm conflicts with a risk policy — follow the risk policy.
 ### Core Execution Principles
 
 1. **Execute within delegated boundaries.** Do not expand scope, change priorities, or take on responsibilities outside your role.
-2. **Seek alignment before changing scope, priority, ownership, risk posture, or external commitments.** When in doubt, escalate — do not decide alone.
+2. **Seek alignment before changing scope, priority, ownership, risk posture, or external commitments.** Apply the Decision Rights matrix — escalate per the Escalation Chain rather than deciding alone on these.
 3. **Decomposition stays local unless the subtask requires independent ownership, tracking, verification, or recovery.** Internal execution steps live in your plan. Collaborative work units become project tickets.

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -747,7 +747,7 @@ Instead of per-event notifications, prefer periodic summaries:
 - 15-30 min progress heartbeats
 - Daily summaries
 
-When in doubt, default to **Stable**. Over-communicating is the failure mode, not the safe choice — the owner will tell you if they want more.
+If the operating mode is not explicitly set, default to **Stable**. Over-communicating is the failure mode, not the safe choice — the owner will tell you if they want more.
 
 ---
 
@@ -1704,3 +1704,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -200,3 +200,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/qa-engineer/prompt.md
+++ b/config/roles/qa-engineer/prompt.md
@@ -130,3 +130,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/qa/prompt.md
+++ b/config/roles/qa/prompt.md
@@ -130,3 +130,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/researcher/prompt.md
+++ b/config/roles/researcher/prompt.md
@@ -113,3 +113,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/sales/prompt.md
+++ b/config/roles/sales/prompt.md
@@ -112,3 +112,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/support/prompt.md
+++ b/config/roles/support/prompt.md
@@ -112,3 +112,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -197,3 +197,30 @@ Your team has a built-in cron system. The orchestrator or user can schedule recu
 
 You do not need to manage cron tasks yourself — the orchestrator handles creation and scheduling. If you need a recurring task set up, ask the orchestrator.
 After checking in, say "Ready for tasks" and wait for the Orchestrator to send you work.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/tpm/prompt.md
+++ b/config/roles/tpm/prompt.md
@@ -113,3 +113,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+

--- a/config/roles/ux-designer/prompt.md
+++ b/config/roles/ux-designer/prompt.md
@@ -114,3 +114,30 @@ When you encounter an error and successfully resolve it:
 1. Immediately run `record-learning` with the exact error, fix, and environment context.
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
+
+
+## Decision Rights
+
+**Decide autonomously when:**
+- The decision is about implementation details (file naming, layout, internal API shape, test order).
+- The decision does not change the user's stated goal.
+- The decision does not reduce the expected outcome.
+- The decision is reversible.
+- The decision can be validated by tests, review, or demo.
+
+**Escalate when:**
+- The goal is unclear.
+- The expected outcome is unclear.
+- Eval criteria are missing or conflicting.
+- There are multiple materially different product directions.
+- The decision changes scope, timeline, cost, data risk, or a user-facing commitment.
+
+## Escalation Chain
+
+**Worker → Team Lead → Orchestrator → Owner**
+
+- Workers do **not** escalate directly to the owner unless explicitly instructed.
+- Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
+- The Orchestrator owns cross-team and owner-facing acceptance.
+- The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
+


### PR DESCRIPTION
## Summary

Closes WI **5ec837e5-bc27-45c0-a3d7-01613d870f12** — P0-4 from `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md`.

Eliminates the vague "ask if unsure / escalate when needed / when in doubt" hints that produced ~5x/conv owner pings for sub-decisions. Replaces with the canonical **Decide-vs-Escalate** matrix (5+5 bullets) and the four-link **Worker → Team Lead → Orchestrator → Owner** chain.

Resumes WIP commit `7b45d723` (DecisionRightsModule scaffold) — adds tests, registers it, and applies the section to all 20 role prompts.

## Two delivery surfaces (both authoritative)

**(1) DecisionRightsModule** — dynamic prompt-assembly path
- `backend/src/services/ai/prompt-modules/decision-rights.module.ts`
- Priority **3.5** (between `role-boundary`=3 and `memory-reference`=4) — sits inside the authority cluster: identity → soul → recovery → role-boundary → **decision-rights**.
- `compactable=false` → Trusted Zone, never truncated under budget pressure.
- `shouldInclude=true` → universal across every role.
- Registered in `prompt-assembly.service.ts` and added to `EVAL_MODE_CORE_MODULES` so eval runs still see authority text.

**(2) Static role prompts** — legacy prompt-builder.service.ts path
- `config/roles/{role}/prompt.md` × 20 (architect, auditor, backend-developer, content-strategist, designer, developer, frontend-developer, fullstack-dev, generalist, ops, orchestrator, product-manager, qa, qa-engineer, researcher, sales, support, team-leader, tpm, ux-designer)
- Identical text appended at end as authority backstop.
- Belt-and-suspenders for runtimes that bypass module assembly.

## Eval criteria — all green

| # | Criterion | Result |
|---|---|---|
| 1 | ALL role prompts under `config/roles/` contain `## Decision Rights` + `## Escalation Chain` | ✅ 20/20 (covered by `decision-rights-role-coverage.test.ts`) |
| 2 | 5 decide + 5 escalate bullets, verbatim per spec | ✅ Tested per-role via regex bullet count |
| 3 | Chain reads `Worker → Team Lead → Orchestrator → Owner`; workers do NOT escalate directly | ✅ Verbatim string + worker-direct-escalation prohibition asserted |
| 4 | `grep -rnE 'ask if unsure\|escalate when needed\|when in doubt' config/roles/` returns 0 hits | ✅ Both case-sensitive AND case-insensitive return 0 |
| 5 | Test asserts each role prompt contains `## Decision Rights` header | ✅ `describe.each(rolePrompts)` dynamic walk — auto-covers any new role |

## Net-zero accounting

Two case-insensitive offenders surgically rewritten (case-sensitive grep was already 0):
- `config/roles/orchestrator/fragments/role-boundary.md:58` — "When in doubt, escalate — do not decide alone." → "Apply the Decision Rights matrix — escalate per the Escalation Chain rather than deciding alone on these."
- `config/roles/orchestrator/prompt.md:750` — "When in doubt, default to **Stable**." → "If the operating mode is not explicitly set, default to **Stable**." (different context — operating-mode default — but same idiom removed for consistency.)

## Tests

| Test file | Count | Status |
|---|---|---|
| `decision-rights.module.test.ts` | 18 | ✅ all passing |
| `decision-rights-role-coverage.test.ts` | 122 (6 props × 20 roles + 2 misc) | ✅ all passing |
| `prompt-assembly.service.test.ts` | updated count assertion (18→19), added evalMode decision-rights inclusion | ⚠️ pre-existing chokidar/readdirp jest loader failure blocks this file from loading on `origin/main` — unrelated to this change. `tsc -p backend/tsconfig.json` clean. |

```
$ jest --testPathPattern='decision-rights' --no-coverage
Test Suites: 2 passed, 2 total
Tests:       140 passed, 140 total
```

## Decision-rights placement decisions

- **Module priority 3.5** — bumped from scaffold's `priority=10` (collided with `learning-reference.module.ts` at 10). 3.5 is the natural authority slot between role-boundary and memory.
- **Static role-prompt placement: bottom of file** — consistent across all 20 prompts; minimal diff disruption; the dynamic path puts it early via priority.
- **Module text vs static text — byte-identical** — module's `build()` returns the exact string in role prompts. Tests assert role-invariance.

## Files changed (26)

- 3 new: `decision-rights.module.ts`, `decision-rights.module.test.ts`, `decision-rights-role-coverage.test.ts`
- 2 modified: `prompt-assembly.service.ts`, `prompt-assembly.service.test.ts`
- 20 role prompts: section appended
- 1 net-zero cleanup: `orchestrator/fragments/role-boundary.md` (+ `orchestrator/prompt.md` line 750)

## Coordination

Leo owns P0-3 (Request Contract + Brief Reception Protocol) on WI `f712a97d`. Both touch `config/roles/`. This PR keeps edits append-only at end-of-file for 19 of 20 prompts (orchestrator has 1 mid-file surgical edit on line 750 for net-zero cleanup), so merge conflicts with P0-3 should localise to orchestrator/team-leader prompts only.

## Test plan

- [x] `decision-rights.module.test.ts` — 18 tests pass
- [x] `decision-rights-role-coverage.test.ts` — 122 tests pass (full role coverage + net-zero invariant)
- [x] `tsc -p backend/tsconfig.json` clean
- [x] `grep -rnE 'ask if unsure|escalate when needed|when in doubt' config/roles/` → 0 hits (both -E and -iE)
- [x] All 20 role prompts contain `## Decision Rights` + `## Escalation Chain` + chain string
- [ ] Arch standing-reviewer to verify content fidelity to spec + module placement decisions
- [ ] Steve / Sam to confirm whether to also delete the now-redundant per-role text once dynamic assembly fully replaces the legacy load path (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)