### PR TITLE
fix(reconciler): F-CYCLE7-3 — null-safety + queued→cancelled correction

### DIFF
--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -24,6 +24,7 @@ import {
 import type { AgentHealth } from './reconcile-rules.js';
 import { createWorkItem, createRequest, createTaskClaim } from '../../types/v2/index.js';
 import type { WorkItem, Request, TaskClaim } from '../../types/v2/index.js';
+import { WORK_ITEM_TRANSITIONS } from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -581,6 +582,55 @@ describe('detectStaleQueuedWorkItems', () => {
     });
     const { staleIds } = detectStaleQueuedWorkItems([running], 60 * 60 * 1000);
     expect(staleIds).toHaveLength(0);
+  });
+
+  // F-CYCLE7-3 (2026-05-07) — regression: emitted correction MUST be a
+  // canonical valid transition. Prior behavior emitted queued→queued
+  // which StorageService rejected with "Invalid status transition:
+  // queued → queued", generating reconciler-error noise that hid real
+  // signal. Per WORK_ITEM_TRANSITIONS in work-item.types.ts, queued can
+  // legally transition to: running, proposed, scheduled, cancelled.
+  // 'expired' is not a valid WorkItemStatus.
+  describe('F-CYCLE7-3: queued→queued correction fix', () => {
+    it('emits queued→cancelled (NOT queued→queued) for stale-queued WorkItems', () => {
+      const stale = makeWorkItem({
+        status: 'queued',
+        createdAt: new Date(Date.now() - 16 * 3600 * 1000).toISOString(), // 16h ago, like the 945min real-world case
+      });
+
+      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+
+      expect(corrections).toHaveLength(1);
+      expect(corrections[0].previousState).toBe('queued');
+      expect(corrections[0].newState).toBe('cancelled');
+      expect(corrections[0].newState).not.toBe('queued');
+    });
+
+    it('emitted newState is a valid transition target per canonical WORK_ITEM_TRANSITIONS', () => {
+      const stale = makeWorkItem({
+        status: 'queued',
+        createdAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
+      });
+
+      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+
+      expect(corrections).toHaveLength(1);
+      const validNextStates = WORK_ITEM_TRANSITIONS['queued'];
+      expect(validNextStates.has(corrections[0].newState as any)).toBe(true);
+      // Specifically NOT a same-state self-loop.
+      expect(corrections[0].newState).not.toBe(corrections[0].previousState);
+    });
+
+    it('reason field still preserves the queue-wait audit info', () => {
+      const stale = makeWorkItem({
+        status: 'queued',
+        createdAt: new Date(Date.now() - 945 * 60 * 1000).toISOString(), // 945min — exact prod scenario
+      });
+
+      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+
+      expect(corrections[0].reason).toMatch(/queued for \d+ minutes without pickup/);
+    });
   });
 });
 

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -497,9 +497,28 @@ export function cascadeCancelChildren(
  * Detects WorkItems that have been in 'queued' status for too long
  * without being picked up. These may indicate assignment problems.
  *
+ * **F-CYCLE7-3 fix (2026-05-07):** Previously emitted `queued → queued`
+ * which is *not* a valid transition per the canonical
+ * {@link WORK_ITEM_TRANSITIONS} table — every emitted correction was
+ * rejected by `StorageService` with `Invalid status transition: queued →
+ * queued`, generating reconciler-error noise that hid real signal. The
+ * comment "Don't change status, just flag for audit" assumed an
+ * audit-only path that doesn't exist: `applyCorrection()` always calls
+ * `pool.updateItemStatus()` which validates against the transition
+ * table.
+ *
+ * **Canonical state machine** (`backend/src/types/v2/work-item.types.ts`):
+ *   `queued` → one of `{ running, proposed, scheduled, cancelled }`.
+ *
+ * `'expired'` is *not* a valid `WorkItemStatus` (see `WORK_ITEM_STATUSES`),
+ * despite earlier reconciler briefs occasionally suggesting it. Of the
+ * canonical options, `cancelled` is the only terminal status reachable
+ * from `queued`, and is the correct semantic for "queued > threshold,
+ * never picked up — work was abandoned."
+ *
  * @param workItems - All WorkItems to check
  * @param staleThresholdMs - How long in queued before considered stale (default: 1h)
- * @returns Corrections for stale queued WorkItems
+ * @returns Corrections for stale queued WorkItems (transition: queued → cancelled)
  */
 export function detectStaleQueuedWorkItems(
   workItems: WorkItem[],
@@ -520,7 +539,9 @@ export function detectStaleQueuedWorkItems(
         entityType: 'work_item',
         entityId: wi.id,
         previousState: 'queued',
-        newState: 'queued', // Don't change status, just flag for audit
+        // queued → cancelled is the canonical valid transition for an
+        // abandoned-in-queue WorkItem. See WORK_ITEM_TRANSITIONS.
+        newState: 'cancelled',
         reason: `WorkItem has been queued for ${Math.round(waitTime / 60000)} minutes without pickup`,
         evidence: `Created at ${wi.createdAt}, waiting for ${Math.round(waitTime / 60000)}m (threshold: ${Math.round(staleThresholdMs / 60000)}m)`,
       }));

