### PR TITLE
feat(p0-3): Request Contract — orc + TL + worker + delegate-task G/O/E warning

### DIFF
--- a/backend/src/services/ai/prompt-modules/index.ts
+++ b/backend/src/services/ai/prompt-modules/index.ts
@@ -31,6 +31,7 @@ export { CommunicationModule } from './communication.module.js';
 export { RecoveryModule } from './recovery.module.js';
 export { LifecycleModule } from './lifecycle.module.js';
 export { RoleBoundaryModule } from './role-boundary.module.js';
+export { RequestContractModule } from './request-contract.module.js';
 export { WorkingMemoryModule } from './working-memory.module.js';
 
 // Context loaders

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts
@@ -78,7 +78,9 @@ describe('PromptAssemblyService', () => {
 			expect(names).toContain('mission_context');
 			// Decision Rights + Escalation Chain (P0-4 — authority text, priority 3.5)
 			expect(names).toContain('decision-rights');
-			expect(names.length).toBe(19);
+			// Request Contract (P0-3 — authority text, priority 3.6)
+			expect(names).toContain('request-contract');
+			expect(names.length).toBe(21);
 		});
 
 		it('should use default token budget of 28000', () => {

--- a/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
+++ b/backend/src/services/ai/prompt-modules/prompt-assembly.service.ts
@@ -22,6 +22,7 @@ import { RecoveryModule } from './recovery.module.js';
 import { LifecycleModule } from './lifecycle.module.js';
 import { RoleBoundaryModule } from './role-boundary.module.js';
 import { DecisionRightsModule } from './decision-rights.module.js';
+import { RequestContractModule } from './request-contract.module.js';
 import { CapabilityOverlayModule } from './capability-overlay.module.js';
 import { DomainSOPModule } from './domain-sop.module.js';
 import { RiskPolicyModule } from './risk-policy.module.js';
@@ -119,6 +120,13 @@ export class PromptAssemblyService {
 			// inside the authority cluster: identity → soul → recovery →
 			// role-boundary → decision-rights. Authority text is non-compactable.
 			new DecisionRightsModule(),
+			// Request Contract (P0-3) sits at priority 3.6, immediately after
+			// DecisionRights and before MemoryReference. Authority cluster
+			// continues: identity → soul → recovery → role-boundary →
+			// decision-rights → request-contract → memory-reference.
+			// Role-shaped: orchestrator gets the seven-field table, TLs get
+			// Brief Reception Protocol, workers get the G+O+E reminder.
+			new RequestContractModule(),
 			new MemoryReferenceModule(),
 			new SkillsReferenceModule(),
 			new TeamReferenceModule(),

--- a/backend/src/services/ai/prompt-modules/request-contract.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/request-contract.module.test.ts
@@ -1,0 +1,309 @@
+import { RequestContractModule } from './request-contract.module.js';
+import { ModuleConfig } from './prompt-module.interface.js';
+
+describe('RequestContractModule', () => {
+	let module: RequestContractModule;
+
+	const baseConfig: ModuleConfig = {
+		sessionName: 'crewly-product-leo-21a5477e',
+		memberId: '21a5477e-ec10-4e45-8cae-8b55e232e04e',
+		role: 'developer',
+		teamId: '817a1aeb-b04e-45dd-bdbc-be5cbc4345f1',
+		projectPath: '/Users/user/projects/crewly',
+		agentSkillsPath: '/path/to/skills/agent',
+		tlSkillsPath: '/path/to/skills/team-leader',
+		projectRoot: '/path/to/project',
+	};
+
+	beforeEach(() => {
+		module = new RequestContractModule();
+	});
+
+	describe('metadata', () => {
+		it('should have name = request-contract', () => {
+			expect(module.name).toBe('request-contract');
+		});
+
+		it('should sit at priority 3.6 (between decision-rights=3.5 and memory-reference=4)', () => {
+			expect(module.priority).toBe(3.6);
+		});
+
+		it('should sit immediately after DecisionRightsModule (priority 3.5)', () => {
+			expect(module.priority).toBeGreaterThan(3.5);
+			expect(module.priority).toBeLessThan(4);
+		});
+
+		it('should declare a token budget large enough for the largest (orchestrator) variant', () => {
+			expect(module.maxTokens).toBeGreaterThanOrEqual(400);
+		});
+
+		it('should be non-compactable (authority text never truncates)', () => {
+			expect(module.compactable).toBe(false);
+		});
+	});
+
+	describe('shouldInclude', () => {
+		it('should always include regardless of role', () => {
+			expect(module.shouldInclude(baseConfig)).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'orchestrator' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'team-leader' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'developer' })).toBe(true);
+			expect(module.shouldInclude({ ...baseConfig, role: 'auditor' })).toBe(true);
+		});
+
+		it('should include when org-role fields are absent', () => {
+			expect(
+				module.shouldInclude({
+					sessionName: 'minimal',
+					memberId: 'm',
+					role: 'developer',
+					agentSkillsPath: '/a',
+					tlSkillsPath: '/t',
+					projectRoot: '/r',
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe('build — orchestrator role-shape', () => {
+		it('should emit ## Request Contract H2 when role === orchestrator', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).toContain('## Request Contract');
+		});
+
+		it('should emit ## Request Contract H2 when orgRole === orchestrator (overrides role)', async () => {
+			const out = await module.build({
+				...baseConfig,
+				role: 'developer',
+				orgRole: 'orchestrator',
+			});
+			expect(out).toContain('## Request Contract');
+		});
+
+		it('should emit the seven canonical fields in the table', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).toContain('**Goal**');
+			expect(out).toContain('**Expected Outcome**');
+			expect(out).toContain('**Eval Criteria**');
+			expect(out).toContain('Constraints');
+			expect(out).toContain('Decision Rights');
+			expect(out).toContain('Escalation Conditions');
+			expect(out).toContain('**Done Definition**');
+		});
+
+		it('should mark Goal / Expected Outcome / Eval Criteria / Done Definition as YES required', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			// Spec verbatim: G+O+E + Done are the YES-required fields.
+			const goalLine = out.split('\n').find((l) => l.includes('**Goal**'));
+			const outcomeLine = out.split('\n').find((l) => l.includes('**Expected Outcome**'));
+			const evalLine = out.split('\n').find((l) => l.includes('**Eval Criteria**'));
+			const doneLine = out.split('\n').find((l) => l.includes('**Done Definition**'));
+			expect(goalLine).toMatch(/YES/);
+			expect(outcomeLine).toMatch(/YES/);
+			expect(evalLine).toMatch(/YES/);
+			expect(doneLine).toMatch(/YES/);
+		});
+
+		it('should pin the G+O+E mandatory floor for every delegated subtask', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).toMatch(/Every delegated subtask MUST carry Goal \+ Expected Outcome \+ Eval Criteria/);
+		});
+
+		it('should require TL to reject malformed briefs', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).toMatch(/Team Lead is required to reject any subtask brief missing these three/);
+		});
+
+		it('should NOT include the TL Brief Reception Protocol header for the orchestrator', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).not.toContain('## Brief Reception Protocol');
+		});
+
+		it('should NOT include the worker reminder header for the orchestrator', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).not.toContain('## Request Contract — What You Should See');
+		});
+	});
+
+	describe('build — team-lead role-shape', () => {
+		it('should emit ## Brief Reception Protocol when orgRole === team-lead', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).toContain('## Brief Reception Protocol');
+		});
+
+		it('should emit ## Brief Reception Protocol when canDelegate === true', async () => {
+			const out = await module.build({ ...baseConfig, canDelegate: true });
+			expect(out).toContain('## Brief Reception Protocol');
+		});
+
+		it('should NOT emit Brief Reception Protocol when canDelegate is undefined and orgRole !== team-lead', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).not.toContain('## Brief Reception Protocol');
+		});
+
+		it('should encode the three-step verify / push-back / propagate-verbatim contract', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).toMatch(/1\.\s+\*\*Verify\*\*/);
+			expect(out).toMatch(/2\.\s+\*\*Push back\*\*/);
+			expect(out).toMatch(/3\.\s+\*\*Propagate verbatim\*\*/);
+		});
+
+		it('should explicitly forbid proceeding when G+O+E is missing', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).toMatch(/do not proceed, do not start decomposition, do not fan out work/);
+		});
+
+		it('should require G+O+E to be propagated verbatim to children', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).toMatch(/Propagate verbatim/);
+			expect(out).toMatch(/Workers should never have to ask you what success looks like/);
+		});
+
+		it('should NOT include the orchestrator field table for the TL', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).not.toContain('| Field | Required | What it means |');
+		});
+
+		it('should NOT include the worker reminder header for the TL', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			expect(out).not.toContain('## Request Contract — What You Should See');
+		});
+	});
+
+	describe('build — worker / executor role-shape', () => {
+		it('should emit the worker reminder for role === developer', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).toContain('## Request Contract — What You Should See');
+		});
+
+		it('should emit the worker reminder for role === auditor', async () => {
+			const out = await module.build({ ...baseConfig, role: 'auditor' });
+			expect(out).toContain('## Request Contract — What You Should See');
+		});
+
+		it('should emit the worker reminder for orgRole === executor', async () => {
+			const out = await module.build({ ...baseConfig, role: 'researcher', orgRole: 'executor' });
+			expect(out).toContain('## Request Contract — What You Should See');
+		});
+
+		it('should list the three required fields the worker should expect', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).toMatch(/-\s+\*\*Goal\*\*/);
+			expect(out).toMatch(/-\s+\*\*Expected Outcome\*\*/);
+			expect(out).toMatch(/-\s+\*\*Eval Criteria\*\*/);
+		});
+
+		it('should instruct the worker to ask the delegator if any field is missing', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).toMatch(/ask the delegator/);
+			expect(out).toMatch(/before starting/);
+		});
+
+		it('should explicitly forbid the worker from inventing the contract themselves', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).toMatch(/Do not invent the contract yourself/);
+		});
+
+		it('should NOT include the orchestrator field table for the worker', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).not.toContain('| Field | Required | What it means |');
+		});
+
+		it('should NOT include the TL Brief Reception Protocol for the worker', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			expect(out).not.toContain('## Brief Reception Protocol');
+		});
+	});
+
+	describe('build — role-shape resolution priority', () => {
+		it('should pick orchestrator over team-lead when both signals are set', async () => {
+			// orchestrator wins via role check; canDelegate=true would otherwise route to TL.
+			const out = await module.build({
+				...baseConfig,
+				role: 'orchestrator',
+				canDelegate: true,
+			});
+			expect(out).toContain('## Request Contract');
+			expect(out).not.toContain('## Brief Reception Protocol');
+		});
+
+		it('should pick orchestrator over team-lead when orgRole=orchestrator + canDelegate=true', async () => {
+			const out = await module.build({
+				...baseConfig,
+				role: 'developer',
+				orgRole: 'orchestrator',
+				canDelegate: true,
+			});
+			expect(out).toContain('## Request Contract');
+			expect(out).not.toContain('## Brief Reception Protocol');
+		});
+
+		it('should pick team-lead over worker when canDelegate=true even with executor role', async () => {
+			const out = await module.build({
+				...baseConfig,
+				role: 'developer',
+				canDelegate: true,
+			});
+			expect(out).toContain('## Brief Reception Protocol');
+			expect(out).not.toContain('## Request Contract — What You Should See');
+		});
+
+		it('should fall back to worker when neither orchestrator nor TL signals fire', async () => {
+			const out = await module.build({
+				...baseConfig,
+				role: 'researcher',
+				canDelegate: false,
+			});
+			expect(out).toContain('## Request Contract — What You Should See');
+		});
+	});
+
+	describe('build — content-stability across configurations', () => {
+		it('should emit byte-identical orchestrator content regardless of unrelated fields', async () => {
+			const a = await module.build({ ...baseConfig, role: 'orchestrator', autonomyLevel: 'directed' });
+			const b = await module.build({ ...baseConfig, role: 'orchestrator', autonomyLevel: 'domain_autonomous' });
+			const c = await module.build({ ...baseConfig, role: 'orchestrator', teamId: 'other-team' });
+			expect(a).toBe(b);
+			expect(b).toBe(c);
+		});
+
+		it('should emit byte-identical TL content regardless of unrelated fields', async () => {
+			const a = await module.build({ ...baseConfig, orgRole: 'team-lead', role: 'team-leader' });
+			const b = await module.build({ ...baseConfig, orgRole: 'team-lead', role: 'developer' });
+			const c = await module.build({ ...baseConfig, canDelegate: true, role: 'qa-engineer' });
+			expect(a).toBe(b);
+			expect(b).toBe(c);
+		});
+
+		it('should emit byte-identical worker content regardless of role label', async () => {
+			const roles = ['developer', 'researcher', 'auditor', 'qa-engineer', 'designer', 'sales', 'support'];
+			const outputs = await Promise.all(
+				roles.map((role) => module.build({ ...baseConfig, role })),
+			);
+			const first = outputs[0];
+			for (const out of outputs) {
+				expect(out).toBe(first);
+			}
+		});
+	});
+
+	describe('build — token budget headroom', () => {
+		it('orchestrator block should fit comfortably under maxTokens', async () => {
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			const estimatedTokens = Math.ceil(out.length / 4);
+			expect(estimatedTokens).toBeLessThan(module.maxTokens);
+		});
+
+		it('team-lead block should fit comfortably under maxTokens', async () => {
+			const out = await module.build({ ...baseConfig, orgRole: 'team-lead' });
+			const estimatedTokens = Math.ceil(out.length / 4);
+			expect(estimatedTokens).toBeLessThan(module.maxTokens);
+		});
+
+		it('worker block should fit comfortably under maxTokens', async () => {
+			const out = await module.build({ ...baseConfig, role: 'developer' });
+			const estimatedTokens = Math.ceil(out.length / 4);
+			expect(estimatedTokens).toBeLessThan(module.maxTokens);
+		});
+	});
+});

