### PR TITLE
feat(v3): producer + worker skills migrate to V3 task-pool — Layer 2 cut

### DIFF
--- a/backend/src/controllers/task-management/task-management.controller.ts
+++ b/backend/src/controllers/task-management/task-management.controller.ts
@@ -1,3 +1,22 @@
+/**
+ * @deprecated v1 task-management subsystem.
+ *
+ * Per `specs/2026-05-06-task-management-v1-deprecation.md`, this controller
+ * and the `.md`-based worker workflow it implements are on the deprecation
+ * path. New work is created exclusively via V3 task-pool
+ * (`backend/src/controllers/task-pool/`) and the V3-native producer/consumer
+ * skills (`config/skills/{orchestrator,team-leader,agent}/...`).
+ *
+ * Endpoints in this file remain mounted only to avoid breaking any agent
+ * skill that has not yet been migrated. They no longer receive new tasks
+ * (since all producers now go through V3) and the `.md` files they
+ * read/write are inert artifacts.
+ *
+ * Removal target: a follow-up PR after Layer 2 Phase C in the spec.
+ *
+ * @module controllers/task-management/task-management.controller
+ */
+
 import { Request, Response } from 'express';
 import type { ApiController } from '../api.controller.js';
 import type { ApiContext } from '../types.js';

--- a/backend/src/services/v3/v3-data.service.test.ts
+++ b/backend/src/services/v3/v3-data.service.test.ts
@@ -563,7 +563,18 @@ describe('V3DataService', () => {
       expect(savedMission.activeProjectTaskIds.length).toBeGreaterThan(0);
     });
 
