### PR TITLE
feat(prompts): wire Execution Mode tier reference into 20 role prompts (Fix 7)

### DIFF
--- a/config/roles/architect/prompt.md
+++ b/config/roles/architect/prompt.md
@@ -115,6 +115,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/auditor/prompt.md
+++ b/config/roles/auditor/prompt.md
@@ -85,6 +85,10 @@ When your message starts with `[SLACK_CONTEXT:channelId=xxx,threadTs=xxx]`, you 
 When your message does NOT start with `[SLACK_CONTEXT:]`, you are in standard audit mode — follow the Audit Cycle steps above and write findings to the audit report.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/backend-developer/prompt.md
+++ b/config/roles/backend-developer/prompt.md
@@ -132,6 +132,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/content-strategist/prompt.md
+++ b/config/roles/content-strategist/prompt.md
@@ -84,6 +84,10 @@ Your team has a built-in cron system. The orchestrator or user can schedule recu
 You do not need to manage cron tasks yourself — the orchestrator handles creation and scheduling. If you need a recurring task set up, ask the orchestrator.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/designer/prompt.md
+++ b/config/roles/designer/prompt.md
@@ -114,6 +114,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -347,6 +347,10 @@ bash {{AGENT_SKILLS_PATH}}/core/cancel-followup/execute.sh --name idle-self-ping
 **Negative pattern to suppress:** "Worker is mid-task waiting on a downstream → stays in busy state → never receives an idle event → never re-checks → sits silent for hours."
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/frontend-developer/prompt.md
+++ b/config/roles/frontend-developer/prompt.md
@@ -132,6 +132,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/fullstack-dev/prompt.md
+++ b/config/roles/fullstack-dev/prompt.md
@@ -132,6 +132,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/generalist/prompt.md
+++ b/config/roles/generalist/prompt.md
@@ -115,6 +115,10 @@ You do not need to manage cron tasks yourself — the orchestrator handles creat
 After checking in, just say "Ready for tasks" and wait for me to send you work.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/ops/prompt.md
+++ b/config/roles/ops/prompt.md
@@ -146,6 +146,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -1682,6 +1682,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -202,6 +202,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/qa-engineer/prompt.md
+++ b/config/roles/qa-engineer/prompt.md
@@ -132,6 +132,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/qa/prompt.md
+++ b/config/roles/qa/prompt.md
@@ -132,6 +132,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/researcher/prompt.md
+++ b/config/roles/researcher/prompt.md
@@ -115,6 +115,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/sales/prompt.md
+++ b/config/roles/sales/prompt.md
@@ -114,6 +114,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/support/prompt.md
+++ b/config/roles/support/prompt.md
@@ -114,6 +114,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -214,6 +214,10 @@ You do not need to manage cron tasks yourself — the orchestrator handles creat
 After checking in, say "Ready for tasks" and wait for the Orchestrator to send you work.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/tpm/prompt.md
+++ b/config/roles/tpm/prompt.md
@@ -115,6 +115,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/roles/ux-designer/prompt.md
+++ b/config/roles/ux-designer/prompt.md
@@ -116,6 +116,10 @@ When you encounter an error and successfully resolve it:
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
 
+## Execution Mode
+
+Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
+
 ## Decision Rights
 
 **Decide autonomously when:**


### PR DESCRIPTION
## Summary

Fix 7 from `.crewly/specs/2026-05-03-agent-improvement-plan.md` §Fix 7. Wires the already-shipped `config/sops/common/dev-process-tiers.md` (Fast / Standard / Release Path SOP, #411) into every role prompt so each role knows which tier to default to and when to escalate.

- Single-paragraph `## Execution Mode` block (1-2 line reference, **no SOP body copy-paste** — net-zero on prompt mass) inserted directly before `## Decision Rights` in 20 role prompts.
- Two block variants (Fast / Standard) keyed off the role's primary work shape per spec defaults.
- Net diff: **+80 / -0** across 20 files (4 lines per prompt).

## Tier mapping

**Per spec §Fix 7 (canonical defaults):**

| Tier | Roles |
|---|---|
| **Fast** (7) | developer, backend-developer, frontend-developer, fullstack-dev, generalist, qa-engineer |
| **Standard** (8) | product-manager, ux-designer, designer, content-strategist, researcher, ops, orchestrator, team-leader, tpm |

**Deviation explanations** (all minor / worker-decision per Decision Rights — wording / unmapped-role placement; no major tier changes from spec defaults):

- `architect`, `auditor` → **Standard**: spec didn't enumerate these; both are review/spec work that affects customer-facing surfaces, so Standard is correct per the dev-process-tiers decision matrix.
- `sales`, `support` → **Standard**: spec didn't enumerate; both are customer-facing roles, so Standard is the matrix-correct default.
- `qa` → **Fast**: alias of `qa-engineer` (verified — diffs only on a couple of role-blurb lines), so it inherits Fast.

If TL prefers any of these flipped, single-line edit per file.

## Block content

**Fast variant** (developer/backend/frontend/fullstack/generalist/qa/qa-engineer):
> Default tier: **Fast Path** (greenfield, internal tools, prototypes). Escalate to Standard for customer-facing or persistence work; Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.

**Standard variant** (product/design/ops/coordination/review roles):
> Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.

## Eval (per spec §Fix 7)

| # | Criterion | Result |
|---|---|---|
| 1 | `grep -L "Execution Mode\|dev-process-tiers" config/roles/*/prompt.md` outputs empty | ✅ 20/20 |
| 2 | Default tier aligns with spec recommendations | ✅ (deviations explained above) |
| 3 | 1-2 line reference, no SOP full-text copy-paste | ✅ single-paragraph reference per prompt |
| 4 | SOP path correct | ✅ `config/sops/common/dev-process-tiers.md` exists |
| 5 | Smoke test | ✅ `prompt-builder.service.test.ts` 152/152 passing |
| 6 | tsc clean | ✅ zero new errors over baseline (markdown-only) |

## Tier metadata

**Tier:** Standard
**Why this tier:** internal SOP/prompt doc that gets loaded into every agent's prompt — affects all agents' behavior; rollback is per-file but blast radius is wide (per `dev-process-tiers.md` ambiguity table).

## Test plan

- [x] grep eval (1) — 20/20 prompts now reference Execution Mode
- [x] Visual review of Fast and Standard sample insertions
- [x] Markdown-structure smoke (Node script: header + tier marker + SOP ref + ordering before Decision Rights)
- [x] `prompt-builder.service.test.ts` (152 tests) green
- [x] tsc baseline diff = 0
- [ ] TL spot-check on tier choices for unmapped roles (architect/auditor/sales/support/qa)

## Context

P0 6/6 all shipped, ORC-approved. Leo on Fix 6, Max on Fix 8 — three of us editing different sections so no merge conflicts expected. Pinging Sam after PR opens per dispatch instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)