### PR TITLE
fix(task-pool): Hygiene #3 + #5 — close pool target-rotation + poll-tasks race (paired)

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -38,7 +38,11 @@ function makeWorkItem(overrides?: Record<string, unknown>) {
     type: 'delegate',
     owner: 'agent',
     title: 'Test task',
-    target: 'agent-1',
+    // Hygiene #3: default target=undefined so existing tests that claim
+    // with arbitrary agent ids continue to pass after the target-respect
+    // gate landed in claimFromPool / claimSpecificItem. Tests that need
+    // an explicit target pass it via overrides — see e.g. the
+    // "target-respect" describe block below for #3 regression coverage.
     ...overrides,
   });
 }
@@ -558,6 +562,205 @@ describe('TaskPoolService', () => {
       // Storage must reflect a single active claim, not two.
       const snapshot = await service.getPoolStatus();
       expect(snapshot.claimed).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Hygiene #3 — target-respect (target rotation regression)
+  //
+  // Before fix: claimFromPool/claimSpecificItem unconditionally rewrote
+  // wi.target = agentId at claim time. When v3-data.service.ts:279 fired
+  // claimFromPool(newAgent, { types: ['delegate'] }) without a target
+  // filter, the FIFO-oldest queued+unclaimed delegate WI got its target
+  // rotated from its original target to newAgent. Steve, Sam, Quinn each
+  // hit this in the 5/9 wave (WI 6e532a8b: Quinn → flopost-dex → null →
+  // flopost-dex; WI 598c91da: Quinn → Sam).
+  //
+  // After fix: a WI with target=A is claimable ONLY by A (or by anyone
+  // when target=undefined, the no-target broadcast pool). Other agents
+  // are silently skipped during candidate selection so they never even
+  // enter the transitionStatus mutator that would have rewritten target.
+  // -----------------------------------------------------------------------
+
+  describe('claimFromPool — target-respect (Hygiene #3)', () => {
+    it('does NOT rotate target when a non-matching agent claims (regression)', async () => {
+      // Insert a WI explicitly targeted at agent-quinn.
+      const wi = makeWorkItem({ title: "Quinn's task", target: 'agent-quinn' });
+      await service.addToPool(wi);
+
+      // Sam tries to claim with no target filter — the SAME shape that
+      // v3-data.service.ts onTaskDelegated used to fire (and rotated
+      // Quinn's WI to Sam in production).
+      const result = await service.claimFromPool('agent-sam', {
+        types: ['delegate'],
+      });
+
+      // After fix: Sam cannot claim Quinn's WI. result is null.
+      expect(result).toBeNull();
+
+      // The WI's target field is preserved as 'agent-quinn'.
+      const items = await service.getAllItems();
+      const stored = items.find((i) => i.id === wi.id)!;
+      expect(stored.target).toBe('agent-quinn');
+      expect(stored.status).toBe('queued'); // status also untouched
+    });
+
+    it('allows the matching target to claim their own WI', async () => {
+      const wi = makeWorkItem({ title: "Quinn's task", target: 'agent-quinn' });
+      await service.addToPool(wi);
+
+      const result = await service.claimFromPool('agent-quinn', {
+        types: ['delegate'],
+      });
+
+      expect(result).not.toBeNull();
+      expect(result!.workItem.target).toBe('agent-quinn');
+      expect(result!.workItem.status).toBe('running');
+    });
+
+    it('still allows any agent to claim a no-target broadcast WI', async () => {
+      // No target — broadcast pool item.
+      const wi = makeWorkItem({ title: 'Broadcast', target: undefined });
+      await service.addToPool(wi);
+
+      const result = await service.claimFromPool('agent-sam');
+      expect(result).not.toBeNull();
+      expect(result!.workItem.target).toBe('agent-sam');
+      expect(result!.workItem.status).toBe('running');
+    });
+
+    it('skips mismatched targets to find the next eligible WI', async () => {
+      // Two queued WIs: Quinn's first (oldest, FIFO), then Sam's broadcast.
+      const wi1 = makeWorkItem({ title: "Quinn's", target: 'agent-quinn' });
+      wi1.createdAt = new Date(Date.now() - 10000).toISOString();
+      const wi2 = makeWorkItem({ title: 'Broadcast', target: undefined });
+      wi2.createdAt = new Date().toISOString();
+
+      await service.addToPool(wi1);
+      await service.addToPool(wi2);
+
+      // Sam claims with no filter — pre-fix would FIFO-pick Quinn's and
+      // rotate target. After fix: Sam skips Quinn's (target mismatch) and
+      // picks the broadcast WI.
+      const result = await service.claimFromPool('agent-sam');
+      expect(result).not.toBeNull();
+      expect(result!.workItem.id).toBe(wi2.id);
+      expect(result!.workItem.title).toBe('Broadcast');
+
+      // Quinn's WI is still queued with original target preserved.
+      const items = await service.getAllItems();
+      const quinnsItem = items.find((i) => i.id === wi1.id)!;
+      expect(quinnsItem.target).toBe('agent-quinn');
+      expect(quinnsItem.status).toBe('queued');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Path-B regression — atomic-claim (claim preserved) target rotation
+  //
+  // Sam captured a 4th wave-instance: WI da8c02b8 was created with
+  // target=Quinn AND a pre-existing active TaskClaim for Quinn (Sam's
+  // manual mitigation). 7 minutes later the target rotated to Sam while
+  // the claim record stayed with Quinn — a rotation path that does NOT
+  // go through claimFromPool/claimSpecificItem (those would have created
+  // a new claim record for Sam).
+  //
+  // Hypothesis verified by these tests: my fix does cover path-B
+  // incidentally because:
+  //   - The pre-existing `!claimedIds.has(wi.id)` filter (line 597)
+  //     already excludes any WI with an active claim from candidate
+  //     selection.
+  //   - The new target-respect filter additionally excludes any WI
+  //     whose target ≠ requesting agent.
+  // Both gates fire BEFORE the transitionStatus mutator that previously
+  // rewrote target. So even if some hypothetical path-B caller triggered
+  // claimFromPool/claimSpecificItem on a claim-preserved WI, the rotation
+  // would short-circuit at filter time.
+  //
+  // If a future path-B is identified that bypasses both gates (e.g. a
+  // direct storage.updateWorkItem(wi.target=...) write outside this
+  // service), these tests document the contract that must hold.
+  // ---------------------------------------------------------------------
+
+  describe('claimFromPool — atomic-claim path-B regression (Hygiene #3)', () => {
+    it('refuses to rotate target on a queued WI that has an active claim record', async () => {
+      // Sam's mitigation pattern: create a WI with target=Quinn AND
+      // pre-attach an active TaskClaim for Quinn (atomic-claim).
+      const wi = makeWorkItem({ title: "Quinn's atomic", target: 'agent-quinn' });
+      await service.addToPool(wi);
+      // Pre-attach an active claim record for Quinn directly on storage.
+      // This simulates the atomic-claim creation pattern Sam used.
+      const existingClaim = {
+        id: 'claim-pre-existing',
+        workItemId: wi.id,
+        agentId: 'agent-quinn',
+        status: 'active' as const,
+        claimedAt: new Date().toISOString(),
+        leaseExpiresAt: new Date(Date.now() + 600000).toISOString(),
+        lastHeartbeatAt: new Date().toISOString(),
+        extensionCount: 0,
+        maxExtensions: 3,
+        leaseDurationMs: 600000,
+      };
+      await storage.addClaim(existingClaim);
+
+      // Sam tries to claim with no target filter — pre-fix this rotated
+      // target. Path-B claim: even if this path were invoked, both the
+      // claimedIds gate AND the target-respect gate must refuse.
+      const result = await service.claimFromPool('agent-sam', {
+        types: ['delegate'],
+      });
+
+      expect(result).toBeNull();
+
+      // Target preserved — no rotation. Claim record preserved.
+      const items = await service.getAllItems();
+      const stored = items.find((i) => i.id === wi.id)!;
+      expect(stored.target).toBe('agent-quinn');
+      expect(stored.status).toBe('queued');
+
+      const claims = await service.getActiveClaims();
+      const ourClaim = claims.find((c) => c.workItemId === wi.id);
+      expect(ourClaim).toBeDefined();
+      expect(ourClaim!.agentId).toBe('agent-quinn');
+    });
+  });
+
+  describe('claimSpecificItem — target-respect (Hygiene #3)', () => {
+    it('refuses to rotate target when a non-matching agent specific-claims (regression)', async () => {
+      const wi = makeWorkItem({ title: "Quinn's task", target: 'agent-quinn' });
+      await service.addToPool(wi);
+
+      // Sam tries to specifically claim Quinn's WI (auto-claim path).
+      const result = await service.claimSpecificItem('agent-sam', wi.id);
+
+      // After fix: refused — null.
+      expect(result).toBeNull();
+
+      // Target preserved.
+      const items = await service.getAllItems();
+      const stored = items.find((i) => i.id === wi.id)!;
+      expect(stored.target).toBe('agent-quinn');
+      expect(stored.status).toBe('queued');
+    });
+
+    it('allows specific claim when target matches', async () => {
+      const wi = makeWorkItem({ title: 'Mine', target: 'agent-leo' });
+      await service.addToPool(wi);
+
+      const result = await service.claimSpecificItem('agent-leo', wi.id);
+      expect(result).not.toBeNull();
+      expect(result!.workItem.target).toBe('agent-leo');
+      expect(result!.workItem.status).toBe('running');
+    });
+
+    it('allows specific claim on a no-target broadcast WI', async () => {
+      const wi = makeWorkItem({ target: undefined });
+      await service.addToPool(wi);
+
+      const result = await service.claimSpecificItem('agent-sam', wi.id);
+      expect(result).not.toBeNull();
+      expect(result!.workItem.target).toBe('agent-sam');
     });
   });
 

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -592,9 +592,25 @@ export class TaskPoolService {
           .map((c) => c.workItemId),
       );
 
-      // Find first matching unclaimed queued item (FIFO by createdAt)
-      const candidates = workItems
+      // Hygiene #3 — target-respect gate. Before this filter, claimFromPool
+      // would FIFO-pick the oldest queued+unclaimed item regardless of
+      // its existing `target` field, then unconditionally rewrite
+      // `wi.target = agentId` in the transitionStatus mutator. That
+      // produced the target-rotation bug observed in the 5/9 wave (WIs
+      // rotating through Quinn → Sam, Leo → Quinn, etc.).
+      //
+      // After this filter:
+      //   - WIs with an explicit target are claimable ONLY by that target.
+      //   - WIs with no target (broadcast pool) remain claimable by any agent.
+      // The defensive identity check in the transitionStatus mutator
+      // below ensures we never accidentally overwrite an existing target
+      // even if a future code path bypasses this filter.
+      const targetRespectingCandidates = workItems
         .filter((wi) => wi.status === 'queued' && !claimedIds.has(wi.id))
+        .filter((wi) => !wi.target || wi.target === agentId);
+
+      // Find first matching unclaimed queued item (FIFO by createdAt)
+      const candidates = targetRespectingCandidates
         .filter((wi) => matchesFilters(wi, filters))
         .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
 
@@ -609,12 +625,21 @@ export class TaskPoolService {
       // same V3 actor-role + state-machine gates as external callers.
       // `startedAt` is set automatically by transitionStatus when
       // newStatus === 'running'; the mutator carries the agent target.
+      //
+      // Hygiene #3 — target-respect (defensive). The candidate filter
+      // above already excludes WIs whose target ≠ agentId, so the only
+      // remaining cases here are (a) wi.target === agentId (no-op assign)
+      // and (b) wi.target === undefined (broadcast claim). Either way we
+      // refuse to overwrite a non-matching existing target.
       const claimedItem = await this.transitionStatus(
         selected.id,
         'running',
         'system',
         (wi) => {
-          wi.target = agentId;
+          if (!wi.target) {
+            wi.target = agentId;
+          }
+          // else: target already === agentId per the filter; leave as-is.
         },
       );
 
@@ -667,17 +692,37 @@ export class TaskPoolService {
       const workItem = await this.storage.findWorkItem(workItemId);
       if (!workItem || workItem.status !== 'queued') return null;
 
+      // Hygiene #3 — target-respect gate. Refuse to claim a WI whose
+      // existing target is set to a different agent. This prevents the
+      // claimSpecificItem path (used by AgentAutoClaimService for
+      // score-based selection) from rotating target onto an idle agent
+      // when another agent is the actual target. Same rule as
+      // claimFromPool: target=undefined (broadcast) is claimable by any
+      // agent; target=agentId is claimable only by that agent.
+      if (workItem.target && workItem.target !== agentId) {
+        this.logger.debug('claimSpecificItem refused — target mismatch', {
+          workItemId,
+          existingTarget: workItem.target,
+          requestingAgent: agentId,
+        });
+        return null;
+      }
+
       const claims = await this.storage.getClaims();
       if (claims.some((c) => c.workItemId === workItemId && c.status === 'active')) return null;
 
       // TRANS-2: route the queued → running flip through transitionStatus
       // (mirrors claimFromPool — same V3 + state-machine gates).
+      // Hygiene #3 defensive: only assign target when it's currently
+      // undefined; never overwrite an existing target.
       const claimedItem = await this.transitionStatus(
         workItemId,
         'running',
         'system',
         (wi) => {
-          wi.target = agentId;
+          if (!wi.target) {
+            wi.target = agentId;
+          }
         },
       );
       if (!claimedItem) return null;

--- a/backend/src/services/v3/v3-data.service.test.ts
+++ b/backend/src/services/v3/v3-data.service.test.ts
@@ -148,10 +148,22 @@ describe('V3DataService', () => {
       expect(addedItem.projectTaskId).toBe('task-1');
     });
 
-    it('should auto-claim WorkItem for target agent after addToPool', async () => {
+    it('should NOT auto-claim WorkItem at delegation time (Hygiene #5 race fix)', async () => {
+      // Pre-Hygiene-5 fix: onTaskDelegated called claimFromPool inline,
+      // transitioning the WI to running BEFORE the targeted agent had a
+      // chance to call poll-tasks. That created two compounding bugs:
+      //   - Hygiene #5: poll-tasks returned available=0 (status was
+      //     already running), forcing direct curl workarounds.
+      //   - Hygiene #3: claimFromPool was passed only `{ types: ['delegate'] }`
+      //     (no target filter), so it FIFO-picked any older queued
+      //     delegate WI and rotated its target to event.assignedTo.
+      //
+      // After fix: WI is created queued. Notification is owned by
+      // WorkItemDispatchSubscriber (already wired). Claim is owned by the
+      // agent's own poll-tasks call.
       const event: TaskDelegatedEvent = {
-        taskId: 'task-autoclaim',
-        title: 'Auto-claim test',
+        taskId: 'task-no-autoclaim',
+        title: 'No-auto-claim test',
         assignedTo: 'agent-max',
         projectPath: '/tmp/test',
         timestamp: new Date().toISOString(),
@@ -160,28 +172,17 @@ describe('V3DataService', () => {
       eventBus.emit('v3:task_delegated', event);
       await new Promise((r) => setTimeout(r, 50));
 
+      // WI is created and added to the pool.
       expect(mockAddToPool).toHaveBeenCalledTimes(1);
-      expect(mockClaimFromPool).toHaveBeenCalledTimes(1);
-      expect(mockClaimFromPool).toHaveBeenCalledWith('agent-max', { types: ['delegate'] });
-    });
+      const addedItem = mockAddToPool.mock.calls[0][0];
+      expect(addedItem.target).toBe('agent-max');
+      // Status is 'queued' — set by createWorkItem default, NOT mutated to running.
+      expect(addedItem.status).toBe('queued');
 
-    it('should not fail if auto-claim throws', async () => {
-      mockClaimFromPool.mockRejectedValueOnce(new Error('No items to claim'));
-
-      const event: TaskDelegatedEvent = {
-        taskId: 'task-claim-fail',
-        title: 'Claim failure test',
-        assignedTo: 'agent-leo',
-        projectPath: '/tmp/test',
-        timestamp: new Date().toISOString(),
-      };
-
-      eventBus.emit('v3:task_delegated', event);
-      await new Promise((r) => setTimeout(r, 50));
-
-      // addToPool should still succeed even if claimFromPool fails
-      expect(mockAddToPool).toHaveBeenCalledTimes(1);
-      expect(mockClaimFromPool).toHaveBeenCalledTimes(1);
+      // Critical regression assertion: claimFromPool MUST NOT be called
+      // synchronously by onTaskDelegated. The targeted agent claims via
+      // their own poll-tasks invocation.
+      expect(mockClaimFromPool).not.toHaveBeenCalled();
     });
 
     it('should skip duplicate WorkItems', async () => {

--- a/backend/src/services/v3/v3-data.service.ts
+++ b/backend/src/services/v3/v3-data.service.ts
@@ -274,16 +274,37 @@ export class V3DataService {
         requestId: resolvedRequestId,
       });
 
-      // Auto-claim for the target agent so WorkItem transitions queued → running
-      try {
-        await taskPool.claimFromPool(event.assignedTo, { types: ['delegate'] });
-      } catch (claimErr) {
-        this.logger.debug('Auto-claim after delegation failed (non-fatal)', {
-          workItemId: workItem.id,
-          target: event.assignedTo,
-          error: claimErr instanceof Error ? claimErr.message : String(claimErr),
-        });
-      }
+      // Hygiene #5 + #3 — DO NOT auto-claim here.
+      //
+      // The previous block did `taskPool.claimFromPool(event.assignedTo,
+      // { types: ['delegate'] })` inline, which transitioned the WI to
+      // `running` synchronously. Two compounding failures fell out of
+      // that:
+      //
+      //   Hygiene #5 (poll-tasks race): the targeted agent's first
+      //     `poll-tasks` call returned `available: 0` because the WI was
+      //     already running. Workers had to fall back to direct curl
+      //     against /task-pool/complete to make progress. Steve, Sam,
+      //     Quinn, Max each hit this in the 5/9 wave.
+      //
+      //   Hygiene #3 (target rotation): `claimFromPool` was passed only
+      //     `{ types: ['delegate'] }` — no target filter. It then
+      //     FIFO-picked the oldest queued+unclaimed delegate WI in the
+      //     pool, which was often a DIFFERENT agent's targeted WI
+      //     (queued because that agent had not claimed yet). The mutator
+      //     unconditionally rewrote `wi.target = event.assignedTo`, so
+      //     a Quinn-targeted WI got rotated to Sam, etc. Pool target
+      //     rotated through 3-4 sessions during the wave (WI 6e532a8b,
+      //     598c91da, c443c2cd).
+      //
+      // Fix: leave the WI queued. Notification is the
+      // {@link WorkItemDispatchSubscriber}'s job — it pushes a
+      // [CREWLY-DISPATCH] message to `target` and the agent's own
+      // `poll-tasks` invocation transitions the WI to running with the
+      // target-respect gate added in the same change to claimFromPool.
+      // No race, no rotation. See spec /tmp/sam-brief-max-hygiene-5-and-3-2026-05-09.md
+      // and the regression tests in v3-data.service.test.ts +
+      // task-pool.service.test.ts (describe 'target-respect' blocks).
 
       // Link WorkItem to Request for bidirectional tracking
       if (resolvedRequestId) {


### PR DESCRIPTION
## Summary

Closes two systemic issues observed across the 5/9 hygiene-cleanup wave (Quinn/Sam/Leo/Max all hit one or both). They share root cause and fix in the same code path:

- **Hygiene #5 (poll-tasks race):** `poll-tasks` returned `available: 0` for verify-WIs targeted at the polling agent because auto-start had already transitioned the WI to `running` before `poll-tasks` fired. Workers fell back to direct `curl` against `/task-pool/complete` to make progress.
- **Hygiene #3 (pool target-rotation):** WIs queued at agent A had their `target` field rotated to agent B mid-flight without explicit handoff. Documented during the wave on WIs `6e532a8b` (Quinn → flopost-dex → null), `598c91da` (Quinn → Sam), `c443c2cd` (Leo → Quinn), `da8c02b8` (Quinn → Sam, atomic-claim).

## Root cause

`claimFromPool` (`task-pool.service.ts:565`) was selecting the FIFO-oldest queued+unclaimed WorkItem matching `filters` and unconditionally rewriting `wi.target = agentId` in the `transitionStatus` mutator. `v3-data.service.ts:onTaskDelegated` then fired `claimFromPool(event.assignedTo, { types: ['delegate'] })` inline immediately after creating a queued WI — with no target filter.

When pre-existing queued WIs targeted at other agents lay around in the pool, the FIFO-oldest one would be picked instead of the just-created WI, and its target would rotate to `event.assignedTo`. That manifested as both #5 (the legitimate WI stays queued, blocking poll-tasks) and #3 (older WI's target rotates).

## Callsite changes (POST-edit lines on this branch)

| Change | File:line | Notes |
|---|---|---|
| Hygiene #5 fix | `backend/src/services/v3/v3-data.service.ts:277-307` | Removed inline `taskPool.claimFromPool(...)` call from `onTaskDelegated`. WI stays queued; `WorkItemDispatchSubscriber` notifies the target; agent claims via own `poll-tasks` call. |
| Hygiene #3 fix — claimFromPool target-respect filter | `backend/src/services/task-pool/task-pool.service.ts:595-617` | New `targetRespectingCandidates` filter: a WI is claimable ONLY when `!wi.target` (broadcast pool) OR `wi.target === agentId`. |
| Hygiene #3 fix — claimFromPool defensive mutator | `backend/src/services/task-pool/task-pool.service.ts:629-651` | `transitionStatus` mutator only assigns target when currently undefined; never overwrites. |
| Hygiene #3 fix — claimSpecificItem target-respect gate | `backend/src/services/task-pool/task-pool.service.ts:695-712` | Explicit refusal log when `existingTarget !== requestingAgent`. Mirrors claimFromPool gate; same defensive mutator. |

## Why this closes both bugs

Both #5 and #3 were symptoms of the same write-pattern: `claimFromPool` rewrote target on a queued WI selected without target filter. Removing the inline call from `onTaskDelegated` (#5 fix) eliminates the most common trigger; adding the target-respect filter (#3 fix) closes any other path that might call `claimFromPool` with a non-target-matching agent — including future skill scripts, future subscribers, and concurrent races.

## Path-B (atomic-claim rotation) — incidentally covered

Sam captured a 4th wave-instance (`da8c02b8`) where target rotated Quinn → Sam while the active TaskClaim record stayed with Quinn. Initial reading suggested a third mutation path beyond `claimFromPool`/`claimSpecificItem`.

**Reconciliation:** an exhaustive grep (`grep -rn '\\.target\\s*=\\s*' backend/src --include='*.ts' | grep -v test | grep -v '==='`) shows there are exactly **four** direct `WI.target` writes in the codebase, all in `task-pool.service.ts`:
- `:640` claimFromPool — gated by this PR
- `:724` claimSpecificItem — gated by this PR
- `:781` releaseBack — sets `target = undefined` only on the non-blocked path (no rotation semantics)
- `:1349` handoff — explicit `POST /api/task-pool/items/:id/handoff` only; no automated callers in repo

There is **no subscriber, scheduler, or event-bus path** that writes `target`. Path-B-as-third-path does not exist.

**Most parsimonious explanation for the observation:** the forensic snapshot at 04:10Z+ landed in the sub-millisecond window between the target-mutator write and the `addClaim()` insert inside `claimFromPool` — by the time of the snapshot, target was rotated but the new claim had not yet been persisted, so the OLD claim record was still visible. The "force-delete `hadActiveClaim=true`" detail supports this: by force-delete time the claim had rotated too. Future debuggers seeing similar "target rotated but claim preserved" reports should land here.

A regression test (`task-pool.service.test.ts` — `claimFromPool — atomic-claim path-B regression`) locks the contract: a WI with target=A AND a pre-existing active TaskClaim for A is claim-able by NO OTHER AGENT. Pre-existing `claimedIds` filter + new target-respect filter both gate it.

## Tests

- `backend/src/services/task-pool/task-pool.service.test.ts` — **+8 regression tests** under three new describe blocks:
  - `claimFromPool — target-respect (Hygiene #3)` — 4 tests: refusal of non-matching claim, allow matching, allow broadcast, skip-then-pick-next-eligible
  - `claimFromPool — atomic-claim path-B regression (Hygiene #3)` — 1 test: claim+target both preserved when non-matching agent attempts claim
  - `claimSpecificItem — target-respect (Hygiene #3)` — 3 tests: refusal/allow/broadcast variants
  - Default `makeWorkItem.target` updated to `undefined` so existing tests that claim with arbitrary agents continue to pass
- `backend/src/services/v3/v3-data.service.test.ts` — Replaced `should auto-claim` with `should NOT auto-claim` regression assertion locking the #5 fix.

```
npx jest backend/src/services/task-pool/task-pool.service.test.ts \
        backend/src/services/v3/v3-data.service.test.ts
→ Test Suites: 2 passed, 2 total
→ Tests:       198 passed, 198 total
```

```
npm run build:backend → clean
```

## What could regress (TL review checklist)

- **Auto-claim happy path** (`AgentAutoClaimService.tryAutoClaimForAgent`): uses `claimSpecificItem` after score-based selection. After fix, mismatched-target candidates are skipped at filter time; the service returns null instead of rotating. No infinite loop — the agent's next idle/poll tick sees the still-queued WI and re-evaluates.
- **Targeted claim happy path** (poll-tasks → `accept-task` skill → `POST /task-pool/claim`): unchanged semantics. Skill calls `claimFromPool` with `agentId` and no target filter; new gate permits `target=agentId` or untargeted WIs — exactly the intended targeted-claim behavior.
- **Handoff API** (`POST /api/task-pool/items/:id/handoff`): unchanged. The only public path that intentionally rewrites `target` on a non-queued WI; this fix doesn't touch it.
- **releaseBack target preservation** (blocked → queued path): unchanged. Target preserved via existing mutator.
- **Concurrent claim serialization**: unchanged. Pre-existing `withClaimLock` mutex keeps two agents from racing the same WI.

## Pre-existing failures (NOT in this PR's scope, confirmed on origin/main)

- 6 vitest-import test suites: `TS2307: Cannot find module 'vitest'` — pre-existing on main, separate hygiene item per Sam.
- `request-notification.service.test:108` — `mockSlackService.sendMessage` not called; verified to fail identically on main without this PR's changes.

## Test plan

- [x] `claimFromPool` refuses non-matching target (regression test)
- [x] `claimSpecificItem` refuses non-matching target (regression test)
- [x] Atomic-claim path-B WI not rotated when non-matching agent claims (path-B coverage test)
- [x] `onTaskDelegated` does NOT call `claimFromPool` (auto-claim removal regression test)
- [x] `npm run build:backend` clean
- [x] Touched-area test suite: 198/198 passing
- [ ] Post-merge replay: pool-add a WI with target=A; pool-add another WI with target=B; verify A's WI target stays A and is claimable only by A via `poll-tasks`; verify B's WI target stays B; verify neither rotates after 10+ minutes idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)