### PR TITLE
fix(hygiene): parentMemberId backfill (Crewly Product) + orc prompt trim

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -24,7 +24,6 @@ If implementation → DELEGATE to an agent.
 
 When a user says "implement X" or "fix X" — this means: find the right agent and delegate the work. It does NOT mean do the work yourself.
 
----
 
 ## Silent by Default (DEFAULT OPERATING MODE)
 
@@ -48,7 +47,6 @@ The owner hired you to deliver results, not to narrate progress or ask permissio
 
 **Onboarding exception:** For the first 1-2 interactions with a brand-new owner who hasn't seen how you work, a single onboarding message explaining "I'll run silently unless a deliverable is ready or I'm blocked" is fine. After that, don't repeat.
 
----
 
 ## Periodic Progress Check-In (User Requests)
 
@@ -84,7 +82,6 @@ Silent Mode is the default **outside** a user request. **Inside** a user request
 
 **Rule of thumb:** Silent by default **outside** a user-request flow; periodic check-in **inside** one. This section governs **when** to ping; the *how* (jargon, tone, formatting) is governed by the **Owner-Facing Communication Standard** below and the **Chat/Slack rules** elsewhere in this prompt.
 
----
 
 ## Owner-Facing Communication Standard
 
@@ -121,7 +118,6 @@ One decision per message. Recommendation above options. Options in business lang
 **Self-check before any owner-facing message:**
 > Would someone who has never heard of our team understand every name, number, and abbreviation? Did I package decision + reason + impact? If asking the owner to decide, did I recommend? If any answer is "no", rewrite.
 
----
 
 ## Quick context about this setup
 
@@ -175,7 +171,6 @@ bash {{ORCHESTRATOR_SKILLS_PATH}}/recall/execute.sh '{"context":"OKR goals activ
 
 **If no active goals exist:** Say "Ready" and wait for the user.
 
----
 
 ## Pipeline-First Planning Discipline (MANDATORY for planning intent)
 
@@ -201,7 +196,6 @@ When you receive a **planning-class intent** from Steve (or any upstream source)
 
 **Self-check before any planning action:** *Have I POSTed a Request for this intent yet?* If no — POST first, then act.
 
----
 
 ## Request Contract
 
@@ -223,7 +217,6 @@ When receiving a request from owner or upstream, every Request you materialise i
 
 The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E markers — non-fatal, but a signal that the brief is malformed and the downstream TL is allowed (and expected) to push back.
 
----
 
 ## Conversation History — Recall Only
 
@@ -233,7 +226,6 @@ It is **not** the source of truth for what work is still in flight. Whether a ta
 
 If history makes you recall an unfinished thread but the pool has nothing on it, either the work is done (history is stale) or you must materialise it as a fresh Request before acting.
 
----
 
 ## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
 
@@ -283,7 +275,6 @@ If a `watch:` or `fallback:` for the same delegatee already exists, do NOT add a
 
 **Recursion clause:** Every delegator hop carries this rule — including ORC→TL, TL→Worker, PM→TL, *and* Worker→Worker (sub-WorkItem dispatch). The pipeline does not exempt any hop.
 
----
 
 ## Autonomous Mode — Default ON
 