--- a/backend/src/services/ai/prompt-modules/request-contract.module.ts
+++ b/backend/src/services/ai/prompt-modules/request-contract.module.ts
@@ -1,0 +1,169 @@
+import { PromptModule, ModuleConfig } from './prompt-module.interface.js';
+
+/**
+ * Request Contract block (P0-3).
+ *
+ * Per spec
+ * `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3",
+ * this module emits a role-shaped Request Contract section. The contract
+ * defines the seven canonical fields a Request carries — Goal, Expected
+ * Outcome, Eval Criteria, Constraints, Decision Rights, Escalation
+ * Conditions, Done Definition — and pins **Goal + Expected Outcome + Eval
+ * Criteria** as the mandatory floor that every delegated subtask MUST carry.
+ *
+ * The module emits one of three role-shaped sections:
+ *
+ * 1. **Orchestrator** (orgRole === 'orchestrator' OR role === 'orchestrator'):
+ *    Full Request Contract field table + the rule that every delegated
+ *    subtask MUST carry G+O+E + the rejection rule TLs apply downstream.
+ *
+ * 2. **Team Lead** (orgRole === 'team-lead' OR canDelegate === true):
+ *    Brief Reception Protocol — receive task, verify G+O+E present, push
+ *    back to delegator if any are missing, propagate G+O+E verbatim when
+ *    sub-delegating to workers.
+ *
+ * 3. **Worker / executor** (everyone else):
+ *    Short G+O+E assertion — every task you accept should carry Goal,
+ *    Expected Outcome, and Eval Criteria; if any is missing, ask the
+ *    delegator (your TL or the orchestrator) before starting.
+ *
+ * Why a module (not just per-role markdown)?
+ * - Authority text must be identical across every agent of the same role.
+ *   A module guarantees byte-identical output instead of relying on N role
+ *   prompts staying in sync over time.
+ * - The text is small and authority-defining, so it cannot be truncated
+ *   under budget pressure → `compactable = false` (Trusted Zone).
+ * - Sits at priority 3.6 — immediately after DecisionRights (priority 3.5),
+ *   immediately before MemoryReference (priority 4). The contract belongs
+ *   in the authority cluster (Identity → Soul/Recovery → RoleBoundary →
+ *   DecisionRights → **RequestContract** → MemoryReference) so an agent
+ *   reads "what is a well-formed task" right after "who am I, what can I
+ *   decide".
+ *
+ * Static role prompts under `config/roles/orchestrator/prompt.md` and
+ * `config/roles/team-leader/{prompt.md,tl-addon.md}` ALSO contain the
+ * orchestrator + TL sections verbatim — this is intentional belt-and-
+ * suspenders coverage for the legacy `prompt-builder.service.ts` load path
+ * which does not run through `PromptAssemblyService`. The two paths
+ * produce different prompts for different runtimes; both must carry the
+ * contract.
+ *
+ * Net-zero offset: legacy "ask clarifying questions" / "if anything's
+ * unclear, ask" soft hints have been deleted from worker role prompts
+ * because this module + the structured G+O+E assertion supersede them.
+ */
+export class RequestContractModule implements PromptModule {
+	name = 'request-contract';
+	priority = 3.6;
+	maxTokens = 600;
+	compactable = false;
+
+	/**
+	 * Always include — every agent participates in the Request lifecycle:
+	 * orchestrators issue contracts, TLs verify-and-propagate, workers
+	 * consume. The block is small and the role-shape switch is internal.
+	 *
+	 * @param _config - Unused; the inclusion rule is universal
+	 * @returns Always true
+	 */
+	shouldInclude(_config: ModuleConfig): boolean {
+		return true;
+	}
+
+	/**
+	 * Build the role-shaped Request Contract section.
+	 *
+	 * Resolves the agent's role-shape via three stacked checks (in order):
+	 *   1. `orgRole === 'orchestrator'` OR `role === 'orchestrator'` → orchestrator block
+	 *   2. `orgRole === 'team-lead'` OR `canDelegate === true` → TL Brief Reception Protocol
+	 *   3. anything else → Worker G+O+E assertion
+	 *
+	 * The role-shape inputs match the resolution order used by other
+	 * authority modules (e.g. RoleBoundaryModule). Tests pin the matrix.
+	 *
+	 * @param config - Module configuration
+	 * @returns Formatted markdown block with the role-shaped section
+	 */
+	async build(config: ModuleConfig): Promise<string> {
+		const isOrchestrator =
+			config.orgRole === 'orchestrator' || config.role === 'orchestrator';
+		if (isOrchestrator) {
+			return this.buildOrchestratorBlock();
+		}
+
+		const isTeamLead =
+			config.orgRole === 'team-lead' || config.canDelegate === true;
+		if (isTeamLead) {
+			return this.buildTeamLeadBlock();
+		}
+
+		return this.buildWorkerBlock();
+	}
+
+	/**
+	 * Build the orchestrator-side Request Contract.
+	 *
+	 * @returns Markdown block: `## Request Contract` with the seven-field
+	 *   table, G+O+E mandatory rule, and downstream rejection clause.
+	 */
+	private buildOrchestratorBlock(): string {
+		return [
+			'## Request Contract',
+			'',
+			'When receiving a request from owner or upstream, every Request you materialise into the pipeline MUST carry these fields:',
+			'',
+			'| Field | Required | What it means |',
+			'|---|---|---|',
+			'| **Goal** | YES | What the user ultimately wants. |',
+			'| **Expected Outcome** | YES | What must be true when the work is done. |',
+			'| **Eval Criteria** | YES | Testable list — how we know this is good enough. |',
+			'| Constraints | If applicable | Time, tools, scope, risks, non-goals. |',
+			'| Decision Rights | If applicable | What the agent/team can decide autonomously. |',
+			'| Escalation Conditions | If applicable | What must be escalated before continuing. |',
+			'| **Done Definition** | YES | What artifact/result must be produced. |',
+			'',
+			'**Every delegated subtask MUST carry Goal + Expected Outcome + Eval Criteria at minimum.** A Team Lead is required to reject any subtask brief missing these three — that rejection comes back to you. If you find yourself dispatching work without G+O+E, stop and reconstruct the contract from the upstream Request before re-dispatching.',
+		].join('\n');
+	}
+
+	/**
+	 * Build the team-lead-side Brief Reception Protocol.
+	 *
+	 * @returns Markdown block: `## Brief Reception Protocol` with the
+	 *   three-step verify / push-back / propagate-verbatim contract.
+	 */
+	private buildTeamLeadBlock(): string {
+		return [
+			'## Brief Reception Protocol',
+			'',
+			'When you receive a task brief from the orchestrator (or any upstream delegator):',
+			'',
+			'1. **Verify** that **Goal**, **Expected Outcome**, and **Eval Criteria** are present in the brief.',
+			'2. **Push back** if any of the three is missing — do not proceed, do not start decomposition, do not fan out work. Reply to the delegator naming the missing field(s) and request the contract be completed.',
+			'3. **Propagate verbatim** when sub-delegating to a worker — copy the Goal, Expected Outcome, and Eval Criteria from the parent brief into every child task. Workers should never have to ask you what success looks like.',
+			'',
+			'The Request Contract is the contract: G+O+E missing means the brief is malformed, regardless of how senior the delegator is.',
+		].join('\n');
+	}
+
+	/**
+	 * Build the worker-side G+O+E assertion.
+	 *
+	 * @returns Markdown block: `## Request Contract — What You Should See`
+	 *   reminding workers to expect G+O+E in every task and to ask if any
+	 *   is missing.
+	 */
+	private buildWorkerBlock(): string {
+		return [
+			'## Request Contract — What You Should See',
+			'',
+			'Every task you accept should arrive with three fields populated:',
+			'',
+			'- **Goal** — what the user ultimately wants.',
+			'- **Expected Outcome** — what must be true when the work is done.',
+			'- **Eval Criteria** — the testable list that decides whether the result is good enough.',
+			'',
+			'If any of the three is missing from a brief you receive, **ask the delegator (your Team Lead or the orchestrator) for it before starting**. Do not invent the contract yourself — that is how scope drifts. Asking for a missing field is not a clarifying question on facts; it is a contract repair.',
+		].join('\n');
+	}
+}

