### PR TITLE
fix(orc): hygiene #6 follow-up — trim 17 more lines (1746→1729) to clear ≤1740 threshold

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -24,7 +24,6 @@ If implementation → DELEGATE to an agent.
 
 When a user says "implement X" or "fix X" — this means: find the right agent and delegate the work. It does NOT mean do the work yourself.
 
-
 ## Crewly Operating Principles
 
 1. Outcome over activity.
@@ -33,8 +32,6 @@ When a user says "implement X" or "fix X" — this means: find the right agent a
 4. Execute immediately if you are a worker.
 5. Verify before claiming done.
 6. Escalate through the hierarchy.
-
----
 
 ## Silent by Default (DEFAULT OPERATING MODE)
 
@@ -57,7 +54,6 @@ The owner hired you to deliver results, not to narrate progress or ask permissio
 - Owner says "多更新一点 / send me daily summaries" → stay in Silent Mode, but add a daily summary cadence
 
 **Onboarding exception:** For the first 1-2 interactions with a brand-new owner who hasn't seen how you work, a single onboarding message explaining "I'll run silently unless a deliverable is ready or I'm blocked" is fine. After that, don't repeat.
-
 
 ## Periodic Progress Check-In (User Requests)
 
@@ -93,7 +89,6 @@ Silent Mode is the default **outside** a user request. **Inside** a user request
 
 **Rule of thumb:** Silent by default **outside** a user-request flow; periodic check-in **inside** one. This section governs **when** to ping; the *how* (jargon, tone, formatting) is governed by the **Owner-Facing Communication Standard** below and the **Chat/Slack rules** elsewhere in this prompt.
 
-
 ## Owner-Facing Communication Standard
 
 > Source of truth: `config/sops/common/owner-facing-communication.md` (SOP `common-owner-facing-communication`). Read it before your first owner-facing message. This section is the binding summary; the SOP is canonical.
@@ -128,7 +123,6 @@ One decision per message. Recommendation above options. Options in business lang
 
 **Self-check before any owner-facing message:**
 > Would someone who has never heard of our team understand every name, number, and abbreviation? Did I package decision + reason + impact? If asking the owner to decide, did I recommend? If any answer is "no", rewrite.
-
 
 ## Quick context about this setup
 
@@ -182,7 +176,6 @@ bash {{ORCHESTRATOR_SKILLS_PATH}}/recall/execute.sh '{"context":"OKR goals activ
 
 **If no active goals exist:** Say "Ready" and wait for the user.
 
-
 ## Pipeline-First Planning Discipline (MANDATORY for planning intent)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.1.
@@ -207,7 +200,6 @@ When you receive a **planning-class intent** from Steve (or any upstream source)
 
 **Self-check before any planning action:** *Have I POSTed a Request for this intent yet?* If no — POST first, then act.
 
-
 ## Request Contract
 
 > Source spec: `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` §"Fix P0-3".
@@ -228,7 +220,6 @@ When receiving a request from owner or upstream, every Request you materialise i
 
 The `delegate-task` skill emits a stderr WARNING when a brief is missing G/O/E markers — non-fatal, but a signal that the brief is malformed and the downstream TL is allowed (and expected) to push back.
 
-
 ## Conversation History — Recall Only
 
 Your conversation history is for **recall only**. Use it to remember context: who asked for what, what you discussed, what decisions you made.
@@ -236,7 +227,6 @@ Your conversation history is for **recall only**. Use it to remember context: wh
 It is **not** the source of truth for what work is still in flight. Whether a task is unfinished — and whether to wake an agent — is decided by the pool: open Requests + queued/blocked WorkItems.
 
 If history makes you recall an unfinished thread but the pool has nothing on it, either the work is done (history is stale) or you must materialise it as a fresh Request before acting.
-
 
 ## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
 
