### PR TITLE
fix(ui): WorkItem detail page — call /items/:id, not /:id

### DIFF
--- a/frontend/src/services/api.service.test.ts
+++ b/frontend/src/services/api.service.test.ts
@@ -175,4 +175,33 @@ describe('ApiService', () => {
       await expect(apiService.getIntentTaskStatistics()).rejects.toThrow('Service unavailable');
     });
   });
+
+  describe('getWorkItem', () => {
+    // Regression: pre-fix, this called `/api/task-pool/${id}` which has no
+    // backend handler (the route registry only mounts
+    // `/api/task-pool/items/:id` for single-item lookup). Express returned
+    // 404 HTML, axios rejected, and every WorkItem detail page rendered
+    // empty — including from the WorkItems list and Request Detail timeline.
+    it('hits /api/task-pool/items/:id (the registered single-item route), not /api/task-pool/:id', async () => {
+      const wi = { id: 'wi-test-1', status: 'queued', title: 'Hello' };
+      const axios = await import('axios');
+      const spy = vi.spyOn(axios.default, 'get').mockResolvedValue({
+        data: { success: true, data: wi },
+      });
+
+      const result = await apiService.getWorkItem('wi-test-1');
+
+      expect(result).toEqual(wi);
+      expect(spy).toHaveBeenCalledWith('/api/task-pool/items/wi-test-1');
+    });
+
+    it('throws when the response indicates failure', async () => {
+      const axios = await import('axios');
+      vi.spyOn(axios.default, 'get').mockResolvedValue({
+        data: { success: false, error: 'WorkItem not found: wi-missing' },
+      });
+
+      await expect(apiService.getWorkItem('wi-missing')).rejects.toThrow('Work item not found');
+    });
+  });
 });

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -1152,7 +1152,12 @@ class ApiService {
   }
 
   async getWorkItem(id: string): Promise<unknown> {
-    const response = await axios.get<ApiResponse<unknown>>(`${API_BASE}/task-pool/${id}`);
+    // Use `/items/:id` not `/:id`. The backend route registry only mounts
+    // GET /api/task-pool/items/:workItemId for single-item lookup; a bare
+    // /api/task-pool/:id has no handler and returns 404 HTML. Without
+    // this prefix every WorkItem detail page silently failed to load —
+    // including from the WorkItems list and Request Detail timeline.
+    const response = await axios.get<ApiResponse<unknown>>(`${API_BASE}/task-pool/items/${id}`);
     if (!response.data.success || !response.data.data) throw new Error('Work item not found');
     return response.data.data;
   }


### PR DESCRIPTION
## Summary

Clicking a WorkItem in the WorkItems list (or Request Detail execution timeline) always loaded an empty/error state.

`apiService.getWorkItem(id)` was calling `GET /api/task-pool/${id}`, but the backend route registry only mounts `/api/task-pool/items/:workItemId` for single-item lookup. The bare `/api/task-pool/:id` has no handler → Express returns 404 HTML → axios rejects → the detail page renders empty.

## Discovery

Steve hit this at 2026-05-08T01:54Z trying to load `localhost:8787/workitems/7f0eaea5-...`. The WI in question had just been deleted, but the same call was failing for **every** WorkItem detail navigation.

## Fix

One line in `frontend/src/services/api.service.ts`: prepend the `/items/` prefix.

Sister to PR #507's `/all` → `/items` list-route fix. Same root-cause class: the task-pool router puts list + detail under different shapes, and the frontend was on the wrong side of that boundary.

## Test plan

- [x] New test pins the URL `getWorkItem` must hit (regression gate)
- [x] New test pins the failure-throws contract
- [x] All 10 frontend api.service tests pass
- [x] Backend `GET /api/task-pool/items/:id` confirmed working (returns the JSON body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)