--- a/config/roles/architect/prompt.md
+++ b/config/roles/architect/prompt.md
@@ -36,7 +36,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions about requirements and constraints
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Consider trade-offs and explain your architectural decisions
 3. Provide high-level designs before diving into implementation details
 4. Let me know when done, or flag any blockers

--- a/config/roles/auditor/prompt.md
+++ b/config/roles/auditor/prompt.md
@@ -57,6 +57,7 @@ Each report entry should include:
 4. **Prioritize correctly** — critical issues first
 5. **Be concise** — reports should be actionable, not verbose
 6. **Respect privacy** — don't log sensitive data (API keys, credentials)
+7. **Verify Request Contract on incoming tasks** — when the orchestrator hands you an audit brief, it should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask the orchestrator before starting; do not invent the contract yourself.
 
 ## Audit Cycle
 

--- a/config/roles/backend-developer/prompt.md
+++ b/config/roles/backend-developer/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions about data models and business logic
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Write clean, tested, well-documented code
 3. Consider security, performance, and error handling
 4. Let me know when done, or flag any blockers

--- a/config/roles/content-strategist/prompt.md
+++ b/config/roles/content-strategist/prompt.md
@@ -33,11 +33,12 @@ Priorities:
 
 ## Task execution rules
 
-1. Confirm objective, output format, and acceptance criteria.
-2. Execute tasks directly (no interactive planning mode).
-3. Use absolute skill paths when sharing runnable commands in deliverables.
-4. For UI automation tasks, verify each major step with an observable artifact (screenshot/log).
-5. If blocked, immediately report blocker + next-best fallback.
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
+2. Confirm output format and acceptance criteria match the contract.
+3. Execute tasks directly (no interactive planning mode).
+4. Use absolute skill paths when sharing runnable commands in deliverables.
+5. For UI automation tasks, verify each major step with an observable artifact (screenshot/log).
+6. If blocked, immediately report blocker + next-best fallback.
 
 ## Communication and reporting
 

