### PR TITLE
fix(ui): /workitems/:id route → WorkItemDetail (was rendering the list)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -38,6 +38,8 @@ vi.mock('./pages/RequestsPage', () => ({ RequestsPage: () => <div>Requests Page<
 vi.mock('./pages/WorkItems', () => ({ WorkItems: () => <div>WorkItems Page</div> }));
 vi.mock('./pages/WorkItemDetail', () => ({ WorkItemDetail: () => <div>WorkItem Detail Page</div> }));
 vi.mock('./pages/Missions', () => ({ Missions: () => <div>Missions Page</div> }));
+vi.mock('./pages/MissionDetail', () => ({ MissionDetail: () => <div>Mission Detail Page</div> }));
+vi.mock('./pages/RequestDetail', () => ({ RequestDetail: () => <div>Request Detail Page</div> }));
 
 // Phase B Slack-like multi-team chat — mounted at /team-chat.
 vi.mock('./components/Chat-team', () => ({
@@ -60,5 +62,25 @@ describe('App routes', () => {
     render(<App />);
 
     expect(await screen.findByTestId('team-chat-route')).toBeInTheDocument();
+  });
+
+  it('mounts WorkItemDetail (not the list) at /workitems/:id', async () => {
+    // Pre-fix the route mounted the list `<WorkItems />` for both /workitems
+    // and /workitems/:id, so clicking a row navigated but rendered the
+    // same list page. The detail component must own the :id route.
+    window.history.pushState({}, '', '/workitems/abc-123');
+
+    render(<App />);
+
+    expect(await screen.findByText('WorkItem Detail Page')).toBeInTheDocument();
+    expect(screen.queryByText('WorkItems Page')).not.toBeInTheDocument();
+  });
+
+  it('still mounts the WorkItems list at /workitems (no id)', async () => {
+    window.history.pushState({}, '', '/workitems');
+
+    render(<App />);
+
+    expect(await screen.findByText('WorkItems Page')).toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import { CloudPortal } from './pages/CloudPortal';
 import { Missions } from './pages/Missions';
 import { MissionDetail } from './pages/MissionDetail';
 import { WorkItems } from './pages/WorkItems';
+import { WorkItemDetail } from './pages/WorkItemDetail';
 import { RequestsPage } from './pages/RequestsPage';
 import { RequestDetail } from './pages/RequestDetail';
 
@@ -93,7 +94,7 @@ function App() {
               <Route path="missions" element={<Missions />} />
               <Route path="missions/:id" element={<MissionDetail />} />
               <Route path="workitems" element={<WorkItems />} />
-              <Route path="workitems/:id" element={<WorkItems />} />
+              <Route path="workitems/:id" element={<WorkItemDetail />} />
 
               <Route
                 path="chat"


### PR DESCRIPTION
## Summary

`<Route path=\"workitems/:id\" element={<WorkItems />} />` was mounted to the **list** component for both `/workitems` and `/workitems/:id`. So clicking a row navigated the URL but rendered the same list page — no detail UI ever showed.

`WorkItemDetail.tsx` already existed; just hadn't been imported and wired up. Match the pattern used by `/missions/:id → MissionDetail` and `/requests/:id → RequestDetail`.

## Discovery

User screenshot at 2026-05-08T02:00Z — URL was `/workitems/699351ab-...` but the page showed the WorkItems list with the WI card visible underneath. After PR #516 fixed the API URL, this route bug is what kept the detail UI dark.

## Third sister bug in this session

| PR | Bug |
|---|---|
| #507 | `/api/task-pool/all` → `/api/task-pool/items` (list API) |
| #516 | `/api/task-pool/:id` → `/api/task-pool/items/:id` (detail API) |
| **#this** | `/workitems/:id` → `WorkItemDetail` (frontend route) |

After all three, the chain works end-to-end: WorkItems list click → correct route → correct API → renders the WI.

## Test plan

- [x] New: `/workitems/:id` mounts `WorkItemDetail`, not the list
- [x] New: `/workitems` (no id) still mounts the list
- [x] All other App tests continue to behave the same way they did pre-change (the `/schedules` redirect test was already failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)