### PR TITLE
feat(prompts): P2 Fix 13 — Crewly Operating Principles header (universal)

### DIFF
--- a/backend/src/services/ai/prompt-modules/operating-principles-role-coverage.test.ts
+++ b/backend/src/services/ai/prompt-modules/operating-principles-role-coverage.test.ts
@@ -1,6 +1,6 @@
 /**
  * Coverage test for Fix 13 (P2) — Crewly Operating Principles header
- * across all role prompts under `config/roles/*/prompt.md`.
+ * across all role prompts under `config/roles/{role}/prompt.md`.
  *
  * Spec: `.crewly/specs/2026-05-03-agent-improvement-plan.md` lines 466-481
  * (Fix 13 — Crewly Operating Principles header).
@@ -72,22 +72,36 @@ describe('Fix 13 — Crewly Operating Principles role coverage', () => {
 
     it('places principles header BEFORE the role identity (top of file)', () => {
       const principlesIdx = content.indexOf('## Crewly Operating Principles');
-      // Identity sections come in many forms across roles — match common headings
+      // Identity sections come in many forms across roles. The marker list
+      // covers all 20 prompts in the current corpus:
+      //   - "Hey! I need your help with"  → 16 prompts (developer, backend,
+      //       frontend, fullstack, generalist, qa, qa-engineer, ops, sales,
+      //       support, product-manager, researcher, designer, ux-designer,
+      //       architect, tpm)
+      //   - "## Your Role"                → team-leader (`## Your Role: Team Leader`)
+      //   - "## Role focus"               → content-strategist (`## Role focus: Content Strategist`)
+      //   - "# Crewly Orchestrator"       → orchestrator (top-level title)
+      //   - "# Crewly Auditor"            → auditor (top-level title)
+      // `## Identity` / `## Primary Identity` kept as defensive fallbacks for
+      // any future role that adopts the standardized identity heading.
       const identityMarkers = [
+        'Hey! I need your help with',
         '## Your Role',
+        '## Role focus',
         '## Identity',
         '## Primary Identity',
         '# Crewly Orchestrator',
+        '# Crewly Auditor',
       ];
       const identityIdx = identityMarkers
         .map((m) => content.indexOf(m))
         .filter((i) => i !== -1)
         .reduce((min, i) => (min === -1 || i < min ? i : min), -1);
-      // If we found an identity marker, principles must precede it.
-      // (Some prompts don't follow the heading template — skip the assertion there.)
-      if (identityIdx !== -1) {
-        expect(principlesIdx).toBeLessThan(identityIdx);
-      }
+      // After expanding the marker list to cover every role's identity
+      // heading variant, every prompt matches at least one marker.
+      // The assertion is now strict for all 20 roles (no silent skip).
+      expect(identityIdx).toBeGreaterThan(-1);
+      expect(principlesIdx).toBeLessThan(identityIdx);
     });
   });
 });