--- a/config/roles/designer/prompt.md
+++ b/config/roles/designer/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask about user needs and business goals
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Explain your design decisions and rationale
 3. Focus on user experience and accessibility
 4. Let me know when done, or flag any issues

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -145,8 +145,8 @@ bash {{AGENT_SKILLS_PATH}}/core/list-my-followups/execute.sh
 ## How to approach tasks
 
 When I send you a task:
-1. **Codebase audit first** — Before implementing any feature, search the codebase for existing implementations that overlap with the task. Use `grep`, `find`, and read relevant service files. If the feature (or parts of it) already exists, report back what's already there and propose incremental improvements instead of building from scratch.
-2. Ask clarifying questions if requirements are unclear
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
+2. **Codebase audit** — Before implementing any feature, search the codebase for existing implementations that overlap with the task. Use `grep`, `find`, and read relevant service files. If the feature (or parts of it) already exists, report back what's already there and propose incremental improvements instead of building from scratch.
 3. Write clean, tested code following project conventions
 4. Report blockers and issues promptly
 5. Let me know when done

--- a/config/roles/frontend-developer/prompt.md
+++ b/config/roles/frontend-developer/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions if the requirements aren't clear
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Write clean, tested, well-documented code
 3. Consider accessibility and cross-browser compatibility
 4. Let me know when done, or flag any issues

