### PR TITLE
fix(reconciler): include orchestrator in agent health map

### DIFF
--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -37,6 +37,7 @@ jest.mock('../task-pool/task-pool.service.js', () => {
 jest.mock('../core/storage.service.js', () => {
   const mockStorage = {
     getTeams: jest.fn().mockResolvedValue([]),
+    getOrchestratorStatus: jest.fn().mockResolvedValue(null),
   };
   return {
     StorageService: {
@@ -423,6 +424,69 @@ describe('LiveReconcilerDataProvider', () => {
       const max = result.get('agent-max')!;
       expect(max.status).toBe('suspended');
       expect(max.activeWorkItemCount).toBe(0);
+    });
+
+    it('includes the orchestrator (virtual member) in the health map', async () => {
+      // Regression: orc is a virtual team member that does NOT live in
+      // teams.json. Without explicit injection, getAgentHealthMap omits it
+      // and detectStuckWorkItems treats every orc-claimed running WI as
+      // "missing agent" → demotes to blocked → infinite re-claim loop.
+      mockStorage.getTeams.mockResolvedValue([]);
+      mockStorage.getOrchestratorStatus.mockResolvedValue({
+        sessionName: 'crewly-orc',
+        agentStatus: 'active',
+        workingStatus: 'idle',
+        runtimeType: 'tmux',
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-09T01:19:00Z',
+      });
+      mockPool.getActiveClaims.mockResolvedValue([]);
+
+      const result = await provider.getAgentHealthMap();
+
+      const orc = result.get('crewly-orc');
+      expect(orc).toBeDefined();
+      expect(orc!.status).toBe('active');
+      expect(orc!.role).toBe('orchestrator');
+      expect(orc!.activeWorkItemCount).toBe(0);
+    });
+
+    it('counts active claims against the orchestrator', async () => {
+      mockStorage.getTeams.mockResolvedValue([]);
+      mockStorage.getOrchestratorStatus.mockResolvedValue({
+        sessionName: 'crewly-orc',
+        agentStatus: 'active',
+        workingStatus: 'in_progress',
+        runtimeType: 'tmux',
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-09T01:19:00Z',
+      });
+      mockPool.getActiveClaims.mockResolvedValue([{ agentId: 'crewly-orc' }]);
+
+      const result = await provider.getAgentHealthMap();
+
+      expect(result.get('crewly-orc')!.activeWorkItemCount).toBe(1);
+    });
+
+    it('omits the orchestrator if status persistence is empty (degrades gracefully)', async () => {
+      mockStorage.getTeams.mockResolvedValue([]);
+      mockStorage.getOrchestratorStatus.mockResolvedValue(null);
+      mockPool.getActiveClaims.mockResolvedValue([]);
+
+      const result = await provider.getAgentHealthMap();
+
+      expect(result.has('crewly-orc')).toBe(false);
+      expect(result.size).toBe(0);
+    });
+
+    it('does not throw if orchestrator status lookup fails', async () => {
+      mockStorage.getTeams.mockResolvedValue([]);
+      mockStorage.getOrchestratorStatus.mockRejectedValue(new Error('disk full'));
+      mockPool.getActiveClaims.mockResolvedValue([]);
+
+      const result = await provider.getAgentHealthMap();
+
+      expect(result.has('crewly-orc')).toBe(false);
     });
 
     it('maps agent statuses correctly', async () => {

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -267,6 +267,40 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         }
       }
 
+      // Add the orchestrator. orc is a virtual team member — it does NOT
+      // appear in `storage.getTeams()`, so the loop above misses it. Without
+      // this entry, any WorkItem with `target=crewly-orc` that transitions
+      // to `running` is mis-identified by `detectStuckWorkItems` as having
+      // a "missing agent", and gets force-demoted back to `blocked`. The
+      // dogfood symptom (2026-05-09): a Plan WI auto-claimed by orc bounced
+      // running → blocked → running → blocked in a wedged loop, the chained
+      // Execute + Review never unlocked, and the parent Slack Request
+      // emitted hours of identical "still 3 blocked" heartbeats.
+      //
+      // We treat any orchestrator status persisted via OrchestratorStatus
+      // as `active` for health-map purposes — the reconciler only needs
+      // "exists / does not exist" granularity here. If the orc isn't
+      // running we'd rather skip the entry than fabricate a stale one,
+      // so we honour the persisted agentStatus when available.
+      try {
+        const orcStatus = await this.storage.getOrchestratorStatus();
+        if (orcStatus?.sessionName) {
+          healthMap.set(orcStatus.sessionName, {
+            sessionName: orcStatus.sessionName,
+            status: this.mapAgentStatus(orcStatus.agentStatus),
+            lastSeenAt: orcStatus.updatedAt,
+            role: 'orchestrator',
+            tags: [],
+            activeWorkItemCount: 0,
+            // teamId/memberId intentionally undefined — orc is virtual.
+          });
+        }
+      } catch (orcErr) {
+        this.logger.debug('Failed to add orchestrator to health map (non-fatal)', {
+          error: orcErr instanceof Error ? orcErr.message : String(orcErr),
+        });
+      }
+
       // Enrich with active claim counts from the pool
       try {
         const pool = TaskPoolService.getInstance();


### PR DESCRIPTION
## Summary
- `getAgentHealthMap()` only iterated `storage.getTeams()` members, so the orchestrator (a virtual member that is **not** in `teams.json`) was always missing from the health map.
- `detectStuckWorkItems` then treated every orc-claimed `running` WI as *"agent not found"* and force-demoted it to `blocked` — AutoClaim re-claimed → reconciler demoted → infinite loop.
- Dogfood evidence (2026-05-09 terminal log): a Slack-driven Plan WI looped `running → blocked → running → blocked`, the chained Execute + Review WIs never unlocked, and the parent Request fired hours of identical "3 blocked" heartbeats.
- Fix: inject orc into the health map via `storage.getOrchestratorStatus()` before return. Non-fatal on failure (debug log), so a missing/corrupt status file can't wedge the reconciler.

## Test plan
- [x] 4 new unit tests in `reconciler-data-provider.test.ts`:
  - includes orc when status is present
  - counts active claims against orc
  - omits orc gracefully when status is null
  - does not throw if status lookup rejects
- [x] All 6 `getAgentHealthMap` tests pass (2 pre-existing + 4 new)
- [x] `tsc --noEmit` clean for touched files
- [ ] Post-merge: purge the wedged Plan/Execute/Review WIs left by the bug and verify a fresh Slack request flows through to delivery without re-blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)