### PR TITLE
fix(scheduler): cleanup race — mtime-guard tmp deletion vs in-flight atomicWrite

### DIFF
--- a/backend/src/services/workflow/scheduler.service.test.ts
+++ b/backend/src/services/workflow/scheduler.service.test.ts
@@ -2150,6 +2150,67 @@ describe('SchedulerService', () => {
 
       cleanupSpy.mockRestore();
     });
+
+    // 2026-05-08: mtime-guarded cleanup, real fs (mocking ESM imports of
+    // fs/promises is unreliable post-instantiation). The bug we're
+    // protecting against is the cleanup deleting a tmp file that another
+    // atomicWriteJson call just created and is about to rename — observed
+    // in the dogfood as recurring `SessionPersistence: ENOENT` warnings
+    // every backend boot.
+    describe('mtime-guarded cleanup (race fix)', () => {
+      const fs = require('fs/promises');
+      const realPath = require('path');
+      const os = require('os');
+      let realTmpDir: string;
+
+      beforeEach(async () => {
+        realTmpDir = await fs.mkdtemp(realPath.join(os.tmpdir(), 'cleanup-mtime-'));
+        (mockStorageService as any).getCrewlyHome = jest.fn().mockReturnValue(realTmpDir);
+      });
+
+      afterEach(async () => {
+        await fs.rm(realTmpDir, { recursive: true, force: true });
+      });
+
+      it('skips tmp files younger than the grace window (in-flight writes)', async () => {
+        // Create a tmp file with a fresh mtime — simulates an
+        // atomicWriteJson call that just created its scratch file and is
+        // about to rename. The cleanup pass must NOT delete it; the
+        // race symptom was exactly that delete causing the rename to ENOENT.
+        const tmp = realPath.join(realTmpDir, 'session-state.json.tmp.9999.fresh');
+        await fs.writeFile(tmp, 'in-flight');
+
+        const cleaned = await service.cleanupStaleTempFiles();
+        expect(cleaned).toBe(0);
+
+        const stillExists = await fs.access(tmp).then(() => true).catch(() => false);
+        expect(stillExists).toBe(true);
+      });
+
+      it('cleans up tmp files older than the grace window (real orphans from prior crash)', async () => {
+        const tmp = realPath.join(realTmpDir, 'recurring-checks.json.tmp.1.crashed');
+        await fs.writeFile(tmp, 'orphan');
+        // Backdate mtime by 5 minutes (well past the 60s grace).
+        const fiveMinAgo = new Date(Date.now() - 5 * 60_000);
+        await fs.utimes(tmp, fiveMinAgo, fiveMinAgo);
+
+        const cleaned = await service.cleanupStaleTempFiles();
+        expect(cleaned).toBe(1);
+
+        const stillExists = await fs.access(tmp).then(() => true).catch(() => false);
+        expect(stillExists).toBe(false);
+      });
+
+      it('handles a tmp file that disappeared mid-scan (other-worker race) without throwing', async () => {
+        // Create then delete inside the same tick — readdir saw it,
+        // stat will fail. Cleanup should swallow + continue.
+        const tmp = realPath.join(realTmpDir, 'projects.json.tmp.2.gone');
+        await fs.writeFile(tmp, 'x');
+        await fs.unlink(tmp);
+
+        await expect(service.cleanupStaleTempFiles()).resolves.toBeDefined();
+      });
+    });
   });
 
   describe('memory pressure handling', () => {

--- a/backend/src/services/workflow/scheduler.service.ts
+++ b/backend/src/services/workflow/scheduler.service.ts
@@ -9,7 +9,7 @@
 
 import { EventEmitter } from 'events';
 import * as path from 'path';
-import { readdir, unlink } from 'fs/promises';
+import { readdir, unlink, stat } from 'fs/promises';
 import { ScheduledCheck } from '../../types/index.js';
 import { v4 as uuidv4 } from 'uuid';
 import * as cron from 'node-cron';
@@ -1648,17 +1648,53 @@ export class SchedulerService extends EventEmitter {
       // #217: Broadened to match ALL atomicWriteFile temp files (*.tmp.{timestamp}.{random})
       const tmpPattern = /\.tmp\.\d+\./;
 
+      // 2026-05-08: Add an mtime guard so the cleanup does not race with
+      // an in-flight atomicWrite. The race symptom was a recurring
+      // `SessionPersistence: Failed to auto-save session state | ENOENT:
+      // rename '.../session-state.json.tmp.xxx' -> 'session-state.json'`
+      // every backend boot — atomicWriteJson would create the .tmp file,
+      // and this cleanup pass (also running at boot) would unlink it
+      // milliseconds before the rename. Treat anything younger than the
+      // grace window as still-in-flight; only files older than that are
+      // truly orphaned (i.e. left behind by a previous crashed process).
+      //
+      // 60s is large enough to absorb the longest plausible
+      // create-then-rename interval (atomic writes complete in <1ms; we
+      // pick 60s to also tolerate a stalled writer), small enough that
+      // a true crash leftover from a prior boot still gets cleaned on
+      // the next boot.
+      const STALE_TMP_GRACE_MS = 60_000;
+      const now = Date.now();
+
       for (const entry of entries) {
-        if (tmpPattern.test(entry)) {
-          try {
-            await unlink(path.join(crewlyHome, entry));
-            cleaned++;
-          } catch (unlinkErr) {
-            this.logger.debug('Failed to remove stale temp file', {
-              file: entry,
-              error: unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr),
-            });
+        if (!tmpPattern.test(entry)) continue;
+        const fullPath = path.join(crewlyHome, entry);
+
+        // mtime guard — skip recent tmp files (in-flight writes).
+        try {
+          const st = await stat(fullPath);
+          if (now - st.mtimeMs < STALE_TMP_GRACE_MS) {
+            continue;
           }
+        } catch (statErr) {
+          // The file disappeared between readdir and stat (unlikely
+          // but possible if another worker won the race). Skip — there
+          // is nothing left for us to clean.
+          this.logger.debug('Failed to stat tmp file (likely already removed)', {
+            file: entry,
+            error: statErr instanceof Error ? statErr.message : String(statErr),
+          });
+          continue;
+        }
+
+        try {
+          await unlink(fullPath);
+          cleaned++;
+        } catch (unlinkErr) {
+          this.logger.debug('Failed to remove stale temp file', {
+            file: entry,
+            error: unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr),
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

Every backend boot emits:
```
WARN [SessionPersistence] Failed to auto-save session state | ENOENT: rename '...session-state.json.tmp.<ts>.<rand>' -> 'session-state.json'
```
because `SchedulerService.cleanupStaleTempFiles` deletes a tmp file that another atomicWrite call just created and is about to rename.

## Fix

60-second mtime guard. Files younger than the grace window are treated as in-flight; only truly orphaned files (from a crashed prior process) get cleaned.

Also: handle the readdir → stat race where another worker won the cleanup (file disappeared mid-scan) — swallow the ENOENT instead of logging a noisy WARN.

## Test plan

- [x] 3 new real-fs tests pass (skip fresh, clean old, survive disappear-mid-scan)
- [x] All 7 existing cleanup-suite tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)