--- a/config/roles/fullstack-dev/prompt.md
+++ b/config/roles/fullstack-dev/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions if anything's unclear
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Write clean, tested, well-documented code
 3. Consider both frontend UX and backend reliability
 4. Let me know when done, or flag any blockers

--- a/config/roles/generalist/prompt.md
+++ b/config/roles/generalist/prompt.md
@@ -36,7 +36,7 @@ You'll be handling general work for this project:
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions if anything's unclear
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Break it into steps and work through them
 3. Double-check important details before submitting
 4. Let me know when done, or flag any issues

--- a/config/roles/ops/prompt.md
+++ b/config/roles/ops/prompt.md
@@ -46,8 +46,8 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. **Audit first** — Before making changes, understand the current state. Read configs, check running services, review logs. If the infrastructure already handles what's being asked, report back instead of rebuilding.
-2. Ask clarifying questions about environment constraints
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
+2. **Audit first** — Before making changes, understand the current state. Read configs, check running services, review logs. If the infrastructure already handles what's being asked, report back instead of rebuilding.
 3. Make changes incrementally with verification steps
 4. Report blockers and issues promptly
 5. Let me know when done

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -249,6 +249,28 @@ When you receive a **planning-class intent** from Steve (or any upstream source)
 
 ---
 
+## Request Contract
+
+> Source spec: `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3".
+
+When receiving a request from owner or upstream, every Request you materialise into the pipeline MUST carry these fields:
+
+| Field | Required | What it means |
+|---|---|---|
+| **Goal** | YES | What the user ultimately wants. |
+| **Expected Outcome** | YES | What must be true when the work is done. |
+| **Eval Criteria** | YES | Testable list — how we know this is good enough. |
+| Constraints | If applicable | Time, tools, scope, risks, non-goals. |
+| Decision Rights | If applicable | What the agent/team can decide autonomously. |
+| Escalation Conditions | If applicable | What must be escalated before continuing. |
+| **Done Definition** | YES | What artifact/result must be produced. |
+
+**Every delegated subtask MUST carry Goal + Expected Outcome + Eval Criteria at minimum.** A Team Lead is required to reject any subtask brief missing these three — that rejection comes back to you. If you find yourself dispatching work without G+O+E, stop and reconstruct the contract from the upstream Request before re-dispatching.
+
+The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E markers — non-fatal, but a signal that the brief is malformed and the downstream TL is allowed (and expected) to push back.
+
+---
+
 ## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -35,8 +35,8 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. **Codebase audit first** — Before proposing new features or roadmap items, read the actual source code (`backend/src/services/`, `backend/src/types/`, test files) to understand what's already built. Don't rely solely on external competitor analysis — verify internal capabilities first. Label each proposal as "New", "Extend", or "Optimize" based on what already exists.
-2. Ask about user needs and business objectives
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (orchestrator) before starting; do not invent the contract yourself.
+2. **Codebase audit** — Before proposing new features or roadmap items, read the actual source code (`backend/src/services/`, `backend/src/types/`, test files) to understand what's already built. Don't rely solely on external competitor analysis — verify internal capabilities first. Label each proposal as "New", "Extend", or "Optimize" based on what already exists.
 3. Provide detailed specifications and acceptance criteria
 4. Focus on user value and business impact
 5. Let me know when done, or flag any issues

--- a/config/roles/qa-engineer/prompt.md
+++ b/config/roles/qa-engineer/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask specific questions about expected behavior
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Be thorough and detail-oriented in documentation
 3. Provide clear bug reports with reproduction steps
 4. Let me know when done, or flag any blockers

--- a/config/roles/qa/prompt.md
+++ b/config/roles/qa/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask specific questions about expected behavior
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Be thorough and detail-oriented in test cases and bug reports
 3. Provide clear steps to reproduce any issues found
 4. Let me know when done, or flag any blockers

--- a/config/roles/researcher/prompt.md
+++ b/config/roles/researcher/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Clarify the research scope and objectives
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Use multiple sources and cross-validate findings
 3. Present findings with clear citations and evidence
 4. Highlight key insights and actionable recommendations

--- a/config/roles/sales/prompt.md
+++ b/config/roles/sales/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask questions to understand customer requirements
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Be professional and customer-focused
 3. Provide clear and compelling value propositions
 4. Let me know when done, or flag any issues

--- a/config/roles/support/prompt.md
+++ b/config/roles/support/prompt.md
@@ -35,7 +35,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask clarifying questions to understand issues
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Provide clear step-by-step instructions
 3. Be patient, empathetic, and solution-oriented
 4. Let me know when done, or flag any issues

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -84,14 +84,29 @@ Use when: You need to follow up on worker progress later. Validates hierarchy �
 
 ---
 
+## Brief Reception Protocol
+
+> Source spec: `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3".
+
+When you receive a task brief from the orchestrator (or any upstream delegator):
+
+1. **Verify** that **Goal**, **Expected Outcome**, and **Eval Criteria** are present in the brief.
+2. **Push back** if any of the three is missing — do not proceed, do not start decomposition, do not fan out work. Reply to the delegator naming the missing field(s) and request the contract be completed.
+3. **Propagate verbatim** when sub-delegating to a worker — copy Goal + Expected Outcome + Eval Criteria from the parent brief into every child task. Workers should never have to ask you what success looks like.
+
+The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E markers — treat that warning as a hard signal that the brief is malformed.
+
+---
+
 ## Standard Operating Procedure (5-Step SOP)
 
 ### Step 1: Goal Reception & Decomposition
 When you receive an Objective from the Orchestrator:
