### PR TITLE
fix(env): CREWLY_HOME-aware prompts-dir + logs-dir resolution (WI-F)

### DIFF
--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -3383,6 +3383,94 @@ describe('AgentRegistrationService', () => {
 			// (verified by checking the file path indicates agent mode was used)
 			expect(result).toBe('/project/.claude/agents/sam-session.md');
 		});
+
+		// =====================================================================
+		// WI-F (2026-05-07) — CREWLY_HOME isolation regression for prompts dir
+		//
+		// Mia's KR3 livewalk on 2026-05-07 02:37Z found the test backend
+		// overwriting Steve's user-prod prompt files (27× crewly-orc-init.md,
+		// 26× crewly-auditor-init.md) at `~/.crewly/prompts/` because
+		// `getInitPromptFilePath` was inlining `os.homedir() + .crewly` and
+		// silently ignoring CREWLY_HOME. Same shape as the PR #452 9-site
+		// sweep but on a missed vector. These guards prove the prompt path
+		// now flows through the canonical `getCrewlyHomePath()` resolver.
+		// =====================================================================
+		describe('CREWLY_HOME isolation for getInitPromptFilePath (WI-F)', () => {
+			let originalCrewlyHome: string | undefined;
+
+			beforeEach(() => {
+				originalCrewlyHome = process.env.CREWLY_HOME;
+			});
+
+			afterEach(() => {
+				if (originalCrewlyHome === undefined) {
+					delete process.env.CREWLY_HOME;
+				} else {
+					process.env.CREWLY_HOME = originalCrewlyHome;
+				}
+			});
+
+			it('writes to ${CREWLY_HOME}/prompts when CREWLY_HOME is set (no developer-home leak)', async () => {
+				process.env.CREWLY_HOME = '/tmp/crewly-test-profile-wi-f';
+
+				const result = await (service as any).writePromptFile(
+					'crewly-orc',
+					'orc init prompt',
+					{ projectPath: '/test/project', runtimeType: 'gemini-cli', role: 'orchestrator' }
+				);
+
+				expect(result).toBe('/tmp/crewly-test-profile-wi-f/prompts/crewly-orc-init.md');
+				// Negative: must NOT leak into developer's real home dir.
+				const realHome = require('os').homedir();
+				expect(result).not.toContain(`${realHome}/.crewly/prompts`);
+			});
+
+			it('falls back to ~/.crewly/prompts when CREWLY_HOME is unset', async () => {
+				delete process.env.CREWLY_HOME;
+
+				const result = await (service as any).writePromptFile(
+					'test-agent',
+					'init prompt',
+					{ runtimeType: 'gemini-cli', role: 'developer' }
+				);
+
+				const path = require('path');
+				const os = require('os');
+				expect(result).toBe(
+					path.join(os.homedir(), '.crewly', 'prompts', 'test-agent-init.md'),
+				);
+			});
+
+			it('treats empty-string CREWLY_HOME as unset', async () => {
+				process.env.CREWLY_HOME = '';
+
+				const result = await (service as any).writePromptFile(
+					'test-agent',
+					'init prompt',
+					{ runtimeType: 'gemini-cli', role: 'developer' }
+				);
+
+				const path = require('path');
+				const os = require('os');
+				expect(result).toBe(
+					path.join(os.homedir(), '.crewly', 'prompts', 'test-agent-init.md'),
+				);
+			});
+
+			it('claude-code agent path is unaffected by CREWLY_HOME (writes under projectPath/.claude/agents)', async () => {
+				process.env.CREWLY_HOME = '/tmp/crewly-test-profile-wi-f';
+
+				const result = await (service as any).writePromptFile(
+					'sam-session',
+					'prompt',
+					{ projectPath: '/proj', runtimeType: RUNTIME_TYPES.CLAUDE_CODE, role: 'developer' }
+				);
+
+				// Claude-code mode short-circuits before hitting getInitPromptFilePath,
+				// so the projectPath-anchored output stays intact regardless of CREWLY_HOME.
+				expect(result).toBe('/proj/.claude/agents/sam-session.md');
+			});
+		});
 	});
 
 	describe('registerMemberActive', () => {

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -18,6 +18,7 @@ import {
 	unregisterInProcessRuntime,
 } from './crewly-agent/in-process-runtime-registry.js';
 import { StorageService } from '../core/storage.service.js';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
 import {
 	CREWLY_CONSTANTS,
 	ENV_CONSTANTS,
@@ -1859,11 +1860,19 @@ After checking in, just say "Ready for tasks" and wait for me to send you work.`
 
 	/**
 	 * Build the unified init prompt path used by non-Claude-Code runtimes.
+	 *
+	 * Anchored on {@link getCrewlyHomePath} so test profiles, KR3 livewalk
+	 * dry-runs, and ESTestNode acceptance harnesses that export
+	 * `CREWLY_HOME=/tmp/...` write into the test profile, not the
+	 * developer's real `~/.crewly/prompts`. WI-F (2026-05-07): the
+	 * previous `path.join(os.homedir(), CREWLY_CONSTANTS.PATHS.CREWLY_HOME,
+	 * ...)` form ignored the env var and let Mia's KR3 livewalk overwrite
+	 * 27 occurrences of `~/.crewly/prompts/crewly-orc-init.md` and 26 of
+	 * `crewly-auditor-init.md` in Steve's user-prod tree at 02:37Z.
 	 */
 	private getInitPromptFilePath(sessionName: string): string {
 		return path.join(
-			os.homedir(),
-			CREWLY_CONSTANTS.PATHS.CREWLY_HOME,
+			getCrewlyHomePath(),
 			'prompts',
 			`${sessionName}-init.md`
 		);

--- a/backend/src/services/core/config.service.test.ts
+++ b/backend/src/services/core/config.service.test.ts
@@ -252,6 +252,68 @@ describe('ConfigService', () => {
 			expect(typeof loggingConfig.enableFileLogging).toBe('boolean');
 			expect(typeof loggingConfig.logDir).toBe('string');
 		});
+
+		// =====================================================================
+		// WI-F (2026-05-07) — CREWLY_HOME isolation regression for logDir
+		//
+		// Mia's KR3 livewalk on 2026-05-07 02:37Z found the test backend
+		// interleaving 52 references of /tmp/crewly-kr3-livewalk-* into
+		// Steve's user-prod `~/.crewly/logs/crewly-2026-05-07.log` because
+		// the default `logDir` ignored CREWLY_HOME and went straight to
+		// `os.homedir()`. Same shape as the PR #452 9-site sweep but on a
+		// missed vector. These guards lock the resolution semantics in.
+		// =====================================================================
+		describe('logDir CREWLY_HOME isolation (WI-F)', () => {
+			test('honours CREWLY_HOME when set (no LOG_DIR override)', () => {
+				mockExistsSync.mockReturnValue(false);
+				process.env.CREWLY_HOME = '/tmp/crewly-test-profile-xyz';
+				delete process.env.LOG_DIR;
+
+				const config = ConfigService.getInstance();
+				const { logDir } = config.get('logging');
+
+				expect(logDir).toBe('/tmp/crewly-test-profile-xyz/logs');
+				// Negative: must NOT have leaked into the developer's home dir.
+				expect(logDir.startsWith(require('os').homedir())).toBe(false);
+			});
+
+			test('falls back to ~/.crewly/logs when CREWLY_HOME is unset', () => {
+				mockExistsSync.mockReturnValue(false);
+				delete process.env.CREWLY_HOME;
+				delete process.env.LOG_DIR;
+
+				const config = ConfigService.getInstance();
+				const { logDir } = config.get('logging');
+
+				const path = require('path');
+				const os = require('os');
+				expect(logDir).toBe(path.join(os.homedir(), '.crewly', 'logs'));
+			});
+
+			test('treats empty-string CREWLY_HOME as unset', () => {
+				mockExistsSync.mockReturnValue(false);
+				process.env.CREWLY_HOME = '';
+				delete process.env.LOG_DIR;
+
+				const config = ConfigService.getInstance();
+				const { logDir } = config.get('logging');
+
+				const path = require('path');
+				const os = require('os');
+				expect(logDir).toBe(path.join(os.homedir(), '.crewly', 'logs'));
+			});
+
+			test('LOG_DIR explicit override still wins over CREWLY_HOME', () => {
+				mockExistsSync.mockReturnValue(false);
+				process.env.CREWLY_HOME = '/tmp/crewly-test-profile-xyz';
+				process.env.LOG_DIR = '/var/log/crewly-explicit';
+
+				const config = ConfigService.getInstance();
+				const { logDir } = config.get('logging');
+
+				expect(logDir).toBe('/var/log/crewly-explicit');
+			});
+		});
 	});
 
 	describe('Security Configuration', () => {

--- a/backend/src/services/core/config.service.ts
+++ b/backend/src/services/core/config.service.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { existsSync, readFileSync, statSync } from 'fs';
 import { LoggerService, ComponentLogger } from './logger.service.js';
+import { getCrewlyHomePath } from './crewly-home.utils.js';
 
 export interface AppConfig {
 	// Server Configuration
@@ -165,7 +166,13 @@ export class ConfigService {
 				level: (process.env.LOG_LEVEL as any) || 'info',
 				format: (process.env.LOG_FORMAT as any) || 'simple',
 				enableFileLogging: process.env.FILE_LOGGING !== 'false',
-				logDir: process.env.LOG_DIR || path.join(os.homedir(), '.crewly', 'logs'),
+				// WI-F (2026-05-07): default log dir must honour CREWLY_HOME so
+				// `CREWLY_HOME=/tmp/...` test profiles do not interleave 52
+				// references of /tmp/crewly-kr3-livewalk-* into the developer's
+				// real `~/.crewly/logs/crewly-2026-05-07.log`. LOG_DIR still
+				// wins (explicit override). Fallback now goes through
+				// `getCrewlyHomePath()` instead of inline `os.homedir()`.
+				logDir: process.env.LOG_DIR || path.join(getCrewlyHomePath(), 'logs'),
 				maxFiles: parseInt(process.env.LOG_MAX_FILES || '5', 10),
 				maxSize: process.env.LOG_MAX_SIZE || '10m',
 			},


### PR DESCRIPTION
## Summary

- **Damage:** Mia's KR3 livewalk on 2026-05-07 02:37Z found the test backend overwriting Steve's user-prod tree because two paths inlined `os.homedir()` and ignored `CREWLY_HOME`: 27× `~/.crewly/prompts/crewly-orc-init.md` overwritten, 26× `crewly-auditor-init.md` overwritten, 52× `/tmp/crewly-kr3-livewalk-*` references interleaved into `~/.crewly/logs/crewly-2026-05-07.log`. Sam's `sed` recovery restored the files; this PR closes the source vector.
- **Fix:** Same shape as the PR #452 9-site sweep — route both paths through the canonical `getCrewlyHomePath()` helper.
- **Out of scope:** ~10 additional `os.homedir() + .crewly` sites surface in a broader grep — flagged to Sam in `report-status` as round-3 sweep candidates per WI-F dispatch guardrails.

## Files

| File | Change |
|---|---|
| `backend/src/services/agent/agent-registration.service.ts` | `getInitPromptFilePath` now uses `getCrewlyHomePath()` instead of inline `os.homedir() + CREWLY_CONSTANTS.PATHS.CREWLY_HOME` |
| `backend/src/services/core/config.service.ts` | `logging.logDir` default now uses `getCrewlyHomePath()`; `LOG_DIR` env override semantics preserved (explicit env still wins) |
| `backend/src/services/agent/agent-registration.service.test.ts` | +4 WI-F regression tests inside the existing `writePromptFile (#207)` describe block |
| `backend/src/services/core/config.service.test.ts` | +4 WI-F regression tests inside the existing `Logging Configuration` describe block |

## Test plan

- [x] `jest backend/src/services/core/config.service.test.ts` → 23/23 pass (19 existing + 4 new)
- [x] `jest backend/src/services/agent/agent-registration.service.test.ts -t writePromptFile` → 8/8 pass (4 existing + 4 new)
- [x] `jest backend/src/services/core/crewly-home.utils.test.ts` → 3/3 pass (helper unaffected)
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [x] **Sam's eval gates green:**
  - `grep -rE "os\.homedir\(\).*\.crewly/prompts" backend/src/` → 0 matches outside test files
  - `grep -rE "os\.homedir\(\).*\.crewly.*logs" backend/src/` → 0 matches outside test files
- [ ] Post-merge operational smoke (Sam):
  - Boot backend with `CREWLY_HOME=/tmp/test-profile` + register a synthetic agent → no writes to `~/.crewly/prompts/` or `~/.crewly/logs/`
  - KR3 re-run unblocked
  - WI-D backend restart now safe (no risk of stale-state re-corrupting prompts)

## Round-3 sweep candidates (NOT in this PR)

Same bug class, different vectors. Surfacing for Sam to scope as a follow-up sweep:

| File | Line | Path |
|---|---|---|
| `backend/src/services/skill/skill-catalog.service.ts` | 169, 342, 349 | catalog dir + marketplace skills + addon skills |
| `backend/src/services/marketplace/marketplace.service.ts` | 25 | module-level `CREWLY_HOME` const |
| `backend/src/services/marketplace/template-marketplace.service.ts` | 32 | module-level `CREWLY_HOME` const |
| `backend/src/services/chat/chat.service.ts` | 124 | chat dir |
| `backend/src/utils/encryption.utils.ts` | 184 | credentials path |
| `backend/src/controllers/marketplace/marketplace.controller.ts` | 292 | marketplace path |
| `backend/src/controllers/messaging/messenger.routes.ts` | 33, 79 | messaging credentials |
| `backend/src/services/memory/session-memory.service.ts` | 89 | session-memory dir |
| `backend/src/services/core/config.service.ts` | 120 | `config.json` read path (separate code path from this PR's `logDir` bug) |
| Already fallback-aware (lower urgency) | | `teams-backup.service.ts:123`, `agent-memory.service.ts:123/135`, `env.config.ts:258` |

## References

- **Umbrella:** ddcc8efa-ecb2-4d5f-ac1a-a77e388bdfa7
- **WI:** WI-F (round-2)
- **Pattern:** PR #452 (commits 34a3a702 + 73af57fd + 004758bf + f373a419 + d98741fe)
- **Helper:** `backend/src/services/core/crewly-home.utils.ts`
- **Mia's audit:** KR3 livewalk corruption report 2026-05-07 02:37Z
- **Backups:** `/tmp/crewly-dispatch-2026-05-07/contaminated-{orc,auditor}-init.md.bak`

🤖 Generated with [Claude Code](https://claude.com/claude-code)