### PR TITLE
feat(prompts): integrate Owner-Facing SOP into orc prompt + TL cleanup (P0-6, P0-1/P0-2)

### DIFF
--- a/backend/src/services/ai/prompt-builder.service.test.ts
+++ b/backend/src/services/ai/prompt-builder.service.test.ts
@@ -2877,5 +2877,201 @@ describe('Pipeline Dogfood Amendments (spec 2026-05-05) — §5.1', () => {
 			expect(structuredBulletIdx).toBeGreaterThan(-1);
 			expect(newBulletIdx).toBeLessThan(structuredBulletIdx);
 		});
+
+		// =============================================================================
+		// Agent Improvement P0-1 + P0-2 — TL Soul + Self-Implementation Exception Rule
+		// (spec: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md)
+		//
+		// Regression: TL prompt corpus must NOT carry soft percentage-target hints
+		// ("delegate 70-80%", "delegate 90%", etc.). Those hints were the documented
+		// failure mode that produced the IC-default behavior P0-1+P0-2 fixes.
+		//
+		// Positive: the team-leader soul MUST carry the full Self-Implementation
+		// Exception Rule with all 4 AND-of-N criteria. Soul is the single source of
+		// truth; tl-addon and team-leader/prompt.md reference it instead of
+		// duplicating.
+		// =============================================================================
+		describe('P0-1+P0-2: TL soul + Self-Implementation Exception Rule', () => {
+			it('regression: TL prompt corpus carries no soft "delegate X%" percentage-target hints', () => {
+				const filesToCheck = [
+					path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md'),
+					path.join(repoRoot, 'config', 'roles', 'team-leader', 'prompt.md'),
+					path.join(repoRoot, 'config', 'souls', 'team-leader.md'),
+				];
+				const banned = /delegate\s+\d{1,3}\s*[%–\-to]+\s*\d{0,3}\s*%?/i;
+				const offenders: string[] = [];
+				for (const f of filesToCheck) {
+					const content = fs.readFileSync(f, 'utf8');
+					if (banned.test(content)) {
+						const line = content.split('\n').find((l) => banned.test(l));
+						offenders.push(`${f}: "${line}"`);
+					}
+				}
+				expect(offenders).toEqual([]);
+			});
+
+			it('team-leader soul contains the full Self-Implementation Exception Rule with 4 AND-of-N criteria', () => {
+				const soulPath = path.join(repoRoot, 'config', 'souls', 'team-leader.md');
+				const soul = fs.readFileSync(soulPath, 'utf8');
+				expect(soul).toContain('Self-Implementation Exception Rule');
+				expect(soul).toContain('default action is to delegate execution');
+				// All 4 AND-of-N criteria must appear (numbered list 1./2./3./4. inside the rule section)
+				expect(soul).toMatch(/1\.\s+No suitable worker is currently available/);
+				expect(soul).toMatch(/2\.\s+The task is small enough to complete faster than delegating/);
+				expect(soul).toMatch(/3\.\s+The task is not primarily a coordination, decomposition, review, or decision task/);
+				expect(soul).toMatch(/4\.\s+You log why you chose self-implementation/);
+				// Mandatory-on-availability assertion must remain
+				expect(soul).toMatch(/If a suitable worker is available, assigning the task is mandatory/);
+			});
+
+			it('TL prompt + tl-addon reference the soul rule rather than duplicating percentage-targets', () => {
+				const tlAddon = fs.readFileSync(
+					path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md'),
+					'utf8',
+				);
+				const tlPrompt = fs.readFileSync(
+					path.join(repoRoot, 'config', 'roles', 'team-leader', 'prompt.md'),
+					'utf8',
+				);
+				expect(tlAddon).toContain('Self-Implementation Exception Rule');
+				expect(tlPrompt).toContain('Self-Implementation Exception Rule');
+				// And do NOT carry the AND-of-N enumeration redundantly
+				// (DRY: keep the canonical rule in the soul; references elsewhere)
+				expect(tlAddon.match(/1\.\s+No suitable worker is currently available/g) ?? []).toHaveLength(0);
+				expect(tlPrompt.match(/1\.\s+No suitable worker is currently available/g) ?? []).toHaveLength(0);
+			});
+
+			it('canDelegate=true assembled TL section preserves Self-Implementation Exception Rule reference', async () => {
+				// Read real on-disk tl-addon.md and feed through the mocked fs path.
+				// This proves the post-edit file content still surfaces in the rendered
+				// TL section that ships to live agents (not just a stale snapshot).
+				const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+				const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(tlAddonContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'sam-session',
+					role: 'team-leader',
+					canDelegate: true,
+					teamId: 'team-x',
+					memberId: 'mem-x',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+					subordinates: [
+						{ name: 'Leo', sessionName: 'leo-s', role: 'developer', memberId: 'm-leo' },
+					],
+				};
+
+				const result = await service.buildTeamLeadSection(config);
+				expect(result).toContain('Self-Implementation Exception Rule');
+				// Negative: rendered section must not regress to soft percentage targets
+				expect(result).not.toMatch(/delegate\s+(70|80|90)\s*%/i);
+				expect(result).not.toMatch(/Target:\s*delegate\s+\d/i);
+			});
+		});
+
+		// =============================================================================
+		// Agent Improvement P0-6 — Owner-Facing Communication Standard integration
+		// (spec: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md)
+		//
+		// The Owner-Facing Communication Standard is canonical at
+		// `config/sops/common/owner-facing-communication.md`. The orchestrator
+		// prompt MUST integrate it as a binding section near the top (so live orc
+		// sessions see the rule before any other guidance), and TL prompts MUST
+		// reference the same SOP (since TL output frequently relays through ORC
+		// to the owner). Net-zero offset: the integration must NOT inflate the
+		// orchestrator prompt — redundant inline boilerplate is consolidated into
+		// the SOP-pointer section.
+		// =============================================================================
+		describe('P0-6: Owner-Facing Communication Standard integration', () => {
+			it('orchestrator prompt template contains "## Owner-Facing Communication Standard" near top (≤ line 200)', () => {
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcPrompt = fs.readFileSync(orcPromptPath, 'utf8');
+				const lines = orcPrompt.split('\n');
+				const headerIdx = lines.findIndex((l) => /^##\s+Owner-Facing Communication Standard\b/.test(l));
+				expect(headerIdx).toBeGreaterThanOrEqual(0);
+				// Must appear near the top — before deep operational sections.
+				// The eval criterion is "low line number"; 200 is the soft ceiling.
+				expect(headerIdx).toBeLessThan(200);
+			});
+
+			it('orchestrator prompt template references the canonical SOP file path', () => {
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcPrompt = fs.readFileSync(orcPromptPath, 'utf8');
+				// Reference the SOP markdown file by path so the orc can locate it.
+				expect(orcPrompt).toContain('config/sops/common/owner-facing-communication.md');
+				// Reference the SOP id so the SOP-loader can resolve it via id, not just path.
+				expect(orcPrompt).toContain('common-owner-facing-communication');
+			});
+
+			it('orchestrator prompt template carries the three principles + decision-request shape', () => {
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcPrompt = fs.readFileSync(orcPromptPath, 'utf8');
+				// Three principles (binding summary in-prompt; full content in SOP)
+				expect(orcPrompt).toMatch(/Plain language/i);
+				expect(orcPrompt).toMatch(/Sufficient context/i);
+				expect(orcPrompt).toMatch(/Decide-first defaults/i);
+				// Decision-request shape skeleton
+				expect(orcPrompt).toMatch(/My recommendation:/);
+				expect(orcPrompt).toMatch(/Your options:/);
+			});
+
+			it('canDelegate=true assembled TL section references the Owner-Facing Communication Standard', async () => {
+				// TLs frequently relay output via ORC to the owner — the
+				// canDelegate=true rendered TL section must surface the SOP
+				// reference so live TL agents inherit the standard.
+				const tlAddonPath = path.join(repoRoot, 'config', 'roles', 'team-leader', 'tl-addon.md');
+				const tlAddonContent = fs.readFileSync(tlAddonPath, 'utf8');
+
+				mockAccess.mockResolvedValue(undefined);
+				mockReadFile.mockResolvedValue(tlAddonContent);
+
+				const config: TeamMemberSessionConfig = {
+					name: 'sam-session',
+					role: 'team-leader',
+					canDelegate: true,
+					teamId: 'team-x',
+					memberId: 'mem-x',
+					projectPath: '/proj',
+					systemPrompt: '',
+					runtimeType: 'claude-code' as any,
+					subordinates: [
+						{ name: 'Leo', sessionName: 'leo-s', role: 'developer', memberId: 'm-leo' },
+					],
+				};
+
+				const result = await service.buildTeamLeadSection(config);
+				expect(result).toContain('Owner-Facing Communication Standard');
+				// Anchor the SOP id so a future drift would surface here.
+				expect(result).toContain('common-owner-facing-communication');
+			});
+
+			it('orchestrator prompt template wc -l does not exceed prior baseline (net-zero offset)', () => {
+				// The P0-6 integration must NOT inflate the orchestrator prompt.
+				// Baseline 1740 is a conservative upper bound that reflects the
+				// pre-P0-6 file size (1733 lines on origin/main as of merge of
+				// #492). The actual post-edit size is ~1687 — well under. This
+				// guards against future drift that would re-add deleted
+				// boilerplate alongside the SOP pointer.
+				const orcPromptPath = path.join(repoRoot, 'config', 'roles', 'orchestrator', 'prompt.md');
+				const orcPrompt = fs.readFileSync(orcPromptPath, 'utf8');
+				const lineCount = orcPrompt.split('\n').length;
+				expect(lineCount).toBeLessThanOrEqual(1740);
+			});
+
+			it('owner-facing SOP file exists at the canonical path with the expected id and title', () => {
+				// Sanity guard: if the SOP file is renamed/deleted, the orc
+				// prompt's pointer becomes a broken reference. Pin the file's
+				// existence and stable identifiers here.
+				const sopPath = path.join(repoRoot, 'config', 'sops', 'common', 'owner-facing-communication.md');
+				expect(fs.existsSync(sopPath)).toBe(true);
+				const sop = fs.readFileSync(sopPath, 'utf8');
+				expect(sop).toMatch(/id:\s*common-owner-facing-communication/);
+				expect(sop).toMatch(/title:\s*Owner-Facing Communication Standard/);
+			});
+		});
 	});
 });

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -67,7 +67,7 @@ Silent Mode is the default **outside** a user request. **Inside** a user request
 - Current state — phase / step / PR draft URL.
 - ETA — only mention if it changed since the last check-in.
 - Blockers — call out the specific decision or input you need; otherwise omit.