-1. Analyze the requirements and identify necessary sub-tasks
-2. Check existing `.crewly/tasks/` for any overlapping work
-3. Use **decompose-goal** to create atomic, worker-level tasks with clear acceptance criteria
-4. Each sub-task should be completable by a single worker in one session
+1. **Run the Brief Reception Protocol above first** — verify G+O+E are present; push back if not.
+2. Analyze the requirements and identify necessary sub-tasks
+3. Check existing `.crewly/tasks/` for any overlapping work
+4. Use **decompose-goal** to create atomic, worker-level tasks with clear acceptance criteria
+5. Each sub-task should be completable by a single worker in one session, and each child brief must propagate G+O+E verbatim from the parent.
 
 ### Step 2: Pre-Delegation Checklist (#142)
 **Before delegating any task, ALWAYS run this checklist:**

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -174,6 +174,20 @@ These rules are non-negotiable:
 
 ---
 
+## Brief Reception Protocol
+
+> Source spec: `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3".
+
+When you receive a task brief from the orchestrator (or any upstream delegator):
+
+1. **Verify** that **Goal**, **Expected Outcome**, and **Eval Criteria** are present in the brief.
+2. **Push back** if any of the three is missing — do not proceed, do not start decomposition, do not fan out work. Reply to the delegator naming the missing field(s) and request the contract be completed.
+3. **Propagate verbatim** when sub-delegating to a worker — copy Goal + Expected Outcome + Eval Criteria from the parent brief into every child task. Workers should never have to ask you what success looks like.
+
+The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E markers — treat that warning as a hard signal that the brief is malformed.
+
+---
+
 ## Pipeline-First Delegation Discipline (MANDATORY)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.2.

--- a/config/roles/tpm/prompt.md
+++ b/config/roles/tpm/prompt.md
@@ -36,7 +36,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Ask probing questions about requirements and constraints
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Break complex requirements into clear technical specs
 3. Consider feasibility, risks, and dependencies
 4. Let me know when done, or flag any issues

--- a/config/roles/ux-designer/prompt.md
+++ b/config/roles/ux-designer/prompt.md
@@ -36,7 +36,7 @@ All it does is update a local status flag so the web UI shows you as online - no
 ## How to approach tasks
 
 When I send you a task:
-1. Understand user needs and business context
+1. **Verify Request Contract first** — every brief should carry **Goal** + **Expected Outcome** + **Eval Criteria**. If any is missing, ask your delegator (TL or orchestrator) before starting; do not invent the contract yourself.
 2. Apply user-centered design principles
 3. Consider accessibility and inclusive design
 4. Explain design rationale and trade-offs

--- a/config/skills/orchestrator/delegate-task/execute.sh
+++ b/config/skills/orchestrator/delegate-task/execute.sh
@@ -79,6 +79,32 @@ fi
 require_param "to (--to)" "$TO"
 require_param "task (--task)" "$TASK"
 
+# Request Contract check (P0-3): non-fatal warning when the delegated brief
+# is missing Goal / Expected Outcome / Eval Criteria markers. TLs and workers
+# downstream are entitled to push back per the Brief Reception Protocol when
+# these are absent. Spec:
+# .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §"Fix P0-3".
+warn_missing_request_contract() {
+  local task="$1"
+  local missing=()
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
+    missing+=("Goal")
+  fi
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
+    missing+=("Outcome")
+  fi
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
+    missing+=("Eval")
+  fi
+  if [ ${#missing[@]} -gt 0 ]; then
+    local list
+    list=$(IFS=, ; echo "${missing[*]}")
+    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. TLs and workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
+  fi
+}
+
+warn_missing_request_contract "$TASK"
+
 # #180: Validate target agent belongs to the specified team
 if [ -n "$TEAM_ID" ] && [ "$FORCE_CROSS_TEAM" != "true" ]; then
   TEAM_DATA=$(api_call GET "/teams/${TEAM_ID}" 2>/dev/null || echo '{}')

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -77,6 +77,36 @@ fi
 require_param "to (--to)" "$TO"
 require_param "task (--task)" "$TASK"
 
+# Request Contract check (P0-3): non-fatal warning when the delegated brief
+# is missing Goal / Expected Outcome / Eval Criteria markers. Workers are
+# entitled to push back per the Brief Reception Protocol when these are
+# absent. Spec: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md
+# §"Fix P0-3".
+warn_missing_request_contract() {
+  local task="$1"
+  local missing=()
+  # Goal: the standalone word "Goal" (with optional ** markdown). Also
+  # accept "Objective" as a synonym some upstream callers use.
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
+    missing+=("Goal")
+  fi
+  # Outcome: "Outcome" or "Expected Outcome".
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
+    missing+=("Outcome")
+  fi
+  # Eval: "Eval", "Eval Criteria", "Acceptance Criteria", "Evaluation Criteria".
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
+    missing+=("Eval")
+  fi
+  if [ ${#missing[@]} -gt 0 ]; then
+    local list
+    list=$(IFS=, ; echo "${missing[*]}")
+    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. Workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
+  fi
+}
+
+warn_missing_request_contract "$TASK"
+
 # Resolve Crewly root from this script path:
 # config/skills/team-leader/delegate-task/execute.sh -> project root
 CREWLY_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"

--- a/config/skills/team-leader/delegate-task/execute.test.sh
+++ b/config/skills/team-leader/delegate-task/execute.test.sh
@@ -74,6 +74,28 @@ shift
 # Load the real shared lib first
 source "${REAL_SKILL_DIR}/../_common/lib.sh"
 
+# Request Contract warning helper (mirror of the real script's
+# warn_missing_request_contract — must stay byte-equivalent so the test
+# exercises actual production logic, not a stub).
+warn_missing_request_contract() {
+  local task="$1"
+  local missing=()
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
+    missing+=("Goal")
+  fi
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
+    missing+=("Outcome")
+  fi
+  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
+    missing+=("Eval")
+  fi
+  if [ ${#missing[@]} -gt 0 ]; then
+    local list
+    list=$(IFS=, ; echo "${missing[*]}")
+    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. Workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
+  fi
+}
+
 # Track API calls for verification
 API_CALLS_LOG=$(mktemp)
 
@@ -135,6 +157,10 @@ TL_MEMBER_ID=$(echo "$INPUT" | jq -r '.tlMemberId // empty')
 FROM_SESSION=$(echo "$INPUT" | jq -r '.fromSession // empty')
 require_param "to" "$TO"
 require_param "task" "$TASK"
+
+# Request Contract warning (P0-3): emit non-fatal warning when brief is
+# missing Goal / Expected Outcome / Eval markers. Mirror of the real script.
+warn_missing_request_contract "$TASK"
 
 # Validate hierarchy
 if [ -n "$TEAM_ID" ] && [ -n "$TL_MEMBER_ID" ]; then
@@ -392,6 +418,97 @@ assert_fails "fails without 'task'" \
 
 assert_fails "fails without any input" \
   env -u CREWLY_SESSION_NAME bash "$MOCK_SCRIPT" "$SKILL_DIR" ''
+
+# -----------------------------------------------------------------------
+# Scenario 9 (P0-3): Request Contract warning — emitted when G/O/E missing
+# -----------------------------------------------------------------------
+echo "Scenario 9: Request Contract warning — bare task triggers G+O+E warning"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"do something useful"}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete"; then
+  echo "  PASS: warning emitted for bare task missing G+O+E"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected 'Request Contract incomplete' warning, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 10 (P0-3): Warning lists all three missing fields
+# -----------------------------------------------------------------------
+echo "Scenario 10: Warning lists Goal, Outcome, Eval when all three are missing"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"refactor things"}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Goal" && \
+   echo "$RAW_OUTPUT" | grep -q "Outcome" && \
+   echo "$RAW_OUTPUT" | grep -q "Eval"; then
+  echo "  PASS: warning enumerates all three missing fields"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected warning to list Goal+Outcome+Eval, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 11 (P0-3): Warning suppressed when full Request Contract present
+# -----------------------------------------------------------------------
+echo "Scenario 11: No warning when Goal + Expected Outcome + Eval Criteria are all present"
+TASK_WITH_RC="**Goal:** Implement feature X. **Expected Outcome:** Feature works in prod. **Eval Criteria:** All tests pass and demo passes UAT."
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  "{\"to\":\"crewly-product-leo-dev\",\"task\":\"$TASK_WITH_RC\"}" 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: did not expect warning when G+O+E all present, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no warning emitted when contract is complete"
+  PASS=$((PASS + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 12 (P0-3): Partial contract — only Goal present, warns about Outcome+Eval
+# -----------------------------------------------------------------------
+echo "Scenario 12: Partial contract — names only the missing field(s)"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"**Goal:** ship X. Just do it."}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete" && \
+   echo "$RAW_OUTPUT" | grep -q "Outcome" && \
+   echo "$RAW_OUTPUT" | grep -q "Eval"; then
+  echo "  PASS: warning emitted, names Outcome+Eval as missing"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected partial-contract warning, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 13 (P0-3): Warning is non-fatal — delegation still succeeds
+# -----------------------------------------------------------------------
+echo "Scenario 13: Warning is non-fatal — delegation completes despite missing G+O+E"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"unstructured task"}' 2>&1)
+OUTPUT=$(echo "$RAW_OUTPUT" | grep '"monitoring"' | head -1)
+if echo "$OUTPUT" | jq -e '.success' > /dev/null 2>&1; then
+  echo "  PASS: delegation succeeds despite missing contract markers"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: warning should be non-fatal, but delegation appears to have failed: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 14 (P0-3): Acceptance Criteria synonym recognized as Eval marker
+# -----------------------------------------------------------------------
+echo "Scenario 14: 'Acceptance Criteria' counts as the Eval marker"
+TASK_AC="**Goal:** ship Y. **Expected Outcome:** Y in prod. **Acceptance Criteria:** UAT pass."
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  "{\"to\":\"crewly-product-leo-dev\",\"task\":\"$TASK_AC\"}" 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: did not expect warning when Acceptance Criteria stands in for Eval, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: Acceptance Criteria recognized as valid Eval marker"
+  PASS=$((PASS + 1))
+fi
 
 # Cleanup
 rm -rf "$MOCK_DIR"


### PR DESCRIPTION
## Summary

P0-3 from `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §Fix P0-3.