--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -181,6 +181,65 @@ describe('LiveReconcilerDataProvider', () => {
       expect(result).toEqual(claims);
       expect(mockPool.getActiveClaims).toHaveBeenCalledTimes(1);
     });
+
+    // F-CYCLE7-3 (2026-05-07) — post-restart hydration safety.
+    // Reproduces the prod 11:19→11:21Z error storm: when storage was
+    // not yet hydrated, the inner pool method threw "Cannot read
+    // properties of undefined (reading 'filter')" every 10s.
+    describe('F-CYCLE7-3: post-restart null-safety', () => {
+      it('returns [] without throwing when pool returns undefined (pre-hydration)', async () => {
+        mockPool.getActiveClaims.mockResolvedValue(undefined as any);
+
+        const result = await provider.getActiveClaims();
+
+        expect(result).toEqual([]);
+      });
+
+      it('returns [] without throwing when pool returns null', async () => {
+        mockPool.getActiveClaims.mockResolvedValue(null as any);
+
+        const result = await provider.getActiveClaims();
+
+        expect(result).toEqual([]);
+      });
+
+      it('returns [] when pool throws TypeError("Cannot read properties of undefined (reading filter)")', async () => {
+        // Exact V8 error shape from the prod log storm.
+        mockPool.getActiveClaims.mockRejectedValue(
+          new TypeError("Cannot read properties of undefined (reading 'filter')"),
+        );
+
+        const result = await provider.getActiveClaims();
+
+        expect(result).toEqual([]);
+      });
+
+      it('demotes storage-not-ready error to debug log (no error log)', async () => {
+        // Capture the logger this provider was given.
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+        const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+        mockPool.getActiveClaims.mockRejectedValue(
+          new TypeError("Cannot read properties of undefined (reading 'filter')"),
+        );
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+      });
+
+      it('still logs at error level for genuine failures (non-hydration errors)', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getActiveClaims.mockRejectedValue(new Error('Database connection refused'));
+
+        const result = await provider.getActiveClaims();
+
+        expect(result).toEqual([]);
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -343,6 +402,51 @@ describe('LiveReconcilerDataProvider', () => {
       const result = await provider.getAvailablePoolItems();
 
       expect(result).toEqual(items);
+    });
+
+    // F-CYCLE7-3 (2026-05-07) — post-restart hydration safety.
+    describe('F-CYCLE7-3: post-restart null-safety', () => {
+      it('returns [] without throwing when pool returns undefined', async () => {
+        mockPool.getAvailableItems.mockResolvedValue(undefined as any);
+
+        const result = await provider.getAvailablePoolItems();
+
+        expect(result).toEqual([]);
+      });
+
+      it('returns [] when pool throws "Cannot read properties of undefined (reading filter)"', async () => {
+        mockPool.getAvailableItems.mockRejectedValue(
+          new TypeError("Cannot read properties of undefined (reading 'filter')"),
+        );
+
+        const result = await provider.getAvailablePoolItems();
+
+        expect(result).toEqual([]);
+      });
+
+      it('demotes storage-not-ready error to debug log', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+        const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+        mockPool.getAvailableItems.mockRejectedValue(
+          new TypeError("Cannot read properties of undefined (reading 'filter')"),
+        );
+
+        await provider.getAvailablePoolItems();
+
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+      });
+
+      it('still logs error for genuine failures', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getAvailableItems.mockRejectedValue(new Error('Disk full'));
+
+        await provider.getAvailablePoolItems();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
     });
   });
 

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -37,6 +37,41 @@ import { isUnderMemoryPressure, getMemoryStats } from '../core/system-health.uti
 /** How long an agent can be unseen before we consider it stale (5 min). */
 const AGENT_STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
+/**
+ * Heuristic: detect "storage not yet hydrated" errors so the data
+ * provider can demote them from `error` to `debug` log level.
+ *
+ * Symptom in production (F-CYCLE7-3, 2026-05-07 11:19→11:21Z): when
+ * the Reconciler's 10s fast-loop runs before the Task Pool's
+ * `pool.json` finishes loading after a SQLite-related restart, an
+ * inner method calls `.filter()` on a still-undefined array slot. The
+ * thrown TypeError carries the canonical V8 message
+ * "Cannot read properties of undefined (reading 'filter')". The catch
+ * already returns `[]`, but it logs at `error` — every 10s for ~110s
+ * — flooding logs and hiding real errors.
+ *
+ * This helper recognizes that specific TypeError shape so we can
+ * silence it (debug log + empty array) without accidentally silencing
+ * unrelated errors. Any error not matched here is still logged as
+ * `error`.
+ */
+function isStorageNotReadyError(message: string): boolean {
+  // V8 / Node throws this exact message on `undefined.filter()` /
+  // `undefined.find()` etc. Match defensively on the readonly bits
+  // ("Cannot read prop" + "of undefined") to be tolerant of small
+  // engine-version wording variations.
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('cannot read') &&
+    lower.includes('of undefined') &&
+    (lower.includes("'filter'") ||
+      lower.includes("'find'") ||
+      lower.includes("'map'") ||
+      lower.includes("'foreach'") ||
+      lower.includes("'length'"))
+  );
+}
+
 // ---------------------------------------------------------------------------
 // LiveReconcilerDataProvider
 // ---------------------------------------------------------------------------
