### PR TITLE
fix(v3): heartbeat closes stale Requests, surfaces cancelled count

### DIFF
--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -122,6 +122,13 @@ function makeSubscriber(opts: {
   const requestService: RequestServiceLike = {
     getById: async (id: string) => requestStore.get(id) ?? null,
     listAll: async () => Array.from(requestStore.values()),
+    update: async (id: string, patch: Partial<Request>) => {
+      const existing = requestStore.get(id);
+      if (!existing) return null;
+      const next = { ...existing, ...patch } as Request;
+      requestStore.set(id, next);
+      return next;
+    },
   };
   const taskPool: TaskPoolServiceLike = {
     findWorkItem: async (id: string) => pool.find((w) => w.id === id),
@@ -451,6 +458,139 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
     posted = await sub.runHeartbeat();
     expect(posted).toBe(0);
     expect(posts).toHaveLength(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Stale-Request closure (2026-05-09 dogfood: Request 6d60a1cd had 4
+  // cancelled WIs but Request stayed in `ready` for hours, generating
+  // misleading "0/4, 进行中 0, 排队 0, 卡住 0" heartbeats every sweep
+  // because the heartbeat text omits the failed/cancelled bucket).
+  // -------------------------------------------------------------------------
+
+  it('closes a stale Request to `cancelled` when every child WI is cancelled', async () => {
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-stale', status: 'cancelled' }),
+      makeWI({ id: 'wi-2', requestId: 'req-stale', status: 'cancelled' }),
+      makeWI({ id: 'wi-3', requestId: 'req-stale', status: 'cancelled' }),
+      makeWI({ id: 'wi-4', requestId: 'req-stale', status: 'cancelled' }),
+    ];
+    const r = makeRequest({ id: 'req-stale', status: 'ready' });
+    const { sub, posts, requestStore } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(0);                            // no misleading ping
+    expect(posts).toHaveLength(0);
+    expect(requestStore.get('req-stale')!.status).toBe('cancelled');
+  });
+
+  it('closes a stale Request to `done` when at least one child WI succeeded', async () => {
+    // Mixed-terminal: some WIs done, some cancelled (e.g. orc cancelled
+    // a follow-up after the main task succeeded). Should land on `done`,
+    // not `cancelled` — work happened.
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-mixed', status: 'verified' }),
+      makeWI({ id: 'wi-2', requestId: 'req-mixed', status: 'cancelled' }),
+    ];
+    const r = makeRequest({ id: 'req-mixed', status: 'running' });
+    const { sub, posts, requestStore } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(0);
+    expect(requestStore.get('req-mixed')!.status).toBe('done');
+  });
+
+  it('hops `ready → running → done` when target is done but direct edge is illegal', async () => {
+    // REQUEST_TRANSITIONS doesn't allow `ready → done`. The closer must
+    // detect this and step through `running` rather than silently giving
+    // up. Without the hop, a Request whose first event was a successful
+    // verify (no intermediate `running` post) would be uncloseable.
+    const wis = [makeWI({ id: 'wi-1', requestId: 'req-ready-done', status: 'done' })];
+    const r = makeRequest({ id: 'req-ready-done', status: 'ready' });
+    const { sub, posts, requestStore } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(0);
+    expect(requestStore.get('req-ready-done')!.status).toBe('done');
+  });
+
+  it('does not crash when requestService.update throws during stale-close', async () => {
+    // Heartbeat sweep iterates every Request; a single update failure
+    // must not poison the rest of the sweep. The next Request still
+    // gets its heartbeat.
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-broken', status: 'cancelled' }),
+      makeWI({ id: 'wi-2', requestId: 'req-broken', status: 'cancelled' }),
+      makeWI({ id: 'wi-3', requestId: 'req-other', status: 'running' }),
+    ];
+    const broken = makeRequest({ id: 'req-broken', status: 'ready' });
+    const other = makeRequest({ id: 'req-other', status: 'running' });
+
+    const { sub, posts, requestStore } = makeSubscriber({ request: broken, pool: wis });
+    requestStore.set(other.id, other);
+    const origUpdate = (sub as unknown as {
+      requestService: RequestServiceLike;
+    }).requestService.update;
+    (sub as unknown as { requestService: RequestServiceLike }).requestService.update = async (
+      id: string,
+      patch: Partial<Request>,
+    ) => {
+      if (id === 'req-broken') throw new Error('disk full');
+      return origUpdate(id, patch);
+    };
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(1); // req-other still posted
+    expect(posts.some((p) => p.channelId)).toBe(true);
+    expect(requestStore.get('req-broken')!.status).toBe('ready'); // unchanged
+  });
+
+  // -------------------------------------------------------------------------
+  // Heartbeat text — surface the cancelled/failed bucket when non-zero.
+  // The original shape hid `failed` and rendered 4 cancelled WIs as
+  // "0/4 with all four buckets at 0", which read as "everything vanished"
+  // rather than "everything got cancelled".
+  // -------------------------------------------------------------------------
+
+  it('includes 取消/失败 count in heartbeat text when some WIs are cancelled', async () => {
+    // Mixed in-flight: 1 done, 1 running, 0 queued, 0 blocked, 2 cancelled.
+    // Not all-terminal, so the close path doesn't fire — heartbeat posts.
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-mix', status: 'done' }),
+      makeWI({ id: 'wi-2', requestId: 'req-mix', status: 'running' }),
+      makeWI({ id: 'wi-3', requestId: 'req-mix', status: 'cancelled' }),
+      makeWI({ id: 'wi-4', requestId: 'req-mix', status: 'cancelled' }),
+    ];
+    const r = makeRequest({ id: 'req-mix', status: 'running' });
+    const { sub, posts } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(1);
+    expect(posts[0].text).toContain('1/4');
+    expect(posts[0].text).toContain('进行中 1');
+    expect(posts[0].text).toContain('取消/失败 2');
+  });
+
+  it('omits the 取消/失败 clause when no WIs are cancelled or failed', async () => {
+    // Avoid noise — only show the bucket when it's actually non-zero.
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-clean', status: 'done' }),
+      makeWI({ id: 'wi-2', requestId: 'req-clean', status: 'running' }),
+    ];
+    const r = makeRequest({ id: 'req-clean', status: 'running' });
+    const { sub, posts } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    expect(posted).toBe(1);
+    expect(posts[0].text).not.toContain('取消');
+    expect(posts[0].text).not.toContain('失败');
   });
 });
 

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -40,9 +40,32 @@
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
 import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
