### PR TITLE
fix(v3): mission decomposition unblock — write canonical dependsOn field

### DIFF
--- a/backend/src/services/v3/mission-executor.service.test.ts
+++ b/backend/src/services/v3/mission-executor.service.test.ts
@@ -124,7 +124,11 @@ describe('MissionExecutorService', () => {
 
       const secondCall = mockAddToPool.mock.calls[1][0];
       expect(secondCall.status).toBe('blocked');
-      expect(secondCall.metadata._dependsOnTitles).toContain('Design schema');
+      // V3 canonical: deps live on `WorkItem.dependsOn` (resolved IDs),
+      // not the dead `metadata._dependsOnTitles` key. The first call's
+      // id is what the second item depends on.
+      const firstCall = mockAddToPool.mock.calls[0][0];
+      expect(secondCall.dependsOn).toContain(firstCall.id);
     });
 
     it('should reject if policy disallows task creation', async () => {

--- a/backend/src/services/v3/mission-executor.service.ts
+++ b/backend/src/services/v3/mission-executor.service.ts
@@ -126,7 +126,6 @@ export class MissionExecutorService {
           suggestedRole: task.suggestedRole,
           estimatedMinutes: task.estimatedMinutes,
           priority: task.priority,
-          _dependsOnTitles: task.dependsOn ?? [],
           krId: task.krId,
           krContribution: task.krContribution,
         },
@@ -134,6 +133,10 @@ export class MissionExecutorService {
 
       if (hasDeps) {
         workItem.status = 'blocked';
+        // `dependsOn` IDs are resolved in the second pass below — here we
+        // only know dep titles. The status flip to `blocked` is enough for
+        // `addToPool` validation; the canonical `dependsOn` field is set
+        // before pool insertion.
       }
 
       titleToId.set(task.title, workItem.id);
@@ -141,7 +144,16 @@ export class MissionExecutorService {
       createdIds.push(workItem.id);
     }
 
-    // Second pass: resolve title-based dependencies to WorkItem IDs
+    // Second pass: resolve title-based dependencies to WorkItem IDs and
+    // populate the canonical `WorkItem.dependsOn` field.
+    //
+    // History: this used to write `metadata._blockedBy` instead, but that
+    // key was only read by a v3-data.service.ts listener whose backing
+    // `v3:task_completed` event was retired in the v1-cleanup campaign
+    // (specs/2026-05-06-task-management-v1-deprecation.md). The pool's
+    // own `resolveBlockedDependents` reads the canonical top-level
+    // `dependsOn` field — which is the one that fires inside the V3
+    // completion lifecycle. So writing here closes the unblock path.
     for (const task of result.tasks) {
       if (!task.dependsOn || task.dependsOn.length === 0) continue;
 
@@ -154,8 +166,8 @@ export class MissionExecutorService {
 
       if (blockedByIds.length > 0) {
         const wi = createdItems.get(workItemId);
-        if (wi?.metadata) {
-          (wi.metadata as Record<string, unknown>)._blockedBy = blockedByIds;
+        if (wi) {
+          wi.dependsOn = blockedByIds;
         }
       }
     }

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -387,8 +387,15 @@ export class V3DataService {
       // Cascade: update parent Request status
       await this.cascadeRequestStatus(match.requestId);
 
-      // Unlock dependent WorkItems (task dependency resolution)
-      await this.unlockDependentWorkItems(match.id);
+      // Dependency unlock now lives in the V3 task-pool itself —
+      // `TaskPoolService.resolveBlockedDependents` runs inside the
+      // `completeItem` / `transitionStatus` lifecycle and reads the
+      // canonical `WorkItem.dependsOn` field. The previous
+      // `unlockDependentWorkItems` helper here read a parallel
+      // `metadata._blockedBy` key that mission-executor wrote — that
+      // mismatch was the silent freeze for mission decomposition with
+      // dependencies. Removed in spec/2026-05-06-task-management-v1-deprecation.md
+      // follow-up.
     } catch (err) {
       this.logger.warn('V3DataService.onTaskCompleted failed (non-fatal)', {
         sessionName: event.sessionName,
@@ -610,56 +617,6 @@ export class V3DataService {
     } catch (err) {
       this.logger.warn('V3DataService.onTaskBlocked failed (non-fatal)', {
         sessionName: event.sessionName,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  /**
-   * Unlocks WorkItems that were blocked by the completed WorkItem.
-   * Scans all blocked items in the pool for `metadata._blockedBy` arrays
-   * containing the completed item's ID. Removes it and transitions
-   * `blocked → queued` when no blockers remain.
-   *
-   * @param completedWorkItemId - The ID of the just-completed WorkItem
-   */
-  private async unlockDependentWorkItems(completedWorkItemId: string): Promise<void> {
-    try {
-      const taskPool = TaskPoolService.getInstance();
-      const allItems = await taskPool.getAllItems();
-
-      for (const wi of allItems) {
-        if (wi.status !== 'blocked') continue;
-
-        const blockedBy = (wi.metadata as Record<string, unknown> | undefined)?._blockedBy;
-        if (!Array.isArray(blockedBy)) continue;
-        if (!blockedBy.includes(completedWorkItemId)) continue;
-
-        const remaining = blockedBy.filter((id: unknown) => id !== completedWorkItemId);
-
-        // Update metadata and potentially unblock
-        if (remaining.length === 0) {
-          await taskPool.updateItemStatus(wi.id, 'queued');
-          this.logger.info('Dependency resolved — WorkItem unblocked', {
-            workItemId: wi.id,
-            resolvedBy: completedWorkItemId,
-          });
-        } else {
-          this.logger.debug('Dependency partially resolved', {
-            workItemId: wi.id,
-            resolvedBy: completedWorkItemId,
-            remainingBlockers: remaining.length,
-          });
-        }
-
-        // Update the _blockedBy metadata
-        if (wi.metadata) {
-          (wi.metadata as Record<string, unknown>)._blockedBy = remaining;
-        }
-      }
-    } catch (err) {
-      this.logger.debug('unlockDependentWorkItems failed (non-fatal)', {
-        completedWorkItemId,
         error: err instanceof Error ? err.message : String(err),
       });
     }


### PR DESCRIPTION
## Summary

Mission-decomposed WorkItems with dependencies were **silently freezing**. Same shape of bug as PR #490 — a write/read field mismatch hidden by V3-cleanup churn.

## The gap

```
mission-executor decomposes phase →
  WI A queued (no deps)
  WI B blocked, metadata._blockedBy = [A.id]    ← writes here

A completes → V3 completeItem → resolveBlockedDependents(A.id) →
  reads wi.dependsOn for blocked items          ← reads here
  finds nothing matching                         ← B never unblocks
  B sits in 'blocked' forever
```

The `metadata._blockedBy` key was once read by `v3-data.service.unlockDependentWorkItems`, triggered by the `v3:task_completed` event. That event was retired in the v1-cleanup campaign — no production publisher remains. Dead code path.

## Fix

1. `mission-executor.processDecomposition` writes the canonical `wi.dependsOn` field (resolved WI IDs) in its second pass, instead of `metadata._blockedBy` / `metadata._dependsOnTitles`.
2. `v3-data.service.unlockDependentWorkItems` deleted — its contract is permanently satisfied by `TaskPoolService.resolveBlockedDependents` inside the V3 completion lifecycle.
3. Test updated to assert `dependsOn` (id-based) instead of the dead metadata key.

Net diff: +30 / −57.

## Test plan
- [x] tsc --noEmit clean
- [x] mission-executor.service.test 8/8 pass
- [x] task-pool.service.test 130+/130+ pass
- [x] v3-data.service.test 30+/30+ pass
- [x] Wider sweep `(mission|task-pool|v3-data|reconcile)`: **702/702** pass; 2 pre-existing suite failures unrelated (vitest-not-jest in task-pool.routes.test, missing `createMonthlyPeriod` export in mission-period.service.test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)