-    it('should write task files to delegated/open when goal:set fires', async () => {
+    /**
+     * Returns the WorkItem objects passed to TaskPoolService.addToPool by
+     * decomposeMissionToTasks during the most recent goal:set handler.
+     */
+    function decomposedWorkItems(): Array<{ title: string; briefMarkdown?: string }> {
+      // mockAddToPool is called with one WorkItem-shaped object per task
+      return mockAddToPool.mock.calls
+        .map((c: any[]) => c[0])
+        .filter((wi: any) => wi && wi.type === 'project_task' && wi.missionId);
+    }
+
+    it('should add task WorkItems to the pool when goal:set fires (V3-only path)', async () => {
       const event: GoalSetEvent = {
         goal: 'Build a new login feature and then integrate with SSO provider and add 2FA support',
         projectPath: '/tmp/test',
@@ -575,20 +586,23 @@ describe('V3DataService', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       // Complex "Build" objective (multiple actions) → 3 tasks (design, implement, test)
-      expect(mockWriteFile).toHaveBeenCalledTimes(3);
+      const items = decomposedWorkItems();
+      expect(items.length).toBe(3);
 
-      // Verify task files are written to correct directory
-      const firstCallPath = mockWriteFile.mock.calls[0][0];
-      expect(firstCallPath).toContain('.crewly/tasks/delegated/open/');
-      expect(firstCallPath).toContain('.md');
+      // Each WI carries the full long-form brief in `briefMarkdown` (replaces
+      // the legacy .md filesystem body — see PR #482/#484).
+      expect(items[0].briefMarkdown).toBeDefined();
+      expect(items[0].briefMarkdown).toContain('Parent mission:');
+      expect(items[0].briefMarkdown).toContain('Build a new login feature');
 
-      // Verify content includes mission reference
-      const firstCallContent = mockWriteFile.mock.calls[0][1];
-      expect(firstCallContent).toContain('Parent mission:');
-      expect(firstCallContent).toContain('Build a new login feature');
+      // No .md files written under .crewly/tasks/delegated/open/ anymore.
+      const taskMdWrites = mockWriteFile.mock.calls.filter((c: any[]) =>
+        typeof c[0] === 'string' && c[0].includes('.crewly/tasks/delegated'),
+      );
+      expect(taskMdWrites).toEqual([]);
     });
 
-    it('should create single task for simple objectives (P0-1 intelligent decomposition)', async () => {
+    it('should create single task WorkItem for simple objectives (P0-1 intelligent decomposition)', async () => {
       const event: GoalSetEvent = {
         goal: 'Fix the login button',
         projectPath: '/tmp/test',
@@ -599,13 +613,12 @@ describe('V3DataService', () => {
       eventBus.emit('v3:goal_set', event);
       await new Promise((r) => setTimeout(r, 50));
 
-      // Simple "Fix" objective → 1 task only
-      expect(mockWriteFile).toHaveBeenCalledTimes(1);
-      const content = mockWriteFile.mock.calls[0][1];
-      expect(content).toContain('Fix the login button');
+      const items = decomposedWorkItems();
+      expect(items.length).toBe(1);
+      expect(items[0].briefMarkdown).toContain('Fix the login button');
     });
 
-    it('should create fix-category tasks for complex bug-related objectives', async () => {
+    it('should create fix-category WorkItems for complex bug-related objectives', async () => {
       const event: GoalSetEvent = {
         goal: 'Fix the memory leak in queue processor and then refactor the connection pooling to prevent recurrence',
         projectPath: '/tmp/test',
@@ -617,12 +630,12 @@ describe('V3DataService', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       // Complex "Fix" keyword → 3 tasks (investigate, fix, verify)
-      expect(mockWriteFile).toHaveBeenCalledTimes(3);
-      const firstContent = mockWriteFile.mock.calls[0][1];
-      expect(firstContent).toContain('Investigate');
+      const items = decomposedWorkItems();
+      expect(items.length).toBe(3);
+      expect(items[0].title.toLowerCase()).toContain('investigate');
     });
 
-    it('should create default tasks for generic complex objectives', async () => {
+    it('should create default-category WorkItems for generic complex objectives', async () => {
       const event: GoalSetEvent = {
         goal: 'Improve team velocity by 20% and then implement automated performance dashboards with weekly reporting and alerting on regressions',
         projectPath: '/tmp/test',
@@ -634,9 +647,9 @@ describe('V3DataService', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       // Complex build → 3 tasks (design, implement, test) — "implement" keyword triggers build category
-      expect(mockWriteFile).toHaveBeenCalledTimes(3);
-      const firstContent = mockWriteFile.mock.calls[0][1];
-      expect(firstContent).toContain('Design approach');
+      const items = decomposedWorkItems();
+      expect(items.length).toBe(3);
+      expect(items[0].briefMarkdown).toContain('Design approach');
     });
 
     it('should resolve ownerId from event.setBy when StorageService finds the member', async () => {

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -745,41 +745,39 @@ export class V3DataService {
   // ---------------------------------------------------------------------------
 
   /**
-   * Decomposes a mission objective into initial ProjectTask files.
+   * Decomposes a mission objective into V3 WorkItems.
    *
-   * Uses keyword-based planning to break the objective into 2-4 actionable
-   * sub-tasks, writes them as markdown files under `.crewly/tasks/delegated/open/`,
-   * and returns the task IDs (filenames without extension).
+   * Per `specs/2026-05-06-task-management-v1-deprecation.md`, the legacy
+   * `.crewly/tasks/delegated/open/*.md` filesystem write has been removed —
+   * V3 task-pool is the sole source of truth for delegated work. Each
+   * planned sub-task lands as a queued WorkItem with the long-form brief
+   * carried in `briefMarkdown` (the same content that previously lived in
+   * the .md body).
    *
-   * @param missionId - The parent mission ID
+   * @param missionId - The parent mission ID (stored on each WI and in the
+   *                    brief's Context section)
    * @param objective - The mission objective text
-   * @param projectPath - Absolute path to the project root
-   * @returns Array of created task IDs (file basenames without .md)
+   * @param projectPath - Reserved for future use (e.g. resolving relative
+   *                     skill paths in the brief). Currently unused but
+   *                     kept in the signature so existing callers don't
+   *                     have to be updated in lockstep.
+   * @returns Array of created WorkItem IDs in plan order
    */
   public static async decomposeMissionToTasks(
     missionId: string,
     objective: string,
-    projectPath: string,
+    _projectPath: string,
   ): Promise<string[]> {
-    const tasksDir = path.join(projectPath, '.crewly', 'tasks', 'delegated', 'open');
-    await ensureDir(tasksDir);
-
     const planned = planTasksFromObjective(objective);
-    const taskIds: string[] = [];
+    const workItemIds: string[] = [];
     const now = new Date().toISOString();
-    const timestamp = Date.now();
 
-    for (let i = 0; i < planned.length; i++) {
-      const task = planned[i];
-      const sanitizedTitle = task.title
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_|_$/g, '')
-        .slice(0, 80);
-      const taskId = `${sanitizedTitle}_${timestamp + i}`;
-      const fileName = `${taskId}.md`;
+    // Lazy-import to avoid a static cycle through TaskPoolService.
+    const { TaskPoolService } = await import('../task-pool/task-pool.service.js');
+    const taskPool = TaskPoolService.getInstance();
 
-      const content = [
+    for (const task of planned) {
+      const briefMarkdown = [
         `# ${task.title}`,
         '',
         task.description,
@@ -794,23 +792,31 @@ export class V3DataService {
         '',
         '## Task Information',
         `- **Priority**: ${task.priority}`,
-        '- **Milestone**: delegated',
         `- **Created at**: ${now}`,
-        '- **Status**: Open',
         `- **Mission ID**: ${missionId}`,
       ].join('\n');
 
-      await fs.writeFile(path.join(tasksDir, fileName), content, 'utf-8');
-      taskIds.push(taskId);
+      const workItem = createWorkItem({
+        type: 'project_task',
+        owner: 'orchestrator',
+        title: task.title,
+        description: task.description.substring(0, 500),
+        briefMarkdown,
+        missionId,
+        maxRetries: 2,
+      });
+
+      await taskPool.addToPool(workItem);
+      workItemIds.push(workItem.id);
     }
 
-    LoggerService.getInstance().createComponentLogger('V3DataService').debug('Decomposed mission into tasks', {
+    LoggerService.getInstance().createComponentLogger('V3DataService').debug('Decomposed mission into WorkItems', {
       missionId,
-      taskCount: taskIds.length,
-      taskIds,
+      taskCount: workItemIds.length,
+      workItemIds,
     });
 
-    return taskIds;
+    return workItemIds;
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -381,6 +381,39 @@ describe('WorkItem Types', () => {
       });
       expect(errors).toEqual([]);
     });
+
+    // briefMarkdown — replaces .md task body in the V3 unification (PR #482).
+    it('accepts briefMarkdown within the size cap', () => {
+      const errors = validateCreateWorkItemInput({
+        type: 'delegate',
+        owner: 'agent',
+        title: 'with brief',
+        briefMarkdown: '# Step 1\nDo the thing.\n# Step 2\nReport back.',
+      });
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects briefMarkdown that is not a string', () => {
+      const errors = validateCreateWorkItemInput({
+        type: 'delegate',
+        owner: 'agent',
+        title: 'bad type',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        briefMarkdown: 123 as any,
+      });
+      expect(errors.some((e) => e.includes('briefMarkdown'))).toBe(true);
+    });
+
+    it('rejects briefMarkdown exceeding the byte cap', () => {
+      const oversize = 'a'.repeat(16 * 1024 + 1); // one byte over 16 KiB
+      const errors = validateCreateWorkItemInput({
+        type: 'delegate',
+        owner: 'agent',
+        title: 'too big',
+        briefMarkdown: oversize,
+      });
+      expect(errors.some((e) => e.includes('briefMarkdown') && e.includes('exceeds'))).toBe(true);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -162,8 +162,17 @@ export interface WorkItem {
   target?: string;
   /** Human-readable title */
   title: string;
-  /** Detailed instructions or description */
+  /** Short summary / instructions (legacy; capped at 500 chars by callers) */
   description?: string;
+  /**
+   * Long-form task brief in markdown. Replaces the legacy
+   * `.crewly/tasks/delegated/*.md` body that v1 task-management used to
+   * write to disk. Carries the full instruction set the worker reads
+   * before starting. Length is capped to {@link MAX_BRIEF_MARKDOWN_BYTES}
+   * by {@link validateCreateWorkItemInput} to keep `pool.json` readable
+   * and within `atomicWriteJson`'s practical size budget.
+   */
+  briefMarkdown?: string;
   /** Lifecycle status */
   status: WorkItemStatus;
   /** When this item should execute (null = immediately) */
@@ -218,6 +227,11 @@ export interface CreateWorkItemInput {
   target?: string;
   title: string;
   description?: string;
+  /**
+   * Long-form task brief in markdown. See {@link WorkItem.briefMarkdown}
+   * for rationale. Validated against {@link MAX_BRIEF_MARKDOWN_BYTES}.
+   */
+  briefMarkdown?: string;
   scheduledAt?: string;
   maxRetries?: number;
   triggerId?: string;
@@ -447,8 +461,29 @@ export function validateCreateWorkItemInput(input: CreateWorkItemInput): string[
   if (input.maxRetries !== undefined && (input.maxRetries < 0 || !Number.isInteger(input.maxRetries))) {
     errors.push('maxRetries must be a non-negative integer');
   }
+  if (input.briefMarkdown !== undefined) {
+    if (typeof input.briefMarkdown !== 'string') {
+      errors.push('briefMarkdown must be a string');
+    } else if (Buffer.byteLength(input.briefMarkdown, 'utf8') > MAX_BRIEF_MARKDOWN_BYTES) {
+      errors.push(
+        `briefMarkdown exceeds ${MAX_BRIEF_MARKDOWN_BYTES} bytes; trim or attach via metadata reference`,
+      );
+    }
+  }
   return errors;
 }
+
+/**
+ * Maximum size of {@link WorkItem.briefMarkdown} in UTF-8 bytes.
+ *
+ * Replaces the legacy `.crewly/tasks/delegated/*.md` files which had no
+ * size cap. 16 KB is enough to carry a typical TL-to-worker dispatch
+ * brief (~ 3000 words) plus a small spec excerpt; longer briefs should
+ * reference an attached file via `metadata` rather than inlining the
+ * full body so `pool.json` stays human-readable and `atomicWriteJson`
+ * stays fast.
+ */
+export const MAX_BRIEF_MARKDOWN_BYTES = 16 * 1024;
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -494,6 +529,7 @@ export function createWorkItem(input: CreateWorkItemInput): WorkItem {
     target: input.target,
     title: input.title,
     description: input.description,
+    briefMarkdown: input.briefMarkdown,
     status: initialStatus,
     scheduledAt: input.scheduledAt,
     createdAt: now,

--- a/config/skills/agent/core/accept-task/execute.sh
+++ b/config/skills/agent/core/accept-task/execute.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
-# Accept and take the next available task from the task queue
+# Claim the next available WorkItem from the V3 task-pool.
+#
+# V3-only as of spec 2026-05-06-task-management-v1-deprecation.md. The
+# legacy `/task-management/take-next` endpoint (which read `.md` files
+# from `delegated/open/`) is no longer the source of truth.
+#
+# Input shape (backwards-compat from v1):
+#   { "sessionName": "dev-1", "projectPath"?: "...", "taskGroup"?: "..." }
+#
+# `taskGroup` (legacy v1 milestone filter) maps to V3's `filters.types`.
+# `teamMemberId` is no longer needed — V3 keys claims by `agentId`
+# (= sessionName).
+
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../../_common/lib.sh"
@@ -10,18 +22,9 @@ INPUT=$(read_json_input "${1:-}")
 SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
 require_param "sessionName" "$SESSION_NAME"
 
-TEAM_MEMBER_ID=$(printf '%s' "$INPUT" | jq -r '.teamMemberId // empty')
-PROJECT_PATH=$(printf '%s' "$INPUT" | jq -r '.projectPath // empty')
-TASK_GROUP=$(printf '%s' "$INPUT" | jq -r '.taskGroup // empty')
+# v1's `taskGroup` is informational metadata; V3 filters by WorkItem `type`
+# instead. We pass the session name as the agent identity and let the pool
+# pick the highest-scored available WI for this agent.
+BODY=$(jq -n --arg agentId "$SESSION_NAME" '{agentId: $agentId}')
 
-BODY=$(jq -n \
-  --arg sessionName "$SESSION_NAME" \
-  --arg teamMemberId "$TEAM_MEMBER_ID" \
-  --arg projectPath "$PROJECT_PATH" \
-  --arg taskGroup "$TASK_GROUP" \
-  '{sessionName: $sessionName} +
-   (if $teamMemberId != "" then {teamMemberId: $teamMemberId} else {} end) +
-   (if $projectPath != "" then {projectPath: $projectPath} else {} end) +
-   (if $taskGroup != "" then {taskGroup: $taskGroup} else {} end)')
-
-api_call POST "/task-management/take-next" "$BODY"
+api_call POST "/task-pool/claim" "$BODY"

--- a/config/skills/agent/core/block-task/execute.sh
+++ b/config/skills/agent/core/block-task/execute.sh
@@ -1,28 +1,46 @@
 #!/bin/bash
-# Mark a task as blocked with a reason and optional questions
+# Mark a WorkItem as blocked with a reason.
+#
+# V3-only as of spec 2026-05-06-task-management-v1-deprecation.md. The
+# legacy `/task-management/block` endpoint (which moved a `.md` file to
+# `delegated/blocked/`) is no longer the source of truth — V3 task-pool's
+# `/task-pool/block/:workItemId` is.
+#
+# Input shape:
+#   { "workItemId": "abc-123", "reason": "missing creds", "questions"?: "...", "urgency"?: "..." }
+#
+# Backwards-compat: if `absoluteTaskPath` is provided instead of
+# `workItemId`, we emit a warning and skip the call rather than fall back
+# to the deprecated v1 path. Callers should obtain `workItemId` from the
+# claim response or from a [CREWLY-DISPATCH] terminal message.
+
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../../_common/lib.sh"
 
 INPUT=$(read_json_input "${1:-}")
-[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"absoluteTaskPath\":\"/path/to/task\",\"reason\":\"Missing API credentials\"}'"
+[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"workItemId\":\"abc-123\",\"reason\":\"Missing API credentials\"}'"
 
-ABSOLUTE_TASK_PATH=$(printf '%s' "$INPUT" | jq -r '.absoluteTaskPath // empty')
+WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
 REASON=$(printf '%s' "$INPUT" | jq -r '.reason // empty')
 QUESTIONS=$(printf '%s' "$INPUT" | jq -r '.questions // empty')
 URGENCY=$(printf '%s' "$INPUT" | jq -r '.urgency // empty')
-require_param "absoluteTaskPath" "$ABSOLUTE_TASK_PATH"
+LEGACY_PATH=$(printf '%s' "$INPUT" | jq -r '.absoluteTaskPath // empty')
+
+if [ -z "$WORK_ITEM_ID" ] && [ -n "$LEGACY_PATH" ]; then
+  echo '{"error":"`absoluteTaskPath` is no longer accepted — pass `workItemId` instead. See spec/2026-05-06-task-management-v1-deprecation.md"}' >&2
+  exit 1
+fi
+
+require_param "workItemId" "$WORK_ITEM_ID"
 require_param "reason" "$REASON"
 
 BODY=$(jq -n \
-  --arg absoluteTaskPath "$ABSOLUTE_TASK_PATH" \
-  --arg taskPath "$ABSOLUTE_TASK_PATH" \
   --arg reason "$REASON" \
-  --arg blockReason "$REASON" \
   --arg questions "$QUESTIONS" \
   --arg urgency "$URGENCY" \
-  '{absoluteTaskPath: $absoluteTaskPath, taskPath: $taskPath, reason: $reason, blockReason: $blockReason} +
+  '{reason: $reason} +
    (if $questions != "" then {questions: $questions} else {} end) +
    (if $urgency != "" then {urgency: $urgency} else {} end)')
 
-api_call POST "/task-management/block" "$BODY"
+api_call POST "/task-pool/block/${WORK_ITEM_ID}" "$BODY"

--- a/config/skills/agent/core/complete-task/execute.sh
+++ b/config/skills/agent/core/complete-task/execute.sh
@@ -61,18 +61,34 @@ if echo "$ABSOLUTE_TASK_PATH" | grep -q '/in_progress/'; then
   fi
 fi
 
+# V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+# Resolve which V3 WorkItem to complete:
+#   1. Explicit `workItemId` from input (preferred)
+#   2. Fall back: query the pool for the agent's currently-running WI
+#
+# The legacy `absoluteTaskPath` input is still accepted but no longer
+# drives the API call — it's only used for logging context. Callers
+# should switch to passing `workItemId`.
+WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
+if [ -z "$WORK_ITEM_ID" ]; then
+  POOL_RESP=$(api_call GET "/task-pool/items?status=running&target=${SESSION_NAME}" 2>/dev/null || echo '{}')
+  WORK_ITEM_ID=$(echo "$POOL_RESP" | jq -r '.workItems[0].id // .data[0].id // empty' 2>/dev/null || true)
+fi
+
+if [ -z "$WORK_ITEM_ID" ]; then
+  echo '{"error":"Could not resolve a running WorkItem for this session — pass `workItemId` explicitly."}' >&2
+  exit 1
+fi
+
 BODY=$(jq -n \
-  --arg absoluteTaskPath "$ABSOLUTE_TASK_PATH" \
-  --arg taskPath "$ABSOLUTE_TASK_PATH" \
-  --arg sessionName "$SESSION_NAME" \
   --arg summary "$SUMMARY" \
   --arg skipGates "$SKIP_GATES" \
   --argjson output "${OUTPUT_JSON:-null}" \
-  '{absoluteTaskPath: $absoluteTaskPath, taskPath: $taskPath, sessionName: $sessionName, summary: $summary} +
+  '{summary: $summary} +
    (if $skipGates == "true" then {skipGates: true} else {} end) +
-   (if $output != null then {output: $output} else {} end)')
+   (if $output != null then {result: $output} else {} end)')
 
-api_call POST "/task-management/complete" "$BODY"
+api_call POST "/task-pool/complete/${WORK_ITEM_ID}" "$BODY"
 
 # Auto-persist the task summary as project knowledge (#127, #219).
 # Use [COMPLETED] prefix so recall can distinguish completed tasks from other patterns.

--- a/config/skills/agent/core/get-my-tasks/execute.sh
+++ b/config/skills/agent/core/get-my-tasks/execute.sh
@@ -81,10 +81,12 @@ if [ -n "$INPUT_JSON" ]; then
 fi
 
 require_param "sessionName (--session)" "$SESSION_NAME"
-require_param "projectPath (--project)" "$PROJECT_PATH"
+# `projectPath` is no longer required for V3 — kept in the input shape
+# for backwards compat with callers who pass it.
 
-# URL-encode the session name and project path for query parameters
+# Per spec 2026-05-06-task-management-v1-deprecation.md, this skill now
+# queries the V3 task-pool. Returns all WorkItems targeted at this agent
+# session that are still in a non-terminal status. Callers wanting only
+# the running one can filter on `.workItems[] | select(.status=="running")`.
 ENCODED_SESSION=$(printf '%s' "$SESSION_NAME" | jq -sRr @uri)
-ENCODED_PROJECT=$(printf '%s' "$PROJECT_PATH" | jq -sRr @uri)
-
-api_call GET "/task-management/tasks?sessionName=${ENCODED_SESSION}&projectPath=${ENCODED_PROJECT}"
+api_call GET "/task-pool/items?target=${ENCODED_SESSION}"

--- a/config/skills/agent/core/report-status/execute.sh
+++ b/config/skills/agent/core/report-status/execute.sh
@@ -42,6 +42,7 @@ SUMMARY=""
 PROJECT_PATH=""
 TASK_PATH=""
 TASK_ID=""
+WORK_ITEM_ID=""
 PROGRESS=""
 STRUCTURED="false"
 
@@ -79,6 +80,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --task-id)
       TASK_ID="$2"
+      shift 2
+      ;;
+    --work-item-id|--wi-id)
+      WORK_ITEM_ID="$2"
       shift 2
       ;;
     --progress)
@@ -130,6 +135,7 @@ if [ -n "$INPUT_JSON" ]; then
   [ -z "$SUMMARY" ] && SUMMARY=$(printf '%s' "$INPUT" | jq -r '.summary // empty')
   [ -z "$TASK_PATH" ] && TASK_PATH=$(printf '%s' "$INPUT" | jq -r '.taskPath // empty')
   [ -z "$TASK_ID" ] && TASK_ID=$(printf '%s' "$INPUT" | jq -r '.taskId // empty')
+  [ -z "$WORK_ITEM_ID" ] && WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
   [ -z "$PROGRESS" ] && PROGRESS=$(printf '%s' "$INPUT" | jq -r '.progress // empty')
   [ -z "$PROJECT_PATH" ] && PROJECT_PATH=$(printf '%s' "$INPUT" | jq -r '.projectPath // empty')
   ARTIFACTS=$(printf '%s' "$INPUT" | jq -c '.artifacts // empty')
@@ -201,19 +207,29 @@ BODY=$(jq -n --arg content "$MESSAGE" --arg senderName "$SESSION_NAME" \
 
 api_call POST "/chat/agent-response" "$BODY"
 
-# If task is done and taskPath provided, move task file to done folder
-if [ "$STATUS" = "done" ] && [ -n "$TASK_PATH" ]; then
-  COMPLETE_BODY=$(jq -n \
-    --arg taskPath "$TASK_PATH" \
-    --arg sessionName "$SESSION_NAME" \
-    '{taskPath: $taskPath, sessionName: $sessionName}')
-  api_call POST "/task-management/complete" "$COMPLETE_BODY" || true
-fi
-
-# Auto-complete tracked tasks when status is done
+# Mark V3 WorkItem(s) for this session as complete when status=done.
+# Per spec/2026-05-06-task-management-v1-deprecation.md, V3 task-pool is now
+# the source of truth — we no longer move .md files via the v1
+# `/task-management/complete{-by-session}` endpoints.
+#
+# Resolution order for which WorkItem to complete:
+#   1. `workItemId` in input (preferred — explicit reference)
+#   2. The agent's currently-running WI fetched from the pool
+#
+# The legacy `taskPath` input is still accepted for backwards compatibility
+# but no longer drives the API call.
 if [ "$STATUS" = "done" ]; then
-  SESSION_BODY=$(jq -n --arg sessionName "$SESSION_NAME" '{sessionName: $sessionName}')
-  api_call POST "/task-management/complete-by-session" "$SESSION_BODY" || true
+  TARGET_WI_ID="${WORK_ITEM_ID:-}"
+  if [ -z "$TARGET_WI_ID" ]; then
+    # Fall back: query pool for this session's running WIs and complete the first match.
+    POOL_RESP=$(api_call GET "/task-pool/items?status=running&target=${SESSION_NAME}" 2>/dev/null || echo '{}')
+    TARGET_WI_ID=$(echo "$POOL_RESP" | jq -r '.workItems[0].id // .data[0].id // empty' 2>/dev/null || true)
+  fi
+
+  if [ -n "$TARGET_WI_ID" ]; then
+    COMPLETE_BODY=$(jq -n --arg summary "$SUMMARY" '{summary: $summary}')
+    api_call POST "/task-pool/complete/${TARGET_WI_ID}" "$COMPLETE_BODY" || true
+  fi
 fi
 
 # Auto-persist key findings as project knowledge when task is done (#127, #219).

--- a/config/skills/orchestrator/delegate-task/execute.sh
+++ b/config/skills/orchestrator/delegate-task/execute.sh
@@ -186,16 +186,22 @@ esac
 
 WI_TITLE="${TITLE:-$(echo "$TASK" | head -c 200)}"
 
+# Per spec 2026-05-06-task-management-v1-deprecation.md, the long-form task
+# body now travels with the WorkItem (`briefMarkdown` field) instead of being
+# written to a `.crewly/tasks/delegated/*.md` file. `description` keeps the
+# legacy short-summary semantics (callers truncate to 500 chars); the full
+# brief lives in `briefMarkdown`.
 POOL_BODY=$(jq -n \
   --arg type "delegate" \
   --arg owner "orchestrator" \
   --arg target "$TO" \
   --arg title "$WI_TITLE" \
   --arg description "$TASK_MESSAGE" \
+  --arg briefMarkdown "$TASK" \
   --arg priority "$WI_PRIORITY" \
   --arg projectPath "${PROJECT_PATH:-}" \
   --arg requestId "${REQUEST_ID:-}" \
-  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end) + (if $requestId != "" then {requestId: $requestId} else {} end)')
+  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end) + (if $requestId != "" then {requestId: $requestId} else {} end)')
 
 # Pipeline-#4 fix (spec 2026-05-05-request-decompose-pipeline-gap.md, Patch B):
 # Route is /api/task-pool/add (not /api/pool/add — that endpoint does not exist

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -169,22 +169,39 @@ if [ "$DELIVER_OK" = "false" ]; then
   }
 fi
 
-# Track the task file path and task ID from create response
-TASK_FILE_PATH=""
+# V3-only producer (spec 2026-05-06-task-management-v1-deprecation.md):
+# We no longer write a `.crewly/tasks/delegated/*.md` file via the legacy
+# `/task-management/create` endpoint. Instead the long-form brief travels
+# on the WorkItem itself (`briefMarkdown` field) and the WI is the sole
+# durable record of this delegation.
 TASK_ID=""
 
-# Create task file in project's .crewly/tasks/ directory
-if [ -n "$PROJECT_PATH" ]; then
-  CREATE_BODY=$(jq -n \
-    --arg projectPath "$PROJECT_PATH" \
-    --arg task "$TASK" \
-    --arg priority "$PRIORITY" \
-    --arg sessionName "$TO" \
-    --arg milestone "delegated" \
-    '{projectPath: $projectPath, task: $task, priority: $priority, sessionName: $sessionName, milestone: $milestone}')
-  CREATE_RESULT=$(api_call POST "/task-management/create" "$CREATE_BODY" 2>/dev/null || true)
-  TASK_FILE_PATH=$(echo "$CREATE_RESULT" | jq -r '.taskPath // empty' 2>/dev/null || true)
-  TASK_ID=$(echo "$CREATE_RESULT" | jq -r '.taskId // empty' 2>/dev/null || true)
+case "$PRIORITY" in
+  critical|urgent) WI_PRIORITY="critical" ;;
+  high)            WI_PRIORITY="high" ;;
+  low)             WI_PRIORITY="low" ;;
+  *)               WI_PRIORITY="medium" ;;
+esac
+
+WI_TITLE="$(echo "$TASK" | head -c 200)"
+
+POOL_BODY=$(jq -n \
+  --arg type "delegate" \
+  --arg owner "team_lead" \
+  --arg target "$TO" \
+  --arg title "$WI_TITLE" \
+  --arg description "$TASK_MESSAGE" \
+  --arg briefMarkdown "$TASK" \
+  --arg priority "$WI_PRIORITY" \
+  --arg projectPath "${PROJECT_PATH:-}" \
+  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end)')
+
+POOL_RESULT=$(api_call POST "/task-pool/add" "$POOL_BODY" 2>/dev/null || echo '{"success":false}')
+POOL_OK=$(echo "$POOL_RESULT" | jq -r '.success // "false"' 2>/dev/null)
+TASK_ID=$(echo "$POOL_RESULT" | jq -r '.data.id // .workItemId // empty' 2>/dev/null || true)
+
+if [ "$POOL_OK" != "true" ]; then
+  echo "{\"warning\":\"Failed to create WorkItem in TaskPool — task delivered to terminal but no durable record\",\"details\":$(echo "$POOL_RESULT" | jq -c . 2>/dev/null || echo '{}')}" >&2
 fi
 
 # Set up idle event subscription for TL monitoring


### PR DESCRIPTION
## Summary

Continues the deprecation work in `specs/2026-05-06-task-management-v1-deprecation.md`. Migrates **all task producers** and the **four most-used worker skills** to V3 task-pool. v1 task-management subsystem is marked `@deprecated`; deletion is deferred to a follow-up per the spec's Phase C.

| | LOC | Status |
|---|---|---|
| `WorkItem.briefMarkdown` schema field | +33 / +3 tests | ✅ |
| Producer migration (orc + tl + mission decompose) | +60 / -54 | ✅ V3-only |
| Worker skills (accept / complete / block / get-my / report-status) | +120 / -55 | ✅ V3 endpoints |
| `task-management.controller` deprecation header | +20 | ✅ |
| Tests: 361/362 pass | | ✅ (1 pre-existing failure unrelated) |

## What this delivers toward the user's outcome

The user's stated goal: "消除重复的架构" — single source of truth for delegated work.

Before this PR: V3 task-pool and v1 `.md` task-management both produced and consumed delegated tasks, with a bridge (`ProjectTaskWatcher`) silently double-creating WorkItems.

After PR #484 (Layer 1): bridge gone; the two systems no longer leak into each other.

**This PR (Layer 2 producer cut):** all *new* tasks go through V3 only. Workers' four most-used skills (claim, complete, block, list) hit V3 endpoints. v1 `task-management.controller` is marked deprecated; its endpoints still respond for any not-yet-migrated skill but receive no new task data.

Net effect: V3 is now the **sole producer** of delegated work. v1 surface remains as a legacy worker workflow API that no longer has any new tasks to operate on. From a "duplicate architecture" standpoint, the duplication is no longer producing parallel state — only the dead v1 surface remains for future cleanup.

## Files changed

### Schema
- `backend/src/types/v2/work-item.types.ts` — `WorkItem.briefMarkdown` field with 16 KB cap
- `backend/src/types/v2/work-item.types.test.ts` — 3 new tests

### Producers
- `config/skills/orchestrator/delegate-task/execute.sh` — adds `briefMarkdown` to add-pool body
- `config/skills/team-leader/delegate-task/execute.sh` — drops `/task-management/create`, builds WorkItem with `briefMarkdown`
- `backend/src/services/v3/v3-data.service.ts:759` — `decomposeMissionToTasks` rewritten (no more `fs.writeFile`)
- `backend/src/services/v3/v3-data.service.test.ts` — 4 tests rewritten to assert `addToPool` instead of filesystem writes

### Worker skills
- `agent/core/accept-task` → `/task-pool/claim`
- `agent/core/complete-task` → `/task-pool/complete/:wi-id`
- `agent/core/block-task` → `/task-pool/block/:wi-id`
- `agent/core/get-my-tasks` → `/task-pool/items?target=...`
- `agent/core/report-status` (done branch) → `/task-pool/complete/:wi-id`

### Deprecation marker
- `backend/src/controllers/task-management/task-management.controller.ts` — `@deprecated` header pointing at the spec

## What still exists post-merge (intentional)

- v1 `task-management.controller` and its endpoints — kept mounted for the v1-specific skills not migrated here (handoff, report-progress, save-working-state, read-task). Those skills become dead-code paths since no producer creates v1 tasks; deletion in Phase C.
- 331 stale `.md` files in `.crewly/tasks/delegated/in_progress/` — inert artifacts, no longer read by any active path. Operational cleanup left to the spec's Phase C migration script.
- `task-planning.service.ts` plan-folder pattern (`plan.md`/`findings.md`/`progress.md`) — worker private notes, intentionally out of scope per the spec's non-goals.

## Skills not migrated (intentional, dead-code-after-merge)

`handoff-task`, `report-progress`, `save-working-state`, `read-task`, `decompose-goal` (TL), `verify-output` (TL `read-task`/`get-output`/`checklist-approve` calls), `create-task` — these have no V3 equivalent yet (per spec Phase A workstreams). They will be migrated or deleted in follow-up PRs once V3 ships those features.

## Sam's in-flight work

`team-leader/prompt.md`, `tl-addon.md`, `prompt-builder.service.test.ts` are Sam's uncommitted P0-1 dogfood work. **Not** included in this PR; he should land them in his own PR.

## Test plan

- [x] `tsc --noEmit -p backend/tsconfig.json` — clean
- [x] `npx jest backend/src/types/v2/work-item.types.test.ts backend/src/services/v3/v3-data.service.test.ts ...` → 361/362 pass
- [x] Pre-existing failure `MUST read` in `session-handoff.service.test.ts:594` verified as origin/main bug (temporary stash + re-run on bare main)
- [ ] Manual verify post-merge: TL `delegate-task` skill creates a WI with `briefMarkdown` populated; worker `accept-task` claims via V3; `complete-task` transitions to `done`
- [ ] No `.crewly/tasks/delegated/*.md` files written by any active code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)