--- a/backend/src/services/ai/prompt-modules/operating-principles-role-coverage.test.ts
+++ b/backend/src/services/ai/prompt-modules/operating-principles-role-coverage.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Coverage test for Fix 13 (P2) — Crewly Operating Principles header
+ * across all role prompts under `config/roles/*/prompt.md`.
+ *
+ * Spec: `.crewly/specs/2026-05-03-agent-improvement-plan.md` lines 466-481
+ * (Fix 13 — Crewly Operating Principles header).
+ *
+ * Mirrors the static-coverage pattern established by PR #481
+ * (`decision-rights-role-coverage.test.ts`) — fast file-content scan,
+ * no runtime prompt assembly required.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+
+/**
+ * Resolve to the repo root from this test file's location.
+ *
+ * Test file lives under `backend/src/services/ai/prompt-modules/`,
+ * five `..` segments up from this file = repo root.
+ */
+const REPO_ROOT = resolve(__dirname, '../../../../..');
+const ROLES_DIR = join(REPO_ROOT, 'config', 'roles');
+
+/** The 6 principle bullets that must appear verbatim in every role prompt. */
+const REQUIRED_PRINCIPLES = [
+  '1. Outcome over activity.',
+  '2. Decide unless the goal is unclear.',
+  '3. Delegate by default if you are a TL.',
+  '4. Execute immediately if you are a worker.',
+  '5. Verify before claiming done.',
+  '6. Escalate through the hierarchy.',
+];
+
+/** Collect all role directories that ship a prompt.md (excludes _common). */
+function listRolePromptPaths(): Array<{ role: string; path: string }> {
+  const entries = readdirSync(ROLES_DIR);
+  const out: Array<{ role: string; path: string }> = [];
+  for (const name of entries) {
+    if (name.startsWith('_')) continue;
+    const rolePath = join(ROLES_DIR, name);
+    if (!statSync(rolePath).isDirectory()) continue;
+    const promptPath = join(rolePath, 'prompt.md');
+    try {
+      statSync(promptPath);
+      out.push({ role: name, path: promptPath });
+    } catch {
+      // No prompt.md in this role dir — skip silently
+    }
+  }
+  return out;
+}
+
+describe('Fix 13 — Crewly Operating Principles role coverage', () => {
+  const rolePrompts = listRolePromptPaths();
+
+  it('finds at least 17 role prompts under config/roles/', () => {
+    // Sanity check — if this fails, the test setup is wrong, not Fix 13
+    expect(rolePrompts.length).toBeGreaterThanOrEqual(17);
+  });
+
+  describe.each(rolePrompts)('role: $role', ({ path }) => {
+    const content = readFileSync(path, 'utf-8');
+
+    it('contains the "## Crewly Operating Principles" section header', () => {
+      expect(content).toContain('## Crewly Operating Principles');
+    });
+
+    it.each(REQUIRED_PRINCIPLES)('contains principle: %s', (principle) => {
+      expect(content).toContain(principle);
+    });
+
+    it('places principles header BEFORE the role identity (top of file)', () => {
+      const principlesIdx = content.indexOf('## Crewly Operating Principles');
+      // Identity sections come in many forms across roles — match common headings
+      const identityMarkers = [
+        '## Your Role',
+        '## Identity',
+        '## Primary Identity',
+        '# Crewly Orchestrator',
+      ];
+      const identityIdx = identityMarkers
+        .map((m) => content.indexOf(m))
+        .filter((i) => i !== -1)
+        .reduce((min, i) => (min === -1 || i < min ? i : min), -1);
+      // If we found an identity marker, principles must precede it.
+      // (Some prompts don't follow the heading template — skip the assertion there.)
+      if (identityIdx !== -1) {
+        expect(principlesIdx).toBeLessThan(identityIdx);
+      }
+    });
+  });
+});

--- a/config/roles/architect/prompt.md
+++ b/config/roles/architect/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with system architecture and technical design for this project.
 
 ## Quick context about this setup

--- a/config/roles/auditor/prompt.md
+++ b/config/roles/auditor/prompt.md
@@ -1,5 +1,16 @@
 # Crewly Auditor — System Prompt
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 You are the **Crewly Auditor**, an autonomous quality observer for the Crewly multi-agent orchestration platform.
 
 ## Your Mission

--- a/config/roles/backend-developer/prompt.md
+++ b/config/roles/backend-developer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with backend development for this project.
 
 ## Quick context about this setup

--- a/config/roles/content-strategist/prompt.md
+++ b/config/roles/content-strategist/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 ## Startup checklist (required)
 
 1. Register yourself:

--- a/config/roles/designer/prompt.md
+++ b/config/roles/designer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with design work for this project.
 
 ## Quick context about this setup

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with software development for this project.
 
 ## Quick context about this setup

--- a/config/roles/frontend-developer/prompt.md
+++ b/config/roles/frontend-developer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with frontend development for this project.
 
 ## Quick context about this setup

--- a/config/roles/fullstack-dev/prompt.md
+++ b/config/roles/fullstack-dev/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with full-stack development for this project.
 
 ## Quick context about this setup

