### PR TITLE
fix(v3): heartbeat dedupe — suppress identical-state pings

### DIFF
--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -404,4 +404,93 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
     expect(posts).toHaveLength(1);
     sub.stop();
   });
+
+  it('suppresses identical-content heartbeats (state-fingerprint dedupe regression gate)', async () => {
+    // 2026-05-09 dogfood: a Slack thread received 7+ identical "still 3
+    // blocked" messages over the day because WI state genuinely hadn't
+    // moved (Plan WI was wedged blocked → Execute + Review depend-blocked)
+    // but the heartbeat cadence faithfully kept firing. The dedupe must
+    // suppress repeat heartbeats while state is unchanged AND emit a
+    // fresh heartbeat as soon as state moves.
+    const wi1 = makeWI({ id: 'wi-1', requestId: 'req-stuck', status: 'blocked', target: '' });
+    const wi2 = makeWI({ id: 'wi-2', requestId: 'req-stuck', status: 'blocked', target: '' });
+    const wi3 = makeWI({ id: 'wi-3', requestId: 'req-stuck', status: 'blocked', target: '' });
+    const r = makeRequest({ id: 'req-stuck', status: 'running' });
+
+    const pool: WorkItem[] = [wi1, wi2, wi3];
+    const { sub, posts } = makeSubscriber({ request: r, pool, heartbeatMinutes: 30 });
+
+    // First sweep — fingerprint not seen before, post.
+    let posted = await sub.runHeartbeat();
+    expect(posted).toBe(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].text).toContain('卡住 3');
+
+    // Hour later, no state change — fingerprint matches, suppress.
+    jest.setSystemTime(new Date('2026-05-09T02:00:00.000Z'));
+    posted = await sub.runHeartbeat();
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(1);
+
+    // Another hour, still no change — still suppress.
+    jest.setSystemTime(new Date('2026-05-09T03:00:00.000Z'));
+    posted = await sub.runHeartbeat();
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(1);
+
+    // State changes (one WI unblocks → running). Fresh fingerprint, post.
+    pool[0].status = 'running';
+    jest.setSystemTime(new Date('2026-05-09T04:00:00.000Z'));
+    posted = await sub.runHeartbeat();
+    expect(posted).toBe(1);
+    expect(posts).toHaveLength(2);
+    expect(posts[1].text).toContain('进行中 1');
+
+    // Same state again, suppress.
+    jest.setSystemTime(new Date('2026-05-09T05:00:00.000Z'));
+    posted = await sub.runHeartbeat();
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeStateFingerprint
+// ---------------------------------------------------------------------------
+
+describe('computeStateFingerprint', () => {
+  it('produces identical fingerprint when only WI ids change but counts match', () => {
+    // Imagine a re-decompose that swaps WI uuids but produces the same
+    // 1 done / 0 running / 0 queued / 3 blocked / 0 failed shape. We
+    // do NOT want this to look like progress — content fingerprint is
+    // counts only.
+    const { computeStateFingerprint } = require('./request-status-update.subscriber.js');
+    const a = [
+      makeWI({ id: 'a-1', status: 'done' }),
+      makeWI({ id: 'a-2', status: 'blocked' }),
+      makeWI({ id: 'a-3', status: 'blocked' }),
+      makeWI({ id: 'a-4', status: 'blocked' }),
+    ];
+    const b = [
+      makeWI({ id: 'b-X', status: 'done' }),
+      makeWI({ id: 'b-Y', status: 'blocked' }),
+      makeWI({ id: 'b-Z', status: 'blocked' }),
+      makeWI({ id: 'b-Q', status: 'blocked' }),
+    ];
+    expect(computeStateFingerprint(a)).toBe(computeStateFingerprint(b));
+  });
+
+  it('produces different fingerprint when a single WI moves status', () => {
+    const { computeStateFingerprint } = require('./request-status-update.subscriber.js');
+    const before = [makeWI({ status: 'blocked' }), makeWI({ status: 'blocked' })];
+    const after = [makeWI({ status: 'blocked' }), makeWI({ status: 'running' })];
+    expect(computeStateFingerprint(before)).not.toBe(computeStateFingerprint(after));
+  });
+
+  it('treats done/verified/done_by_worker as the same "done" bucket', () => {
+    const { computeStateFingerprint } = require('./request-status-update.subscriber.js');
+    const a = [makeWI({ status: 'done' }), makeWI({ status: 'done' })];
+    const b = [makeWI({ status: 'verified' }), makeWI({ status: 'done_by_worker' })];
+    expect(computeStateFingerprint(a)).toBe(computeStateFingerprint(b));
+  });
 });

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -143,6 +143,37 @@ interface ParsedSlackContext {
  * @param scid - The Request's `sourceConversationItemId`
  * @returns Parsed context, or null if the id is not a Slack id we recognise
  */
+/**
+ * Compute a stable, content-only fingerprint of a Request's child-WI
+ * state. Two snapshots produce the same fingerprint iff every status
+ * count is equal — so a heartbeat that would say "still 3 blocked, 0
+ * done" matches the previous "still 3 blocked, 0 done" and gets
+ * suppressed by {@link RequestStatusUpdateSubscriber.runHeartbeat}.
+ *
+ * Uses status counts only — not WI ids or titles — so cosmetic
+ * re-decompositions of the same Request (different uuids, same shape)
+ * still match. WI churn that doesn't move the count needle isn't a
+ * progress signal.
+ *
+ * @param childWIs - All WIs whose `requestId` matches the parent
+ * @returns A short string fingerprint, e.g. `done=1,running=0,queued=0,blocked=3,failed=0,total=4`
+ */
+export function computeStateFingerprint(childWIs: WorkItem[]): string {
+  const counts = { done: 0, running: 0, queued: 0, blocked: 0, failed: 0 };
+  for (const wi of childWIs) {
+    const s = wi.status;
+    if (s === 'done' || s === 'verified' || s === 'done_by_worker') counts.done++;
+    else if (s === 'running') counts.running++;
+    else if (s === 'queued') counts.queued++;
+    else if (s === 'blocked') counts.blocked++;
+    else if (s === 'failed' || s === 'cancelled') counts.failed++;
+  }
+  return (
+    `done=${counts.done},running=${counts.running},queued=${counts.queued},` +
+    `blocked=${counts.blocked},failed=${counts.failed},total=${childWIs.length}`
+  );
+}
+
 export function parseSlackThreadContext(scid: string | undefined): ParsedSlackContext | null {
   if (!scid || !scid.startsWith('slack-')) return null;
   const m = scid.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
@@ -169,6 +200,25 @@ export class RequestStatusUpdateSubscriber {
 
   /** In-memory map: requestId → epoch ms of last status post. */
   private readonly lastPostedAt: Map<string, number> = new Map();
+  /**
+   * In-memory map: requestId → state-fingerprint of the last heartbeat
+   * post. The heartbeat sweep skips a Request if its current fingerprint
+   * matches the last one — there's no point telling the user "still 3
+   * blocked" once an hour when nothing has changed since the previous
+   * "still 3 blocked" message.
+   *
+   * Bug shape (2026-05-09 dogfood): a Slack thread received 7+ identical
+   * "⏳ 还在做。已完成 0/4, 进行中 0, 排队 0, 卡住 3" messages over the
+   * day because the WI state genuinely hadn't moved (Plan WI was wedged
+   * blocked) but the heartbeat cadence faithfully kept firing. Plain-
+   * language UX rule: a "no change" heartbeat IS noise, not signal.
+   *
+   * Fingerprint is derived from the {done, running, queued, blocked,
+   * failed, total} counts (see {@link buildHeartbeatText}). Only counts —
+   * not WI ids or titles — so cosmetic re-decompositions don't trigger
+   * a fresh ping.
+   */
+  private readonly lastHeartbeatFingerprint: Map<string, string> = new Map();
   /** In-flight async dispatch promises (test affordance). */
   private readonly pendingDispatches: Set<Promise<void>> = new Set();
 
@@ -284,16 +334,30 @@ export class RequestStatusUpdateSubscriber {
       if (last !== undefined && now - last < stalenessMs) continue;
 
       // No status update has been emitted for this Request since the
-      // heartbeat window started. Post a heartbeat unless there's
-      // genuinely nothing to report (zero in-flight WIs).
+      // heartbeat window started. Post a heartbeat unless either:
+      //   (a) there's genuinely nothing to report (zero in-flight WIs), or
+      //   (b) the WI state-fingerprint matches the last heartbeat — i.e.
+      //       nothing has changed since we last said "still 3 blocked",
+      //       so saying it again is noise.
       const items = await this.taskPool.getAllItems();
       const childWIs = items.filter((wi) => wi.requestId === r.id);
       if (childWIs.length === 0) continue;
+
+      const fingerprint = computeStateFingerprint(childWIs);
+      const lastFp = this.lastHeartbeatFingerprint.get(r.id);
+      if (lastFp === fingerprint) {
+        this.logger.debug('Heartbeat skipped — state unchanged since last post', {
+          requestId: r.id,
+          fingerprint,
+        });
+        continue;
+      }
 
       const text = this.buildHeartbeatText(r, childWIs);
       try {
         await this.slackPoster({ channelId: slackCtx.channelId, text, threadTs: slackCtx.threadTs });
         this.lastPostedAt.set(r.id, now);
+        this.lastHeartbeatFingerprint.set(r.id, fingerprint);
         posted++;
       } catch (err) {
         this.logger.warn('Heartbeat post failed', {


### PR DESCRIPTION
## Summary

PR #524's heartbeat sweep correctly fired every 30 min, but if WI state hadn't moved between sweeps it sent the *exact same content*. Dogfood: 7+ identical "⏳ 还在做。已完成 0/4 ... 卡住 3" pings on one Slack thread over a single day because Plan WI was wedged blocked.

The heartbeat copy literally promises "我会在有变化时再更新" ("I'll update when something changes"). The implementation must honour that — repeating the same fingerprint IS the opposite of "有变化".

## Fix

Per-Request state fingerprint: `done=X,running=Y,queued=Z,blocked=W,failed=F,total=N`. Heartbeat sweep skips if the fingerprint matches the last one we sent for that Request. As soon as any count moves, a fresh heartbeat fires.

## Test plan

- [x] Regression: 4 sweeps over 4 hours with no WI state change → 1 post (not 4)
- [x] State change after 4th sweep → fresh post immediately
- [x] Fingerprint is content-only (uuid swap, same shape → match)
- [x] Counts-sensitive (one status move → mismatch)
- [x] done/verified/done_by_worker collapse to one bucket
- [x] All 17/17 subscriber tests pass
- [x] Backend build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)