### PR TITLE
fix(reconciler): F-CYCLE7-3-FU — structural classifier + cancelled-event subscriber audit

### DIFF
--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -240,6 +240,142 @@ describe('LiveReconcilerDataProvider', () => {
         expect(errorSpy).toHaveBeenCalled();
       });
     });
+
+    // F-CYCLE7-3-FU (2026-05-07) — structural-shape coverage.
+    //
+    // The original classifier whitelisted method names
+    // (`filter|find|map|forEach|length`); a future consumer reaching
+    // for `.some()` / `.every()` / `.reduce()` / `.includes()` /
+    // `.indexOf()` / `.slice()` would re-introduce the noise pattern
+    // because its V8 shape would not match. The structural classifier
+    // (instanceof TypeError + "cannot read … of undefined") covers
+    // every method/property access on `undefined` in one rule and
+    // future-proofs the demotion against consumer drift.
+    describe('F-CYCLE7-3-FU: structural classifier (post-whitelist)', () => {
+      // Methods that adjacent reconciler code reaches for today + the
+      // ones likely to land via future audits. Each must be DEMOTED to
+      // debug, not logged at error.
+      const v8MethodShapes = [
+        "Cannot read properties of undefined (reading 'filter')",
+        "Cannot read properties of undefined (reading 'find')",
+        "Cannot read properties of undefined (reading 'map')",
+        "Cannot read properties of undefined (reading 'forEach')",
+        "Cannot read properties of undefined (reading 'length')",
+        "Cannot read properties of undefined (reading 'some')",
+        "Cannot read properties of undefined (reading 'every')",
+        "Cannot read properties of undefined (reading 'reduce')",
+        "Cannot read properties of undefined (reading 'includes')",
+        "Cannot read properties of undefined (reading 'indexOf')",
+        "Cannot read properties of undefined (reading 'slice')",
+        "Cannot read properties of undefined (reading 'flat')",
+        // Property access (no method call), e.g. `claims.id` on an
+        // undefined slot — same V8 shape, no enclosing parens needed.
+        "Cannot read properties of undefined (reading 'id')",
+        "Cannot read properties of undefined (reading 'status')",
+      ];
+
+      for (const shape of v8MethodShapes) {
+        it(`demotes to debug: ${shape}`, async () => {
+          const errorSpy = jest.spyOn((provider as any).logger, 'error');
+          const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+          mockPool.getActiveClaims.mockRejectedValue(new TypeError(shape));
+
+          const result = await provider.getActiveClaims();
+
+          expect(result).toEqual([]);
+          expect(errorSpy).not.toHaveBeenCalled();
+          expect(debugSpy).toHaveBeenCalled();
+        });
+      }
+
+      it('matches the older Node V8 shape ("Cannot read property X of undefined")', async () => {
+        // Node ≤ 14 emits the singular "property" form. The classifier
+        // must accept both the modern "properties of undefined (reading
+        // X)" and the older "property 'X' of undefined" — both share
+        // the readonly anchors `cannot read` + `of undefined`.
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+        const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+        mockPool.getActiveClaims.mockRejectedValue(
+          new TypeError("Cannot read property 'filter' of undefined"),
+        );
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+      });
+
+      // ---------------------- Negative cases -------------------------
+      // The classifier MUST NOT silence genuine bugs. Each of the
+      // following is a different bug class from hydration-not-ready
+      // and deserves its `error`-level log.
+
+      it('does NOT silence "Cannot read properties of NULL" (different bug class)', async () => {
+        // null != undefined in V8 error messages. A null pointer is a
+        // "we lost a reference" bug, not "storage warming up".
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+        const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+        mockPool.getActiveClaims.mockRejectedValue(
+          new TypeError("Cannot read properties of null (reading 'filter')"),
+        );
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).toHaveBeenCalled();
+        expect(debugSpy).not.toHaveBeenCalled();
+      });
+
+      it('does NOT silence "X is not a function" TypeErrors (missing API, not hydration)', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getActiveClaims.mockRejectedValue(
+          new TypeError("pool.someUnknownMethod is not a function"),
+        );
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      it('does NOT silence non-TypeError throws even if the message matches', async () => {
+        // The instanceof TypeError narrow guards against accidental
+        // matches by message-content alone (e.g. an Error subclass
+        // whose author included the V8 phrase verbatim in a wrapper).
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getActiveClaims.mockRejectedValue(
+          new Error("Cannot read properties of undefined (reading 'filter')"),
+        );
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      it('does NOT silence "Database connection refused" or other genuine downstream failures', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getActiveClaims.mockRejectedValue(new Error('Database connection refused'));
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
+
+      it('does NOT silence non-Error throws (string thrown, etc.)', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        mockPool.getActiveClaims.mockRejectedValue('string-thrown' as any);
+
+        await provider.getActiveClaims();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -442,6 +578,43 @@ describe('LiveReconcilerDataProvider', () => {
         const errorSpy = jest.spyOn((provider as any).logger, 'error');
 
         mockPool.getAvailableItems.mockRejectedValue(new Error('Disk full'));
+
+        await provider.getAvailablePoolItems();
+
+        expect(errorSpy).toHaveBeenCalled();
+      });
+    });
+
+    // F-CYCLE7-3-FU (2026-05-07) — confirm both call sites
+    // (`getActiveClaims` and `getAvailablePoolItems`) share the same
+    // structural classifier behavior. Smaller smoke than the
+    // exhaustive block on getActiveClaims, just verifying the second
+    // call site doesn't drift.
+    describe('F-CYCLE7-3-FU: structural classifier (post-whitelist) — second call site', () => {
+      it.each([
+        ["Cannot read properties of undefined (reading 'some')"],
+        ["Cannot read properties of undefined (reading 'reduce')"],
+        ["Cannot read properties of undefined (reading 'indexOf')"],
+        ["Cannot read property 'filter' of undefined"], // older V8 shape
+      ])('demotes %s to debug', async (shape: string) => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+        const debugSpy = jest.spyOn((provider as any).logger, 'debug');
+
+        mockPool.getAvailableItems.mockRejectedValue(new TypeError(shape));
+
+        const result = await provider.getAvailablePoolItems();
+
+        expect(result).toEqual([]);
+        expect(errorSpy).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+      });
+
+      it('does NOT silence "Cannot read properties of null" on second call site', async () => {
+        const errorSpy = jest.spyOn((provider as any).logger, 'error');
+
+        mockPool.getAvailableItems.mockRejectedValue(
+          new TypeError("Cannot read properties of null (reading 'filter')"),
+        );
 
         await provider.getAvailablePoolItems();
 

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -50,26 +50,51 @@ const AGENT_STALE_THRESHOLD_MS = 5 * 60 * 1000;
  * already returns `[]`, but it logs at `error` — every 10s for ~110s
  * — flooding logs and hiding real errors.
  *
- * This helper recognizes that specific TypeError shape so we can
- * silence it (debug log + empty array) without accidentally silencing
- * unrelated errors. Any error not matched here is still logged as
- * `error`.
+ * **F-CYCLE7-3-FU (2026-05-07, PR review #511 follow-up):** The original
+ * implementation enumerated `'filter'|'find'|'map'|'forEach'|'length'`
+ * in the message. That whitelist was brittle — adjacent reconciler /
+ * future-consumer code reaches for `.some()` / `.every()` / `.reduce()` /
+ * `.includes()` / `.indexOf()` / `.slice()` / property accesses that
+ * throw the SAME V8 TypeError shape during the same hydration window
+ * but are silently dropped from this classifier, re-introducing the
+ * noise pattern this PR is trying to silence.
+ *
+ * The fix mirrors the discipline used in
+ * `backend/src/utils/native-binding.utils.ts#isNativeArchMismatchError`
+ * (F-CYCLE7-1): match the **structural** error shape, not enumerated
+ * call sites.
+ *
+ * Contract:
+ *   1. Must be a real `TypeError` (not just any thrown value with a
+ *      matching string — that narrows the false-positive surface).
+ *   2. Message must carry both readonly anchors of the V8 shape:
+ *      `"Cannot read"` AND `"of undefined"`. The middle (`property` /
+ *      `properties of undefined (reading 'X')` / older `property 'X'
+ *      of undefined`) varies between Node versions; we don't anchor
+ *      on it.
+ *
+ * Negative cases this MUST reject (all tested):
+ *   - `Cannot read properties of null (reading 'filter')` — a null
+ *     pointer is a different bug class from hydration-not-ready.
+ *   - `TypeError: foo is not a function` — symptom of a missing API.
+ *   - Non-TypeError throws (`new Error('Cannot read … of undefined')`)
+ *     — strings can match by accident; the type narrow guards.
+ *   - `'Database connection refused'` — genuine downstream failure.
+ *
+ * @param error - The thrown value to classify. Anything not a
+ *   TypeError fails immediately, so callers can pass `error: unknown`
+ *   without pre-checks.
+ * @returns True iff the error is the V8 hydration-not-ready shape.
  */
-function isStorageNotReadyError(message: string): boolean {
-  // V8 / Node throws this exact message on `undefined.filter()` /
-  // `undefined.find()` etc. Match defensively on the readonly bits
-  // ("Cannot read prop" + "of undefined") to be tolerant of small
-  // engine-version wording variations.
-  const lower = message.toLowerCase();
-  return (
-    lower.includes('cannot read') &&
-    lower.includes('of undefined') &&
-    (lower.includes("'filter'") ||
-      lower.includes("'find'") ||
-      lower.includes("'map'") ||
-      lower.includes("'foreach'") ||
-      lower.includes("'length'"))
-  );
+function isStorageNotReadyError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
+  const lower = error.message.toLowerCase();
+  // The two readonly anchors of the V8 / Node error shape, present
+  // across all engine versions and all property/method accesses on
+  // an undefined value:
+  //   modern V8: "Cannot read properties of undefined (reading 'X')"
+  //   older V8:  "Cannot read property 'X' of undefined"
+  return lower.includes('cannot read') && lower.includes('of undefined');
 }
 
 // ---------------------------------------------------------------------------
@@ -189,16 +214,18 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
       }
       return claims;
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      // Storage-not-ready manifests as ".filter() on undefined" during
-      // the post-restart hydration window. Demote to debug so it
-      // doesn't drown out real errors in the log stream.
-      if (isStorageNotReadyError(msg)) {
+      // Storage-not-ready manifests as ".filter() / .some() / etc. on
+      // undefined" during the post-restart hydration window. The
+      // classifier checks `instanceof TypeError` + the V8 message
+      // shape — see the doc-comment on `isStorageNotReadyError` for
+      // why we no longer enumerate method names.
+      if (isStorageNotReadyError(error)) {
         this.logger.debug('Active claims unavailable (storage not yet hydrated)', {
-          error: msg,
+          error: (error as Error).message,
         });
         return [];
       }
+      const msg = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to get active claims', { error: msg });
       return [];
     }
@@ -401,13 +428,13 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
       }
       return items;
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (isStorageNotReadyError(msg)) {
+      if (isStorageNotReadyError(error)) {
         this.logger.debug('Available pool items unavailable (storage not yet hydrated)', {
-          error: msg,
+          error: (error as Error).message,
         });
         return [];
       }
+      const msg = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to get available pool items', { error: msg });
       return [];
     }

--- a/scripts/replay-cycle7-3-fu.mjs
+++ b/scripts/replay-cycle7-3-fu.mjs
@@ -1,0 +1,96 @@
+/**
+ * F-CYCLE7-3-FU replay validation.
+ *
+ * Source-shape invariants asserted on the merged tree:
+ *   1. `isStorageNotReadyError` is now an `instanceof TypeError` +
+ *      structural-message classifier — NOT an enumerated method
+ *      whitelist. Specifically the source must NOT contain the
+ *      whitelist tokens `'filter'|'find'|'map'|'forEach'|'length'`
+ *      anymore (those were the brittle list).
+ *   2. The classifier signature accepts `error: unknown` (post-fix),
+ *      not `message: string` (pre-fix).
+ *   3. The two call sites in `getActiveClaims` /
+ *      `getAvailablePoolItems` pass the error itself (not a
+ *      pre-extracted `msg` string) into the classifier.
+ *
+ * Pass condition: exits 0 with `[replay] PASS`.
+ *
+ * Usage (from repo root, post-merge):
+ *   node scripts/replay-cycle7-3-fu.mjs
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const sourcePath = resolve(
+	here,
+	'..',
+	'backend',
+	'src',
+	'services',
+	'reconciler',
+	'reconciler-data-provider.ts',
+);
+const src = readFileSync(sourcePath, 'utf-8');
+
+let failures = 0;
+function assert(condition, label, detail) {
+	const status = condition ? 'PASS' : 'FAIL';
+	if (!condition) failures += 1;
+	console.log(`[replay] ${status} — ${label}${detail ? ` (${detail})` : ''}`);
+}
+
+// 1. Structural classifier present.
+assert(
+	/function\s+isStorageNotReadyError\s*\(\s*error:\s*unknown\s*\)/.test(src),
+	'isStorageNotReadyError accepts `error: unknown`',
+);
+
+// 2. instanceof TypeError narrow present.
+assert(
+	/error\s+instanceof\s+TypeError/.test(src),
+	'classifier narrows on `error instanceof TypeError`',
+);
+
+// 3. Structural anchors present (cannot read + of undefined).
+assert(
+	src.includes("'cannot read'") && src.includes("'of undefined'"),
+	'classifier checks both readonly V8 anchors',
+);
+
+// 4. Whitelist tokens GONE. Each test searches for the previous
+//    `lower.includes("'filter'")`-style whitelist line; any match
+//    means the brittle whitelist regressed back in.
+const oldWhitelistPatterns = [
+	/lower\.includes\(\s*"'filter'"\s*\)/,
+	/lower\.includes\(\s*"'find'"\s*\)/,
+	/lower\.includes\(\s*"'map'"\s*\)/,
+	/lower\.includes\(\s*"'forEach'"\s*\)/,
+	/lower\.includes\(\s*"'length'"\s*\)/,
+];
+for (const pat of oldWhitelistPatterns) {
+	assert(!pat.test(src), `whitelist token absent: ${pat.source}`);
+}
+
+// 5. Call sites pass the error directly, not a pre-extracted string.
+//    The post-fix shape is `if (isStorageNotReadyError(error))` — NOT
+//    `if (isStorageNotReadyError(msg))`.
+assert(
+	src.includes('isStorageNotReadyError(error)'),
+	'call sites pass the original error, not a pre-extracted string',
+);
+assert(
+	!/isStorageNotReadyError\(\s*msg\s*\)/.test(src),
+	'no leftover msg-string call site',
+);
+
+console.log();
+if (failures === 0) {
+	console.log('[replay] PASS — all source-shape invariants hold');
+	process.exit(0);
+} else {
+	console.error(`[replay] FAIL — ${failures} invariant(s) violated`);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary

Fast-follow on **PR #510 (F-CYCLE7-3)** addressing the two non-blocking pre-review findings (mine, https://github.com/stevehuang0115/crewly/pull/510#pullrequestreview).

- **Finding 2 fixed**: `isStorageNotReadyError` enumerated method whitelist (`'filter'|'find'|'map'|'forEach'|'length'`) replaced with structural match — `error instanceof TypeError && /cannot read.*of undefined/i.test(message)`. Mirrors the discipline in `backend/src/utils/native-binding.utils.ts#isNativeArchMismatchError` (F-CYCLE7-1): match the structural error shape, not enumerated call sites. Eliminates the future-consumer hazard where adjacent reconciler code reaching for `.some()` / `.every()` / `.reduce()` / `.includes()` / `.indexOf()` / `.slice()` would throw the same V8 shape during the same hydration window but be silently dropped from the classifier.
- **Finding 3b investigated**: full audit of every cancellation-aware consumer under `backend/src/services`. Net result: **no subscriber patches needed**. Findings + observable-asymmetry follow-up below.

@stevehuang0115 — flagged for review per your standing-down note. Will NOT merge before your sign-off.

## Reference: PR #510 review comment
https://github.com/stevehuang0115/crewly/pull/510#pullrequestreview-79OxLr

## What's in the PR

| File | Change |
|---|---|
| `backend/src/services/reconciler/reconciler-data-provider.ts` | (a) `isStorageNotReadyError(message: string)` → `isStorageNotReadyError(error: unknown)`. (b) `instanceof TypeError` narrow added. (c) Method whitelist removed; structural anchors only (`'cannot read'` + `'of undefined'`). (d) Both call sites in `getActiveClaims` / `getAvailablePoolItems` pass the error itself, not a pre-extracted message string. (e) Doc comment expanded with negative-case contract. |
| `backend/src/services/reconciler/reconciler-data-provider.test.ts` | **+25 cases** under `F-CYCLE7-3-FU: structural classifier (post-whitelist)`: 14 V8 method shapes (filter/find/map/forEach/length/some/every/reduce/includes/indexOf/slice/flat/id/status) + older-Node singular form (`Cannot read property 'X' of undefined`) + 5 negatives (null vs undefined, "is not a function", non-TypeError, "Database connection refused", non-Error throw) + 4 second-call-site smoke + 1 second-call-site negative. |
| `scripts/replay-cycle7-3-fu.mjs` | **NEW** — 10-invariant source-shape replay validator. Asserts: classifier signature accepts `unknown`, `instanceof TypeError` narrow present, both readonly anchors present, all 5 old-whitelist tokens GONE, call sites pass error directly. Exit 0 = all green. |

## Eval criteria status

| Criterion | Status |
|---|---|
| All existing F-CYCLE7-3 tests still green (137 reconciler + 172 task-pool) | ✅ 334 pass / 6 suites |
| New whitelist→structural tests cover ≥6 method names + 3 negative cases | ✅ 14 method shapes + 6 negatives |
| PR body lists every cancelled-event subscriber audited with origin verdict | ✅ table below |
| One-command repro for replay validation in PR body | ✅ `node scripts/replay-cycle7-3-fu.mjs` |
| tsc clean | ✅ `tsc --noEmit -p backend/tsconfig.json` exit 0 |

## Cancelled-event subscriber audit

**Setup:** Pre-#510, reconciler emitted `queued → queued`, which `StorageService` rejected. So every cancellation-aware consumer downstream **never saw a reconciler-driven cancel**. Post-#510, reconciler-driven `cancelled` lands. Audited each consumer for origination-source assumptions.

### Push subscribers (EventBus `task:cancelled`)

| Subscriber | Origin verdict |
|---|---|
| **No subscriber found** | `task:cancelled` is declared in `backend/src/types/event-bus.types.ts` (line 37, 115) as a CRITICAL_EVENT_TYPE, but **no service publishes it** and **no service subscribes to it**. Only references are validation/type-coverage tests in `event-bus.types.test.ts` and `hierarchy-integration.test.ts` (literal in array iteration, not real subscription). Confirmed via `grep -rn "'task:cancelled'\|\"task:cancelled\""` and `grep -rn "on\('task:cancelled\|subscribe.*cancelled"`. |

**Verdict:** Push-subscription surface is empty. No origination assumptions to audit.

### Pull consumers (filters reading `wi.status === 'cancelled'`)

Each is origin-agnostic by construction — they care that the WI is terminal, not who terminated it.

| Site | Code shape | Origin verdict |
|---|---|---|
| `backend/src/services/v3/v3-data.service.ts:451` | `m.status !== 'cancelled'` exclusion filter | ✅ origin-agnostic |
| `backend/src/services/v3/v3-data.service.ts:644` | early-return if Request already terminal | ✅ origin-agnostic |
| `backend/src/services/v3/v3-data.service.ts:666-667` | Request cascade: `every(s === 'failed' || s === 'cancelled')` → Request = `cancelled` | ⚠️ see asymmetry note below |
| `backend/src/services/agent/active-work-briefing.service.ts:113,126` | Terminal-status exclusion from briefings | ✅ origin-agnostic |
| `backend/src/services/agent/agent-heartbeat-monitor.service.ts:658` | Idle-detection filter (`wi.status !== 'done' && wi.status !== 'cancelled'`) | ✅ origin-agnostic |
| `backend/src/services/v3/mission-executor.service.ts:347,387` | Mission completion filter + explicit cascade-cancel write | ✅ origin-agnostic |
| `backend/src/services/v3/request.service.ts:406` | `if (status === 'done' \|\| status === 'cancelled')` cleanup hook | ✅ origin-agnostic |
| `backend/src/services/v3/trigger-engine.service.ts:389,392,468` | Trigger lifecycle (`trigger.status === 'cancelled'`) — separate entity, not WorkItem | n/a (different entity) |
| `backend/src/services/workflow/scheduler.service.ts:361` | Completion check on scheduled-checks | ✅ origin-agnostic |
| `backend/src/services/intent-task/intent-task.service.ts:49,914` | Terminal-status filter for intent tasks | ✅ origin-agnostic |
| `backend/src/services/memory/memory.service.ts:898` | Terminal-status filter for memory cleanup | ✅ origin-agnostic |
| `backend/src/services/hierarchy/hierarchy-reporting.service.ts:324` | `case 'cancelled':` in status-rollup switch | ✅ origin-agnostic |
| `backend/src/services/intent-task/intent-task-follow-up.service.ts:32-36` | Terminal-status follow-up cancellation | ✅ origin-agnostic |
| `backend/src/controllers/task-management/in-progress-tasks.controller.ts:32` | Display filter | ✅ origin-agnostic |
| `backend/src/controllers/team/team.controller.ts:2094` | Display filter | ✅ origin-agnostic |
| `backend/src/controllers/task-pool/task-pool.controller.ts:969` | Cleanup endpoint filter | ✅ origin-agnostic |
| `backend/src/index.ts:2592,2615` | Server-startup orphan-cleanup terminal-status set | ✅ origin-agnostic |

### Observable behavioral asymmetry (out-of-scope, flagged for follow-up)

`updateItemStatus` in `task-pool.service.ts` (the path the reconciler takes via `applyCorrection`) **does NOT publish any EventBus event** — only writes a log line. The Request status cascade in `V3DataService.cascadeRequestStatus` is triggered by the `v3:task_completed` event handler (`onTaskCompleted`), which fires only when an agent reports task completion. **Therefore reconciler-driven `queued → cancelled` does NOT cascade to the parent Request** in this PR's behavioral path — while agent-completed terminal transitions do.

This is **not a regression introduced by F-CYCLE7-3** (the rejection-loop pre-merge masked the issue with noise instead of exposing it), and the cascade-machinery review is large enough to warrant a separate ticket. Two reasonable fix shapes for follow-up:

1. Publish `task:cancelled` from `updateItemStatus` when `newStatus === 'cancelled'`, then add a subscriber in `v3-data.service.ts` symmetric to `onTaskCompleted` that calls `cascadeRequestStatus`. Cleanest if other consumers want to listen.
2. Call `cascadeRequestStatus` directly from `applyCorrection` for `entityType === 'work_item'` whenever the new state is terminal. Smaller blast radius but couples reconciler to v3-data.

Both are out of scope for this fast-follow.

## Test plan

- [x] `npx jest backend/src/services/reconciler backend/src/services/task-pool` → **334 pass / 6 suites / 0 fail** (was 309 before this PR).
- [x] `tsc --noEmit -p backend/tsconfig.json` → clean.
- [x] `node scripts/replay-cycle7-3-fu.mjs` → 10/10 invariants PASS.
- [x] Specific new sub-suites:
  - `getActiveClaims > F-CYCLE7-3-FU: structural classifier (post-whitelist)` — 21 cases
  - `getAvailablePoolItems > F-CYCLE7-3-FU: structural classifier (post-whitelist) — second call site` — 5 cases
  - All 14 V8 method shapes demoted to debug ✓
  - Older Node singular-form (`Cannot read property 'X' of undefined`) demoted to debug ✓
  - `Cannot read properties of NULL (...)` does NOT silence ✓
  - `foo is not a function` TypeError does NOT silence ✓
  - Non-TypeError with matching message does NOT silence ✓
  - `Database connection refused` does NOT silence ✓
  - String-thrown does NOT silence ✓

## One-command post-merge replay

```bash
# (1) From repo root, after merge:
cd <repo-root> && \
  node scripts/replay-cycle7-3-fu.mjs && \
  npx jest backend/src/services/reconciler backend/src/services/task-pool --forceExit

# Expected: replay PASSes 10/10; jest 334 pass / 6 suites / 0 fail.
```

Reference: F-CYCLE7-3 PR #510 (merged); F-CYCLE7-1 PR #511 (`isNativeArchMismatchError` for the parallel structural pattern).