### PR TITLE
fix(slack): /slack/send marks thread replied_completed — stop restart-replay storm

### DIFF
--- a/backend/src/controllers/slack/slack.controller.test.ts
+++ b/backend/src/controllers/slack/slack.controller.test.ts
@@ -169,6 +169,57 @@ describe('Slack Controller', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
     });
+
+    it('marks the thread-status entry as replied_completed (recovery-replay regression gate)', async () => {
+      // 2026-05-08 dogfood: every backend restart re-enqueued the user's
+      // original Slack message via ThreadStatusQueueService.recoverPendingThreads,
+      // and orc would re-reply to the same message multiple times. Root
+      // cause: /api/slack/send sent the reply but never marked the
+      // thread-status entry as replied_completed, so the next boot's
+      // recovery loop saw it as unreplied. The fix marks the entry here.
+      const { ThreadStatusQueueService } = await import(
+        '../../services/messaging/thread-status-queue.service.js'
+      );
+      const tsq = ThreadStatusQueueService.getInstance();
+      // Reset internal state — the singleton may carry over from prior tests.
+      // We test the markReplied side-effect via getStatus / get().
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'sendMessage').mockResolvedValue('1707.999');
+
+      const channelId = 'CUNIQUE-1';
+      const threadTs = '1707.thread-1';
+
+      // No pre-tracked entry — simulates orc replying to a thread we
+      // haven't recorded inbound for. The handler should still create
+      // the entry + mark replied so future restarts skip it.
+      await request(app).post('/api/slack/send').send({
+        channelId,
+        text: 'sup',
+        threadTs,
+      });
+
+      const threadKey = `${channelId}:${threadTs}`;
+      const entry = tsq.get(threadKey);
+      expect(entry).toBeDefined();
+      expect(entry?.status).toBe('replied_completed');
+      expect(entry?.repliedAt).toBeDefined();
+    });
+
+    it('does not crash when threadTs is omitted (no-thread DM path)', async () => {
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'sendMessage').mockResolvedValue('1707.005');
+
+      const response = await request(app).post('/api/slack/send').send({
+        channelId: 'C-NOTHREAD',
+        text: 'top-level message',
+        // intentionally no threadTs
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
   });
 
   describe('POST /api/slack/notify', () => {

--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -236,6 +236,58 @@ router.post('/send', async (req: Request, res: Response, next: NextFunction) => 
       }
     }
 
+    // Mark the thread as replied_completed in the thread-status queue.
+    //
+    // Bug from 2026-05-08 dogfood: every backend restart re-enqueued the
+    // user's original Slack message via the
+    // `ThreadStatusQueueService.recoverPendingThreads` → message-queue
+    // `[RECOVERY]` path. orc would then "re-reply" to the same message
+    // multiple times after each restart, even though the user only sent
+    // one message and orc had already replied.
+    //
+    // Root cause: when orc invoked `reply-slack` skill → `POST /slack/send`,
+    // we sent to Slack + persisted to chat, but we never updated the
+    // thread-status entry. The entry stayed in `received` (or
+    // `replied_waiting_actions`) status, so the recovery loop on the
+    // next boot considered it unreplied and re-fired it.
+    //
+    // Fix: mark the thread as `replied_completed` here, atomically with
+    // the actual Slack send. Now the next restart sees a terminal status
+    // and skips re-enqueue.
+    //
+    // Why `replied_completed` and not `replied_to_follow_up`: orc has
+    // produced its user-facing acknowledgement; whatever async work
+    // continues downstream (Request → WIs → workers) is tracked by the
+    // pool, not by the thread-status queue. Conflating "user got a reply"
+    // with "all downstream work resolved" was the original architectural
+    // mistake — they belong in different queues.
+    //
+    // Best-effort: if the threadKey isn't tracked yet (rare race where
+    // the trackInbound call hasn't landed) or the markReplied throws,
+    // we log and continue — Slack delivery is the primary success
+    // criterion, thread-status is bookkeeping.
+    if (threadTs && channelId) {
+      try {
+        const { ThreadStatusQueueService } = await import('../../services/messaging/thread-status-queue.service.js');
+        const tsq = ThreadStatusQueueService.getInstance();
+        const threadKey = `${channelId}:${threadTs}`;
+        // Create the entry if it isn't tracked yet, then mark replied.
+        // The trackInbound is idempotent — if the entry exists, this is
+        // a no-op via `get(threadKey)` short-circuit.
+        if (!tsq.get(threadKey)) {
+          tsq.trackInbound({
+            threadKey,
+            conversationId: conversationId || `slack-${channelId}-${String(threadTs).replace('.', '-')}`,
+            source: 'slack',
+            messagePreview: '[reply-only — no inbound recorded]',
+          });
+        }
+        tsq.markReplied(threadKey, 'replied_completed');
+      } catch {
+        // Non-fatal — Slack delivery succeeded, thread bookkeeping is best-effort
+      }
+    }
+
     res.json({
       success: true,
       data: { messageTs },


### PR DESCRIPTION
## Summary

When orc invokes the `reply-slack` skill (→ `POST /api/slack/send`), the Slack reply is sent + persisted to chat, but **the thread-status queue entry is never marked replied**. On every backend restart, `ThreadStatusQueueService.recoverPendingThreads` sees the non-terminal entry and re-enqueues the user's original message into the message queue with a `[RECOVERY]` prefix. orc treats it as a fresh query and replies again. Net effect: one inbound message → many orc replies.

## Trace from dogfood

User's 19:22 Slack message replayed at every backend restart today — 01:23, 01:44, 15:42, 17:03, 20:22. Five orc-replies for one inbound.

## Fix

In `POST /api/slack/send`, after `slackService.sendMessage` succeeds with `threadTs + channelId`, mark the thread entry as `replied_completed`. The recovery loop's `isTerminalStatus` check then skips it on next boot.

## Why `replied_completed`

orc's reply IS the user-facing acknowledgement. Downstream async work (Request → WIs → workers) is tracked in the pool, not in thread-status. Conflating "user got a reply" with "all downstream work resolved" was the original architectural mistake.

## Test plan

- [x] New test pins `replied_completed` after /slack/send (regression gate)
- [x] New test pins no-crash on omitted threadTs (top-level message)
- [x] 40/40 slack.controller tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)