### PR TITLE
fix(v3): Slack→Request auto-classify + wake-action team plumbing + UI completed-WI visibility

### DIFF
--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -185,14 +185,17 @@ export function emitChatV2RequestCreated(
       const existing = await svc.findBySourceConversationItemId(sourceId);
       if (existing) return;
 
-      const { generateRequestTitle } = await import('../../services/v3/v3-data.service.js');
+      const { generateRequestTitle, classifyIntent } = await import('../../services/v3/v3-data.service.js');
       const rawText = message.content || '';
+      const { intentLevel, intentCategory } = classifyIntent(rawText);
       await svc.create({
-        title: generateRequestTitle(rawText, 'other'),
+        title: generateRequestTitle(rawText, intentCategory),
         description: rawText,
         sourceConversationItemId: sourceId,
         priority: 'normal',
         tags: ['chat-v2'],
+        intentLevel,
+        intentCategory,
       });
     } catch {
       // Non-critical — Request creation failure must not break chat send.

--- a/backend/src/controllers/chat/chat.controller.ts
+++ b/backend/src/controllers/chat/chat.controller.ts
@@ -106,13 +106,16 @@ export async function sendMessage(
         // Deduplicate: one Request per conversation message
         const existing = await requestSvc.findBySourceConversationItemId(result.message.id);
         if (!existing) {
-          const { generateRequestTitle } = await import('../../services/v3/v3-data.service.js');
+          const { generateRequestTitle, classifyIntent } = await import('../../services/v3/v3-data.service.js');
+          const { intentLevel, intentCategory } = classifyIntent(content);
           const request = await requestSvc.create({
-            title: generateRequestTitle(content, 'other'),
+            title: generateRequestTitle(content, intentCategory),
             description: content,
             sourceConversationItemId: result.message.id,
             priority: 'normal',
             tags: ['chat-ui'],
+            intentLevel,
+            intentCategory,
           });
           // P2-2: RequestTracker.setActiveRequest write removed. The
           // companion read in v3-data.service.ts no longer falls back to

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -717,6 +717,16 @@ export function detectUnclaimedTasks(
       score: bestAgent.score,
       scoreBreakdown: bestAgent.breakdown,
       triggeredAt: new Date().toISOString(),
+      // Propagate team identifiers so the wake-action HTTP call can hit
+      // `/api/teams/:teamId/members/:memberId/start` (the only registered
+      // route). Without these, the data-provider falls back to
+      // `/api/teams/members/start` which has no router match — the server
+      // matches the catch-all `/:teamId/members/:memberId/start` with
+      // teamId="members", memberId="start", and returns 404 "Team not
+      // found". This silent breakage made hybrid-wake a no-op for
+      // inactive team members across the entire fleet.
+      teamId: bestAgent.agent.teamId,
+      memberId: bestAgent.agent.memberId,
     });
 
     unclaimedWorkItemIds.push(wi.id);

--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -487,13 +487,21 @@ export class SlackOrchestratorBridge extends EventEmitter {
                 return;
               }
 
-              const { generateRequestTitle } = await import('../v3/v3-data.service.js');
+              const { generateRequestTitle, classifyIntent } = await import('../v3/v3-data.service.js');
+              // Auto-classify so request-decompose.subscriber sees correct
+              // intentLevel/intentCategory. Without this, every Slack-auto
+              // Request defaulted to L1+other and was never decomposed
+              // into delegation WorkItems — the entire Slack→WorkItem
+              // pipeline was silently no-op.
+              const { intentLevel, intentCategory } = classifyIntent(rawText);
               const request = await svc.create({
-                title: generateRequestTitle(rawText, 'other'),
+                title: generateRequestTitle(rawText, intentCategory),
                 description: rawText,
                 sourceConversationItemId: msgId,
                 priority: 'normal',
                 tags: ['slack'],
+                intentLevel,
+                intentCategory,
               });
               // P2-2: RequestTracker.setActiveRequest write removed. The
               // companion read in v3-data.service.ts no longer falls back

--- a/backend/src/services/v3/request.service.test.ts
+++ b/backend/src/services/v3/request.service.test.ts
@@ -72,6 +72,10 @@ describe('RequestService', () => {
         sourceConversationItemId: 'conv-123',
         title: 'Deploy to staging',
         description: 'Deploy the current build to the staging environment',
+        // Pin classification so the test asserts CRUD semantics, not the
+        // auto-classify fallback (covered by its own test below).
+        intentLevel: 'L1',
+        intentCategory: 'other',
       });
 
       expect(request.id).toBeDefined();
@@ -80,6 +84,40 @@ describe('RequestService', () => {
       expect(request.priority).toBe('normal');
       expect(request.intentLevel).toBe('L1');
       expect(request.workItemIds).toEqual([]);
+    });
+
+    it('auto-classifies intent when caller omits intentLevel/intentCategory', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+
+      // "Deploy ... staging environment" matches the L2 deploy/env trigger
+      // and the deployment category. Without the auto-classify backstop,
+      // this would default to L1+other and request-decompose.subscriber
+      // would silently skip auto-decomposition — the original Slack→0WIs bug.
+      const request = await service.create({
+        sourceConversationItemId: 'conv-auto-classify',
+        title: 'Deploy to staging',
+        description: 'Deploy the current build to the staging environment',
+      });
+
+      expect(request.intentLevel).toBe('L2');
+      expect(request.intentCategory).toBe('deployment');
+    });
+
+    it('preserves explicit intent values when caller provides them', async () => {
+      const service = RequestService.getInstance('/tmp/test-project');
+
+      // Caller knows better — e.g. an agent pre-classified upstream.
+      // The service must NOT overwrite explicit values with the heuristic.
+      const request = await service.create({
+        sourceConversationItemId: 'conv-explicit',
+        title: 'something',
+        description: 'Deploy the current build to the staging environment',
+        intentLevel: 'L1',
+        intentCategory: 'communication',
+      });
+
+      expect(request.intentLevel).toBe('L1');
+      expect(request.intentCategory).toBe('communication');
     });
 
     it('should throw on invalid input', async () => {

--- a/backend/src/services/v3/request.service.ts
+++ b/backend/src/services/v3/request.service.ts
@@ -25,7 +25,7 @@ import {
   type WorkItem,
   TERMINAL_WORK_ITEM_STATUSES,
 } from '../../types/v2/work-item.types.js';
-import { planTasksFromObjective, type PlannedTask } from './v3-data.service.js';
+import { classifyIntent, planTasksFromObjective, type PlannedTask } from './v3-data.service.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
 
 /** Directory name under .crewly for request storage. */
@@ -263,7 +263,24 @@ export class RequestService {
       throw new Error(`Invalid CreateRequestInput: ${errors.join('; ')}`);
     }
 
-    const request = createRequest(input);
+    // Auto-classify intent when caller didn't pass explicit values.
+    // Without this fallback, every Request from a non-classifying caller
+    // landed as L1+other and was silently skipped by the auto-decompose
+    // subscriber — Slack/chat ingress paths hit this, and the entire
+    // Request → WorkItem pipeline became a no-op for inbound user
+    // messages. Explicit caller values still win (an agent that
+    // computed L2+code_change at the source keeps that classification).
+    const needsClassify = input.intentLevel === undefined || input.intentCategory === undefined;
+    const classified = needsClassify ? classifyIntent(input.description) : null;
+    const enriched: CreateRequestInput = classified
+      ? {
+          ...input,
+          intentLevel: input.intentLevel ?? classified.intentLevel,
+          intentCategory: input.intentCategory ?? classified.intentCategory,
+        }
+      : input;
+
+    const request = createRequest(enriched);
     await this.save(request);
     this.logger.debug('Request created', { id: request.id, title: request.title });
 

--- a/backend/src/tests/v3-pipeline-e2e.integration.test.ts
+++ b/backend/src/tests/v3-pipeline-e2e.integration.test.ts
@@ -386,4 +386,125 @@ describe('V3 pipeline E2E', () => {
       }
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: Slack-shaped Request (no explicit intent) → auto-classify → WIs
+  //
+  // Regression gate for the silent Slack/chat ingress bug (2026-05-06): the
+  // Slack bridge + chat controllers called `RequestService.create()` without
+  // passing `intentLevel` / `intentCategory`, leaving them at the L1+other
+  // default. The decompose subscriber's filter (`L2` + actionable category)
+  // then skipped every Slack-originated Request, so the orc-reply SLA path
+  // immediately auto-closed the Request with zero WorkItems queued.
+  //
+  // Fix: `RequestService.create` auto-classifies via `classifyIntent` when
+  // the caller omits the intent fields. This test pins that contract from the
+  // outside — if the backstop is removed or the classifier returns L1/other
+  // for an obviously-actionable description, the entire Slack→worker path
+  // reverts to silent-skip and this test will fail.
+  // ---------------------------------------------------------------------------
+
+  describe('Slack-shaped Request → auto-classify → WIs → dispatch', () => {
+    it('classifies an unscored inbound Request and decomposes it into WorkItems', async () => {
+      const fixture = await buildFixture();
+      try {
+        // 1) Create a Request the way the Slack/chat ingress does it pre-fix:
+        //    no intentLevel, no intentCategory. The description is the actual
+        //    user-message shape that previously regressed — multi-spec
+        //    delegation language matching the L2 file-extension trigger AND
+        //    the planning category. If the service-layer classifier wires up
+        //    correctly, this lands as L2+planning and the decompose subscriber
+        //    accepts it.
+        const request = await fixture.requestService.create({
+          sourceConversationItemId: 'slack-D0AC7NF5N7L-1778119901.952909',
+          title: '[Request] arrange the team to work on these designs',
+          description:
+            'Can the team take on these two design specs? Please plan, ' +
+            'implement, and verify the work end-to-end.\n' +
+            '- ./specs/2026-05-03-agent-improvement-plan.md\n' +
+            '- ./specs/2026-05-03-agent-improvement-p0-execution.md',
+          tags: ['slack'],
+          // Deliberately NO intentLevel / intentCategory — this is the bug
+          // shape. The service must classify on our behalf.
+        });
+
+        // 2) Service backstop must have populated the intent fields.
+        expect(request.intentLevel).toBe('L2');
+        // The description carries multi-step delegation language ("plan,
+        // implement, and verify") and an actionable spec list — accept any
+        // actionable category the classifier picks (planning is the most
+        // likely, but the contract this test protects is "actionable", not
+        // "planning specifically"). Pinning to a single category would make
+        // the test brittle to classifier-tuning landings.
+        expect(['planning', 'code_change', 'research', 'debugging', 'deployment'])
+          .toContain(request.intentCategory);
+
+        // 3) The decompose subscriber should have accepted the request and
+        //    queued at least one WorkItem. Pre-fix: this assertion was the
+        //    silent failure point — items.length stayed at 0 forever and the
+        //    SLA path closed the Request with no children.
+        await waitFor(async () => {
+          const items = await fixture.taskPool.getAllItems();
+          return items.some((wi) => wi.requestId === request.id);
+        });
+        const decomposed = (await fixture.taskPool.getAllItems()).filter(
+          (wi) => wi.requestId === request.id,
+        );
+        expect(decomposed.length).toBeGreaterThan(0);
+
+        // 4) Trigger the autonomy loop and confirm AutoClaim picks one up
+        //    and dispatches. This proves the full Slack→worker chain is
+        //    reachable from a no-intent inbound Request.
+        fixture.bus.publish({
+          id: 'evt-idle-slack',
+          type: 'agent:idle',
+          timestamp: new Date().toISOString(),
+          teamId: 't',
+          teamName: 't',
+          memberId: 'm',
+          memberName: 'm',
+          sessionName: 'dev-1',
+          previousValue: 'in_progress',
+          newValue: 'idle',
+          changedField: 'workingStatus',
+        });
+
+        await waitFor(() => dispatchCallsFor('dev-1').length > 0);
+        expect(dispatchCallsFor('dev-1').length).toBeGreaterThanOrEqual(1);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it('preserves explicit intent values when caller passes them (no overwrite)', async () => {
+      const fixture = await buildFixture();
+      try {
+        // The classifier would say L2+deployment for this description, but
+        // an explicit caller (e.g. an orc that already classified) should
+        // win. This test guards the "explicit > heuristic" precedence rule
+        // in the service-layer fallback.
+        const request = await fixture.requestService.create({
+          sourceConversationItemId: 'explicit-1',
+          title: 'pinned',
+          description: 'Deploy the build to the staging environment now',
+          intentLevel: 'L1',
+          intentCategory: 'communication',
+        });
+        expect(request.intentLevel).toBe('L1');
+        expect(request.intentCategory).toBe('communication');
+
+        // Filter must skip — non-actionable category. No WIs should land.
+        await new Promise<void>((res) => {
+          const t = setTimeout(res, 50);
+          t.unref?.();
+        });
+        const items = (await fixture.taskPool.getAllItems()).filter(
+          (wi) => wi.requestId === request.id,
+        );
+        expect(items.length).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  });
 });

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -1142,7 +1142,12 @@ class ApiService {
   }
 
   async getWorkItems(): Promise<unknown[]> {
-    const response = await axios.get<ApiResponse<unknown[]>>(`${API_BASE}/task-pool/all`);
+    // Use `/items` (audit-shaped) not `/all` (claimable-only). The `/all`
+    // alias filters to queued+unclaimed, which hides done/blocked/running/
+    // cancelled WIs — breaking the WorkItems page and the Request detail
+    // execution timeline (where users need to see the full progress
+    // history, including completed and in-flight items).
+    const response = await axios.get<ApiResponse<unknown[]>>(`${API_BASE}/task-pool/items`);
     return response.data.data || [];
   }
 


### PR DESCRIPTION
## Summary

Three independent regressions that together broke the long-line outcome (*system runs entirely on requests/workitems, autonomous progression driven by these workitems*):

1. **Slack/chat ingress never classified intent** → every inbound user message defaulted to `L1+other`, auto-decompose subscriber filtered them out, Request closed via `orc_reply` SLA path with ZERO delegation WorkItems queued. Fixed at 4 boundaries (3 ingress call sites + service-layer backstop).

2. **WakeAction never propagated `teamId/memberId`** → reconciler hit fallback URL `/api/teams/members/start` which doesn't exist; route matched `:teamId="members"` `:memberId="start"` and returned 404 "Team not found". Hybrid-wake was a **silent fleet-wide no-op** for inactive team members.

3. **Request detail page Execution Timeline** only showed claimable WIs (`/api/task-pool/all` is queued+unclaimed-only) → completed/running/blocked items disappeared from the user-visible progress timeline. Switched to `/api/task-pool/items`.

## Test plan

- [x] Unit: `request.service.test.ts` 50/50 pass (3 new: pin / auto-classify / preserve-explicit)
- [x] Integration: `v3-pipeline-e2e.integration.test.ts` 4/4 pass (2 new scenarios: Slack-shape no-intent decompose+dispatch, explicit-intent precedence)
- [x] Manual e2e dogfood: Slack message `这两份设计可以让团队来安排做一下吗 • .crewly/specs/...md` landed as `L2+planning`, decomposed into 3 delegation WIs (Plan/Execute/Review), hybrid-wake spawned Sam (team-leader), AutoClaim dispatched. Verified by `[CREWLY-DISPATCH]` marker in worker terminal.

## Files

| File | Δ |
|---|---|
| `backend/src/services/slack/slack-orchestrator-bridge.ts` | +classifyIntent at ingress |
| `backend/src/controllers/chat/chat.controller.ts` | +classifyIntent at ingress |
| `backend/src/controllers/chat-v2/chat-v2.controller.ts` | +classifyIntent at ingress |
| `backend/src/services/v3/request.service.ts` | +service-layer auto-classify backstop |
| `backend/src/services/v3/request.service.test.ts` | +3 tests |
| `backend/src/services/reconciler/reconcile-rules.ts` | +teamId/memberId in WakeAction |
| `backend/src/tests/v3-pipeline-e2e.integration.test.ts` | +2 scenarios |
| `frontend/src/services/api.service.ts` | `/all` → `/items` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)