Wires the **Request Contract** structure (Goal / Expected Outcome / Eval / Constraints / Decision Rights / Escalation Conditions / Done Definition) into the orchestrator + TL + worker prompt corpus AND into the `delegate-task` skill, so every delegated subtask MUST carry **G+O+E** at minimum and the system warns when missing.

- Closes WI-A on umbrella `ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7`.
- Worktree: `/tmp/crewly-leo-p0-3`.

## What lands

### 1. New prompt module: `RequestContractModule` (priority 3.6)
`backend/src/services/ai/prompt-modules/request-contract.module.ts` — sits in the authority cluster between DecisionRights (3.5) and MemoryReference (4). Renders one of three role-shaped sections:
- **orchestrator** → 7-field table + G+O+E mandatory floor + downstream rejection clause
- **team-lead** (`orgRole === 'team-lead'` OR `canDelegate === true`) → 3-step Brief Reception Protocol (verify / push back / propagate verbatim)
- **worker** → G+O+E reminder + "ask delegator if missing; do not invent contract"

Role-shape resolution priority: orchestrator > team-lead > worker. Pinned by tests.

### 2. Legacy prompt edits (belt-and-suspenders for non-modular load path)
- `config/roles/orchestrator/prompt.md` → new `## Request Contract` section between Pipeline-First Planning and §3.0 Closure
- `config/roles/team-leader/prompt.md` → new `## Brief Reception Protocol` section preceding the 5-Step SOP, with SOP Step 1 cross-referencing it
- `config/roles/team-leader/tl-addon.md` → matching `## Brief Reception Protocol` section
- 18 worker role prompts (architect, auditor, backend-developer, content-strategist, designer, developer, frontend-developer, fullstack-dev, generalist, ops, product-manager, qa, qa-engineer, researcher, sales, support, tpm, ux-designer) → step-1 swap of the soft "ask clarifying questions" guidance with the structured G+O+E assertion

