### PR TITLE
fix(agent-registration): require is not defined in active-work-briefing (F-NEW-1)

### DIFF
--- a/backend/src/services/agent/active-work-briefing.service.test.ts
+++ b/backend/src/services/agent/active-work-briefing.service.test.ts
@@ -570,4 +570,69 @@ describe('ActiveWorkBriefingService', () => {
       expect(md).toContain('  - Do the thing');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // ESM require bridge — local regression guard (F-NEW-1, auditor cycle 1)
+  // ---------------------------------------------------------------------------
+  //
+  // The lazy load inside `getInstance()` was originally written as bare
+  // `require('../v3/request.service.js')`, which crashes under ESM (production)
+  // with `require is not defined`. The skill `get-my-active-work` and
+  // `AgentRegistrationService.activeWorkBriefing` both flow through that
+  // factory at session startup, so EVERY session was hitting the error
+  // (auditor cycle 1 reported 25 occurrences in a single day).
+  //
+  // The fix replaces bare `require(` with `nodeRequire(` (a CJS↔ESM bridge
+  // anchored to `pathToFileURL(process.argv[1])`). This guard scans the
+  // service source directly so a future contributor cannot silently revert
+  // the bridge or add a fresh bare `require(` in the same file.
+  //
+  // Static-only because under ts-jest's CJS transpile `typeof require ===
+  // 'function'` is true, so the runtime path picks the global `require`
+  // and never hits the createRequire branch — the runtime bug is invisible
+  // here. Source-scanning is the correct shape.
+  describe('ESM require bridge regression (F-NEW-1)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const fs = require('fs') as typeof import('fs');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const path = require('path') as typeof import('path');
+
+    const SERVICE_PATH = path.resolve(__dirname, 'active-work-briefing.service.ts');
+
+    /**
+     * Strip line and block comments so historical references inside JSDoc
+     * (e.g. "originally `require()`'d" wording in the file's own docblock)
+     * do not false-positive against the regex below.
+     */
+    const stripComments = (s: string): string =>
+      s
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .split('\n')
+        .map((line) => line.replace(/\/\/.*$/, ''))
+        .join('\n');
+
+    it('source contains no bare `require(` calls outside of comments', () => {
+      const code = stripComments(fs.readFileSync(SERVICE_PATH, 'utf8'));
+      // Match `require(` or `require ` followed by `(` — but NOT `nodeRequire(`,
+      // `createRequire(`, or property-style `.require(`. Word-boundary lookbehind
+      // anchors the bare global form.
+      const BARE_REQUIRE = /(?<![A-Za-z0-9_$.])require\s*\(/g;
+      const matches = code.match(BARE_REQUIRE) ?? [];
+      expect(matches).toEqual([]);
+    });
+
+    it('source uses the canonical `nodeRequire` bridge', () => {
+      const code = stripComments(fs.readFileSync(SERVICE_PATH, 'utf8'));
+      // The lazy loads inside getInstance() must go through `nodeRequire`.
+      expect(code).toMatch(/nodeRequire\s*\(\s*['"]\.\.\/v3\/request\.service\.js['"]\s*\)/);
+      expect(code).toMatch(
+        /nodeRequire\s*\(\s*['"]\.\.\/task-pool\/task-pool\.service\.js['"]\s*\)/,
+      );
+      // And the bridge itself must be defined the canonical way (anchored
+      // to process.argv[1] via pathToFileURL — see commit 070cd3e5).
+      expect(code).toMatch(
+        /createRequire\s*\(\s*pathToFileURL\s*\(\s*process\.argv\[1\]/,
+      );
+    });
+  });
 });

--- a/backend/src/services/agent/active-work-briefing.service.ts
+++ b/backend/src/services/agent/active-work-briefing.service.ts
@@ -27,6 +27,8 @@
  * @module services/agent/active-work-briefing.service
  */
 
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
 import { LoggerService } from '../core/logger.service.js';
 import type { ComponentLogger } from '../core/logger.service.js';
 import { ORCHESTRATOR_ROLE, ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
@@ -38,8 +40,35 @@ import type { WorkItem, WorkItemStatus } from '../../types/v2/work-item.types.js
 // AgentRegistrationService test suite — do not transitively pull in
 // `v3/v3-data.service.ts` and `v3/project-task-watcher.service.ts`
 // (which loads `chokidar`, which fails to parse as ESM under ts-jest's
-// CommonJS transform). The runtime singletons are require()'d lazily
-// inside {@link ActiveWorkBriefingService.getInstance} below.
+// CommonJS transform). The runtime singletons are loaded LAZILY through
+// `nodeRequire` (defined just below) inside
+// {@link ActiveWorkBriefingService.getInstance}.
+
+/**
+ * CJS-style `require` for the lazy load inside `getInstance`. This file
+ * compiles to ESM (root package has `"type": "module"`) where the bare
+ * `require` global is undefined — which is exactly the bug fixed here:
+ * the previous bare `require(...)` calls threw `require is not defined`
+ * for every agent registration that flowed through
+ * `ActiveWorkBriefingService.getInstance()` (the active-work-briefing
+ * controller and `AgentRegistrationService.activeWorkBriefing` path),
+ * breaking the get-my-active-work skill at session startup.
+ *
+ * Pattern matches the canonical fix established by commit 070cd3e5
+ * (`fix(esm): anchor createRequire to process.argv[1]`):
+ * - Under ts-jest's CJS transpile, the global `require` is real, so we
+ *   reuse it (cheaper, plays well with jest module mocking).
+ * - Under ESM (production), we `createRequire` anchored to the entry
+ *   script via `pathToFileURL(process.argv[1])` so Node's resolver walks
+ *   up to find `node_modules`. We do NOT use
+ *   `new Function('return import.meta.url')()` because that body
+ *   evaluates in non-module scope and fails at runtime
+ *   (`Cannot use 'import.meta' outside a module`).
+ */
+const nodeRequire: NodeRequire =
+  typeof require === 'function'
+    ? require
+    : createRequire(pathToFileURL(process.argv[1] || process.cwd()).href);
 
 /**
  * Narrow projection of `RequestService` used by the briefing — only
@@ -314,9 +343,9 @@ export class ActiveWorkBriefingService {
   public static getInstance(): ActiveWorkBriefingService {
     if (!ActiveWorkBriefingService.instance) {
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const { RequestService } = require('../v3/request.service.js');
+      const { RequestService } = nodeRequire('../v3/request.service.js');
       // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-      const { TaskPoolService } = require('../task-pool/task-pool.service.js');
+      const { TaskPoolService } = nodeRequire('../task-pool/task-pool.service.js');
       ActiveWorkBriefingService.instance = new ActiveWorkBriefingService(
         () => RequestService.getInstance(),
         () => TaskPoolService.getInstance(),

--- a/backend/src/services/memory/vector-store.service.test.ts
+++ b/backend/src/services/memory/vector-store.service.test.ts
@@ -101,6 +101,13 @@ describe('ESM require pattern (cross-file regression guard)', () => {
     'backend/src/services/browser/browser-bridge.service.ts',
     'backend/src/services/slack/cross-machine-message.service.ts',
     'backend/src/controllers/agent-stream/agent-stream.controller.ts',
+    // Added 2026-05-07 (auditor cycle 1, F-NEW-1): the bare `require()` calls
+    // inside ActiveWorkBriefingService.getInstance() threw `require is not
+    // defined` for every agent registration that touched the active-work
+    // briefing path (skill `get-my-active-work` and AgentRegistrationService),
+    // breaking session startup. Now bridged via the canonical createRequire
+    // pattern; this guard locks the bridge in.
+    'backend/src/services/agent/active-work-briefing.service.ts',
   ];
 
   // The broken pattern's distinguishing feature: `createRequire(new Function(`


### PR DESCRIPTION
## Summary

- **Bug:** Every agent session-start `get-my-active-work` call (and every `AgentRegistrationService.activeWorkBriefing` flow) crashed with `require is not defined`. Auditor cycle 1 (2026-05-07) recorded **25 occurrences in a single day**; Sam, Max, Mia, and Ava all reproduced live during their session-starts. The bug was breaking the dispatch protocol Sam was using to coordinate the team.
- **Root cause:** `backend/src/services/agent/active-work-briefing.service.ts:317-319` used bare `require('../v3/request.service.js')` and `require('../task-pool/task-pool.service.js')` inside `getInstance()`. Bare `require` is undefined under the production ESM build, but ts-jest's CJS transpile masked it (`typeof require === 'function'` is true in tests).
- **Fix:** Same shape as the canonical sweep in commit `070cd3e5` ("anchor createRequire to process.argv[1]"). Define a module-scoped `nodeRequire` that uses the global `require` under CJS and `createRequire(pathToFileURL(process.argv[1]).href)` under ESM, then route both lazy loads through it.

## Files

| File | Change |
|---|---|
| `backend/src/services/agent/active-work-briefing.service.ts` | + `import { createRequire } from 'module'`, + `import { pathToFileURL } from 'url'`, + `nodeRequire` const, route both lazy loads through `nodeRequire(...)` |
| `backend/src/services/agent/active-work-briefing.service.test.ts` | +2 local regression guards (no-bare-require + canonical bridge present) |
| `backend/src/services/memory/vector-store.service.test.ts` | Added the briefing service to the cross-file `ESM_BRIDGED_FILES` regression list |

## Test plan

- [x] `jest backend/src/services/agent/active-work-briefing.service.test.ts` → 27/27 pass (25 pre-existing + 2 new)
- [x] `jest backend/src/services/memory/vector-store.service.test.ts -t 'ESM require pattern'` → 8/8 cross-file guard entries pass
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [x] Compiled `dist/backend/.../active-work-briefing.service.js` shows `nodeRequire` const at module-init and `nodeRequire(...)` at the two lazy-load sites
- [ ] Post-merge operational smoke (Sam will run on the deployed backend):
  - `bash config/skills/agent/core/get-my-active-work/execute.sh --session crewly-product-sam-9487fefe --role team-leader` → expect HTTP 200, no `require is not defined`
  - Audit cycle 2 confirms `require is not defined` count → 0
  - Existing sessions (Sam, Max, Mia, Ava) self-heal on next session-start

## Why static-analysis-only for the regression guards

The runtime bug only manifests under ESM (production). ts-jest transpiles the test under CJS, where `typeof require === 'function'` is true, so the runtime path picks the global `require` and never exercises the createRequire branch. Source-scanning is the correct shape for the regression — it locks the bridge against a future contributor reverting to bare `require(` even though tests would silently pass either way.

## References

- **Umbrella:** ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7
- **WI:** 6590b6e2-c43d-4483-b7fc-660727401983 (WI-D)
- **Audit:** `.crewly/audit-reports/2026-05-07-audit-cycle1.md` § F-NEW-1
- **Canonical pattern:** commit `070cd3e5` (`fix(esm): anchor createRequire to process.argv[1]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)