### PR TITLE
fix(task-pool): complete API requires non-empty 'summary' (Done Definition)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -14,6 +14,7 @@ import {
   scanExpired,
   revokeAndRelease,
   deleteItem,
+  completeItem,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
 // Express types used for mock helpers below
@@ -44,6 +45,9 @@ const mockService = {
   scanExpiredClaims: jest.fn(),
   revokeAndRelease: jest.fn(),
   removeFromPool: jest.fn(),
+  completeItem: jest.fn(),
+  findWorkItem: jest.fn(),
+  setOutput: jest.fn(),
 };
 
 (TaskPoolService.getInstance as any) = jest.fn().mockReturnValue(mockService);
@@ -589,6 +593,110 @@ describe('TaskPoolController', () => {
       await deleteItem(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // completeItem (2026-05-08): require non-empty `summary` (Done Definition)
+  // ---------------------------------------------------------------------
+  describe('completeItem (require summary)', () => {
+    beforeEach(() => {
+      mockService.findWorkItem.mockResolvedValue({ id: 'wi-1', output: null });
+      mockService.setOutput.mockResolvedValue(undefined);
+      mockService.completeItem.mockResolvedValue(undefined);
+    });
+
+    it('returns 400 when result is missing entirely (fake-completion regression)', async () => {
+      // 2026-05-08 dogfood: Sam and Leo both marked WIs done_by_worker
+      // with `output=null, notes=null`. The Request Contract Done
+      // Definition requires "what artifact/result must be produced". The
+      // gate enforces it at the API boundary so workers can't claim
+      // completion without producing artefacts.
+      const req = mockReq({
+        params: { workItemId: 'wi-1' },
+        body: { agentId: 'agent-1' },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          code: 'complete_requires_summary',
+        }),
+      );
+      expect(mockService.completeItem).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when summary is an empty string', async () => {
+      const req = mockReq({
+        params: { workItemId: 'wi-2' },
+        body: { agentId: 'agent-1', result: { summary: '' } },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockService.completeItem).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when summary is only whitespace', async () => {
+      const req = mockReq({
+        params: { workItemId: 'wi-3' },
+        body: { agentId: 'agent-1', result: { summary: '   \n\t  ' } },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockService.completeItem).not.toHaveBeenCalled();
+    });
+
+    it('accepts a non-empty summary and persists it onto WorkItem.output', async () => {
+      const req = mockReq({
+        params: { workItemId: 'wi-4' },
+        body: {
+          agentId: 'leo',
+          result: { summary: 'Designed schema for users table; 4 fields finalized.' },
+        },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(mockService.completeItem).toHaveBeenCalledWith(
+        'wi-4',
+        expect.objectContaining({ summary: expect.stringContaining('Designed schema') }),
+      );
+      // Output is persisted with the summary.
+      expect(mockService.setOutput).toHaveBeenCalledWith(
+        'wi-4',
+        expect.objectContaining({ summary: expect.stringContaining('Designed schema') }),
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      );
+    });
+
+    it('preserves caller-supplied non-summary result fields on output', async () => {
+      const req = mockReq({
+        params: { workItemId: 'wi-5' },
+        body: {
+          agentId: 'leo',
+          result: { summary: 'Shipped PR #123', prNumber: 123, links: ['github.com/foo'] },
+        },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(mockService.setOutput).toHaveBeenCalledWith(
+        'wi-5',
+        expect.objectContaining({
+          summary: 'Shipped PR #123',
+          prNumber: 123,
+          links: ['github.com/foo'],
+        }),
+      );
     });
   });
 });

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -376,6 +376,54 @@ export async function completeItem(req: Request, res: Response): Promise<void> {
       return;
     }
 
+    // Require a non-empty `summary` string in the body. 2026-05-08 dogfood:
+    // Sam and Leo both marked WIs `done_by_worker` with empty output —
+    // workers were claiming completion without producing artifacts.
+    // Pool stored these as terminal-success but with `output=null,
+    // notes=null` (fake completion). The Done Definition in the Request
+    // Contract requires "what artifact/result must be produced". Enforce
+    // it at the API boundary so the proof of work lands with the
+    // transition, not as an afterthought.
+    //
+    // Skills already pass `summary`: the agent and orchestrator
+    // complete-task skills both emit `{summary: "..."}` in the body.
+    // Empty-summary callers (legacy or buggy) get a 400 with a
+    // helpful error directing them to populate `summary`.
+    const summary = typeof result?.summary === 'string' ? result.summary.trim() : '';
+    if (summary.length === 0) {
+      res.status(400).json({
+        success: false,
+        error:
+          `complete requires a non-empty 'summary' string in body.result. ` +
+          `Workers must report what they produced (artifact, decision, verified result) — ` +
+          `not just mark "done". This enforces the Request Contract Done Definition.`,
+        code: 'complete_requires_summary',
+      });
+      return;
+    }
+
+    // Persist the summary onto the WorkItem.output. This makes the proof of
+    // work queryable via `GET /api/task-pool/items/:id` (Request detail
+    // page), and downstream services that want to read what the worker
+    // actually produced (verifier, reviewer, mission audit) don't have to
+    // dig back through chat logs.
+    try {
+      const existing = await getService().findWorkItem(workItemId);
+      const mergedOutput: Record<string, unknown> = {
+        ...(existing?.output ?? {}),
+        summary,
+        // Preserve any caller-supplied result fields beyond `summary`
+        // (e.g. `links`, `prNumber`) as-is.
+        ...(result ?? {}),
+      };
+      await getService().setOutput(workItemId, mergedOutput);
+    } catch (err) {
+      logger.warn('Failed to persist completion summary onto WI.output (non-fatal)', {
+        workItemId,
+        error: formatError(err),
+      });
+    }
+
     await getService().completeItem(workItemId, result);
 
     // V3.1: Project task completion


### PR DESCRIPTION
## Summary

`POST /api/task-pool/complete/:workItemId` now requires a non-empty `result.summary` string. Empty/missing/whitespace returns `400 complete_requires_summary`.

## Why

2026-05-08 dogfood: Sam and Leo both marked WIs `done_by_worker` with `output=null, notes=null`. Workers claimed terminal-success without producing any artifact — fake completion. The Request Contract Done Definition says "what artifact/result must be produced"; the gate now enforces it at the API boundary.

The summary is persisted onto `WorkItem.output` so the artifact is queryable via `GET /api/task-pool/items/:id` and visible in the Request detail page.

## Compatibility

- Agent `core/complete-task` skill already requires `summary` at skill layer.
- Orchestrator `complete-task` already passes `summary`.
- `report-status` skill empty-summary path now correctly rejects with a clear error.

## Files

| File | Δ |
|---|---|
| `backend/src/controllers/task-pool/task-pool.controller.ts` | +gate + persist-to-output |
| `backend/src/controllers/task-pool/task-pool.controller.test.ts` | +5 tests |

## Test plan

- [x] Rejects missing result, empty summary, whitespace-only summary
- [x] Accepts non-empty summary, persists to `WorkItem.output`
- [x] Preserves caller-supplied non-summary fields (prNumber, links)
- [x] 38/38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)