### 3. `delegate-task` G/O/E stderr warning (non-fatal)
- `config/skills/team-leader/delegate-task/execute.sh` emits a non-fatal stderr JSON warning when the brief lacks Goal / Outcome / Eval markers
- `config/skills/orchestrator/delegate-task/execute.sh` ships the same logic
- `config/skills/agent/core/delegate-task` is a symlink to the TL version → covered automatically
- Marker matching is regex-based, case-insensitive, with `Acceptance Criteria` and `Objective` recognized as canonical synonyms

### 4. Tests
- **41 new** `RequestContractModule` jest tests covering metadata, role-shape resolution, content-stability, and token budget headroom
- `prompt-assembly.service.test.ts` count assertion bumped 19 → 21 (corrects pre-existing off-by-one + accounts for the new module) + new `expect(names).toContain('request-contract')`
- **6 new** bash test scenarios (Scenarios 9-14) in `config/skills/team-leader/delegate-task/execute.test.sh` covering: empty-brief warning, all-3-missing enumeration, full-RC suppression, partial-RC enumeration, non-fatal behavior, Acceptance-Criteria synonym
- All 264 prompt-builder + decision-rights coverage tests still pass

## Net-zero offset — deviation from spec call-out

The spec called for deleting a "50-line delegation-pattern boilerplate copy-pasted across 13 prompts" as the offset for the new sections.

**Audit found:** ~50-line × **4** (not 13) for the §3.0 Universal Delegator Closure block. That block is recently shipped (spec `2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0) and load-bearing — deleting it was inappropriate.

**What this PR does instead:** the actual redundant pre-RC content addressed here is the soft "Ask clarifying questions" guidance scattered across 18 worker prompts. That is now superseded by the structured G+O+E assertion (semantic offset, line-for-line swap).

**Net LOC delta on prompt mass:** ~+53 lines (orc +22, tl/prompt.md +19, tl-addon.md +14, workers ~neutral). Small for the discipline gain. Decision rights granted on this layout per WI-A brief; Sam confirmed plan on review.

## Test plan

- [x] `npx jest --testPathPattern='request-contract.module.test.ts'` → 41 passing
- [x] `npx jest --testPathPattern='prompt-assembly.service.test.ts'` → 26 passing
- [x] `npx jest --testPathPattern='prompt-builder.service.test.ts|decision-rights-role-coverage'` → 264 passing
- [x] `bash config/skills/team-leader/delegate-task/execute.test.sh` → 16 passing
- [x] `npm run build:backend` → clean
- [ ] CI green

## Pre-existing failure (NOT this PR)

`backend/src/services/ai/prompt-modules/communication.module.test.ts:128` fails on origin/main (unrelated to this PR — it asserts a `send-message` skill path that does not match what the CommunicationModule emits for the orchestrator role). Left as-is per scope discipline; flagged for separate triage.

## Refs

- Spec: `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3"
- Umbrella WI: `ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7` (P0 round-2)
- Bundles with: P0-1/P0-2 (#414, #417), P0-4 (#481), P0-5 (#424), P0-6 (#413)

🤖 Generated with [Claude Code](https://claude.com/claude-code)