@@ -133,16 +168,38 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
   /**
    * Returns all active/expiring TaskClaims.
    *
-   * @returns Active claims
+   * **F-CYCLE7-3 (2026-05-07):** Returns `[]` defensively if the pool
+   * returns a non-array (e.g. partial post-restart hydration where
+   * `pool.json` is missing the `claims` field). Storage-not-ready is
+   * logged at `debug`, not `error`, to avoid the post-restart error
+   * storm seen at 11:19→11:21Z. Genuine failures (thrown errors) keep
+   * their `error`-level log.
+   *
+   * @returns Active claims (always an array)
    */
   async getActiveClaims(): Promise<TaskClaim[]> {
     try {
       const pool = TaskPoolService.getInstance();
-      return await pool.getActiveClaims();
+      const claims = await pool.getActiveClaims();
+      if (!Array.isArray(claims)) {
+        this.logger.debug('Active claims unavailable (storage not yet hydrated)', {
+          received: typeof claims,
+        });
+        return [];
+      }
+      return claims;
     } catch (error) {
-      this.logger.error('Failed to get active claims', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const msg = error instanceof Error ? error.message : String(error);
+      // Storage-not-ready manifests as ".filter() on undefined" during
+      // the post-restart hydration window. Demote to debug so it
+      // doesn't drown out real errors in the log stream.
+      if (isStorageNotReadyError(msg)) {
+        this.logger.debug('Active claims unavailable (storage not yet hydrated)', {
+          error: msg,
+        });
+        return [];
+      }
+      this.logger.error('Failed to get active claims', { error: msg });
       return [];
     }
   }
@@ -324,16 +381,34 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
    * Returns all available (queued, unclaimed) WorkItems from the Task Pool.
    * Used by Hybrid Wake to find items that need agents.
    *
-   * @returns Available pool items
+   * **F-CYCLE7-3 (2026-05-07):** Returns `[]` defensively if the pool
+   * returns a non-array (e.g. partial post-restart hydration where
+   * `pool.json` is missing the `workItems` field). Storage-not-ready is
+   * logged at `debug`, not `error`, to avoid the post-restart error
+   * storm seen at 11:19→11:21Z.
+   *
+   * @returns Available pool items (always an array)
    */
   async getAvailablePoolItems(): Promise<WorkItem[]> {
     try {
       const pool = TaskPoolService.getInstance();
-      return await pool.getAvailableItems();
+      const items = await pool.getAvailableItems();
+      if (!Array.isArray(items)) {
+        this.logger.debug('Available pool items unavailable (storage not yet hydrated)', {
+          received: typeof items,
+        });
+        return [];
+      }
+      return items;
     } catch (error) {
-      this.logger.error('Failed to get available pool items', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const msg = error instanceof Error ? error.message : String(error);
+      if (isStorageNotReadyError(msg)) {
+        this.logger.debug('Available pool items unavailable (storage not yet hydrated)', {
+          error: msg,
+        });
+        return [];
+      }
+      this.logger.error('Failed to get available pool items', { error: msg });
       return [];
     }
   }

--- a/backend/src/services/task-pool/pool-storage.test.ts
+++ b/backend/src/services/task-pool/pool-storage.test.ts
@@ -97,6 +97,71 @@ describe('PoolStorage', () => {
       const d2 = await storage.load();
       expect(d1).toBe(d2);
     });
+
+    // F-CYCLE7-3 (2026-05-07) — defensive normalization. A partial /
+    // pre-migration on-disk shape (missing one or both arrays) caused
+    // ".filter() on undefined" downstream in ReconcilerDataProvider.
+    // load() now coerces missing arrays to [] once, so every consumer
+    // can rely on the PoolData invariant.
+    describe('F-CYCLE7-3: partial on-disk shape normalization', () => {
+      it('normalizes missing workItems field to []', async () => {
+        const filePath = path.join(tempDir, 'pool.json');
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({ claims: [], lastUpdatedAt: new Date().toISOString() }),
+        );
+
+        const fresh = new PoolStorage({ dataDir: tempDir });
+        const data = await fresh.load();
+
+        expect(data.workItems).toEqual([]);
+        expect(Array.isArray(data.workItems)).toBe(true);
+        await fresh.destroy();
+      });
+
+      it('normalizes missing claims field to []', async () => {
+        const filePath = path.join(tempDir, 'pool.json');
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({ workItems: [], lastUpdatedAt: new Date().toISOString() }),
+        );
+
+        const fresh = new PoolStorage({ dataDir: tempDir });
+        const data = await fresh.load();
+
+        expect(data.claims).toEqual([]);
+        expect(Array.isArray(data.claims)).toBe(true);
+        await fresh.destroy();
+      });
+
+      it('normalizes both fields when on-disk shape is just `{}`', async () => {
+        const filePath = path.join(tempDir, 'pool.json');
+        await fs.writeFile(filePath, JSON.stringify({}));
+
+        const fresh = new PoolStorage({ dataDir: tempDir });
+        const data = await fresh.load();
+
+        expect(data.workItems).toEqual([]);
+        expect(data.claims).toEqual([]);
+        await fresh.destroy();
+      });
+
+      it('getWorkItems() / getClaims() never return undefined even on partial shape', async () => {
+        const filePath = path.join(tempDir, 'pool.json');
+        await fs.writeFile(filePath, JSON.stringify({ lastUpdatedAt: 'x' }));
+
+        const fresh = new PoolStorage({ dataDir: tempDir });
+        // The downstream regression: .filter() on whatever this returns.
+        const items = await fresh.getWorkItems();
+        const claims = await fresh.getClaims();
+
+        expect(() => items.filter(() => true)).not.toThrow();
+        expect(() => claims.filter(() => true)).not.toThrow();
+        expect(items).toEqual([]);
+        expect(claims).toEqual([]);
+        await fresh.destroy();
+      });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/backend/src/services/task-pool/pool-storage.ts
+++ b/backend/src/services/task-pool/pool-storage.ts
@@ -97,39 +97,62 @@ export class PoolStorage {
   /**
    * Loads pool data from disk (or returns cached copy).
    *
-   * @returns Current pool data
+   * **F-CYCLE7-3 (2026-05-07):** Normalizes legacy / partial on-disk
+   * shapes — if a previous write produced a `pool.json` missing the
+   * `workItems` or `claims` arrays (root cause of the post-restart
+   * `Cannot read properties of undefined (reading 'filter')` storm in
+   * `ReconcilerDataProvider`), we coerce the missing slots to `[]`
+   * before caching so every downstream consumer can rely on the
+   * `PoolData` invariant.
+   *
+   * @returns Current pool data with `workItems` and `claims` guaranteed to be arrays
    */
   async load(): Promise<PoolData> {
     if (this.cache) return this.cache;
 
     await ensureDir(path.dirname(this.filePath));
-    const data = await safeReadJson<PoolData>(
+    const raw = await safeReadJson<PoolData>(
       this.filePath,
       createEmptyPoolData(),
       this.logger,
     );
-    this.cache = data;
-    return data;
+    // Defensive normalization. `safeReadJson` round-trips whatever
+    // shape is on disk, so a partial / pre-migration file can produce
+    // `data.workItems === undefined`. Repair to canonical shape once,
+    // here, instead of every read site.
+    const normalized: PoolData = {
+      workItems: Array.isArray(raw?.workItems) ? raw.workItems : [],
+      claims: Array.isArray(raw?.claims) ? raw.claims : [],
+      lastUpdatedAt: raw?.lastUpdatedAt ?? new Date(0).toISOString(),
+    };
+    this.cache = normalized;
+    return normalized;
   }
 
   /**
    * Returns all work items currently in the pool.
    *
+   * Always returns an array — `load()` normalizes a missing
+   * `workItems` field to `[]` (F-CYCLE7-3).
+   *
    * @returns Array of WorkItems
    */
   async getWorkItems(): Promise<WorkItem[]> {
     const data = await this.load();
-    return data.workItems;
+    return data.workItems ?? [];
   }
 
   /**
    * Returns all claims.
    *
+   * Always returns an array — `load()` normalizes a missing `claims`
+   * field to `[]` (F-CYCLE7-3).
+   *
    * @returns Array of TaskClaims
    */
   async getClaims(): Promise<TaskClaim[]> {
     const data = await this.load();
-    return data.claims;
+    return data.claims ?? [];
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes two related reconciler-noise bugs from the cycle-7 audit (§2.3):

1. **Post-restart `.filter()`-on-undefined error storm** (11:19→11:21Z today, ~110s, every ~10s)
   - `ReconcilerDataProvider.getActiveClaims()` / `.getAvailablePoolItems()` threw `Cannot read properties of undefined (reading 'filter')` when storage was not yet hydrated after the SQLite-related restart.
2. **`queued → queued` correction storm** (02:03Z, 9+ rejected corrections)
   - `detectStaleQueuedWorkItems` emitted same-state self-loop transitions; `StorageService` correctly rejected each with "Invalid status transition: queued → queued" — but the noise hid real signal.

## Fix Shape — Defense in Depth

### Bug 1: null-safety
- **Root cause** (`backend/src/services/task-pool/pool-storage.ts`): `load()` now normalizes a partial on-disk shape (missing `workItems` or `claims` arrays) to canonical `[]` once at the cache boundary, so every consumer can rely on the `PoolData` invariant.
- **Boundary defense** (`backend/src/services/reconciler/reconciler-data-provider.ts`): A new `isStorageNotReadyError()` helper classifies the V8 TypeError (`"Cannot read properties of undefined (reading 'filter'/'find'/'map'/...)"`) as storage-not-ready and demotes it from `error` → `debug` log. Genuine errors (`Database connection refused`, etc.) still log at `error`.

### Bug 2: invalid transition
- **Canonical reference**: `backend/src/types/v2/work-item.types.ts` `WORK_ITEM_TRANSITIONS` — `queued` legally goes to `{ running, proposed, scheduled, cancelled }`.
- **Brief vs. canonical divergence (documented per discipline rule)**: brief suggested `expired` *or* `cancelled`; `'expired'` is **not** a valid `WorkItemStatus` per `WORK_ITEM_STATUSES`. Canonical wins. Of the legal transitions, `cancelled` is the only terminal state and is the correct semantic for "queued > threshold, never picked up — abandoned." The 945-minute prod scenario fits this exactly.
- Fix in correction generator (`detectStaleQueuedWorkItems`), **not** in `StorageService` transition table — preserves transition validation as the trustworthy gate.

## Test plan

- [x] `backend/src/services/reconciler/reconcile-rules.test.ts` — **74 passing** (+3 new under `F-CYCLE7-3: queued→queued correction fix`):
  - emits `queued→cancelled` (not `queued→queued`)
  - newState is a valid transition target per canonical `WORK_ITEM_TRANSITIONS`
  - reason field still preserves audit info
- [x] `backend/src/services/reconciler/reconciler-data-provider.test.ts` — **29 passing** (+8 new under `F-CYCLE7-3: post-restart null-safety` for both `getActiveClaims` and `getAvailablePoolItems`):
  - `[]` when pool returns `undefined` / `null`
  - `[]` + debug-log (not error) when pool throws the V8 TypeError shape
  - error-level log preserved for genuine failures
- [x] `backend/src/services/task-pool/pool-storage.test.ts` — **23 passing** (+4 new under `F-CYCLE7-3: partial on-disk shape normalization`):
  - missing `workItems` / `claims` / both fields all coerce to `[]`
  - `getWorkItems()` / `getClaims()` never return undefined
- [x] Full `reconciler` suite: **3 files / 137 tests passing**
- [x] Full `task-pool` suite: **3 files / 172 tests passing**
- [x] tsc on changed files: clean

## Post-merge replay validation (one-command)

```bash
node /tmp/replay-validation-cycle7-3.mjs
```

Asserts source-shape invariants: classifier present, hydration errors demoted to `debug`, queued→cancelled in correction generator, no surviving `queued→queued` anti-pattern, pool-storage normalizes missing arrays. Result on this branch: **7/7 ✓**.

For runtime smoke against a live instance, grep for the symptom in the next 5 min of logs:

```bash
grep -E "Cannot read properties of undefined.*reading.*filter|Invalid status transition: queued → queued" \
  ~/.crewly/logs/crewly-$(date +%Y-%m-%d).log | tail -50
```

Expected post-merge: zero matches in the 5-minute window after restart.

Reference: `.crewly/audit-reports/2026-05-07-audit-cycle7.md` §2.3 (lines 134-153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)