@@ -858,7 +849,6 @@ To ensure tasks are specific and context-aware (avoiding generic "Plan/Execute/R
 
 **Rule**: A user message like "Build a login page" should result in 5-8 specific WorkItems (e.g., "Design login UI", "Implement auth API", "Write integration tests", etc.), NOT 3 generic ones.
 
----
 
 ## IMPORTANT: Session Management
 
@@ -1260,7 +1250,6 @@ When you receive messages from Slack, they include a `[Thread context file: <pat
 4. Read the thread file's frontmatter to get `channel` and `thread` values
 5. Use `reply-slack` skill with `channelId` and `threadTs` to reply in the original thread
 
----
 
 ## Self-Improvement Capabilities
 
@@ -1333,7 +1322,6 @@ self_improve({ action: "rollback", reason: "Tests failing after change" })
 - Third-party dependencies (package.json) without approval
 - Database schemas without migration plans
 
----
 
 ## Communication Channels
 
@@ -1347,7 +1335,6 @@ You now have multiple communication channels:
 
 Adapt your communication style based on the channel being used.
 
----
 
 ## Proactive Knowledge Management
 
@@ -1485,7 +1472,6 @@ User: `[CHAT:conv-789] The deploy looks good. Can you also run the test suite an
 
 (Skip "The deploy looks good" — that's feedback, not a task)
 
----
 
 ## User Intent Detection
 


### PR DESCRIPTION
## Summary

Closes two friction points surfaced during the 5/9 wave:

- **Item #1 — parentMemberId backfill (Crewly Product team)** — TL-scope `start-agent` skill failed for offline workers because their team-config rows lacked `parentMemberId` pointing to Sam (TL). Sam hit this trying to wake Max + Quinn during the agent-improvement reconcile and had to route through ORC's cross-team start authority.
- **Item #6 — orc prompt trim** — Pre-existing test failure on `main`: `backend/src/services/ai/prompt-builder.service.test.ts:3206` asserts orchestrator prompt.md must be ≤ 1740 lines (split-length); actual was 1749. Confirmed not in F14 scope by Max.

Paired in one PR per Sam brief — both small, mechanical, low-risk; pairing amortizes review overhead.

---

## Item #1 — parentMemberId backfill

**File** (OUTSIDE repo): `~/.crewly/teams/28a4ac10-f37f-4286-ad8c-6926a0e177f5/config.json`

**Members updated** (added `"parentMemberId": "9487fefe-18cc-4b0d-8be8-2b10ebb9624b"` = Sam's memberId):
| Name | memberId | role | parentMemberId after |
|---|---|---|---|
| Leo | `21a5477e-ec10-4e45-8cae-8b55e232e04e` | developer | `9487fefe-...` |
| Max | `358c7cb7-eb20-482a-87b2-655eb8cdde4e` | developer | `9487fefe-...` |
| Quinn | `47ce967d-ff5a-44f2-8aed-0f0925e918f8` | developer | `9487fefe-...` |
| Ava | `c3e742bc-6cb8-407d-b5f5-91a7c6b66d45` | ux-designer | `9487fefe-...` |

**Skipped intentionally:** Sam (TL — is the parent), Mia (PM — does not report to TL per brief).

**Mechanism:** direct JSON edit (`~/.crewly/` is outside the repo; `update-team` API does not support incremental member updates per Sam's gotcha memory). Backend re-reads team-config from disk on each request — no restart needed; verified via `GET /api/teams/28a4ac10...` reflects new state.

**Validation (non-destructive):** ran TL-scope `start-agent` for each of the 4 backfill targets with a deliberately-bogus `tlMemberId=00000000-0000-0000-0000-000000000000`. Each call passed the empty-`parentMemberId` guard and errored at the `Hierarchy violation` check, citing the populated parent (e.g. `parentMemberId=9487fefe-18cc-4b0d-8be8-2b10ebb9624b`). Pre-edit, this same call would have errored `has no parentMemberId set` instead. This non-destructively proves all 4 rows are correctly populated without actually starting any agent (which would have disrupted Leo/Max/Quinn active sessions).

**Cross-team gap audit (FOLLOW-UP scope, NOT in this PR per brief):** 10 other teams have the same gap.

| Team | Members missing parentMemberId |
|---|---|
| Crewly Marketing | Ella, Luna, Grace, Lyra, self-watch-scribe (5/5) |
| CE | Owen, Vera (2/2) |
| Flopost | Dex (1/2) |
| Crewly Architect | Arch (1/1) |
| Crewly Pro Victor | Victor (1/1) |
| Think Tank | Sage, Kai (2/3) |
| Crewly Support | Iris, Reed, Sora (3/3) |
| Stevesprompt | dev1, Ryan (2/2) |
| Strategy | Ethan, Iris (2/2) |

→ ORC to schedule a follow-up wave that decides each team's parent topology (some have no TL → may need a different parent or scope rule).

---

## Item #6 — orc prompt trim

**File** (POST-edit citations):
- `config/roles/orchestrator/prompt.md` — split-length 1735 lines (was 1749), under the test threshold of 1740 with 5-line breathing room.
- Test asserting limit: `backend/src/services/ai/prompt-builder.service.test.ts:3192` (post-edit).

**Approach: MECHANICAL ONLY** — no Mia consult required.

Removed 14 inconsistent freestanding `---` horizontal-rule separators that immediately preceded `## ` H2 headers. The early sections of the doc used `---` before each H2; later sections (the majority) drop the convention. Normalized to the dominant later-doc style.

Each removal followed the identical 3-line pattern:
```
<previous content>

---            ← removed

## Header      ← kept
```
becomes:
```
<previous content>


## Header
```

H2 headers continue to provide clear section separation. No prompt content semantics removed. No prompt behavior change.

**Removed lines** (PRE-edit numbering, in the 1749-line file): `27, 51, 87, 124, 178, 204, 226, 236, 286, 861, 1263, 1336, 1350, 1488`.

**Test results:**
- `backend/src/services/ai/prompt-builder.service.test.ts` — **156/156 pass**, including the previously-failing line-count test.
- `backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts` — 27/27 pass.
- Combined prompt-suite: **183/183 green**.

---

## Eval Criteria Mapping

| # | Criterion | Status |
|---|---|---|
| 1 | Item 1: TL-scope `start-agent` succeeds for Leo, Max, Quinn (now also Ava per scope add). | ✅ Validated via bogus-TL pattern; all 4 reach hierarchy-check, empty-parentMemberId guard cleared. |
| 2 | Item 6: line-count test passes; orc prompt loads via prompt-assembly without error. | ✅ 156/156 prompt-builder + 27/27 prompt-assembly. |
| 3 | PR body documents member rows + TL ID + trim approach + final-state file:line citations. | ✅ Above. |
| 4 | Build + tests green: `npm run build && npm run test:unit`. | ✅ tsc clean; prompt-suite 183/183. (Wider `test:unit` has 40 pre-existing failed suites from vitest-import-under-jest in unrelated files like task-pool.routes.test.ts — present on `main` HEAD, NOT introduced by this PR.) |
| 5 | No behavior regression — orc prompt still functions; team-config validates. | ✅ Backend GET reflects edits; prompt-assembly tests confirm orc prompt template contains required sections (Owner-Facing Communication Standard, three principles, decision-request shape) post-trim. |

---

## Notes

- **Brief drift note:** brief said current was 1748/drift +11 to 1759. My pristine-main read showed 1748 wc-l = 1749 split-length. Ran with the actual file state. Test threshold is 1740 split-length, so the 14-line trim leaves a comfortable 5-line margin regardless of which baseline was right.
- **Atomic-claim flag worked:** WI 5b1d20ad created with `metadata.atomicClaim=true` stayed targeted to Leo throughout — no rotation through `Quinn → flopost-dex → null → flopost-dex` like predecessor c443c2cd. Surfaced separately to Sam → ORC for broader rollout consideration.
- Worktree: `/private/tmp/crewly-leo-hygiene-1-6`, branch `leo/hygiene-1-and-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)