### PR TITLE
fix(knowledge): FTS5 sanitizer — phrase-quote tokenization (F-FTS5: comma + hyphen + colon traps)

### DIFF
--- a/backend/src/services/knowledge/fts5-index.service.test.ts
+++ b/backend/src/services/knowledge/fts5-index.service.test.ts
@@ -233,6 +233,76 @@ describeIfNative('Fts5IndexService', () => {
       // Should not throw despite special chars
       expect(() => service.search('"quoted" AND (nested)')).not.toThrow();
     });
+
+    // ---------------------------------------------------------------------
+    // F-FTS5 hotfix regression guards (Kai WI-E triage, 2026-05-07)
+    //
+    // Before the toFts5Phrase sanitizer, these inputs raised
+    //   - `fts5: syntax error near ","`     (comma case, 22/44 daily fails)
+    //   - `no such column: leader`          (hyphen case, 22/44 daily fails)
+    // and were silently swallowed by the search() catch-block, returning
+    // empty results. These tests pin: (a) no throw, AND (b) results actually
+    // come back from a seeded index that genuinely matches the query.
+    // ---------------------------------------------------------------------
+    it('F-FTS5 regression: comma-delimited query no longer raises "syntax error near \',\'" and surfaces matches', () => {
+      // Pre-fix: the comma was parsed by FTS5 as a column-list separator,
+      // raising `fts5: syntax error near ","` which the catch-block
+      // silently swallowed (returning []).
+      // Post-fix: phrase-quote tokenization splits on whitespace+comma,
+      // each token is wrapped, and implicit-AND surfaces matches.
+      //
+      // Query terms here all appear in the seeded `deploy-guide` doc
+      // ("Step by step deployment instructions for production.") so the
+      // implicit-AND match must succeed — proving (a) no throw AND
+      // (b) the comma path is now functionally complete, not just
+      // silently empty as before.
+      let results: ReturnType<typeof service.search> = [];
+      expect(() => {
+        results = service.search('deployment, instructions, production');
+      }).not.toThrow();
+      expect(results.some((r) => r.id === 'deploy-guide')).toBe(true);
+    });
+
+    it('F-FTS5 regression: hyphenated role names like "team-leader" do not raise "no such column" and match indexed phrases', () => {
+      // Pre-fix: `team-leader` parsed as `team` followed by column filter
+      // `-leader`, raising `no such column: leader` which the catch-block
+      // silently swallowed.
+      // Post-fix: `"team-leader"` is wrapped as a literal phrase. FTS5's
+      // unicode61 tokenizer splits the phrase content into adjacent
+      // tokens `team`+`leader` at query time — which matches the same
+      // tokens FTS5 stored at index time when the document was
+      // tokenized. Adjacent-tokens phrase match precisely against
+      // documents containing `team-leader`.
+      service.upsertDocument(
+        createDoc({
+          id: 'tl-handbook',
+          title: 'Team Leader Handbook',
+          tags: 'team-leader management',
+          content:
+            'Guidance for the team-leader role: decompose, delegate, verify, report.',
+          category: 'Roles',
+        }),
+      );
+      let results: ReturnType<typeof service.search> = [];
+      expect(() => {
+        // Use only tokens present in tl-handbook so the implicit-AND
+        // match is satisfied. The KEY regression guard is the
+        // hyphenated `team-leader` phrase NOT triggering a column-filter
+        // parser error — proven by both `not.toThrow()` AND the
+        // non-empty match (silent-swallow pre-fix would also have given
+        // `not.toThrow()`, so the match assertion is the real proof).
+        results = service.search('team-leader, decompose, delegate');
+      }).not.toThrow();
+      expect(results.some((r) => r.id === 'tl-handbook')).toBe(true);
+    });
+
+    it('F-FTS5 regression: colon-bearing tokens (column-filter trap) do not throw', () => {
+      // Without phrase-wrapping, `task:review` parsed as column filter
+      // against a `task` column → `no such column: task`. Now it is a
+      // literal phrase that the index tokenizer strips back to
+      // `task`+`review` — no parser error.
+      expect(() => service.search('task:review prompt:builder')).not.toThrow();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/knowledge/fts5-index.service.ts
+++ b/backend/src/services/knowledge/fts5-index.service.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync } from 'fs';
 import { createRequire } from 'module';
 import { pathToFileURL } from 'url';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { toFts5Phrase } from './fts5-query-sanitizer.js';
 
 // ---------------------------------------------------------------------------
 // Lazy module loading
@@ -229,8 +230,16 @@ export class Fts5IndexService {
     const db = this.getDb();
     const limit = options?.limit ?? 10;
 
-    // Sanitize query: remove characters that break FTS5 MATCH syntax
-    const sanitized = query.replace(/['"*(){}[\]^~\\]/g, ' ').trim();
+    // Sanitize query via phrase-quote tokenization. See
+    // {@link toFts5Phrase} for the full design rationale — short version:
+    // the previous regex-strip sanitizer left commas, hyphens, colons, and
+    // FTS5 keywords intact, causing 44 silent agent-recall failures per day
+    // (F-FTS5 / WI-E triage). Phrase-quoting neutralizes ALL operator
+    // characters because FTS5 does not parse operators inside `"..."`
+    // phrases. Each token round-trips through unicode61 at index AND
+    // query time, so recall is preserved for hyphenated identifiers like
+    // `team-leader`.
+    const sanitized = toFts5Phrase(query);
     if (sanitized.length === 0) {
       return [];
     }

--- a/backend/src/services/knowledge/fts5-query-sanitizer.test.ts
+++ b/backend/src/services/knowledge/fts5-query-sanitizer.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Unit tests for {@link toFts5Phrase} — pure, no SQLite dependency.
+ *
+ * The integration-side tests (which exercise the sanitizer through
+ * {@link Fts5IndexService.search} against a real FTS5 index) live in
+ * `fts5-index.service.test.ts`. They skip locally when the better-sqlite3
+ * native binary is missing for the host architecture, but run in CI.
+ *
+ * These tests are sqlite-free so they ALWAYS run — including locally — and
+ * pin the F-FTS5 hotfix contract: F-FTS5 was Kai's WI-E triage finding
+ * (44 daily occurrences: 22 comma + 22 hyphen `team-leader` failures in
+ * agent recall MATCH queries).
+ *
+ * @module services/knowledge/fts5-query-sanitizer.test
+ */
+
+import { toFts5Phrase } from './fts5-query-sanitizer.js';
+
+describe('toFts5Phrase', () => {
+  describe('empty / whitespace inputs return empty string', () => {
+    it('returns empty string for empty input', () => {
+      expect(toFts5Phrase('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+      expect(toFts5Phrase('   ')).toBe('');
+      expect(toFts5Phrase('\t\n  ')).toBe('');
+    });
+
+    it('returns empty string for delimiter-only input', () => {
+      expect(toFts5Phrase(',,,')).toBe('');
+      expect(toFts5Phrase('  ,  ')).toBe('');
+      expect(toFts5Phrase(' , , ')).toBe('');
+    });
+  });
+
+  describe('happy-path tokenization', () => {
+    it('wraps a single token in double quotes', () => {
+      expect(toFts5Phrase('foo')).toBe('"foo"');
+    });
+
+    it('whitespace-separated tokens become implicit-AND quoted phrases', () => {
+      // Kai's spec test #1
+      expect(toFts5Phrase('developer session startup')).toBe(
+        '"developer" "session" "startup"',
+      );
+    });
+
+    it('collapses runs of whitespace', () => {
+      expect(toFts5Phrase('  multiple   spaces\there  ')).toBe(
+        '"multiple" "spaces" "here"',
+      );
+    });
+  });
+
+  describe('F-FTS5 BUG-FIX: comma-delimited input no longer breaks the parser', () => {
+    it('comma-separated phrases tokenize cleanly (Kai spec test #2)', () => {
+      // The exact failure mode in 22/44 daily occurrences: agent recall
+      // contexts that say "developer session startup, recent tasks,
+      // unfinished work" used to raise `fts5: syntax error near ","`.
+      const input =
+        'developer session startup, recent tasks, unfinished work';
+      const expected =
+        '"developer" "session" "startup" "recent" "tasks" "unfinished" "work"';
+      expect(toFts5Phrase(input)).toBe(expected);
+    });
+
+    it('comma-only delimiter (no whitespace) tokenizes', () => {
+      expect(toFts5Phrase('a,b,c')).toBe('"a" "b" "c"');
+    });
+
+    it('mixed comma + whitespace runs collapse', () => {
+      expect(toFts5Phrase('a, b , c   ,   d')).toBe('"a" "b" "c" "d"');
+    });
+
+    it('Kai spec test #7 — realistic recall-context smoke', () => {
+      const input = 'P1 Bug A, intent classifier ZH parity';
+      const expected =
+        '"P1" "Bug" "A" "intent" "classifier" "ZH" "parity"';
+      expect(toFts5Phrase(input)).toBe(expected);
+    });
+  });
+
+  describe('F-FTS5 BUG-FIX: hyphenated tokens preserved as phrases', () => {
+    it('hyphenated role names stay inside one phrase (Kai spec test #3)', () => {
+      // The exact failure mode in 22/44 daily occurrences: agent role
+      // strings like `team-leader` used to raise `no such column: leader`
+      // because FTS5 parsed `-leader` as column-filter exclusion.
+      //
+      // The phrase `"team-leader"` is safe because FTS5's MATCH parser
+      // does not interpret operators INSIDE phrase quotes. The unicode61
+      // tokenizer then splits the phrase content into adjacent tokens
+      // `team`+`leader` for matching against the index — preserving
+      // recall against documents indexed with `team-leader` exactly.
+      expect(toFts5Phrase('team-leader session startup')).toBe(
+        '"team-leader" "session" "startup"',
+      );
+    });
+
+    it('multi-segment hyphenated identifiers preserved', () => {
+      expect(toFts5Phrase('crewly-product-max-358c7cb7')).toBe(
+        '"crewly-product-max-358c7cb7"',
+      );
+    });
+
+    it('leading and trailing hyphens preserved (no column-filter ambiguity)', () => {
+      // A bare leading `-` would have been parsed as exclusion; phrase-
+      // wrapping makes it a literal token that FTS5 will tokenize and
+      // search for inside the index.
+      expect(toFts5Phrase('-flag')).toBe('"-flag"');
+      expect(toFts5Phrase('flag-')).toBe('"flag-"');
+    });
+  });
+
+  describe('colon-bearing tokens (column-filter trap) neutralized', () => {
+    it('colon-prefixed and colon-mid tokens preserved as phrases (Kai spec test #4)', () => {
+      expect(toFts5Phrase('task: review prompt:builder')).toBe(
+        '"task:" "review" "prompt:builder"',
+      );
+    });
+
+    it('column-filter-style input becomes literal phrases', () => {
+      // Without the sanitizer, `category:onboarding` would parse as a
+      // column filter against a `category` column; now it's just a
+      // phrase that the index won't match (FTS5 strips the colon at
+      // tokenization).
+      expect(toFts5Phrase('category:onboarding')).toBe('"category:onboarding"');
+    });
+  });
+
+  describe('quote escaping (defensive — `"` → `""` per FTS5 phrase syntax)', () => {
+    it('single embedded quote is doubled (Kai spec test #5)', () => {
+      // `say "hello" world` has a token `"hello"` after splitting on
+      // whitespace — the literal quote chars survive (split is on
+      // [\s,]+, NOT on quote). Each quote inside the token is doubled
+      // per FTS5 phrase syntax, then the whole token is wrapped.
+      expect(toFts5Phrase('say "hello" world')).toBe(
+        '"say" """hello""" "world"',
+      );
+    });
+
+    it('repeated quotes are each doubled', () => {
+      expect(toFts5Phrase('a"b"c')).toBe('"a""b""c"');
+    });
+  });
+
+  describe('FTS5 operator neutralization (intentional trade-off)', () => {
+    it('AND / OR / NOT keywords become literal phrases', () => {
+      // Documented trade-off: this sanitizer drops FTS5 operator
+      // support. All callers on this path are auto-generated context
+      // strings; if a future caller needs operators, expose a separate
+      // searchRaw() API.
+      expect(toFts5Phrase('foo AND bar')).toBe('"foo" "AND" "bar"');
+      expect(toFts5Phrase('foo OR bar')).toBe('"foo" "OR" "bar"');
+    });
+
+    it('parentheses and other punctuation survive inside phrases (no parser trap)', () => {
+      // Without phrase-wrapping, these would have hit the FTS5 parser
+      // and broken. Inside a phrase, they are literal — the unicode61
+      // tokenizer strips them at index/query time.
+      expect(toFts5Phrase('(grouped)')).toBe('"(grouped)"');
+      expect(toFts5Phrase('star*term')).toBe('"star*term"');
+    });
+  });
+
+  describe('unicode safety', () => {
+    it('non-ASCII tokens are preserved verbatim inside phrases', () => {
+      expect(toFts5Phrase('日本語 测试 한국어')).toBe(
+        '"日本語" "测试" "한국어"',
+      );
+    });
+
+    it('emoji-bearing tokens are preserved (FTS5 strips them at tokenization)', () => {
+      expect(toFts5Phrase('hello 🌟 world')).toBe('"hello" "🌟" "world"');
+    });
+  });
+});

--- a/backend/src/services/knowledge/fts5-query-sanitizer.ts
+++ b/backend/src/services/knowledge/fts5-query-sanitizer.ts
@@ -1,0 +1,119 @@
+/**
+ * FTS5 Query Sanitizer
+ *
+ * Pure helper that converts an arbitrary input string into a safe SQLite FTS5
+ * MATCH query via phrase-quote tokenization. Used by
+ * {@link Fts5IndexService.search} so that programmatically constructed
+ * agent-context strings never accidentally parse as FTS5 operators.
+ *
+ * **Why this helper exists.** SQLite FTS5 has a rich query grammar with
+ * column filters (`column:term`), set-column lists (`{c1, c2}: term`),
+ * phrase syntax (`"phrase"`), boolean operators (`AND`, `OR`, `NOT`),
+ * proximity (`NEAR(...)`), prefix (`term*`), and grouping (`(...)`). When
+ * arbitrary user / agent-context text is concatenated into a MATCH query,
+ * these operators trigger:
+ *
+ * - **commas** are parsed as column-list separators →
+ *   `fts5: syntax error near ","` (e.g. `"foo, bar"` blows up)
+ * - **hyphens inside identifiers** like `team-leader` parse as `team`
+ *   followed by column filter `-leader` → `no such column: leader`
+ * - **colons** parse as column filter operator → `no such column: ...`
+ * - **bare AND / OR / NOT** in mixed-case input parse as keywords
+ *
+ * The previous regex-strip sanitizer at `Fts5IndexService.search` only
+ * removed `' " * ( ) { } [ ] ^ ~ \\` — it left commas, hyphens, colons, and
+ * all FTS5 keywords intact. Result: 44 silent search failures per day
+ * (22 comma + 22 hyphen) for agent recall on 2026-05-07 alone.
+ *
+ * **Approach (Kai's WI-E F-FTS5 triage recommendation).** Split tokens on
+ * **whitespace + comma only** — NOT on word boundaries — then wrap each
+ * non-empty token in double quotes for FTS5 phrase syntax. Phrases are
+ * **literal** — no operator parsing happens inside the quotes — so any
+ * residual operator-like content (hyphens, colons, asterisks, AND/OR/NOT
+ * keywords) is neutralized. Tokens are joined with whitespace, which FTS5
+ * treats as implicit AND.
+ *
+ * **Why split on whitespace+comma instead of word boundaries.** A token like
+ * `team-leader` wrapped as the phrase `"team-leader"` is parsed by FTS5's
+ * MATCH parser as a single phrase node, then internally the
+ * `unicode61` tokenizer (used at index time) splits the phrase into
+ * adjacent tokens `team` + `leader`. The MATCH operation thus requires
+ * those tokens to appear adjacent in the document — which matches docs
+ * that were indexed with `team-leader` exactly. Splitting on word
+ * boundaries at query-time would produce `"team" "leader"` (loose AND),
+ * matching docs with `team` and `leader` anywhere — looser than the
+ * caller intended. **Kai's approach preserves precision for hyphenated
+ * identifiers without losing the comma/colon-safety win.**
+ *
+ * **Trade-off (intentional).** This sanitizer DROPS FTS5 operator support:
+ * `AND`, `OR`, `NOT`, `NEAR(...)`, column-filter prefixes, and prefix
+ * wildcards (`term*`) all become literal phrases. All callers on this
+ * path are auto-generated agent-context strings, not user-typed search
+ * queries — they don't need operator support. If a future caller needs
+ * the full FTS5 grammar, expose a separate `searchRaw()` API rather than
+ * loosening this sanitizer.
+ *
+ * @module services/knowledge/fts5-query-sanitizer
+ */
+
+/**
+ * Convert an arbitrary input string into a safe FTS5 MATCH query via
+ * phrase-quote tokenization.
+ *
+ * The result is one of:
+ * - `''` — when the input is empty / whitespace-only / only contains
+ *   delimiter characters. Callers MUST check for empty and skip the
+ *   MATCH query (return empty results).
+ * - `'"tok1" "tok2" ..."'` — a sequence of double-quoted phrases joined
+ *   by whitespace (implicit AND in FTS5).
+ *
+ * Pre-existing double quotes inside a token are escaped per FTS5 phrase
+ * syntax (`"` → `""`). This is defensive — auto-generated context
+ * strings rarely contain quotes — but it makes the helper safely
+ * reusable beyond the current call site.
+ *
+ * @param input - Raw query string from user input or agent-context concat.
+ * @returns Safe FTS5 MATCH expression, or `''` if no tokens remain.
+ *
+ * @example
+ * ```typescript
+ * toFts5Phrase('developer session startup');
+ * // → '"developer" "session" "startup"'
+ *
+ * toFts5Phrase('developer session startup, recent tasks, unfinished work');
+ * // → '"developer" "session" "startup" "recent" "tasks" "unfinished" "work"'
+ * // (comma fix — was: "syntax error near ',''")
+ *
+ * toFts5Phrase('team-leader session startup');
+ * // → '"team-leader" "session" "startup"'
+ * // (hyphen fix — was: "no such column: leader". The phrase `"team-leader"`
+ * //  matches docs indexed with `team-leader` exactly, since the unicode61
+ * //  tokenizer splits the phrase content the same way at both index and
+ * //  query time.)
+ *
+ * toFts5Phrase('say "hello" world');
+ * // → '"say" """hello""" "world"'    (quotes escaped as "")
+ *
+ * toFts5Phrase('   ,  ');             // → ''
+ * toFts5Phrase('***');                // → '"***"'  (literal phrase, FTS5 strips
+ *                                     //   non-word chars at tokenization → no match)
+ * ```
+ */
+export function toFts5Phrase(input: string): string {
+  if (!input) {
+    return '';
+  }
+
+  return input
+    // Split on whitespace + comma only. NOT on word boundaries — see module
+    // doc above for why preserving hyphens/colons inside tokens is correct.
+    .split(/[\s,]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+    // Escape pre-existing double quotes per FTS5 phrase syntax (`"` → `""`),
+    // then wrap the whole token in double quotes. The result is always a
+    // valid FTS5 phrase even if the token contained operator-like
+    // punctuation (hyphens, colons, asterisks, parens, etc.).
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(' ');
+}


### PR DESCRIPTION
## Summary

F-FTS5 hotfix per Kai's WI-E triage. Round-2 umbrella `ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7`.

### Bug (Kai's root cause analysis)

Old sanitizer at `backend/src/services/knowledge/fts5-index.service.ts:233`:
```ts
const sanitized = query.replace(/['"*(){}[\]^~\\]/g, ' ').trim();
```

It stripped only 11 operator chars and left `,`, `-`, `:`, plus FTS5 keywords (`AND`/`OR`/`NOT`/`NEAR`) intact. Result: **44 silent failures per day on agent recall** (22 comma + 22 hyphen):

| Input | Pre-fix FTS5 error | Symptom |
| --- | --- | --- |
| `developer session startup, recent tasks` | `fts5: syntax error near ","` | catch-block swallowed → `[]` |
| `team-leader session startup` | `no such column: leader` (FTS5 parsed `-leader` as column-filter exclusion) | catch-block swallowed → `[]` |
| `task:review prompt:builder` | `no such column: task` | catch-block swallowed → `[]` |

Combined with F2 (Gemini embedding 404), recall was silently near-broken at session-start for ALL agents.

### Fix shape (Kai-recommended, ~10 src LoC)

New pure helper `toFts5Phrase()` in `backend/src/services/knowledge/fts5-query-sanitizer.ts`:
- Splits input on **whitespace + comma only** (NOT word boundaries — see below).
- Wraps each non-empty token in double quotes for FTS5 phrase syntax.
- Defensively escapes pre-existing `"` inside tokens as `""` per FTS5 phrase syntax.
- Joins quoted phrases with whitespace (FTS5 implicit AND).

Wired into `Fts5IndexService.search()` (line 232–243). The catch-block, return-empty-on-empty, and prepared-statement bindings are unchanged.

### Why split on whitespace+comma instead of word-boundaries

A token like `team-leader` wrapped as the single phrase `"team-leader"` is parsed by FTS5's MATCH parser as one phrase node. Internally the `unicode61` tokenizer (used at index time) splits the phrase content into adjacent tokens `team`+`leader` for matching. Documents indexed with `team-leader` were tokenized identically at index time, so the phrase match against them is **precise** (adjacent-tokens). Splitting at word boundaries at query time would emit `"team" "leader"` (loose AND) — matches docs with both words anywhere, looser than the caller intended.

### Trade-off (intentional, documented)

This sanitizer drops FTS5 operator support (`AND`/`OR`/`NOT`/`NEAR`/column-filter/prefix-wildcard). All callers on this path are auto-generated agent-context strings, not user-typed queries — they don't need operators. Future caller wanting full grammar gets a separate `searchRaw()` API.

## Verification

- ✅ **21/21 new toFts5Phrase unit tests pass** (`fts5-query-sanitizer.test.ts`) — sqlite-free, run everywhere
  - Covers Kai's spec test cases #1–#7 + edge cases (empty, delimiter-only, multi-segment hyphens, leading/trailing hyphens, column-filter style, repeated quotes, AND/OR keywords, parens/asterisk, CJK + emoji unicode)
- ✅ **3 new F-FTS5 regression integration tests** in `fts5-index.service.test.ts` (skip on missing native sqlite, run in CI):
  - Comma-delimited recall context surfaces matches against seeded docs
  - Hyphenated `team-leader` phrase matches `tl-handbook` doc without raising `no such column`
  - Colon-bearing tokens do not throw
- ✅ **Full `backend/src/services/knowledge/` test suite: 204/204 pass, 8/8 suites pass**
- ✅ TypeScript clean (`tsc --noEmit -p backend/tsconfig.json`, zero output)
- ✅ Built in `/tmp/crewly-max-fts5-hotfix` worktree, rebased on top of `08d609b0` (Leo WI-A merged) which is on top of `fa05720e` (Quinn WI-D merged) per Sam's sequencing

## Test plan
- [x] All sanitizer unit tests pass
- [x] All FTS5 integration tests pass (with native sqlite available locally)
- [x] All knowledge dir tests pass (204/204)
- [x] TypeScript clean
- [x] Rebased onto current origin/main HEAD (post-Leo P0-3, post-Quinn F-NEW-1)
- [ ] CI green (no checks configured on this repo, MERGEABLE)
- [ ] Sam ack

## Source
- Kai's WI-E F-FTS5 triage report (≤50 line spec sketch sent 2026-05-07)
- `.crewly/audit-reports/2026-05-07-audit-cycle1.md` (F-FTS5 finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)