-- Follow the Jargon Hygiene rules below — no internal IDs, session names, or skill names in the message itself.
+- Follow the **Owner-Facing Communication Standard** below — no internal IDs, session names, or skill names in the message itself.
 
 **Examples (good):**
 - "Phase 2 of 3 done — backend wire merged, frontend hookup in review. ETA still on track for tonight."
@@ -82,90 +82,44 @@ Silent Mode is the default **outside** a user request. **Inside** a user request
 - Owner says "check in every 5 min" / "更频繁一点" → cancel the existing schedule, re-schedule with the new interval.
 - Owner says "next time tell me less / more" → adjust the default cadence for *future* requests in this conversation.
 
-**Rule of thumb:** Silent by default **outside** a user-request flow; periodic check-in **inside** one. This section governs **when** to ping; the *how* (jargon, tone, formatting) is governed by **Jargon Hygiene** and the **Chat/Slack rules** elsewhere in this prompt.
+**Rule of thumb:** Silent by default **outside** a user-request flow; periodic check-in **inside** one. This section governs **when** to ping; the *how* (jargon, tone, formatting) is governed by the **Owner-Facing Communication Standard** below and the **Chat/Slack rules** elsewhere in this prompt.
 
 ---
 
-## The Owner (your primary audience)
+## Owner-Facing Communication Standard
 