--- a/config/roles/generalist/prompt.md
+++ b/config/roles/generalist/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with a bunch of tasks for this project.
 
 ## Quick context about this setup

--- a/config/roles/ops/prompt.md
+++ b/config/roles/ops/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with operations and infrastructure for this project.
 
 ## Quick context about this setup

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -26,6 +26,17 @@ When a user says "implement X" or "fix X" — this means: find the right agent a
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 ## Silent by Default (DEFAULT OPERATING MODE)
 
 The owner hired you to deliver results, not to narrate progress or ask permission for every step. Unless the owner explicitly pauses you or asks for approval mode, you operate in **Silent Mode**.

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with product management for this project.
 
 ## Quick context about this setup

--- a/config/roles/qa-engineer/prompt.md
+++ b/config/roles/qa-engineer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with QA engineering for this project.
 
 ## Quick context about this setup

--- a/config/roles/qa/prompt.md
+++ b/config/roles/qa/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with quality assurance and testing for this project.
 
 ## Quick context about this setup

--- a/config/roles/researcher/prompt.md
+++ b/config/roles/researcher/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with research work for this project.
 
 ## Quick context about this setup

--- a/config/roles/sales/prompt.md
+++ b/config/roles/sales/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with sales and customer engagement for this project.
 
 ## Quick context about this setup

--- a/config/roles/support/prompt.md
+++ b/config/roles/support/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with customer support for this project.
 
 ## Quick context about this setup

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -12,6 +12,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 ## Your Role: Team Leader
 
 You are a **Team Leader** (hierarchyLevel=1) responsible for managing a sub-team of workers. You receive high-level goals from the Orchestrator and own the full lifecycle: decompose, delegate, monitor, verify, and report.

--- a/config/roles/tpm/prompt.md
+++ b/config/roles/tpm/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with technical product management for this project.
 
 ## Quick context about this setup

--- a/config/roles/ux-designer/prompt.md
+++ b/config/roles/ux-designer/prompt.md
@@ -10,6 +10,17 @@ Messages in this terminal come from the Crewly orchestrator, which coordinates y
 
 ---
 
+## Crewly Operating Principles
+
+1. Outcome over activity.
+2. Decide unless the goal is unclear.
+3. Delegate by default if you are a TL.
+4. Execute immediately if you are a worker.
+5. Verify before claiming done.
+6. Escalate through the hierarchy.
+
+---
+
 Hey! I need your help with UX design work for this project.
 
 ## Quick context about this setup


### PR DESCRIPTION
## Summary

Closes Fix 13 from `.crewly/specs/2026-05-03-agent-improvement-plan.md` lines 466-481. Adds the 6-line **Crewly Operating Principles** section as a universal header to all 20 role prompts under `config/roles/*/prompt.md`. Sits at the **TOP** of each prompt — between the `# Crewly Agent Environment` framing block and the role-specific identity section — establishing shared cognitive ground before role-specific instructions diverge.

## The 6 principles (verbatim per spec)

1. Outcome over activity.
2. Decide unless the goal is unclear.
3. Delegate by default if you are a TL.
4. Execute immediately if you are a worker.
5. Verify before claiming done.
6. Escalate through the hierarchy.

## Why this matters

The 6 principles serve as the **summary card** sitting on top of the longer P0 sections shipped earlier this week:

- P0-1/P0-2 team-leader soul + Self-Implementation Exception Rule (#414/#417/#493)
- P0-3 Request Contract (#495)
- P0-4 Decision Rights + Escalation Chain (#481)
- P0-5 End-of-Turn Delivery Verification (#424)
- P0-6 Owner-Facing Communication Standard (#413/#493)

Same cognitive role as the operating-principles header in classic eng playbooks — read the 6 lines, you've absorbed the operating contract; the longer sections fill in the *how*.

## Net-zero offset — partial deviation, documented (revised post-#500)

Spec called for "these 6 lines replace dozens of scattered admonitions across prompts."

**Audit reality at PR-open time** (pre-#500): `grep` for `Be helpful / Be professional / Communicate clearly` surfaced only 2 hits (Sales = "professional and customer-focused", Support = "patient, empathetic, solution-oriented"). I deferred those cuts as content-bearing.

**Audit reality post-#500**: Max's Fix 8 (Lazy Anti-Patterns, merged 3b74f14f) cut **7 vague platitudes** including the 2 Sales/Support phrases I'd left. So the post-merge state is: my Fix 13 deferred deletions, Max's Fix 8 made them anyway because his 7 anti-pattern bullets subsume the same intent more crisply. Net-zero pressure on the corpus is met by the combined PRs even though my PR alone is +220 lines.

**Net mass impact of THIS PR**: +220 lines (11 lines × 20 prompts). Documented as deviation. Same pattern Leo applied on P0-3 (#495): when spec target doesn't match audit reality, document the gap rather than padding for fake net-zero.

## Eval criteria — all green (re-verified post `15cdbdc8` test fix)

| # | Criterion | Result |
|---|---|---|
| 1 | All 20 role prompts contain `## Crewly Operating Principles` | ✅ 20/20 |
| 2 | All 6 principles present verbatim per spec | ✅ 20/20 × 6 = 120 verbatim bullet assertions |
| 3 | Principles header placed BEFORE role identity | ✅ **20/20 STRICT** (was 2/20 strict + 18 silent-skip pre-`15cdbdc8`; Quinn caught) |
| 4 | Coverage test under `backend/src/services/ai/prompt-modules/` | ✅ `operating-principles-role-coverage.test.ts` mirrors PR #481 pattern. **Post-`15cdbdc8`**: JSDoc `*/` close fixed (had been killing test compile, running zero assertions). Now genuinely runs all 160 assertions (20 header + 120 bullets + 20 placement). |
| 5 | tsc clean | ✅ markdown-only edits + 1 test file |

## Tier metadata

**Tier:** Standard
**Why this tier:** Internal SOP/prompt doc loaded into every agent's prompt. Affects all agents' behavior; rollback is per-file but blast radius is wide. Per `dev-process-tiers.md`.

## Coordination — final state

- **Quinn's #498 (Fix 7)** merged 702cbd69 — Execution Mode block before Decision Rights. Two clean rebases (post-#498, post-#500). ✅
- **Max's #500 (Fix 8)** merged 3b74f14f — Lazy Anti-Patterns module + 20-prompt static + 7 vague-platitude cuts. ✅
- **This PR (#499)** rebased clean onto post-#500 main. After merge, prompt structure reads: env → operating principles → role identity → role body → execution mode → decision rights → request contract → lazy anti-patterns → end. Coherent stack.

## Test plan

- [x] grep eval: 20/20 prompts have `## Crewly Operating Principles`
- [x] 6 principles verbatim across all 20 prompts (coverage test asserts 120 bullet matches)
- [x] Placement assertion: principles appear before role identity heading — **20/20 STRICT** post `15cdbdc8`
- [x] Coverage test compiles and runs (post-`15cdbdc8` JSDoc fix)
- [x] Visual review of TL, orc, developer, PM, content-strategist samples — clean structure
- [x] Quinn changes-requested review addressed (`15cdbdc8`)
- [ ] Quinn re-LGTM → merge

## Self-implementation justification

Per team-leader soul §Self-Implementation Exception Rule (4 AND-of-N):
1. ✅ All other workers (Leo/Max/Quinn) busy with Fix 6/7/8 — no idle worker available
2. ✅ Small (220-line markdown insert + 1 test file) — faster as self-impl than delegate+verify
3. ✅ Not a coordination/decomposition/review/decision task — pure prompt edit
4. ✅ Logged here in PR body

## Commits

- `5e8adf40` — initial Fix 13 (insertion + coverage test stub)
- `15cdbdc8` — fix: P0 JSDoc `*/` close + tighten placement to 20/20 strict (per Quinn review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)