### PR TITLE
fix(v3): auto-decompose chains Plan→Execute→Review with sequential deps

### DIFF
--- a/backend/src/services/v3/request-decompose.subscriber.test.ts
+++ b/backend/src/services/v3/request-decompose.subscriber.test.ts
@@ -277,6 +277,87 @@ describe('RequestDecomposeSubscriber', () => {
       const queued = (taskPool as unknown as { queued: WorkItem[] }).queued;
       expect(queued[0].metadata).toMatchObject({ autoDecomposed: true });
     });
+
+    it('resolves dependsOnTitles to WI ids and flips dependents to status=blocked (Sam-bug regression)', async () => {
+      // 2026-05-08 dogfood: Sam claimed the Review WI and marked it
+      // done_by_worker BEFORE Execute was done — because the fan-out
+      // emitted no dependency hints, all three queued concurrently and
+      // AutoClaim could pick any. Subscriber must resolve a planner-
+      // emitted `dependsOnTitles` into the canonical `WorkItem.dependsOn`
+      // (id list) AND set status='blocked' on the dependent so the
+      // pool's blocker-resolver gates the claim until the parent terminates.
+      const seedLocal: Map<string, Request> = new Map();
+      const planMock = jest.fn(async () => ({
+        message: 'irrelevant',
+        tasks: [
+          {
+            title: 'Plan: foo',
+            description: 'plan it',
+            acceptanceCriteria: ['planned'],
+            priority: 'high' as const,
+          },
+          {
+            title: 'Execute: foo',
+            description: 'do it',
+            acceptanceCriteria: ['done'],
+            priority: 'high' as const,
+            dependsOnTitles: ['Plan: foo'],
+          },
+          {
+            title: 'Review: foo',
+            description: 'check it',
+            acceptanceCriteria: ['reviewed'],
+            priority: 'low' as const,
+            dependsOnTitles: ['Execute: foo'],
+          },
+        ],
+        reasoning: 'sequential 3-step',
+        strategy: 'generic' as const,
+      }));
+      const fakeRequestService = {
+        getById: async (id: string) => seedLocal.get(id) ?? null,
+        plan: planMock,
+      } as unknown as RequestService;
+      const localPool = makeFakeTaskPool();
+      const localBus = makeFakeEventBus();
+      const localSub = new RequestDecomposeSubscriber({
+        eventBus: localBus,
+        requestService: fakeRequestService,
+        taskPool: localPool,
+        logger: SILENT_LOGGER,
+      });
+      const r = makeRequest();
+      seedLocal.set(r.id, r);
+      localSub.start();
+      await deliverRequestCreated(localBus, r.id);
+      await localSub.flushPending();
+
+      const queued = (localPool as unknown as { queued: WorkItem[] }).queued;
+      expect(queued).toHaveLength(3);
+
+      const planWi = queued.find((w) => w.title === 'Plan: foo');
+      const executeWi = queued.find((w) => w.title === 'Execute: foo');
+      const reviewWi = queued.find((w) => w.title === 'Review: foo');
+      expect(planWi).toBeDefined();
+      expect(executeWi).toBeDefined();
+      expect(reviewWi).toBeDefined();
+
+      // Plan: starts unblocked. `dependsOn` may be unset (undefined) or
+      // empty array — `createWorkItem` factory chooses one shape and we
+      // accept both since the *behaviour* is "no blockers".
+      expect(planWi!.status).toBe('queued');
+      const planDeps = planWi!.dependsOn ?? [];
+      expect(planDeps).toEqual([]);
+
+      // Execute: blocked by Plan's id.
+      expect(executeWi!.status).toBe('blocked');
+      expect(executeWi!.dependsOn).toEqual([planWi!.id]);
+
+      // Review: blocked by Execute's id (NOT by Plan — that's the
+      // specific shape the dogfood bug needed to fail before the fix).
+      expect(reviewWi!.status).toBe('blocked');
+      expect(reviewWi!.dependsOn).toEqual([executeWi!.id]);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/v3/request-decompose.subscriber.ts
+++ b/backend/src/services/v3/request-decompose.subscriber.ts
@@ -365,16 +365,52 @@ export class RequestDecomposeSubscriber {
     // restart-replay.
     this.decomposedRequestIds.add(requestId);
 
+    // Two-pass fan-out so `dependsOnTitles` can be resolved to WorkItem IDs:
+    //   Pass 1 — build all WorkItems (without resolved deps) so we have a
+    //            complete title→id map.
+    //   Pass 2 — for each task with `dependsOnTitles`, look up the matching
+    //            WorkItem ids and write them into `wi.dependsOn` (canonical
+    //            field). Items that depend on something also flip to status
+    //            'blocked' so they don't get claimed before their dependency
+    //            completes (mirrors mission-executor's PR #491 fix).
+    //   Pass 3 — addToPool in plan order. Mission-executor takes the same
+    //            shape; symmetrising here means the pool always sees a
+    //            self-consistent dependency graph at insertion time.
     const queuedIds: string[] = [];
+    const titleToId = new Map<string, string>();
+    const builtItems: WorkItem[] = [];
+
+    // Pass 1: build (no deps)
     for (const task of plan.tasks) {
       const wi = this.buildWorkItemFromTask(task, request);
+      builtItems.push(wi);
+      titleToId.set(task.title, wi.id);
+    }
+
+    // Pass 2: resolve dependsOnTitles → dependsOn (id list) + status='blocked'
+    for (let i = 0; i < plan.tasks.length; i++) {
+      const task = plan.tasks[i];
+      const wi = builtItems[i];
+      if (!task.dependsOnTitles || task.dependsOnTitles.length === 0) continue;
+      const blockedByIds = task.dependsOnTitles
+        .map((title) => titleToId.get(title))
+        .filter((id): id is string => id !== undefined);
+      if (blockedByIds.length > 0) {
+        wi.dependsOn = blockedByIds;
+        wi.status = 'blocked';
+      }
+    }
+
+    // Pass 3: addToPool. Insert in plan order so the dependency-resolver
+    // sees parents before children at the moment of insertion.
+    for (const wi of builtItems) {
       try {
         await this.taskPool.addToPool(wi);
         queuedIds.push(wi.id);
       } catch (err) {
         this.logger.warn('addToPool failed during auto-decompose (non-fatal)', {
           requestId,
-          taskTitle: task.title,
+          taskTitle: wi.title,
           error: err instanceof Error ? err.message : String(err),
         });
       }

--- a/backend/src/services/v3/v3-data.service.test.ts
+++ b/backend/src/services/v3/v3-data.service.test.ts
@@ -1153,6 +1153,30 @@ describe('planTasksFromObjective', () => {
     expect(tasks[2].title).toContain('Review');
   });
 
+  it('chains Plan → Execute → Review with sequential dependsOnTitles (regression gate)', () => {
+    // 2026-05-08 dogfood: Sam claimed Review and marked done_by_worker
+    // BEFORE Execute was done — because the planner emitted no
+    // dependency hints, all three queued concurrently and AutoClaim
+    // could pick any. Subscriber must now resolve these titles into
+    // `WorkItem.dependsOn` (canonical) so Execute is blocked until
+    // Plan completes, and Review is blocked until Execute completes.
+    const tasks = planTasksFromObjective(
+      'Improve team velocity by 20% and then optimize the reporting pipeline with weekly updates and alerting on regressions',
+    );
+    expect(tasks).toHaveLength(3);
+    expect(tasks[0].title).toContain('Plan');
+    expect(tasks[1].title).toContain('Execute');
+    expect(tasks[2].title).toContain('Review');
+
+    // Plan starts unblocked.
+    expect(tasks[0].dependsOnTitles).toBeUndefined();
+    // Execute waits for Plan.
+    expect(tasks[1].dependsOnTitles).toEqual([tasks[0].title]);
+    // Review waits for Execute (NOT Plan — Sam-bug regression: Review
+    // must not be claimable until Execute is done).
+    expect(tasks[2].dependsOnTitles).toEqual([tasks[1].title]);
+  });
+
   it('should include acceptance criteria on all tasks', () => {
     const tasks = planTasksFromObjective('Create a new API endpoint');
     for (const task of tasks) {

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -924,6 +924,23 @@ export interface PlannedTask {
   acceptanceCriteria: string[];
   /** Task priority */
   priority: 'high' | 'medium' | 'low';
+  /**
+   * Titles of other planned tasks this one depends on. The fan-out caller
+   * (request-decompose subscriber, mission executor) is expected to map
+   * these titles to the resolved WorkItem IDs and write them into
+   * `WorkItem.dependsOn` before queueing.
+   *
+   * **Why titles, not indices.** Titles survive plan() reordering and
+   * make the dependency intent self-documenting in the plan output.
+   *
+   * **Sequential plans.** A planner that wants strict A→B→C ordering
+   * sets `B.dependsOnTitles = [A.title]` and `C.dependsOnTitles = [B.title]`.
+   * Without this, all three tasks queue concurrently and a worker can
+   * claim Review before Execute is done — observed in the 2026-05-08
+   * dogfood, where Sam claimed Review while Plan/Execute were still
+   * blocked.
+   */
+  dependsOnTitles?: string[];
 }
 
 /**
@@ -1099,9 +1116,19 @@ export function planTasksFromObjective(objective: string): PlannedTask[] {
     }];
   }
 
+  // Generic Plan → Execute → Review chain. Strict sequential dependency
+  // is encoded via `dependsOnTitles` so the fan-out subscriber writes
+  // `WorkItem.dependsOn` correctly: Execute waits for Plan, Review waits
+  // for Execute. Without these, all three queue concurrently and a
+  // worker can claim Review before Execute completes — observed in the
+  // 2026-05-08 dogfood (Sam claimed Review with empty output while Plan
+  // and Execute were still blocked).
+  const planTitle = `Plan: ${truncate(objective, 60)}`;
+  const executeTitle = `Execute: ${truncate(objective, 60)}`;
+  const reviewTitle = `Review: ${truncate(objective, 60)}`;
   return [
     {
-      title: `Plan: ${truncate(objective, 60)}`,
+      title: planTitle,
       description: `Create an execution plan for: ${objective}. Break down the work into concrete steps.`,
       acceptanceCriteria: [
         'Execution plan created',
@@ -1111,7 +1138,7 @@ export function planTasksFromObjective(objective: string): PlannedTask[] {
       priority: 'high',
     },
     {
-      title: `Execute: ${truncate(objective, 60)}`,
+      title: executeTitle,
       description: `Execute the plan for: ${objective}. Complete all steps identified in the planning phase.`,
       acceptanceCriteria: [
         'All planned steps completed',
@@ -1119,9 +1146,10 @@ export function planTasksFromObjective(objective: string): PlannedTask[] {
         'Build passes',
       ],
       priority: 'high',
+      dependsOnTitles: [planTitle],
     },
     {
-      title: `Review: ${truncate(objective, 60)}`,
+      title: reviewTitle,
       description: `Review the completed work for: ${objective}. Verify quality, completeness, and alignment with the original objective.`,
       acceptanceCriteria: [
         'Work reviewed for quality',
@@ -1129,6 +1157,7 @@ export function planTasksFromObjective(objective: string): PlannedTask[] {
         'Documentation updated if needed',
       ],
       priority: 'low',
+      dependsOnTitles: [executeTitle],
     },
   ];
 }


### PR DESCRIPTION
## Summary

The 3-WI auto-decomposition (Plan / Execute / Review) emitted no dependency hints, so all three queued concurrently. In the 2026-05-08 dogfood, Sam claimed Review and marked it `done_by_worker` with empty output while Plan and Execute were still blocked — out-of-order completion + zero artifact = fake progress.

## Fix

- **Planner** (`v3-data.service.ts:planTasksFromObjective`) sets `dependsOnTitles` on Execute (waits for Plan) and Review (waits for Execute).
- **Subscriber** (`request-decompose.subscriber.ts:handleRequestCreated`) resolves titles → WI ids and writes `WorkItem.dependsOn` + flips `status='blocked'`, mirroring the shape mission-executor already uses.

## Type addition

`PlannedTask.dependsOnTitles?: string[]` — optional, backwards-compatible.

## Test plan

- [x] `planTasksFromObjective` pins the Plan/Execute/Review chain shape
- [x] subscriber regression test pins resolved `dependsOn` ids + `status='blocked'`, including the Sam-specific shape (Review depends on Execute, not on Plan)
- [x] 106/106 v3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)