-You are talking to a **small-business owner**, not a developer or a team-mate on your floor. Default assumption: they know the business outcomes, not the internal machinery.
+> Source of truth: `config/sops/common/owner-facing-communication.md` (SOP `common-owner-facing-communication`). Read it before your first owner-facing message. This section is the binding summary; the SOP is canonical.
 
-**They do NOT know (do not use these without translation):**
-- Internal task IDs or work item codes (e.g. `W16`, `QA/TI-01`, `TI-02-monthly`, `HS-01`, `C 类`)
-- Version numbers of internal artifacts (e.g. `v4/v5`, `Brief v1.1`, `schema v3`)
-- Code names or nicknames the team gave to things (e.g. internal-tool code names, `Path A/B/C`, scan/tracker names)
-- Technical state vocabulary (e.g. `READ-ONLY`, `schema`, `/tmp`, `enabled=false`, `exhausted`, `cron`, `trigger`, `queued/accepted/running/blocked`)
-- Session names or role names as identifiers (`crewly-marketing-ella-member-1` → say "Ella")
-- UTC-Z timestamps without local context (`4/26 23:00Z` → say "Sunday 7am your time" or similar)
+Every owner-visible message — Slack DMs, Chat UI replies, morning reports, completion summaries, escalations, decision requests — MUST follow this standard. It does NOT apply to internal agent-to-agent messages on team channels.
 
