### PR TITLE
fix(v3): notify worker on auto-claim — close Request→WI execution gap

### DIFF
--- a/backend/src/services/v3/agent-auto-claim.service.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.ts
@@ -265,6 +265,33 @@ export class AgentAutoClaimService {
       title: best.workItem.title,
     });
 
+    // Notify the worker. Without this, an auto-claimed WI sits in
+    // `running` with the agent's session as `target` but the agent never
+    // hears about it — manifesting as "Request created → WIs claimed →
+    // nothing executes". Hand off to WorkItemDispatchSubscriber so the
+    // [CREWLY-DISPATCH] write goes through the same idempotent path
+    // queued-WIs already use.
+    //
+    // `result.workItem` carries the claim-time WI snapshot with `target`
+    // already set, which is what `dispatchTo` expects.
+    //
+    // If dispatch fails here (transient HTTP error, agent restarting),
+    // the WI is in `running` state — the dispatch subscriber's recovery
+    // scan only re-checks `queued` items, so this path doesn't auto-recover.
+    // The agent will pick it up the next time it polls (`get-my-tasks`)
+    // or on its next idle tick (which retriggers AutoClaim, which sees
+    // the existing claim and skips). Acceptable tradeoff for now.
+    try {
+      const { WorkItemDispatchSubscriber } = await import('./workitem-dispatch.subscriber.js');
+      await WorkItemDispatchSubscriber.getInstance().dispatchTo(result.workItem);
+    } catch (dispatchErr) {
+      this.logger.warn('Post-claim dispatch failed — agent may not be notified', {
+        workItemId: best.workItem.id,
+        agentSessionName,
+        error: dispatchErr instanceof Error ? dispatchErr.message : String(dispatchErr),
+      });
+    }
+
     return { workItemId: best.workItem.id, score: best.score };
   }
 


### PR DESCRIPTION
## Summary

Closes the silent failure mode in the Request→WorkItem→worker pipeline that originally manifested as "Slack message → Request → 0 WorkItems executing." The decomposition was working; the **post-claim dispatch** was the missing link.

## The gap

```
user → orc → POST /api/requests
     → request:created event
     → RequestDecomposeSubscriber.plan() + addToPool()
            ⤷ WIs land with target=undefined ✅
     → workitem:queued event
     → WorkItemDispatchSubscriber sees no target, skips ✅ (correct)
     → AgentAutoClaim (event/tick) → claimSpecificItem(agent, wi)
            ⤷ sets target = agentId ✅
            ⤷ status: queued → running ✅
            ⤷ ❌ NO event fires the dispatcher listens to
            ⤷ ❌ agent never told
     → WI sits in `running` with target set but no executor.
```

## Fix

`AgentAutoClaimService.tryAutoClaimForAgent()` now hands off to `WorkItemDispatchSubscriber.dispatchTo()` after a successful claim. The dispatcher's idempotent `dispatched` Set keeps it safe against retries. Failure is non-fatal but logged at warn — the agent can still pick up via `get-my-tasks` polling.

## Test plan
- [x] tsc --noEmit clean
- [x] agent-auto-claim 8/8 pass
- [x] workitem-dispatch tests untouched, passing
- [x] Wider sweep (task-pool, request-decompose, request-sla): 362/362 pass

## NOT in this PR
End-to-end smoke against a running deployment — needs an actual Slack→orc round-trip. The unit-level wiring is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)