-import type { Request } from '../../types/v2/request.types.js';
-import type { WorkItem } from '../../types/v2/work-item.types.js';
-import { TERMINAL_REQUEST_STATUSES } from '../../types/v2/index.js';
+import type { Request, RequestStatus } from '../../types/v2/request.types.js';
+import type { WorkItem, WorkItemStatus } from '../../types/v2/work-item.types.js';
+import { TERMINAL_REQUEST_STATUSES, isValidRequestTransition } from '../../types/v2/index.js';
+
+/**
+ * WorkItem statuses that count as "terminal" for the heartbeat's
+ * is-this-Request-actually-still-in-flight check. Includes both
+ * success-shaped terminals (done/verified/done_by_worker) and
+ * abandoned-shaped terminals (cancelled/failed/rejected).
+ *
+ * If every child WI of a Request lands in this set but the Request
+ * itself is still non-terminal, something upstream skipped the cascade
+ * (see 2026-05-09 dogfood bug: `cascadeRequestStatus` only fires from
+ * the retired `v3:task_*` events on V3DataService, so out-of-band
+ * cancellations leave the Request orphaned in `ready`). The heartbeat
+ * sweep treats this as "close the Request" rather than firing a
+ * misleading "still 0/4" ping.
+ */
+const TERMINAL_WORKITEM_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>([
+  'done',
+  'verified',
+  'done_by_worker',
+  'cancelled',
+  'failed',
+  'rejected',
+]);
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -86,6 +109,13 @@ const SUBSCRIBED_EVENTS: readonly EventType[] = [
 export interface RequestServiceLike {
   getById(id: string): Promise<Request | null>;
   listAll(): Promise<Request[]>;
+  /**
+   * Patch a Request's persisted state. The heartbeat-driven cascade only
+   * uses `{ status }` to close stale-but-non-terminal Requests, but the
+   * production type signature is wider — keep the signature loose so
+   * fakes can pass `Partial<Request>` without compiler grief.
+   */
+  update(id: string, patch: Partial<Request>): Promise<unknown>;
 }
 
 /**
@@ -343,6 +373,23 @@ export class RequestStatusUpdateSubscriber {
       const childWIs = items.filter((wi) => wi.requestId === r.id);
       if (childWIs.length === 0) continue;
 
+      // All-terminal guard — when every child WI is terminal but the
+      // Request itself is still non-terminal, the cascade upstream got
+      // skipped (cascadeRequestStatus is wired to the retired
+      // `v3:task_*` events on V3DataService — see 2026-05-09 dogfood
+      // bug, Request 6d60a1cd had 4 cancelled WIs and the Request
+      // stayed in `ready` for hours, generating misleading
+      // "0/4, 进行中 0, 排队 0, 卡住 0" heartbeats every sweep).
+      // Close the Request instead of pinging the user with a
+      // confusing zero-everywhere line.
+      const allTerminal = childWIs.every((wi) =>
+        TERMINAL_WORKITEM_STATUSES.has(wi.status),
+      );
+      if (allTerminal) {
+        await this.closeStaleRequest(r, childWIs);
+        continue;
+      }
+
       const fingerprint = computeStateFingerprint(childWIs);
       const lastFp = this.lastHeartbeatFingerprint.get(r.id);
       if (lastFp === fingerprint) {
@@ -469,11 +516,79 @@ export class RequestStatusUpdateSubscriber {
       else if (s === 'failed' || s === 'cancelled') counts.failed++;
       else counts.other++;
     }
+    // Only surface the failed/cancelled bucket when it's non-zero.
+    // Hiding it unconditionally (the original shape) was the bug —
+    // 4 cancelled WIs rendered as "0/4, 进行中 0, 排队 0, 卡住 0",
+    // which reads as "everything vanished" rather than "everything
+    // got cancelled". The all-terminal guard in runHeartbeat now
+    // intercepts the pure-cancelled case, but a mixed Request with
+    // some cancelled and some still in-flight would still hit this
+    // path, so include the count for honesty.
+    const tail = counts.failed > 0 ? `, 取消/失败 ${counts.failed}` : '';
     return (
       `⏳ 还在做。已完成 ${counts.done}/${childWIs.length}, ` +
-      `进行中 ${counts.running}, 排队 ${counts.queued}, 卡住 ${counts.blocked}。` +
+      `进行中 ${counts.running}, 排队 ${counts.queued}, 卡住 ${counts.blocked}${tail}。` +
       ` 我会在有变化时再更新。`
     );
+  }
+
+  /**
+   * Close a Request whose every child WI has reached a terminal status
+   * but whose own status hasn't been cascaded. Picks `done` if any
+   * child landed on a success-shaped terminal; otherwise `cancelled`.
+   *
+   * Honours `REQUEST_TRANSITIONS` — `ready → done` is illegal in the
+   * state machine, so for `ready` Requests we step through `running`
+   * first (a single `running` hop is harmless because the Request is
+   * about to land in a terminal state immediately after).
+   *
+   * Best-effort. Logs but does not throw on failure: the heartbeat
+   * sweep must keep moving across other Requests.
+   */
+  private async closeStaleRequest(request: Request, childWIs: WorkItem[]): Promise<void> {
+    const hasSuccess = childWIs.some(
+      (wi) => wi.status === 'done' || wi.status === 'verified' || wi.status === 'done_by_worker',
+    );
+    const target: RequestStatus = hasSuccess ? 'done' : 'cancelled';
+
+    const log = (extra: Record<string, unknown> = {}) => ({
+      requestId: request.id,
+      previousStatus: request.status,
+      newStatus: target,
+      childCount: childWIs.length,
+      childStatuses: childWIs.map((wi) => wi.status),
+      ...extra,
+    });
+
+    try {
+      // Direct transition when allowed.
+      if (isValidRequestTransition(request.status, target)) {
+        await this.requestService.update(request.id, { status: target });
+        this.logger.info('Heartbeat closed stale Request (all children terminal)', log());
+        return;
+      }
+
+      // `ready → done` is invalid; step through `running` first.
+      // ready → running → done is the canonical path for Requests
+      // that bypassed the running stage entirely.
+      if (
+        target === 'done' &&
+        isValidRequestTransition(request.status, 'running') &&
+        isValidRequestTransition('running', 'done')
+      ) {
+        await this.requestService.update(request.id, { status: 'running' });
+        await this.requestService.update(request.id, { status: 'done' });
+        this.logger.info('Heartbeat closed stale Request via running hop', log());
+        return;
+      }
+
+      this.logger.warn('Heartbeat: stale Request close blocked by state machine', log());
+    } catch (err) {
+      this.logger.warn('Heartbeat: stale Request close failed', {
+        ...log(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/specs/2026-05-09-agent-improvement-reconcile-audit.md
+++ b/specs/2026-05-09-agent-improvement-reconcile-audit.md
@@ -1,0 +1,193 @@
+# Agent-Improvement Reconcile Audit (2026-05-09)
+
+**Author:** Sam (Crewly Product TL)
+**Triggered by:** Steve's Slack ask 1778288945 — "这两份设计可以让团队来安排做一下吗 / 如果还没有做完的话 可以完成"
+**Source specs audited:**
+- `.crewly/specs/2026-05-03-agent-improvement-plan.md` (14 fixes across P0/P1/P2)
+- `.crewly/specs/2026-05-03-agent-improvement-p0-execution.md` (6 P0 fixes — P0-1..P0-6)
+**PR window audited:** #453 → #531 (merged 2026-05-06 → 2026-05-09)
+**Discipline:** 2026-05-06 reconcile-before-redispatch rule. The 5-3 reconcile saved 6–10 dev-hours by catching 4-of-6 already-shipped P0 items; same here.
+
+---
+
+## TL;DR
+
+**13 of 15 unique items already shipped. 0 not-started. 2 partial/superseded.**
+
+The two 5-3 specs were drafted as forward-looking plans on 5-3, but most of the work was actually executed across PRs #412–#525 over 5-4 → 5-9. There is **no net-new implementation work to dispatch**. Two cosmetic/ongoing items remain (Fix 10 explicit naming, Fix 12 ongoing prompt-mass cleanup) and are recommended as low-priority cleanups, not new features.
+
+| Category | Count |
+|---|---|
+| ✅ Shipped | 13 |
+| 🟡 Partial / superseded | 2 |
+| 🔴 Not-started | **0** |
+| **Net-new dispatch needed** | **0** (cleanups optional) |
+
+---
+
+## Cross-spec Item Map
+
+The two specs overlap heavily. P0-execution doc's P0-1..P0-5 are the same items as plan doc's Fix 1..5. P0-6 is the only item present **only** in the P0-execution doc. So unique items = plan(14) + P0-execution-only(1) = **15 unique items**.
+
+| Plan-doc Fix # | P0-doc Fix # | Item Title |
+|---|---|---|
+| 1 | P0-1 | Sam Role Reframe + team-leader soul |
+| 2 | P0-2 | Self-Implementation Exception Rule |
+| 3 | P0-3 | Request Contract Structure |
+| 4 | P0-4 | Decision Rights + Escalation Chain |
+| 5 | P0-5 | End-of-Turn Delivery Verification |
+| — | P0-6 | Owner-Facing Communication Standard (NEW in P0 doc) |
+| 6 | — | Default Execution Loop (replaces "Ready for tasks") |
+| 7 | — | Code Commit SOP Fast/Standard/Release tiering |
+| 8 | — | Lazy Behavior Anti-Patterns |
+| 9 | — | TL Management Loop |
+| 10 | — | Acceptance Authority hierarchy |
+| 11 | — | Goal/Mission auto-injection |
+| 12 | — | Prompt mass cleanup |
+| 13 | — | Crewly Operating Principles header |
+| 14 | — | Behavior observability + metrics |
+
+---
+
+## Verdict per Item
+
+### P0 (5-3 plan, also in P0-execution doc)
+
+#### Fix 1 / P0-1 — Sam Role Reframe + team-leader soul → ✅ Shipped
+- **#414** (MERGED 2026-05-04) — `feat(souls): team-leader soul + role-boundaries (P0-1 Phase 1, markdown-only)`
+- **#417** (MERGED 2026-05-04) — `feat(prompt): P0-1 Phase 2 — wire team-leader soul in prompt builder`
+- **#493** (MERGED 2026-05-07) — `feat(prompts): integrate Owner-Facing SOP into orc prompt + TL cleanup (P0-6, P0-1/P0-2)`
+- Verification: `config/souls/team-leader.md` exists; `config/roles/team-leader/{prompt.md,role-boundaries.md,role.json,tl-addon.md,fragments/}` all in place; my own session prompt (this audit) shows the team-leader soul as primary identity layer.
+
+#### Fix 2 / P0-2 — Self-Implementation Exception Rule → ✅ Shipped
+- **#414** (MERGED 2026-05-04) — bundled with P0-1 soul authoring.
+- Verification: `config/souls/team-leader.md:32` has the section verbatim with the 4 AND-of-N criteria.
+- Net-zero offset confirmed: percentage targets removed; soul says "No percentage targets."
+
+#### Fix 3 / P0-3 — Request Contract Structure → ✅ Shipped
+- **#495** (MERGED 2026-05-07) — `feat(p0-3): Request Contract — orc + TL + worker + delegate-task G/O/E warning`
+- Verification: `config/roles/team-leader/prompt.md:98` has the **Brief Reception Protocol** section; `delegate-task` skill emits warning when G/O/E missing.
+
+#### Fix 4 / P0-4 — Decision Rights + Escalation Chain → ✅ Shipped
+- **#481** (MERGED 2026-05-06) — `feat(prompts): P0-4 Decision Rights + Escalation Chain across all agent roles`
+- Verification: `Worker → Team Lead → Orchestrator → Owner` chain present in 9+ role prompts (developer, fullstack-dev, frontend-developer, ux-designer, sales, tpm, product-manager, qa, …).
+
+#### Fix 5 / P0-5 — End-of-Turn Delivery Verification (orc) → ✅ Shipped
+- **#424** (MERGED 2026-05-04) — `P0-5: orc End-of-Turn Delivery Verification (pre-yield self-check)`
+- Verification: orchestrator prompt fragments reference reply-slack delivery check.
+
+### P0-execution-doc-only
+
+#### P0-6 — Owner-Facing Communication Standard → ✅ Shipped
+- **#413** (MERGED 2026-05-04) — `docs(sops): owner-facing communication standard (P0 / Decision 6)`
+- **#493** (MERGED 2026-05-07) — `feat(prompts): integrate Owner-Facing SOP into orc prompt + TL cleanup (P0-6, P0-1/P0-2)`
+- Verification: SOP file exists; orc prompt now references it as a top-of-prompt section.
+
+### P1 (5-3 plan)
+
+#### Fix 6 — Default Execution Loop → ✅ Shipped
+- **#502** (MERGED 2026-05-07) — `feat(prompts): P1 Fix 6 — Default Execution Loop replaces "Ready for tasks" closer across 20 role prompts`
+- Verification: my own session prompt has the `## Default Execution Loop` section verbatim.
+
+#### Fix 7 — Code Commit SOP Fast/Standard/Release tiering → ✅ Shipped
+- **#498** (MERGED 2026-05-07) — `feat(prompts): wire Execution Mode tier reference into 20 role prompts (Fix 7)`
+- Verification: Execution Mode reference present across role prompts.
+
+#### Fix 8 — Lazy Behavior Anti-Patterns → ✅ Shipped
+- **#500** (MERGED 2026-05-07) — `feat(prompts): P1 Fix 8 — Lazy Behavior Anti-Patterns across all agent roles`
+- Verification: my own session prompt has the `## Lazy Behavior Anti-Patterns` section verbatim with all 7 enumerated anti-patterns.
+
+### P2 (5-3 plan)
+
+#### Fix 9 — TL Management Loop → ✅ Shipped (embedded in soul)
+- **#414** (MERGED 2026-05-04) — TL Management Loop substance lives in `config/souls/team-leader.md:22-28` as the **Default Operating Mode** loop: `Decompose → Delegate → Unblock → Verify → Report`.
+- Note: shipped under the soul authoring (Phase 1 of P0-1) rather than as a distinct P2 PR. The substance — that TLs own the outcome until verified — is enforced.
+
+#### Fix 10 — Acceptance Authority hierarchy → 🟡 Partial / superseded
+- Substance shipped across:
+  - **#495** (Request Contract — TL must verify against eval before accepting)
+  - **#481** (Escalation Chain — `Orchestrator owns cross-team and owner-facing acceptance` line in 9+ role prompts)
+  - **#414** (team-leader soul — outcome ownership + verifier role)
+- **Gap:** the explicit 3-tier section labeled "Acceptance Authority" (worker = "ready for review" / TL = "accepted" / orc = final) is **not** a discrete named heading anywhere. The behavior is enforced; the canonical naming is not.
+- **Severity:** cosmetic. The intent is met by P0-3+P0-4+team-leader soul.
+
+#### Fix 11 — Goal/Mission auto-injection → ✅ Shipped
+- Code present:
+  - `backend/src/services/memory/mission-context.service.ts` (+ `.test.ts`)
+  - `backend/src/services/ai/prompt-modules/mission-context.module.ts` (+ `.test.ts`)
+  - Registered in `backend/src/services/ai/prompt-modules/index.ts:29` (`export { MissionContextModule } from './mission-context.module.js';`)
+- Wired into `prompt-assembly.service.ts` so mission context flows into every agent's assembled prompt.
+- Note: I cannot find a single PR title that names this fix; it appears to have shipped under one of the broader prompt-builder rework PRs in the #480-#500 window. Functional verification is positive.
+
+#### Fix 12 — Prompt mass cleanup → 🟡 In-flight (hygiene-class)
+- Continuous progress, not a single PR:
+  - **#528** (MERGED 2026-05-09) — `fix(orc): hygiene #1 + #6 — parentMemberId backfill + orc prompt trim`
+  - **#529** (MERGED 2026-05-09) — `fix(orc): trim 17 more lines (1746→1729)` follow-up to #528
+- **Status today:** orc prompt at 1729 lines. **5-3 plan target was 30%+ reduction** from the 1584-line baseline → target ~1100 lines. We have not reduced — we have grown then trimmed. Net mass is up vs. 5-3 baseline because the new sections (Request Contract, Decision Rights, Escalation, Default Execution Loop, Lazy Anti-Patterns, Operating Principles, Owner-Facing SOP) added body even with offsets.
+- **Severity:** P2. Ongoing hygiene work already in train; orc prompt has a hygiene budget enforced at ≤1740.
+
+#### Fix 13 — Crewly Operating Principles header → ✅ Shipped
+- **#499** (MERGED 2026-05-09) — `feat(prompts): P2 Fix 13 — Crewly Operating Principles header (universal)`
+
+#### Fix 14 — Behavior observability + metrics → ✅ Shipped
+- **#412** (MERGED 2026-05-04) — `feat(observability): minimal internal metrics — agent_behavior_log (P0 / Decision 4)` — table + service.
+- **#525** (MERGED 2026-05-09) — `feat(observability): F14 — wire AgentBehaviorLogService at 4 event boundaries` — the actual telemetry callsites that emit data.
+
+---
+
+## Section: Net-new items to dispatch
+
+**Zero 🔴 items.** No net-new implementation work needed.
+
+| Item | Severity | Recommended owner | Effort | Why not just close it? |
+|---|---|---|---|---|
+| Fix 10 — Acceptance Authority discrete naming | 🟡 cosmetic | **Leo** (small prompt edit) | 30 min | Behavior is enforced via P0-3+P0-4+soul. Adding a single 12-line "Acceptance Authority" header in `config/souls/team-leader.md` (and brief mention in `config/roles/orchestrator/prompt.md`) gives reviewers a canonical reference. Optional. |
+| Fix 12 — Prompt mass reduction toward 30% target | 🟡 ongoing | **Leo** (continues current trim cycle) | recurring | Already in train; orc trims #528, #529. Recommend setting a measurement waypoint: snapshot total prompt-corpus byte count today, set 4-week reduction goal of 15% (more realistic than 30% given P0/P1 additions). |
+
+**Decision Rights exercised:** per brief, only escalate if >5 🔴 items. Zero 🔴 means I'm finalizing without further owner gate. Both 🟡 items are below the threshold for spinning up a worker — Leo can take them as backlog cleanup if/when bandwidth opens.
+
+---
+
+## Section: Spec items now obsolete / superseded
+
+These were in the 5-3 plan but have been overtaken by other landed work — not silently dropped:
+
+1. **Plan doc Fix 1 sub-detail: "load `team-leader.md` soul AND `team-leader/role-boundaries.md` FIRST, then append developer as Capability Specialty"** — implementation diverged. The shipped form (#414+#417+#493) loads team-leader soul + role + tl-addon, with developer profile available via team-config but not literally appended as a "Capability Specialty" section. The functional outcome — TL framing dominates — is achieved. The literal section title was not adopted.
+
+2. **Plan doc Fix 11 + Memory Phase 1 dependency** — 5-3 plan said Fix 11 was "P2, gated until after onboarding 5/9 ships." The code shipped earlier than that gate. The gate itself is moot.
+
+3. **Plan doc Fix 12: 30%+ prompt mass reduction target** — superseded by reality. Net additions from the same plan (P0+P1 sections in every prompt) make 30% reduction infeasible without removing content the plan itself approved. Recommend revising target to 10–15% reduction over the next 4 weeks.
+
+4. **P0-execution-doc Execution Schedule (Mon 5/4 → Sun 5/10 day-by-day)** — superseded by actual execution. Most P0 work landed on 5/4 + 5/6 + 5/7 (front-loaded). The Sat 5/9 / Sun 5/10 buffer days were not used.
+
+5. **P0-execution-doc Owner Map (`Leo or Max ... Sam supervises`)** — superseded by the actual labor split. Shipped PRs are authored across the team; Sam was reviewer on a subset, not all.
+
+---
+
+## Cross-check counts
+
+| Source | P0 count | P1 count | P2 count | Total |
+|---|---|---|---|---|
+| `2026-05-03-agent-improvement-plan.md` (Fix 1–14) | 5 | 3 | 6 | 14 |
+| `2026-05-03-agent-improvement-p0-execution.md` (P0-1..P0-6) | 6 | 0 | 0 | 6 |
+| **Unique** (overlap removed) | 6 | 3 | 6 | **15** |
+
+**Audit row count: 15 ✅** — matches.
+
+---
+
+## Done Definition (from brief)
+
+- shipped-count: **13**
+- in-flight-count: **2** (Fix 10 cosmetic backlog, Fix 12 ongoing trim)
+- net-new-count: **0**
+- audit-md-path: `specs/2026-05-09-agent-improvement-reconcile-audit.md` (moved from `.crewly/specs/` because `.crewly/` is gitignored — layout decision per Decision Rights; tracked-spec convention matches prior audits like `specs/security-audit-2026-04-07.md`)
+- audit-pr-number: (filled in after `gh pr create`)
+
+---
+
+## Steve-facing summary (plain language)
+
+The two designs are **already built**. We did them last week (5/4 – 5/9) — most of the work shipped under the labels P0-1 through P0-6 plus P1 Fix 6/7/8 and P2 Fix 13/14. There is **nothing new to dispatch**. Two small cleanups remain (giving one section a canonical name, and continuing to trim the orchestrator prompt). Neither is urgent. If you want them, I can have Leo pick them up next week as backlog cleanup.
+
+The reconcile-before-redispatch discipline saved us from a re-do here — same as it did on 5-6 when we caught 4-of-6 already-shipped items.


### PR DESCRIPTION
## Summary
Fixes the misleading heartbeat the user hit during 2026-05-09 dogfood —
a Slack thread received `⏳ 还在做。已完成 0/4, 进行中 0, 排队 0, 卡住 0。`
Looks like the WIs vanished. Actually all 4 child WIs were `cancelled`
and the parent Request was orphaned in `ready`.

## Two stacked bugs

**Bug 1 — heartbeat text undercount.** `buildHeartbeatText` lumped
`cancelled` into the `failed` bucket but the displayed string only
showed done/running/queued/blocked — so 4 cancelled WIs disappeared
from the message entirely.
→ Append `, 取消/失败 N` to the line when N > 0.

**Bug 2 — orphaned Request never closed.** `cascadeRequestStatus` lives
in `V3DataService` and only fires from the retired `v3:task_*` events
(see `mission-executor.service.ts:152` comment about v1-cleanup).
Out-of-band cancellations leave the Request stuck in its pre-cancellation
status forever. Heartbeat then pings the user with the now-misleading
"0/4" line every sweep.
→ In `runHeartbeat`: when every child WI is in a terminal status, skip
the post and patch the Request to the right terminal status (`done` if
any child succeeded, `cancelled` if all were abandoned). Honours
`REQUEST_TRANSITIONS` — `ready → done` is illegal so the closer hops
`ready → running → done`. `update` failures are logged and swallowed
so one bad Request doesn't poison the sweep.

## Out of scope
The deeper fix — emit `task:cancelled` from the task-pool and wire a
proper subscriber to `cascadeRequestStatus` — is a follow-up. The
heartbeat-driven catch in this PR closes wedged Requests with at most
one heartbeat-interval (30 min) of latency, which is enough to unblock
the immediate UX symptom.

## Test plan
- [x] 6 new unit tests in `request-status-update.subscriber.test.ts`:
  - all-cancelled children → Request closed to `cancelled`, no post
  - mixed terminal (some done + some cancelled) → Request closed to `done`
  - `ready` Request with a `done` child → hops via `running`
  - `update` failure on one Request doesn't break the sweep
  - heartbeat text includes `取消/失败 N` when non-zero
  - heartbeat text omits the cancelled clause when zero
- [x] All 23 subscriber tests pass (existing 17 + 6 new)
- [x] Full backend `tsc --noEmit` clean for touched files (no new errors)
- [x] `npm run build` succeeds
- [ ] Post-merge: live verify by purging the stale Request 6d60a1cd and
      watching the next heartbeat sweep — should NOT re-fire on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)