### PR TITLE
fix(orc): conversation history is recall-only — pool gates work-in-flight

### DIFF
--- a/backend/src/services/ai/prompt-modules/request-contract.module.test.ts
+++ b/backend/src/services/ai/prompt-modules/request-contract.module.test.ts
@@ -114,6 +114,20 @@ describe('RequestContractModule', () => {
 			expect(out).toMatch(/Team Lead is required to reject any subtask brief missing these three/);
 		});
 
+		it('should pin "conversation history is recall only — pool gates work-in-flight"', async () => {
+			// Root cause from 2026-05-08 dogfood: orc's claude conversation
+			// memory persisted "I owe Sam a sign-off" across PTY restarts;
+			// the pool had been purged but history hadn't, so orc resurrected
+			// Sam via a follow-up send-message. Fix lives in the prompt:
+			// history is for recall, the pool is the truth for what's still
+			// in flight. If a refactor strips this section, this test fails
+			// loud.
+			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
+			expect(out).toMatch(/Conversation History — Recall Only/);
+			expect(out).toMatch(/recall only/);
+			expect(out).toMatch(/decided by the pool/);
+		});
+
 		it('should NOT include the TL Brief Reception Protocol header for the orchestrator', async () => {
 			const out = await module.build({ ...baseConfig, role: 'orchestrator' });
 			expect(out).not.toContain('## Brief Reception Protocol');

--- a/backend/src/services/ai/prompt-modules/request-contract.module.ts
+++ b/backend/src/services/ai/prompt-modules/request-contract.module.ts
@@ -123,6 +123,14 @@ export class RequestContractModule implements PromptModule {
 			'| **Done Definition** | YES | What artifact/result must be produced. |',
 			'',
 			'**Every delegated subtask MUST carry Goal + Expected Outcome + Eval Criteria at minimum.** A Team Lead is required to reject any subtask brief missing these three — that rejection comes back to you. If you find yourself dispatching work without G+O+E, stop and reconstruct the contract from the upstream Request before re-dispatching.',
+			'',
+			'### Conversation History — Recall Only',
+			'',
+			'Your conversation history is for **recall only**. Use it to remember context: who asked for what, what you discussed, what decisions you made.',
+			'',
+			'It is **not** the source of truth for what work is still in flight. Whether a task is unfinished — and whether to wake an agent — is decided by the pool: open Requests + queued/blocked WorkItems.',
+			'',
+			'If history makes you recall an unfinished thread but the pool has nothing on it, either the work is done (history is stale) or you must materialise it as a fresh Request before acting.',
 		].join('\n');
 	}
 

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -225,6 +225,16 @@ The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E m
 
 ---
 
+## Conversation History — Recall Only
+
+Your conversation history is for **recall only**. Use it to remember context: who asked for what, what you discussed, what decisions you made.
+
+It is **not** the source of truth for what work is still in flight. Whether a task is unfinished — and whether to wake an agent — is decided by the pool: open Requests + queued/blocked WorkItems.
+
+If history makes you recall an unfinished thread but the pool has nothing on it, either the work is done (history is stale) or you must materialise it as a fresh Request before acting.
+
+---
+
 ## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.


### PR DESCRIPTION
## Summary

Adds a one-section principle to the orchestrator prompt:

> Conversation history is for **recall only**. Whether work is still in flight — and whether to wake an agent — is decided by the pool (open Requests + queued/blocked WorkItems).

## Why

2026-05-08 dogfood: after we purged pool / requests / cron-tasks / session-state and ran `crewly service restart`, orc still resurrected Sam (an inactive team-leader) within 22 seconds of going idle. Sam booted with an empty active-work briefing — `openRequests:0, activeWorkItems:0, pendingReviews:0, outboundDelegations:0`.

Forensics: orc's claude conversation history (persisted across PTY restarts) carried threads from hours earlier — "kit-amendment fold awaiting ORC sign-off", "Cron-8164bb86 next cycle T+4h" (cron already deleted), "Request 19b2d525 reconciled" (Request already purged). orc read history, recalled "I owe Sam a sign-off", invoked the `send-message` skill — which auto-starts offline targets to deliver. Sam was resurrected by recalled intent, not by real work.

This breaks the long-line outcome invariant: **agent wake-up MUST be gated by the pool, never by recalled intent.**

## Approach

Prompt-layer fix per Steve's direction. No skill or backend change. Teach orc the distinction:

- **Conversation history** → for recall (who asked, what we discussed, decisions made).
- **Pool** → source of truth for what's still in flight.

If history triggers a recall-and-act impulse but the pool has nothing on the thread, either the work is done (history is stale) or orc must materialise a fresh Request before acting.

## Files

| File | Δ |
|---|---|
| `backend/src/services/ai/prompt-modules/request-contract.module.ts` | +section in `buildOrchestratorBlock()` |
| `config/roles/orchestrator/prompt.md` | +matching section after `## Request Contract` (belt-and-suspenders for legacy prompt-builder load path) |
| `backend/src/services/ai/prompt-modules/request-contract.module.test.ts` | +1 test that pins the section's required keys |

## Test plan

- [x] `request-contract.module.test.ts` 42/42 pass (1 new)
- [x] Quality gates green on commit
- [x] Both prompt-build paths carry the same content

🤖 Generated with [Claude Code](https://claude.com/claude-code)