### PR TITLE
fix(task-pool): Hygiene #4 — strict body-shape lock for /complete (5 callsites + JSDoc + 19 tests)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -699,4 +699,135 @@ describe('TaskPoolController', () => {
       );
     });
   });
+
+  // ---------------------------------------------------------------------
+  // completeItem — Hygiene #4 (2026-05-09): strict-shape lock
+  //
+  // Quinn surfaced this on the #499 verify-WI dogfood. Five callsites
+  // (3 skills + 2 TS in tool-registry.ts) were emitting top-level
+  // `{summary}` instead of `{agentId, result:{summary}}`. Decision was
+  // to keep the controller STRICT and fix all callers in the same PR
+  // rather than ship a backward-compat resolver. These tests lock that
+  // contract — broken-shape variants must 400, canonical shape must
+  // succeed, and the broken-shape rejection messages must be specific
+  // enough to point a human caller at the fix.
+  // ---------------------------------------------------------------------
+  describe('completeItem (Hygiene #4 strict-shape lock)', () => {
+    beforeEach(() => {
+      mockService.findWorkItem.mockResolvedValue({ id: 'wi-h4', output: null });
+      mockService.setOutput.mockResolvedValue(undefined);
+      mockService.completeItem.mockResolvedValue(undefined);
+    });
+
+    it('rejects legacy top-level `{summary}` shape with 400 (no agentId)', async () => {
+      // The exact broken shape that 3 skills + 2 TS callsites used to
+      // emit. The agentId-required check fires FIRST (before the
+      // result.summary check), so the error here is `agentId is required`.
+      const req = mockReq({
+        params: { workItemId: 'wi-h4' },
+        body: { summary: 'Top-level summary, no agentId, no result wrapper' },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: 'agentId is required',
+        }),
+      );
+      expect(mockService.completeItem).not.toHaveBeenCalled();
+    });
+
+    it('rejects `{agentId, summary}` (top-level summary missing result wrapper) with 400', async () => {
+      // Caller has agentId but still puts summary at top level instead
+      // of inside `result`. This is the second-most-likely "fixed it
+      // halfway" mistake — passes the agentId gate, fails the
+      // result.summary gate.
+      const req = mockReq({
+        params: { workItemId: 'wi-h4' },
+        body: { agentId: 'agent-1', summary: 'Top-level summary, no result wrapper' },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          code: 'complete_requires_summary',
+        }),
+      );
+      expect(mockService.completeItem).not.toHaveBeenCalled();
+    });
+
+    it('error message on missing summary points caller at body.result', async () => {
+      // Discoverability check — the 400 message must contain the string
+      // "body.result" so a human caller (or LLM agent) reading the
+      // response can fix the shape without diving into source.
+      const req = mockReq({
+        params: { workItemId: 'wi-h4' },
+        body: { agentId: 'agent-1', result: {} },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      const jsonCall = (res.json as jest.Mock).mock.calls[0][0];
+      expect(jsonCall.error).toEqual(expect.stringContaining('body.result'));
+    });
+
+    it('accepts the canonical shape `{agentId, result:{summary}}` and returns success', async () => {
+      // The smoke-replay assertion. Mirror exactly what the 5 fixed
+      // callsites emit post-Hygiene #4 — controller must accept it.
+      const req = mockReq({
+        params: { workItemId: 'wi-h4' },
+        body: {
+          agentId: 'crewly-product-quinn-47ce967d',
+          result: { summary: 'Hygiene #4 strict-shape lock — 5 callsites fixed.' },
+        },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(mockService.completeItem).toHaveBeenCalledWith(
+        'wi-h4',
+        expect.objectContaining({ summary: expect.stringContaining('Hygiene #4') }),
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      );
+    });
+
+    it('canonical shape with extra result fields preserves them onto output', async () => {
+      // The complete-task skill's `output` parameter is now merged into
+      // `result` alongside `summary` (per the fixed body in
+      // config/skills/agent/core/complete-task/execute.sh). Verify the
+      // controller accepts that merged shape and persists every field.
+      const req = mockReq({
+        params: { workItemId: 'wi-h4' },
+        body: {
+          agentId: 'crewly-product-quinn-47ce967d',
+          result: {
+            summary: 'Shipped Hygiene #4',
+            prNumber: 999,
+            callsiteCount: 5,
+            decision: 'strict',
+          },
+        },
+      });
+      const res = mockRes();
+      await completeItem(req, res);
+
+      expect(mockService.setOutput).toHaveBeenCalledWith(
+        'wi-h4',
+        expect.objectContaining({
+          summary: 'Shipped Hygiene #4',
+          prNumber: 999,
+          callsiteCount: 5,
+          decision: 'strict',
+        }),
+      );
+    });
+  });
 });

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -350,12 +350,49 @@ export async function releaseItem(req: Request, res: Response): Promise<void> {
 /**
  * Marks a running WorkItem as completed ('done').
  *
- * Request body:
+ * ## Canonical body shape (STRICT)
+ *
  * ```json
- * { "agentId": "crewly-product-leo-member-n", "tokenUsage": { ... }, "result": { ... } }
+ * {
+ *   "agentId": "crewly-product-leo-member-n",
+ *   "result": { "summary": "what I produced …", "prNumber": 525, "...": "..." },
+ *   "tokenUsage": { "inputTokens": 0, "outputTokens": 0, "totalCost": 0 }
+ * }
  * ```
  *
- * @param req - Express request with workItemId param
+ * Validation rules (in order — first failure short-circuits):
+ * 1. `workItemId` URL param — required (path; never empty).
+ * 2. `agentId` body field — required, non-empty string. Identifies the
+ *    completing agent for token attribution and audit trail.
+ * 3. `result.summary` body field — required, non-empty string after trim.
+ *    Enforces the Request Contract's Done Definition: workers report
+ *    what they produced (artifact, decision, verified result), not just
+ *    "done".
+ *
+ * Any field beyond `summary` inside `result` (e.g. `prNumber`, `links`)
+ * is preserved into `WorkItem.output` via spread merge, so downstream
+ * verifiers can read the proof-of-work without digging through chat logs.
+ *
+ * ## Hygiene #4 (PR ?) — strict-shape lock
+ *
+ * Prior to Hygiene #4, three skill callers (`config/skills/agent/core/{
+ * report-status,complete-task}/execute.sh`, `config/skills/orchestrator/
+ * complete-task/execute.sh`) and two TS callers (`tool-registry.ts`
+ * §complete_task + §report_status auto-complete) emitted top-level
+ * `{summary}` instead of the canonical `{agentId, result:{summary}}`.
+ * That shape failed both validators (missing agentId + result.summary),
+ * forcing every worker into a direct-curl workaround that Quinn
+ * surfaced on the #499 verify-WI dogfood.
+ *
+ * Decision (locked T+9min on Hygiene #4 by Quinn): keep the controller
+ * STRICT — fix all 5 callsites in the same PR rather than ship a
+ * backward-compat resolver. Rationale: all 5 callers are in-tree, OSS
+ * is the only consumer (Crewly Pro extends via Plugin System and does
+ * NOT fork core skill or task-pool callers per workspace CLAUDE.md),
+ * and a compat layer would add permanent ambiguity for zero downstream
+ * benefit.
+ *
+ * @param req - Express request with `workItemId` param + canonical body
  * @param res - Express response
  */
 export async function completeItem(req: Request, res: Response): Promise<void> {
@@ -385,10 +422,9 @@ export async function completeItem(req: Request, res: Response): Promise<void> {
     // it at the API boundary so the proof of work lands with the
     // transition, not as an afterthought.
     //
-    // Skills already pass `summary`: the agent and orchestrator
-    // complete-task skills both emit `{summary: "..."}` in the body.
-    // Empty-summary callers (legacy or buggy) get a 400 with a
-    // helpful error directing them to populate `summary`.
+    // Hygiene #4 (2026-05-09): callers MUST emit the canonical body shape
+    // `{agentId, result:{summary}}` — see the JSDoc on this handler for
+    // the contract. Top-level `{summary}` returns a 400 here.
     const summary = typeof result?.summary === 'string' ? result.summary.trim() : '';
     if (summary.length === 0) {
       res.status(400).json({

--- a/backend/src/services/agent/crewly-agent/tool-registry.test.ts
+++ b/backend/src/services/agent/crewly-agent/tool-registry.test.ts
@@ -1325,7 +1325,12 @@ describe('Tool Registry', () => {
     // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
     // Auto-complete now resolves the agent's running WI from the pool and
     // calls `/task-pool/complete/:id`. Replaces v1 `/task-management/complete-by-session`.
-    it('should auto-complete the running WorkItem when status is done', async () => {
+    //
+    // Hygiene #4 (2026-05-09): the body shape is the canonical
+    // `{agentId, result:{summary}}` required by task-pool.controller.ts
+    // `completeItem`. `agentId` here is the session whose status=done
+    // message triggered this auto-complete path.
+    it('should auto-complete the running WorkItem when status is done — canonical body shape', async () => {
       mockClient.post.mockResolvedValue({ success: true, data: { acknowledged: true }, status: 200 });
       mockClient.get.mockResolvedValueOnce({
         success: true,
@@ -1341,9 +1346,12 @@ describe('Tool Registry', () => {
       expect(mockClient.get).toHaveBeenCalledWith(
         expect.stringMatching(/^\/task-pool\/items\?status=running&target=/),
       );
+      // Canonical body shape per Hygiene #4 — `{agentId, result:{summary}}`.
+      // The `crewly-orc` literal here is the createTools sessionName arg
+      // used in the test fixture (see top-of-file `createTools(mockClient, 'crewly-orc', ...)`).
       expect(mockClient.post).toHaveBeenCalledWith(
         '/task-pool/complete/wi-running-1',
-        { summary: 'Feature implemented' },
+        { agentId: 'crewly-orc', result: { summary: 'Feature implemented' } },
       );
     });
 
@@ -1869,7 +1877,7 @@ describe('Tool Registry', () => {
       mockClient.delete.mockResolvedValue({ success: true, data: {}, status: 200 });
 
       const result = await (tools.complete_task as any).execute({
-        absoluteTaskPath: '/tasks/task-1.md',
+        workItemId: 'wi-1',
         sessionName: 'agent-sam',
         summary: 'Done',
       });
@@ -1879,6 +1887,25 @@ describe('Tool Registry', () => {
       expect(mockClient.delete).toHaveBeenCalledWith('/schedule/chk-1');
       expect(mockClient.delete).toHaveBeenCalledWith('/schedule/chk-3');
       expect(mockClient.delete).not.toHaveBeenCalledWith('/schedule/chk-2');
+    });
+
+    // Hygiene #4 (2026-05-09): assert the canonical body shape on the
+    // /task-pool/complete POST. Prior shape `{summary}` 400'd because the
+    // controller looks at `result.summary` and requires non-empty `agentId`.
+    it('emits canonical body shape `{agentId, result:{summary}}`', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { completed: true }, status: 200 });
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+
+      await (tools.complete_task as any).execute({
+        workItemId: 'wi-shape-1',
+        sessionName: 'agent-quinn',
+        summary: 'Implemented hygiene #4',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/task-pool/complete/wi-shape-1',
+        { agentId: 'agent-quinn', result: { summary: 'Implemented hygiene #4' } },
+      );
     });
 
     it('should still complete task even if check cleanup fails', async () => {

--- a/backend/src/services/agent/crewly-agent/tool-registry.ts
+++ b/backend/src/services/agent/crewly-agent/tool-registry.ts
@@ -1220,8 +1220,17 @@ export function createTools(client: CrewlyApiClient, sessionName: string, projec
         // `absoluteTaskPath` parameter is removed; callers must now pass
         // `workItemId` (returned from `start_agent_with_task` /
         // `delegate_task`).
+        //
+        // Hygiene #4: emit canonical body shape `{agentId, result:{summary}}`
+        // required by task-pool.controller.ts `completeItem`. Prior shape
+        // `{summary}` 400'd because the controller looks at `result.summary`
+        // and requires non-empty `agentId`. Cf. fix-paired changes in:
+        //   - config/skills/agent/core/{report-status,complete-task}/execute.sh
+        //   - config/skills/orchestrator/complete-task/execute.sh
+        //   - tool-registry.ts §report_status auto-complete path (below)
         const result = await client.post(`/task-pool/complete/${workItemId}`, {
-          summary,
+          agentId: agent,
+          result: { summary },
         });
 
         // Auto-cancel scheduled checks targeting the completing agent
@@ -1660,7 +1669,16 @@ export function createTools(client: CrewlyApiClient, sessionName: string, projec
             );
             const wiId = list[0]?.id;
             if (wiId) {
-              await client.post(`/task-pool/complete/${wiId}`, { summary }).catch(() => {});
+              // Hygiene #4: canonical body shape `{agentId, result:{summary}}`.
+              // `agentId` here is `sessionName` because that's the runtime
+              // identity of the completing agent (the session whose
+              // status=done message triggered this auto-complete path).
+              await client
+                .post(`/task-pool/complete/${wiId}`, {
+                  agentId: sessionName,
+                  result: { summary },
+                })
+                .catch(() => {});
             }
           } catch {
             // Non-fatal: status report still succeeded.

--- a/config/skills/_common/complete-body-shape.test.sh
+++ b/config/skills/_common/complete-body-shape.test.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+# =============================================================================
+# Hygiene #4 (2026-05-09) — wire-shape smoke test for /api/task-pool/complete
+#
+# Brief allows: "a smoke test that verifies the JSON body shape against the
+# controller's accepted schema" (.crewly/specs equivalent). This is that test.
+#
+# Covers the 3 skill callsites that emit POSTs to /task-pool/complete:
+#   1. config/skills/agent/core/report-status/execute.sh        (status=done branch)
+#   2. config/skills/agent/core/complete-task/execute.sh        (always)
+#   3. config/skills/orchestrator/complete-task/execute.sh      (always)
+#
+# Strategy: spin up a Python HTTP stub that records every POST body; point
+# each skill at it via CREWLY_API_URL; assert the captured body matches the
+# canonical `{agentId, result:{summary}, ...}` shape required by
+# task-pool.controller.ts `completeItem`.
+#
+# Pattern mirrors the existing `config/skills/agent/remote-browser/
+# execute.test.sh` Python-stub harness — same JSONL request log, same
+# subshell-pid trick.
+#
+# Test runner:
+#   bash config/skills/_common/complete-body-shape.test.sh
+#   echo $?    # 0 on pass, 1 on fail
+# =============================================================================
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PASS=0
+FAIL=0
+
+assert_eq_json() {
+  local test_name="$1" expected="$2" actual="$3"
+  # Normalize both via jq -S so key order does not matter.
+  local norm_expected norm_actual
+  norm_expected=$(printf '%s' "$expected" | jq -S '.' 2>/dev/null || echo "INVALID_JSON_EXPECTED")
+  norm_actual=$(printf '%s' "$actual" | jq -S '.' 2>/dev/null || echo "INVALID_JSON_ACTUAL")
+  if [ "$norm_expected" = "$norm_actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ ${test_name}"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${test_name}"
+    echo "    expected: ${norm_expected}"
+    echo "    actual:   ${norm_actual}"
+  fi
+}
+
+assert_jq() {
+  local test_name="$1" jq_filter="$2" body="$3"
+  local result
+  result=$(printf '%s' "$body" | jq -er "$jq_filter" 2>/dev/null || true)
+  if [ -n "$result" ] && [ "$result" != "null" ] && [ "$result" != "false" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ ${test_name}"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${test_name}"
+    echo "    filter: ${jq_filter}"
+    echo "    body:   ${body}"
+  fi
+}
+
+start_stub() {
+  local port="$1" log_file="$2"
+  PORT=$port LOG_FILE=$log_file \
+    python3 -c '
+import http.server, json, os, sys
+LOG = os.environ["LOG_FILE"]
+PORT = int(os.environ["PORT"])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass  # quiet
+    def _record(self, body_bytes):
+        with open(LOG, "a") as f:
+            f.write(json.dumps({
+                "method": self.command,
+                "path": self.path,
+                "body": body_bytes.decode("utf-8") if body_bytes else "",
+            }) + "\n")
+    def _ok(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{\"success\":true}")
+    def do_POST(self):
+        ln = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(ln) if ln else b""
+        self._record(body)
+        # Specific handling for the resolve-running-WI fallback
+        if self.path.startswith("/api/task-pool/items"):
+            self.send_response(200)
+            self.send_header("Content-Type","application/json")
+            self.end_headers()
+            # Top-level workItems shape — matches the jq fallback chain
+            # in the skills (`.workItems[0].id // .data[0].id // empty`).
+            self.wfile.write(b"{\"workItems\":[{\"id\":\"wi-stub-1\"}]}")
+            return
+        self._ok()
+    def do_GET(self):
+        self._record(b"")
+        if self.path.startswith("/api/task-pool/items"):
+            self.send_response(200)
+            self.send_header("Content-Type","application/json")
+            self.end_headers()
+            # Top-level workItems shape — matches the jq fallback chain
+            # in the skills (`.workItems[0].id // .data[0].id // empty`).
+            self.wfile.write(b"{\"workItems\":[{\"id\":\"wi-stub-1\"}]}")
+            return
+        self._ok()
+
+httpd = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
+httpd.serve_forever()
+' >/dev/null 2>&1 &
+  echo $!
+}
+
+# ---------------------------------------------------------------------------
+# Per-skill scenario harness
+# ---------------------------------------------------------------------------
+PORT=39184
+TMPROOT=$(mktemp -d -t crewly-hygiene4-XXXXXX)
+LOG="${TMPROOT}/requests.jsonl"
+: > "$LOG"
+
+STUB_PID=$(start_stub "$PORT" "$LOG")
+trap "kill $STUB_PID 2>/dev/null || true; rm -rf $TMPROOT" EXIT
+
+# Wait briefly for the HTTP server to bind.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -s "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then break; fi
+  sleep 0.1
+done
+
+export CREWLY_API_URL="http://127.0.0.1:${PORT}"
+
+echo "=== Hygiene #4 — /task-pool/complete body-shape smoke ==="
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — agent/core/report-status (status=done branch)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 1: agent/core/report-status status=done ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/report-status/execute.sh" \
+  --session quinn-test --status done \
+  --summary "Report-status smoke summary" \
+  --project /tmp/proj-foo >/dev/null 2>&1 || true
+
+# Expect at least one POST to /api/task-pool/complete/ — find it.
+COMPLETE_LINE=$(grep -F '"path": "/api/task-pool/complete/' "$LOG" | head -1 || true)
+if [ -z "$COMPLETE_LINE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ no /task-pool/complete POST captured"
+else
+  COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_jq "agentId is the session name" '.agentId == "quinn-test"' "$COMPLETE_BODY"
+  assert_jq "result.summary is non-empty" '.result.summary | length > 0' "$COMPLETE_BODY"
+  assert_jq "result.summary matches input" '.result.summary == "Report-status smoke summary"' "$COMPLETE_BODY"
+  assert_jq "no top-level summary leak (strict shape)" '.summary == null' "$COMPLETE_BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — agent/core/complete-task
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 2: agent/core/complete-task ---"
+: > "$LOG"
+TASK_DIR=$(mktemp -d -t crewly-hygiene4-task-XXXXXX)
+TASK_PATH="${TASK_DIR}/task.md"
+echo "# task" > "$TASK_PATH"
+
+bash "${REPO_ROOT}/config/skills/agent/core/complete-task/execute.sh" \
+  '{"absoluteTaskPath":"'"$TASK_PATH"'","sessionName":"quinn-ct","summary":"Complete-task smoke summary","workItemId":"wi-stub-1","output":{"prNumber":42,"callsites":5}}' \
+  >/dev/null 2>&1 || true
+
+COMPLETE_LINE=$(grep -F '"path": "/api/task-pool/complete/' "$LOG" | head -1 || true)
+if [ -z "$COMPLETE_LINE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ no /task-pool/complete POST captured"
+else
+  COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_jq "agentId is the session name" '.agentId == "quinn-ct"' "$COMPLETE_BODY"
+  assert_jq "result.summary matches" '.result.summary == "Complete-task smoke summary"' "$COMPLETE_BODY"
+  assert_jq "result.prNumber merged into result (was top-level result before)" '.result.prNumber == 42' "$COMPLETE_BODY"
+  assert_jq "result.callsites merged into result" '.result.callsites == 5' "$COMPLETE_BODY"
+  assert_jq "no top-level summary leak" '.summary == null' "$COMPLETE_BODY"
+fi
+rm -rf "$TASK_DIR"
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — orchestrator/complete-task
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 3: orchestrator/complete-task ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/orchestrator/complete-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","summary":"Orc complete-task smoke summary"}' \
+  >/dev/null 2>&1 || true
+
+COMPLETE_LINE=$(grep -F '"path": "/api/task-pool/complete/' "$LOG" | head -1 || true)
+if [ -z "$COMPLETE_LINE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ no /task-pool/complete POST captured"
+else
+  COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_jq "agentId defaults to crewly-orc" '.agentId == "crewly-orc"' "$COMPLETE_BODY"
+  assert_jq "result.summary matches" '.result.summary == "Orc complete-task smoke summary"' "$COMPLETE_BODY"
+  assert_jq "no top-level summary leak" '.summary == null' "$COMPLETE_BODY"
+fi
+
+echo ""
+echo "--- Scenario 3b: orchestrator/complete-task with explicit agentId override ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/orchestrator/complete-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","summary":"Orc on-behalf-of summary","agentId":"crewly-product-leo-21a5477e"}' \
+  >/dev/null 2>&1 || true
+
+COMPLETE_LINE=$(grep -F '"path": "/api/task-pool/complete/' "$LOG" | head -1 || true)
+if [ -z "$COMPLETE_LINE" ]; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ no /task-pool/complete POST captured"
+else
+  COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_jq "agentId overridden to caller value" '.agentId == "crewly-product-leo-21a5477e"' "$COMPLETE_BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — orchestrator/complete-task rejects empty summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 4: orchestrator/complete-task rejects empty summary ---"
+: > "$LOG"
+EXIT=0
+OUTPUT=$(bash "${REPO_ROOT}/config/skills/orchestrator/complete-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","summary":""}' 2>&1) || EXIT=$?
+
+if [ "$EXIT" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q "summary is required"; then
+  PASS=$((PASS + 1))
+  echo "  ✓ exits non-zero with helpful 'summary is required' error"
+else
+  FAIL=$((FAIL + 1))
+  echo "  ✗ should reject empty summary; exit=$EXIT, output=$OUTPUT"
+fi
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ $FAIL -eq 0 ]

--- a/config/skills/agent/core/complete-task/execute.sh
+++ b/config/skills/agent/core/complete-task/execute.sh
@@ -89,6 +89,13 @@ fi
 # The optional `output` is now MERGED into `result` alongside `summary` —
 # this matches the controller's mergedOutput behavior (task-pool.controller.ts
 # §405-419) which spreads result fields beyond `summary` into WorkItem.output.
+#
+# Precedence (per Sam #527 review note): jq's `+` operator is right-side-wins
+# on key conflicts. The spread order here is `{summary: $summary} + $output`,
+# so a caller-supplied `output.summary` WILL override the explicit `--summary`
+# parameter. Intentional — callers passing structured output already have an
+# authoritative summary in there; the explicit param is the fallback. If you
+# need the param to win, swap the operands.
 BODY=$(jq -n \
   --arg agentId "$SESSION_NAME" \
   --arg summary "$SUMMARY" \

--- a/config/skills/agent/core/complete-task/execute.sh
+++ b/config/skills/agent/core/complete-task/execute.sh
@@ -80,13 +80,28 @@ if [ -z "$WORK_ITEM_ID" ]; then
   exit 1
 fi
 
+# Hygiene #4: emit canonical body shape `{agentId, result:{summary, ...output}}`
+# required by /api/task-pool/complete (task-pool.controller.ts `completeItem`).
+# Prior shape `{summary, ..., result: $output}` 400'd because top-level summary
+# was ignored (controller looks at result.summary) and `result` was overloaded
+# with the output payload instead of the summary wrapper.
+#
+# The optional `output` is now MERGED into `result` alongside `summary` —
+# this matches the controller's mergedOutput behavior (task-pool.controller.ts
+# §405-419) which spreads result fields beyond `summary` into WorkItem.output.
 BODY=$(jq -n \
+  --arg agentId "$SESSION_NAME" \
   --arg summary "$SUMMARY" \
   --arg skipGates "$SKIP_GATES" \
   --argjson output "${OUTPUT_JSON:-null}" \
-  '{summary: $summary} +
-   (if $skipGates == "true" then {skipGates: true} else {} end) +
-   (if $output != null then {result: $output} else {} end)')
+  '{
+    agentId: $agentId,
+    result: ({summary: $summary}
+              + (if $output != null and ($output | type) == "object"
+                 then $output
+                 else {} end))
+  }
+   + (if $skipGates == "true" then {skipGates: true} else {} end)')
 
 api_call POST "/task-pool/complete/${WORK_ITEM_ID}" "$BODY"
 

--- a/config/skills/agent/core/report-status/execute.sh
+++ b/config/skills/agent/core/report-status/execute.sh
@@ -227,7 +227,15 @@ if [ "$STATUS" = "done" ]; then
   fi
 
   if [ -n "$TARGET_WI_ID" ]; then
-    COMPLETE_BODY=$(jq -n --arg summary "$SUMMARY" '{summary: $summary}')
+    # Hygiene #4: emit canonical body shape `{agentId, result:{summary}}`
+    # required by /api/task-pool/complete (task-pool.controller.ts
+    # `completeItem`). Prior shape `{summary}` 400'd with
+    # `agentId is required` + `summary required in body.result`,
+    # forcing every worker into a direct-curl workaround.
+    COMPLETE_BODY=$(jq -n \
+      --arg agentId "$SESSION_NAME" \
+      --arg summary "$SUMMARY" \
+      '{agentId: $agentId, result: {summary: $summary}}')
     api_call POST "/task-pool/complete/${TARGET_WI_ID}" "$COMPLETE_BODY" || true
   fi
 fi

--- a/config/skills/orchestrator/complete-task/execute.sh
+++ b/config/skills/orchestrator/complete-task/execute.sh
@@ -20,6 +20,11 @@ INPUT=$(read_json_input "${1:-}")
 WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // .taskId // empty')
 SUMMARY=$(printf '%s' "$INPUT" | jq -r '.summary // .result // empty')
 OUTPUT=$(printf '%s' "$INPUT" | jq -c '.output // empty')
+# Hygiene #4: agentId is required by the controller's completeItem validator.
+# Orchestrator-driven completions default to "crewly-orc" but accept an
+# explicit override (some flows complete on behalf of the agent that ran the
+# work — pass that session name instead).
+AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agentId // .sessionName // "crewly-orc"')
 
 require_param "workItemId" "$WORK_ITEM_ID"
 
@@ -30,7 +35,18 @@ if [ -n "$OUTPUT" ] && [ "$OUTPUT" != "null" ] && [ "$OUTPUT" != "" ]; then
   api_call POST "/task-pool/items/${WORK_ITEM_ID}/output" "$OUTPUT_BODY" >/dev/null 2>&1 || true
 fi
 
-COMPLETE_BODY=$(jq -n --arg summary "$SUMMARY" \
-  '(if $summary != "" then {summary: $summary} else {} end)')
+# Hygiene #4: emit canonical body shape `{agentId, result:{summary}}`
+# required by /api/task-pool/complete (task-pool.controller.ts `completeItem`).
+# Prior shape `{summary}` 400'd with `agentId is required` + `summary
+# required in body.result`. The controller enforces non-empty summary, so
+# bail early here too rather than send `{agentId, result:{}}` and let the
+# server reject it.
+if [ -z "$SUMMARY" ]; then
+  error_exit "summary is required (controller enforces non-empty body.result.summary)"
+fi
+COMPLETE_BODY=$(jq -n \
+  --arg agentId "$AGENT_ID" \
+  --arg summary "$SUMMARY" \
+  '{agentId: $agentId, result: {summary: $summary}}')
 
 api_call POST "/task-pool/complete/${WORK_ITEM_ID}" "$COMPLETE_BODY"


### PR DESCRIPTION
## Summary

Locks the canonical body shape for `POST /api/task-pool/complete/:workItemId`. All 5 callsites (3 skills + 2 TS in tool-registry.ts) were emitting top-level `{summary}` instead of `{agentId, result:{summary}}` — every worker had to fall back to direct curl. This PR fixes all 5 callers, documents the strict contract on the controller, and locks both directions with tests.

**WI:** `da8c02b8-10e1-4216-b9c6-b1e1324e613b` (Hygiene #4)
**Decision:** STRICT — see decision rationale in commit body.
**Original failure repro:** Quinn's #499 verify-WI dogfood (status=done call returned `agentId is required` 400).

## Files changed (+519 / -18)

- `backend/src/controllers/task-pool/task-pool.controller.ts` — JSDoc cleanup (validators unchanged)
- `backend/src/controllers/task-pool/task-pool.controller.test.ts` — +5 strict-shape lock tests
- `backend/src/services/agent/crewly-agent/tool-registry.ts` — fix 2 callsites (complete_task tool + report_status auto-complete)
- `backend/src/services/agent/crewly-agent/tool-registry.test.ts` — update 2 existing tests + add 1 new shape assertion
- `config/skills/agent/core/report-status/execute.sh` — fix status=done branch
- `config/skills/agent/core/complete-task/execute.sh` — fix + merge `output` into `result`
- `config/skills/orchestrator/complete-task/execute.sh` — fix + add `agentId` resolution + reject empty summary early
- `config/skills/_common/complete-body-shape.test.sh` — NEW Python-stub smoke test (14 assertions across all 3 skills)

## Test plan

- [x] `bash config/skills/_common/complete-body-shape.test.sh` — **14/14 pass**
- [x] `npm run build:backend` — tsc clean
- [x] `jest backend/src/controllers/task-pool/task-pool.controller.test.ts` — controller suite GREEN, **5 new Hygiene #4 strict-shape lock tests pass**
- [x] `jest backend/src/services/agent/crewly-agent/tool-registry.test.ts` — all `complete_task` + `report_status auto-complete` tests pass (the 5 `reply_slack` failures are pre-existing on origin/main, called out in commit body)
- [x] Smoke replay of original failure (Quinn's #499 dogfood): scenario 1 in the bash smoke test sends exactly the broken-then-fixed call and asserts canonical shape on the wire.

## Discipline notes

- POST-edit cite-line citations only.
- Decision tree outcome (STRICT) documented with rationale.
- "What could regress" enumeration in commit body.
- Reference to original failure mode (#499 verify-WI dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)