### PR TITLE
fix(skills): F-CYCLE7-4 — SKILL.md frontmatter restore + catalog regression test

### DIFF
--- a/backend/src/utils/skill-md-files.regression.test.ts
+++ b/backend/src/utils/skill-md-files.regression.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression test — every SKILL.md in `config/skills/**` must parse cleanly.
+ *
+ * Audit Cycle 7 (F-CYCLE7-4) found 7 SKILL.md files missing the YAML frontmatter
+ * delimiter, causing 120 `SkillCatalogService` load failures per day. The 7
+ * skills were callable via Bash but undiscoverable through the catalog,
+ * silently degrading any agent that lists by frontmatter.
+ *
+ * This regression scans the live `config/skills/**` tree and asserts:
+ *   1. Every SKILL.md file is parseable by `parseSkillMd` (delimiters present).
+ *   2. The frontmatter satisfies the catalog's minimum required field set
+ *      (`name`, `description`, `category`) — see
+ *      `skill-catalog.service.ts:loadSkillFromSkillMd` (lines ~610-636) for
+ *      the consuming code.
+ *
+ * Acts as the lightweight CI lint the audit recommended: any future SKILL.md
+ * added without frontmatter fails this test, surfacing the drift at PR time
+ * rather than at runtime via `[SkillCatalogService] Failed to load skill`
+ * log noise.
+ *
+ * Reference: .crewly/audit-reports/2026-05-07-audit-cycle7.md §2.4.
+ *
+ * @module utils/skill-md-files.regression.test
+ */
+
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { parseSkillMd } from './skill-md-parser.js';
+
+/**
+ * Glob `config/skills/**\/SKILL.md` from the repo root using `find`.
+ *
+ * Uses `find` instead of an npm glob lib to avoid adding a test-only
+ * dependency. Jest runs this file under ts-jest CommonJS, so `__dirname`
+ * is available; we walk up from `backend/src/utils` (3 levels) to repo root.
+ */
+function discoverSkillMdFiles(): string[] {
+  // backend/src/utils -> repo root (walk up 3 levels)
+  const repoRoot = path.resolve(__dirname, '../../..');
+  const skillsRoot = path.join(repoRoot, 'config', 'skills');
+
+  const out = execSync(`find "${skillsRoot}" -name SKILL.md -type f`, {
+    encoding: 'utf-8',
+  });
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+describe('SKILL.md frontmatter regression (F-CYCLE7-4)', () => {
+  const REQUIRED_FIELDS = ['name', 'description', 'category'] as const;
+
+  // Discover files at suite-load time so the suite-level describe carries
+  // the file count in the test name and per-file `it` blocks isolate failures.
+  const files = discoverSkillMdFiles();
+
+  it('should discover at least one SKILL.md file', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  describe.each(files)('%s', (filePath) => {
+    let content: string;
+    let parsed: ReturnType<typeof parseSkillMd> | null = null;
+    let parseError: Error | null = null;
+
+    beforeAll(() => {
+      content = readFileSync(filePath, 'utf-8');
+      try {
+        parsed = parseSkillMd(content);
+      } catch (e) {
+        parseError = e instanceof Error ? e : new Error(String(e));
+      }
+    });
+
+    it('parses without throwing (frontmatter delimiters present)', () => {
+      expect(parseError).toBeNull();
+      expect(parsed).not.toBeNull();
+    });
+
+    it('frontmatter satisfies catalog-required fields (name, description, category)', () => {
+      // Skip if upstream parse already failed — that test will report the real signal.
+      if (!parsed) return;
+      const fm = parsed.frontmatter;
+      const missing = REQUIRED_FIELDS.filter(
+        (field) => !fm[field] || typeof fm[field] !== 'string'
+      );
+      expect(missing).toEqual([]);
+    });
+  });
+});

--- a/config/skills/agent/core/cancel-followup/SKILL.md
+++ b/config/skills/agent/core/cancel-followup/SKILL.md
@@ -1,3 +1,21 @@
+---
+name: cancel-followup
+description: Cancel a follow-up trigger previously created with `schedule-followup` or `watch-for-event`, by trigger id or by team-scoped name.
+version: 1.0.0
+category: followup
+skillType: claude-skill
+tags:
+  - followup
+  - trigger
+  - lifecycle
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # cancel-followup
 
 Cancel a follow-up trigger you previously created with `schedule-followup` or

--- a/config/skills/agent/core/list-my-followups/SKILL.md
+++ b/config/skills/agent/core/list-my-followups/SKILL.md
@@ -1,3 +1,21 @@
+---
+name: list-my-followups
+description: List every follow-up trigger owned by your team — call before creating a new watcher to avoid duplicates, or when auditing why something keeps firing.
+version: 1.0.0
+category: followup
+skillType: claude-skill
+tags:
+  - followup
+  - trigger
+  - audit
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # list-my-followups
 
 List every follow-up trigger owned by your team. Call this **before** creating

--- a/config/skills/agent/core/reply-channel/SKILL.md
+++ b/config/skills/agent/core/reply-channel/SKILL.md
@@ -1,3 +1,22 @@
+---
+name: reply-channel
+description: Send an agent-authored message back to a chat channel — used by the chat MVP dispatch loop after processing a `[CHAT:<channelId>]` prompt.
+version: 1.0.0
+category: comm
+skillType: claude-skill
+tags:
+  - chat
+  - comm
+  - channel
+  - reply
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # reply-channel
 
 Send an agent-authored message back to a chat channel. Used by the chat MVP

--- a/config/skills/agent/core/schedule-followup/SKILL.md
+++ b/config/skills/agent/core/schedule-followup/SKILL.md
@@ -1,3 +1,22 @@
+---
+name: schedule-followup
+description: Schedule a future check-in that creates a WorkItem for you or another agent at a specific time (one-shot or bounded recurring).
+version: 1.0.0
+category: followup
+skillType: claude-skill
+tags:
+  - followup
+  - schedule
+  - cron
+  - workitem
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # schedule-followup
 
 Schedule a future check-in that creates a WorkItem for you or another agent.

--- a/config/skills/agent/core/watch-for-event/SKILL.md
+++ b/config/skills/agent/core/watch-for-event/SKILL.md
@@ -1,3 +1,22 @@
+---
+name: watch-for-event
+description: Subscribe to a system event (like agent:idle or task:completed) and create a WorkItem every time it fires — reactive follow-up, not time-based.
+version: 1.0.0
+category: followup
+skillType: claude-skill
+tags:
+  - followup
+  - event
+  - reactive
+  - workitem
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # watch-for-event
 
 Subscribe to a system event (like `agent:idle` or `task:completed`) and create

--- a/config/skills/agent/xhs-article-to-image/SKILL.md
+++ b/config/skills/agent/xhs-article-to-image/SKILL.md
@@ -1,3 +1,23 @@
+---
+name: xhs-article-to-image
+description: Convert markdown articles into XiaoHongShu (小红书) style portrait image cards (1080×1440 PNGs) for social distribution.
+version: 1.0.0
+category: content
+skillType: claude-skill
+tags:
+  - content
+  - image
+  - xhs
+  - marketing
+  - playwright
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 60000
+---
+
 # xhs-article-to-image
 
 Convert markdown articles into XiaoHongShu (小红书) style image cards.

--- a/config/skills/auditor/score-task/SKILL.md
+++ b/config/skills/auditor/score-task/SKILL.md
@@ -1,10 +1,25 @@
 ---
 name: Score Task
 description: "Score a completed task's quality (0-100) for tracking per-agent quality metrics."
+version: 1.0.0
+category: quality
+skillType: claude-skill
+assignableRoles:
+  - auditor
 triggers:
   - score task
   - quality score
   - rate task
+tags:
+  - quality
+  - audit
+  - metrics
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
 ---
 
 # Score Task

--- a/config/skills/orchestrator/cancel-all-schedules/SKILL.md
+++ b/config/skills/orchestrator/cancel-all-schedules/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: cancel-all-schedules
-description: Cancel all active scheduled checks. Optionally filter by session or age.
+description: Cancel all active scheduled checks, optionally filtered by session or age (nuclear cleanup).
+version: 1.0.0
+category: scheduling
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+tags:
+  - schedule
+  - cleanup
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
 ---
 
 # cancel-all-schedules

--- a/config/skills/orchestrator/list-schedules/SKILL.md
+++ b/config/skills/orchestrator/list-schedules/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: list-schedules
-description: List all active scheduled checks. Optionally filter by session name.
+description: List all active scheduled checks (one-time and recurring), optionally filtered by session name.
+version: 1.0.0
+category: scheduling
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+tags:
+  - schedule
+  - audit
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
 ---
 
 # list-schedules

--- a/config/skills/orchestrator/update-team-member/SKILL.md
+++ b/config/skills/orchestrator/update-team-member/SKILL.md
@@ -1,3 +1,23 @@
+---
+name: update-team-member
+description: Update a team member's properties — name, role, runtimeType, systemPrompt — via the team membership API.
+version: 1.0.0
+category: team
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+tags:
+  - team
+  - member
+  - admin
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
 # update-team-member
 
 Update a team member's properties including name, role, runtimeType, systemPrompt, and other attributes.


### PR DESCRIPTION
## Summary

Closes audit finding **F-CYCLE7-4** (P1) from `.crewly/audit-reports/2026-05-07-audit-cycle7.md` §2.4.

- **120 occurrences/day** of `[SkillCatalogService] Failed to load skill from SKILL.md — missing opening frontmatter delimiter (---)` eliminated.
- **10 SKILL.md files patched** (audit named 7; the new regression test surfaced **3 additional hidden cases** with valid delimiters but missing `category` field — same effective bug, different log line).
- **New regression test** (`backend/src/utils/skill-md-files.regression.test.ts`) scans all `config/skills/**/SKILL.md` and asserts each parses + carries `name` + `description` + `category` — acts as the lightweight CI lint the audit recommended.

## Files changed

**Skills patched (frontmatter restored or completed):**
- `config/skills/agent/core/cancel-followup/SKILL.md`
- `config/skills/agent/core/list-my-followups/SKILL.md`
- `config/skills/agent/core/reply-channel/SKILL.md`
- `config/skills/agent/core/schedule-followup/SKILL.md`
- `config/skills/agent/core/watch-for-event/SKILL.md`
- `config/skills/agent/xhs-article-to-image/SKILL.md`
- `config/skills/orchestrator/update-team-member/SKILL.md`
- `config/skills/orchestrator/list-schedules/SKILL.md` *(hidden — had delimiters, missing `category`)*
- `config/skills/orchestrator/cancel-all-schedules/SKILL.md` *(hidden — same)*
- `config/skills/auditor/score-task/SKILL.md` *(hidden — same)*

**New regression guard:**
- `backend/src/utils/skill-md-files.regression.test.ts` — globs `config/skills/**/SKILL.md`, parses each, asserts catalog-required fields present.

## Test plan

- [x] `npx jest --testPathPattern='skill-md-' --no-coverage` → **300/300 passing** (5 from existing parser tests + 295 SKILL.md regression assertions)
- [x] Manual verification: each of the 10 patched files starts with `---` and contains `name:` + `description:` + `category:` fields
- [x] Pre-merge replay validation steps (run from repo root after merge):
  ```bash
  npx jest --testPathPattern='skill-md-files.regression' --no-coverage
  # Expect: PASS, 295/295 tests, 0 failures
  ```
- [ ] Post-merge: tail `~/.crewly/logs/crewly-*.log` for 5 min — confirm `[SkillCatalogService] Failed to load skill from SKILL.md` count drops from ~120/day to 0

## Why the regression test catches more than the audit

The auditor sampled the production log for the explicit "missing opening frontmatter delimiter" string and found 7 distinct skill dirs. But `SkillCatalogService.loadSkillFromSkillMd` ALSO returns null when frontmatter is present-but-missing required fields — that path emits a DIFFERENT log line (`SKILL.md missing required fields`) and was not in the audit grep. The regression test covers both failure modes, so we close the documented 7 + 3 hidden tail in one PR.

## Decision rights exercised

- **Field set chosen**: `name + description + version + category + skillType + execution` (mirrors `recall/SKILL.md`); added `assignableRoles` where the skill is namespace-locked (orchestrator/auditor skills) and `tags` for catalog filtering.
- **Did not add CI hook** (audit suggested pre-commit lint). Embedded the equivalent guard as a unit test that runs in `npm test` — same protection, no new CI infrastructure.
- **Did not extend `parseSkillMd`** to enforce required fields (catalog's `loadSkillFromSkillMd` already does this) — the regression test covers consumer-side guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)