@@ -285,7 +275,6 @@ If a `watch:` or `fallback:` for the same delegatee already exists, do NOT add a
 **Negative pattern to suppress:** "ORC sends `delegate-task` to Sam → goes idle → forgets the delegation → 4 hours later checks status manually because no event ever woke them." Replace with subscribe+fallback **at dispatch time**, cancel-on-verify.
 
 **Recursion clause:** Every delegator hop carries this rule — including ORC→TL, TL→Worker, PM→TL, *and* Worker→Worker (sub-WorkItem dispatch). The pipeline does not exempt any hop.
-
 
 ## Autonomous Mode — Default ON
 
@@ -860,7 +849,6 @@ To ensure tasks are specific and context-aware (avoiding generic "Plan/Execute/R
 
 **Rule**: A user message like "Build a login page" should result in 5-8 specific WorkItems (e.g., "Design login UI", "Implement auth API", "Write integration tests", etc.), NOT 3 generic ones.
 
-
 ## IMPORTANT: Session Management
 
 Crewly uses **PTY terminal sessions**, NOT tmux. Do NOT use tmux commands like `tmux list-sessions` or `tmux attach`.
@@ -1261,7 +1249,6 @@ When you receive messages from Slack, they include a `[Thread context file: <pat
 4. Read the thread file's frontmatter to get `channel` and `thread` values
 5. Use `reply-slack` skill with `channelId` and `threadTs` to reply in the original thread
 
-
 ## Self-Improvement Capabilities
 
 > **Delegation first:** If any developer agent is available, delegate codebase
@@ -1333,7 +1320,6 @@ self_improve({ action: "rollback", reason: "Tests failing after change" })
 - Third-party dependencies (package.json) without approval
 - Database schemas without migration plans
 
-
 ## Communication Channels
 
 You now have multiple communication channels:
@@ -1345,7 +1331,6 @@ You now have multiple communication channels:
 | Slack    | Mobile updates   | Concise, scannable      |
 
 Adapt your communication style based on the channel being used.
-
 
 ## Proactive Knowledge Management
 
@@ -1482,7 +1467,6 @@ User: `[CHAT:conv-789] The deploy looks good. Can you also run the test suite an
 2. `{"intent":"Fix any test failures found","level":"L1","category":"debugging"}`
 
 (Skip "The deploy looks good" — that's feedback, not a task)
-
 
 ## User Intent Detection
 
@@ -1688,7 +1672,6 @@ When you encounter an error and successfully resolve it:
 2. If the fix is broadly reusable, store it with `remember` at project scope so other agents inherit it.
 3. Do not finish the task without recording at least one actionable learning when debugging occurred.
 
-
 ## Execution Mode
 
 Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
@@ -1717,7 +1700,6 @@ Default tier: **Standard Path** (customer-facing or coordination work). Drop to 
 - Team Leads resolve implementation and team-level decisions; escalate only when scope, priority, or acceptance criteria change.
 - The Orchestrator owns cross-team and owner-facing acceptance.
 - The Owner is consulted only for goal change, scope change, customer-facing commitment, irreversible expense, or strategic direction.
-
 
 ## Lazy Behavior Anti-Patterns
 


### PR DESCRIPTION
## Summary

Closes the line-count regression on `main` that PR #528 left behind. Per Sam's "ship now" call: this is COMPLETION of the original Hygiene #6 brief, not new scope. The brief said *"trim orc prompt back under 1740"*; the goal is the test passing. PR #528 didn't fully achieve the goal because the file shifted underneath me between brief-survey and merge time.

## Why a follow-up was needed

PR #528 cited 14 deletions against my pristine-main read of 1748 wc-l. By merge time, `origin/main^` was actually 1759 wc-l — PR #499 (P2 Fix 13 — Crewly Operating Principles header) had landed in between, adding 11 lines + a new redundant `---\n\n## ` separator at then-pre-line-38 that I never cited because it didn't exist in my pristine read. Squash-merge produced 1745 wc-l = 1746 split-length on `main`, still 6 over the test threshold of 1740 → `prompt-builder.service.test.ts:3206` was RED on `main` post-merge.

Self-discovered via the post-merge cite-confirmation Sam asked for, surfaced honestly via [PR #528 comment](https://github.com/stevehuang0115/crewly/pull/528#issuecomment-4411478752), Sam approved option (a) — ship now.

## What this PR does

Two mechanical normalizations, no content removed, no behavior change:

1. **Removes the surviving redundant `---` separator** (added by PR #499) that preceded `## Silent by Default`. Same pattern as the 14 deletions in PR #528 — `---\n\n## Header` → `\n\n## Header`. The `---` + its trailing blank both go because the surrounding section already provides a blank-line separator.

2. **Collapses 16 double-blank-line clusters** left behind by PR #528's deletions. Each `---` removal in #528 left a sandwich of two blanks where the separator used to be. Markdown renders both `\n\n\n` and `\n\n` as a single paragraph break, so collapsing to single blanks is pure normalization with no rendering change.

## File state

| | wc-l | split-length | margin vs test threshold ≤1740 |
|---|---|---|---|
| Before this PR (`origin/main` post-#528) | 1745 | **1746** | -6 (test RED) |
| After this PR | 1727 | **1728** | +12 (test GREEN with breathing room) |

## POST-edit cite block (per F14 SOP)

All anchors below are POST-edit line numbers in the resulting file. Each removal landed where the `---` or extra-blank-line previously sat, immediately followed by the `## Header` listed:

| Removal | POST-edit anchor (1-indexed) | Section the removal precedes |
|---|---|---|
| 1 — collapsed double-blank | L27 | `## Crewly Operating Principles` |
| 2 — surviving `---` (PR #499 add) | L36 | `## Silent by Default (DEFAULT OPERATING MODE)` |
| 3 — `---`'s trailing blank | L36 | `## Silent by Default (DEFAULT OPERATING MODE)` |
| 4 — collapsed double-blank | L58 | `## Periodic Progress Check-In (User Requests)` |
| 5 — collapsed double-blank | L92 | `## Owner-Facing Communication Standard` |
| 6 — collapsed double-blank | L127 | `## Quick context about this setup` |
| 7 — collapsed double-blank | L179 | `## Pipeline-First Planning Discipline (MANDATORY for planning intent)` |
| 8 — collapsed double-blank | L203 | `## Request Contract` |
| 9 — collapsed double-blank | L223 | `## Conversation History — Recall Only` |
| 10 — collapsed double-blank | L231 | `## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)` |
| 11 — collapsed double-blank | L279 | `## Autonomous Mode — Default ON` |
| 12 — collapsed double-blank | L852 | `## IMPORTANT: Session Management` |
| 13 — collapsed double-blank | L1252 | `## Self-Improvement Capabilities` |
| 14 — collapsed double-blank | L1323 | `## Communication Channels` |
| 15 — collapsed double-blank | L1335 | `## Proactive Knowledge Management` |
| 16 — collapsed double-blank | L1471 | `## User Intent Detection` |
| 17 — collapsed double-blank | L1675 | `## Execution Mode` |
| 18 — collapsed double-blank | L1704 | `## Lazy Behavior Anti-Patterns` |

(18 line indices flagged for removal → 17 net deletions; #2 and #3 share an anchor because the `---` and its adjacent blank both land at L36's predecessor position.)

## Tests

- `backend/src/services/ai/prompt-builder.service.test.ts` — **156/156 PASS** including the line-count test at L3206 (now GREEN with the 1728-split-length file).
- `backend/src/services/ai/prompt-modules/prompt-assembly.service.test.ts` — 27/27 PASS.
- Combined: **183/183 PASS**.
- `tsc -p backend/tsconfig.json` — clean.

## Lesson banked (also surfaced in PR #528 comment + agent memory)

`canonical-source-wins` rule applies to **file-at-MERGE-time**, not file-at-brief-survey-time. For line-count-sensitive work, always re-pull `origin/main` and re-read the file count immediately before opening a PR. Same family as cite-discipline (POST-edit citations) — both are AT-MERGE-TIME-not-BRIEF-TIME-reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)