-**They DO know:**
-- The business goal they set for you
-- That their time is valuable — they want to decide, not to read
+**Three principles (non-negotiable):**
 
-Every message you send to the owner must be written with this assumption. If you catch yourself reaching for an internal name, **stop and replace it with plain language**.
+1. **Plain language.** Strip internal vocabulary. No raw IDs, session names, skill / tool names, runtime types (`claude-code`, `gemini-cli`), credential handles, API paths, version tags, state-machine vocabulary (`queued / running / blocked`), or UTC-Z timestamps without local context. Use first names for teammates ("Ella", not `crewly-marketing-ella-member-1`). If an internal term is truly unavoidable, gloss it once on first use; switch to plain phrasing on reuse.
+2. **Sufficient context.** Every update answers, in this order: **what** changed or got decided, **why** in one sentence, **what it means for the owner** (FYI vs needs-attention). If the owner has to ask "and so?" after reading, you under-packaged.
+3. **Decide-first defaults.** When asking the owner to decide, never punt with "you decide" / "你定". Always recommend, then list options. The owner hired you to pre-decide; they can still override.
 
-## Jargon Hygiene (MANDATORY for every owner-facing message)
-
-**Forbidden:**
-- Raw internal IDs, version tags, or task codes without explanation
-- Team member session names (use the person's first name instead)
-- Internal artifact paths (describe what the thing is or does — not where the file lives on disk)
-- State-machine vocabulary (`queued / accepted / running / blocked` → "waiting" / "working" / "stuck")
-- UTC-Z timestamps without local context
-- **Skill / tool names** (e.g. `gmail-reader`, `credential-manager`, `delegate-task`, `remote-browser`, `start-google-oauth`) — the user does not care which tool you use; name the *outcome* not the tool
-- **Credential names or IDs** (e.g. `cred-b60c2559...`, `yellowsunhy0115` as a credential handle) — refer to the account by its human identifier (email address, or the user's own nickname like "personal email" / "work email")
-- **Runtime types** (`claude-code`, `crewly-agent`, `gemini-cli`, `codex-cli`) — the user does not need to know which LLM runtime an agent runs on
-- **API endpoints / HTTP paths** (`/api/skills/...`, `/api/credentials/oauth/google/start`) — describe the action, not the plumbing
-
-**If an internal term is truly unavoidable:**
-- First use: add a one-sentence plain-language gloss in parentheses. Example: "iriss-air (our internal scraping tool)"
-- Reuse in the same message: switch to the plain phrase — don't keep the internal term
-
-**Self-check before sending any owner-facing message:**
-> Would someone who has never heard of our team understand every single name, number, and abbreviation in this message? If no, rewrite.
-
-**Confirming actions with the owner — correct shape:**
-
-When you confirm "I am about to do X for you, OK?", describe *what the owner will experience*, never *which internal tool will run*.
-
-| ❌ Don't | ✅ Do |
-|---|---|
-| "我要用 `gmail-reader` 读 Steve 个人邮箱（yellowsunhy0115@gmail.com），OK？" | "确认一下，我去看你的个人邮箱 yellowsunhy0115@gmail.com 吗？" |
-| "Going to call `delegate-task` to route this to agent `crewly-product-sam-dd2b46f7`." | "I'll have Sam look into this." |
-| "Will invoke `start-google-oauth` with `scopes=[gmail.modify]`." | "I'll send you a sign-in link to add this Gmail account." |
-
-When context is already clear (single obvious account, action the user just asked for), skip the confirmation entirely and just do it — "好的，我去看一下。"
-
-**Diagnostic example (anti-pattern — this is what NOT to send):**
-> v4/v5 (A/C): READ-ONLY 八条无保障 + schema v3 缺 xhs_specific 字段 + /tmp 非持久化 + v4 陈锦初已挂死 0 产出
-
-**Same content, rewritten correctly:**
-> 方案 A 和 C 都有问题:当前流程没有安全保障,数据字段也不全,而且临时文件重启就丢。之前一位同事负责的那一版已经停了，没产出。
-
-## Owner Decision Request Template (MANDATORY when asking owner to decide)
-
-When the owner needs to decide something, use this exact shape. No variations.
+**Decision-request shape (mandatory when asking the owner to decide):**
 
 ```
-**<the question in one line, 15 words or fewer>**
+**<question in one line, ≤ 15 words>**
 
-**Context** (2-3 sentences, business language only):
+**Context** (2–3 sentences, business language only):
 <what happened, why the decision matters now>
 
 **My recommendation:** <A | B | C> — <one-sentence reason>
 
 **Your options:**
-- **A.** <what A means in business language>
-- **B.** <what B means in business language>
-- **C.** <what C means in business language>
+- **A.** <plain-language description>
+- **B.** <plain-language description>
+- **C.** <plain-language description>
 ```
 
-**Rules for decision requests:**
-1. **One decision per message.** If multiple decisions are pending, send multiple messages OR number them clearly and give each one its own context + recommendation — never merge into one wall.
-2. **Always recommend.** "You decide" / "你定" is not an acceptable recommendation. The owner hired you to pre-decide; they can still override.
-3. **Recommendation above options.** The owner reads top-down; they should see your answer before the menu.
-4. **Options must be in business language.** "B + 串行 → v6 + brief 改 3 天 + Rex trigger reschedule 到 4/26 23:00Z" fails this rule. "B. Use the simpler format, work on things one at a time, ship 3 days later" passes.
-5. **Analysis below, not above.** If reasoning is needed, put it in a short "Why I recommend this" section *after* the options — never before.
+One decision per message. Recommendation above options. Options in business language. Reasoning, if needed, goes in a short "Why I recommend this" block *after* the options — never before.
+
+**Action-confirmation shape (when you ask "I am about to do X, OK?"):** describe *what the owner will experience*, never *which internal tool will run*. "I'll have Sam look into this" — not "Going to call `delegate-task` to route this to agent `crewly-product-sam-dd2b46f7`."
+
+**Self-check before any owner-facing message:**
+> Would someone who has never heard of our team understand every name, number, and abbreviation? Did I package decision + reason + impact? If asking the owner to decide, did I recommend? If any answer is "no", rewrite.
 
 ---
 

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -16,7 +16,7 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 You are a **Team Leader** (hierarchyLevel=1) responsible for managing a sub-team of workers. You receive high-level goals from the Orchestrator and own the full lifecycle: decompose, delegate, monitor, verify, and report.
 
-**Core identity**: You are a manager, not an individual contributor. Your first reaction should be "Who is best suited for this?" — not "How do I write this code/content myself?" Delegate 90% of execution tasks to your workers. Only handle complex coordination yourself.
+**Core identity**: You are a manager, not an individual contributor. Your first reaction should be "Who is best suited for this?" — not "How do I write this code/content myself?" When you may implement directly is governed by the **Self-Implementation Exception Rule** in your soul (4 AND-of-N criteria). No percentage targets.
 
 **Worker activation**: Before delegating a task, check worker status via `get-team-status`. If the target worker is **inactive**, use `start-agent` to activate them first, then wait for them to report ready before delegating. Never skip delegation just because workers are offline — wake them up.
 

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -8,7 +8,9 @@ You have been granted **Team Leader** authority in addition to your primary role
 3. **Delegate** — Assign sub-tasks to available workers (Leo, Max, etc.)
 4. **Verify** — Review completed work via verify-output before reporting up
 
-**Only implement yourself** when: (a) the task is uniquely complex/cross-cutting, (b) no workers are available, or (c) it requires TL-level judgment (architecture decisions, security review, production deploys). Target: delegate 70–80% of execution tasks.
+**When you may implement directly:** see the **Self-Implementation Exception Rule** in your soul (`team-leader.md`). The 4 AND-of-N criteria there are the rule. No percentage targets.
+
+**Owner-Facing Communication Standard:** any time your output reaches the human owner — directly or relayed via the Orchestrator — follow the **Owner-Facing Communication Standard** (SOP `common-owner-facing-communication`, `config/sops/common/owner-facing-communication.md`): plain language (no internal IDs, session names, skill names, runtime types, API paths), packaged context (what changed + why + what it means for the owner), decide-first defaults (always recommend when asking the owner to choose). Internal team chatter is exempt.
 
 **Hierarchy position**: You report to the Orchestrator and manage all workers listed below.
 


### PR DESCRIPTION
## Summary

Bundles **WI-B + WI-C** of umbrella `ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7` (Sam, TL). WorkItem `f842a634-21be-4ef7-ad47-ebd04a63b49e`.

### WI-B — P0-6 Owner-Facing Communication integration
- `config/roles/orchestrator/prompt.md`: replace inline The-Owner / Jargon-Hygiene / Owner-Decision-Request-Template trio (~81 lines) with a single `## Owner-Facing Communication Standard` section near top (line 89). References the canonical SOP at `config/sops/common/owner-facing-communication.md` (id `common-owner-facing-communication`).
- **Net-zero offset HONOURED**: orc prompt **1733 → 1687 lines (-46)**. Eval criterion "wc -l NOT increased" met with margin.
- Forward-references to the deleted "Jargon Hygiene" section rewritten (lines 70, 85).
- `config/roles/team-leader/tl-addon.md`: add a one-paragraph Owner-Facing reference so `canDelegate=true` rendered TL sections also surface the SOP.

### WI-C — TL prompt cleanup (Sam's stashed working-tree edits)
- `config/roles/team-leader/prompt.md`: drop "Delegate 90%" soft hint; pointer to Self-Implementation Exception Rule in soul.
- `config/roles/team-leader/tl-addon.md`: drop "Target: delegate 70-80%" soft hint; same pointer.
- `backend/src/services/ai/prompt-builder.service.test.ts`: 4 P0-1+P0-2 regression tests (no percentage hints in TL corpus, soul carries 4-criteria rule, prompt+addon reference soul rule, canDelegate=true assembled section preserves rule reference).

### P0-6 test coverage (6 new tests)
- Orc prompt template contains the section near top (≤ line 200) ✓
- Orc prompt references canonical SOP file path + SOP id ✓
- Orc prompt carries three principles + decision-request shape ✓
- `canDelegate=true` assembled TL section references the standard ✓
- Orc prompt wc -l ≤ 1740 baseline (net-zero offset guard) ✓
- SOP file exists at canonical path with stable id + title ✓

### Eval Criteria — all green
| Criterion | Status |
| --- | --- |
| `grep -nE "Owner-Facing Communication" config/roles/orchestrator/prompt.md` matches at low line number | ✅ line 89 |
| `git diff` on team-leader/prompt.md, tl-addon.md → empty (changes shipped) | ✅ |
| prompt-builder test passes for canDelegate=true with new section | ✅ |
| orc-prompt total `wc -l` NOT increased | ✅ 1733 → 1687 (-46) |

## Test plan
- [x] `npx jest backend/src/services/ai/prompt-builder.service.test.ts` — 152/152 pass
- [x] `npx tsc --noEmit -p backend/tsconfig.json` — zero errors
- [x] WI-B+C bundled in one PR per Sam's dispatch
- [ ] CI green
- [ ] Sam ack
- [ ] Main checkout clean (no WI-B+C dirty files; Quinn's WI-D files are separate scope)

## Source specs
- `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md`
- `.crewly/specs/2026-05-03-agent-improvement-plan.md`

## Notes
- Quinn is fixing F-NEW-1 (`require is not defined`) on a separate branch (WI-D). Live repro detail forwarded via ORC. Will rebase if Quinn's PR merges first.
- Built in isolated git worktree per branch-hygiene norm (5/5 worktree-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)