### PR TITLE
feat(v3): cascade Request status on live task lifecycle events

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -73,6 +73,7 @@ import {
 	setRequestDecomposeSubscriber,
 } from './services/v3/request-decompose.subscriber.js';
 import { RequestStatusUpdateSubscriber } from './services/v3/request-status-update.subscriber.js';
+import { RequestCascadeSubscriber } from './services/v3/request-cascade.subscriber.js';
 import { setRequestServiceEventBus, RequestService } from './services/v3/request.service.js';
 import { getSlackService } from './services/slack/slack.service.js';
 import { SlackThreadStoreService, setSlackThreadStore, getSlackThreadStore } from './services/slack/slack-thread-store.service.js';
@@ -197,6 +198,7 @@ export class CrewlyServer {
 	/** Pipeline-#4 follow-up: subscribes to request:created and auto-decomposes actionable L2 Requests via plan() → addToPool. */
 	private requestDecomposeSubscriber: RequestDecomposeSubscriber | null = null;
 	private requestStatusUpdateSubscriber: RequestStatusUpdateSubscriber | null = null;
+	private requestCascadeSubscriber: RequestCascadeSubscriber | null = null;
 	private notifyReconciliationService!: NotifyReconciliationService;
 	private systemResourceAlertService!: SystemResourceAlertService;
 	private reconcilerService: ReconcilerService | null = null;
@@ -512,6 +514,19 @@ export class CrewlyServer {
 				heartbeatMinutes: 30,
 			});
 			this.requestStatusUpdateSubscriber.start();
+
+			// Cascade subscriber: keeps Request.status in sync with the
+			// aggregate state of its child WIs by reacting to live task
+			// lifecycle events. Closes the gap left by V3DataService's
+			// retired `v3:task_*` subscriptions (see 2026-05-09 dogfood
+			// note in request-cascade.subscriber.ts).
+			this.requestCascadeSubscriber = new RequestCascadeSubscriber({
+				eventBus: this.eventBusService,
+				requestService: RequestService.getInstance(),
+				taskPool: TaskPoolService.getInstance(),
+				notifier: this.eventBusService,
+			});
+			this.requestCascadeSubscriber.start();
 		} catch (subscriberBootErr) {
 			// Degraded mode: SLA tracking + auto-decompose are off, but the
 			// API surface and rest of the backend continue to serve. Ops can
@@ -535,6 +550,10 @@ export class CrewlyServer {
 			if (this.requestStatusUpdateSubscriber) {
 				try { this.requestStatusUpdateSubscriber.stop(); } catch { /* best-effort */ }
 				this.requestStatusUpdateSubscriber = null;
+			}
+			if (this.requestCascadeSubscriber) {
+				try { this.requestCascadeSubscriber.stop(); } catch { /* best-effort */ }
+				this.requestCascadeSubscriber = null;
 			}
 		}
 

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -553,6 +553,66 @@ export class TaskPoolService {
   }
 
   /**
+   * Publish `task:cancelled` whenever a WorkItem transitions to the
+   * cancelled status via {@link updateItemStatus} or {@link transitionStatus}.
+   *
+   * **Why this exists.** 2026-05-09 dogfood: 4 child WIs of a Slack-
+   * originated Request all landed in `cancelled` (orc-not-in-health-map
+   * loop, fixed in #531) but the Request stayed in `ready` for hours.
+   * `cascadeRequestStatus` only fires from V3DataService's task
+   * handlers, which are wired to the retired `v3:task_*` events
+   * (`mission-executor.service.ts:152` v1-cleanup comment) — so out-of-
+   * band cancellations never reached cascade. The heartbeat sweep
+   * eventually caught it (#533), but with up-to-30-min latency that
+   * showed up as a misleading "0/4 in every bucket" ping in the user's
+   * Slack thread.
+   *
+   * Publishing `task:cancelled` lets `RequestCascadeSubscriber` close
+   * the Request within seconds of the last child cancelling, instead
+   * of waiting for the heartbeat catch.
+   *
+   * Mirrors {@link publishTaskDoneByWorker} / {@link publishTaskRejected}
+   * so the EventBus surface stays uniform.
+   *
+   * @param workItem - The WI snapshot AFTER the cancelled transition committed
+   * @param previousStatus - The status it transitioned from (for the event payload)
+   */
+  private publishTaskCancelled(
+    workItem: WorkItem,
+    previousStatus: WorkItemStatus,
+  ): void {
+    if (!this.eventBus) {
+      this.logger.debug('No EventBus wired — skipping task:cancelled publish', {
+        workItemId: workItem.id,
+      });
+      return;
+    }
+    try {
+      this.eventBus.publish({
+        id: `task:cancelled:${workItem.id}`,
+        type: 'task:cancelled',
+        timestamp: new Date().toISOString(),
+        teamId: '',
+        teamName: '',
+        memberId: '',
+        memberName: '',
+        sessionName: '',
+        previousValue: previousStatus,
+        newValue: 'cancelled',
+        changedField: 'taskStatus',
+        workItemId: workItem.id,
+        missionId: workItem.missionId,
+        requestId: workItem.requestId,
+      });
+    } catch (err) {
+      this.logger.warn('task:cancelled publish threw', {
+        workItemId: workItem.id,
+        error: formatError(err),
+      });
+    }
+  }
+
+  /**
    * Claims the next available WorkItem from the pool for an agent.
    *
    * Selection strategy: FIFO among matching unclaimed 'queued' items.
@@ -1553,6 +1613,14 @@ export class TaskPoolService {
       to: newStatus,
       actorRole,
     });
+
+    // Cascade signal — let RequestCascadeSubscriber close the parent
+    // Request without waiting for the heartbeat catch. See
+    // {@link publishTaskCancelled} for the full bug writeup.
+    if (newStatus === 'cancelled') {
+      const post = await this.storage.findWorkItem(workItemId);
+      if (post) this.publishTaskCancelled(post, item.status);
+    }
   }
 
   /**
@@ -1682,7 +1750,16 @@ export class TaskPoolService {
     // resolved value rather than re-fetching. Coerce `undefined` (item
     // removed during the race window) to `null` to match the declared
     // return type.
-    return (await this.storage.findWorkItem(workItemId)) ?? null;
+    const post = (await this.storage.findWorkItem(workItemId)) ?? null;
+
+    // Cascade signal — let RequestCascadeSubscriber close the parent
+    // Request without waiting for the heartbeat catch. See
+    // {@link publishTaskCancelled} for the full bug writeup.
+    if (newStatus === 'cancelled' && post) {
+      this.publishTaskCancelled(post, item.status);
+    }
+
+    return post;
   }
 
   /**

--- a/backend/src/services/v3/cascade-request-status.test.ts
+++ b/backend/src/services/v3/cascade-request-status.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for the standalone cascadeRequestStatus helper.
+ *
+ * Mirrors the semantics of the original V3DataService.cascadeRequestStatus
+ * implementation (so behaviour-preserving extraction is verifiable) and
+ * adds the new `ready → running → done` hop for Requests whose first
+ * lifecycle event is a successful verify.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { cascadeRequestStatus, type CascadeDeps } from './cascade-request-status.js';
+import type { Request } from '../../types/v2/request.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+
+const SILENT_LOGGER = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 'req-1',
+    title: 'test',
+    sourceConversationItemId: 'slack-CTEST-1707000000.000001',
+    intentLevel: 'L2',
+    intentCategory: 'planning',
+    actionable: true,
+    status: 'running',
+    workItemIds: [],
+    createdAt: '2026-05-09T01:00:00.000Z',
+    updatedAt: '2026-05-09T01:00:00.000Z',
+    ...overrides,
+  } as Request;
+}
+
+function makeWI(overrides: Partial<WorkItem>): WorkItem {
+  return {
+    id: 'wi-1',
+    title: 'test wi',
+    description: '',
+    status: 'queued',
+    requestId: 'req-1',
+    target: '',
+    type: 'delegate',
+    createdAt: '2026-05-09T01:00:00.000Z',
+    updatedAt: '2026-05-09T01:00:00.000Z',
+    ...overrides,
+  } as WorkItem;
+}
+
+function makeDeps(opts: {
+  request?: Request;
+  pool?: WorkItem[];
+  updateThrows?: Error;
+} = {}): { deps: CascadeDeps; requestStore: Map<string, Request>; updates: Array<[string, Partial<Request>]>; notified: Array<{ event: string; payload: unknown }> } {
+  const requestStore = new Map<string, Request>();
+  if (opts.request) requestStore.set(opts.request.id, opts.request);
+  const updates: Array<[string, Partial<Request>]> = [];
+  const notified: Array<{ event: string; payload: unknown }> = [];
+
+  const deps: CascadeDeps = {
+    requestService: {
+      getById: async (id: string) => requestStore.get(id) ?? null,
+      update: async (id: string, patch: Partial<Request>) => {
+        if (opts.updateThrows) throw opts.updateThrows;
+        updates.push([id, patch]);
+        const existing = requestStore.get(id);
+        if (existing) requestStore.set(id, { ...existing, ...patch } as Request);
+        return null;
+      },
+    },
+    taskPool: {
+      getAllItems: async () => opts.pool ?? [],
+    },
+    logger: SILENT_LOGGER as unknown as CascadeDeps['logger'],
+    notifier: {
+      emit: (event, payload) => notified.push({ event, payload }),
+    },
+  };
+
+  return { deps, requestStore, updates, notified };
+}
+
+describe('cascadeRequestStatus', () => {
+  it('no-ops on undefined requestId (event is for an unlinked WI)', async () => {
+    const { deps, updates } = makeDeps({});
+    await cascadeRequestStatus(undefined, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('no-ops when the Request is already terminal (done)', async () => {
+    const r = makeRequest({ status: 'done' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'cancelled' })],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('no-ops when the Request has no child WIs', async () => {
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates } = makeDeps({ request: r, pool: [] });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('cascades to done when every child landed on a success terminal', async () => {
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates, notified } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({ id: 'a', status: 'done' }),
+        makeWI({ id: 'b', status: 'verified' }),
+        makeWI({ id: 'c', status: 'done_by_worker' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'done' }]]);
+    expect(notified).toEqual([
+      { event: 'v3:request_updated', payload: { requestId: 'req-1', status: 'done', previousStatus: 'running' } },
+    ]);
+  });
+
+  it('cascades to cancelled when every child is cancelled or failed', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({ id: 'a', status: 'cancelled' }),
+        makeWI({ id: 'b', status: 'cancelled' }),
+        makeWI({ id: 'c', status: 'failed' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'cancelled' }]]);
+  });
+
+  it('cascades to running when any child is running, regardless of other state', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({ id: 'a', status: 'running' }),
+        makeWI({ id: 'b', status: 'queued' }),
+        makeWI({ id: 'c', status: 'cancelled' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'running' }]]);
+  });
+
+  it('does NOT cascade when all WIs are still queued (work delegated, not started)', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'queued' }), makeWI({ status: 'queued' })],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('cascades to blocked when every non-queued child is blocked and none are running', async () => {
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({ id: 'a', status: 'blocked' }),
+        makeWI({ id: 'b', status: 'blocked' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'blocked' }]]);
+  });
+
+  it('hops `ready → running → done` when the direct edge is illegal', async () => {
+    // REQUEST_TRANSITIONS forbids `ready → done`. The cascade must
+    // detect this and step via running so a fast verify (Plan WI
+    // skipped the running stage entirely) still closes cleanly.
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'verified' })],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([
+      ['req-1', { status: 'running' }],
+      ['req-1', { status: 'done' }],
+    ]);
+  });
+
+  it('does not throw when the target status is not reachable from current state', async () => {
+    // Pathological case: pretend the Request has an exotic in-flight
+    // status that neither matches a direct nor hop edge for the
+    // computed target. Cascade should log + return, NOT throw.
+    const r = makeRequest({ status: 'waiting_confirmation' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'blocked' })],
+    });
+    // waiting_confirmation → blocked is NOT in REQUEST_TRANSITIONS.
+    await expect(cascadeRequestStatus(r.id, deps)).resolves.toBeUndefined();
+    expect(updates).toEqual([]);
+  });
+
+  it('swallows `requestService.update` failures (best-effort contract)', async () => {
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'done' })],
+      updateThrows: new Error('disk full'),
+    });
+    await expect(cascadeRequestStatus(r.id, deps)).resolves.toBeUndefined();
+    expect(updates).toEqual([]); // updates array tracks only succeeded writes
+  });
+
+  it('does not re-emit when newStatus matches current status', async () => {
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates, notified } = makeDeps({
+      request: r,
+      pool: [makeWI({ status: 'running' })],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+    expect(notified).toEqual([]);
+  });
+});

--- a/backend/src/services/v3/cascade-request-status.ts
+++ b/backend/src/services/v3/cascade-request-status.ts
@@ -1,0 +1,196 @@
+/**
+ * Standalone cascade-request-status helper.
+ *
+ * Extracted from `V3DataService.cascadeRequestStatus` so that any
+ * subscriber on the central EventBus can call it without dragging in
+ * the V3DataService singleton or being forced through V3DataService's
+ * internal `v3:task_*` event subscriptions (which were retired in the
+ * v1-cleanup campaign — `mission-executor.service.ts:152`).
+ *
+ * The 2026-05-09 dogfood bug shape:
+ *   - All 4 child WIs of a Slack-originated Request landed in
+ *     `cancelled`.
+ *   - V3DataService's onTaskCompleted/onTaskFailed handlers
+ *     (which were the ONLY callers of cascade) never fired because
+ *     their `v3:task_*` events were dead.
+ *   - Request stayed in `ready` for hours.
+ *   - Heartbeat sweep faithfully posted "0/4, 进行中 0..." every cycle.
+ *
+ * The fix path: emit `task:cancelled` from the task-pool when a WI
+ * lands in cancelled, subscribe to it (and the other live task
+ * lifecycle events) in `RequestCascadeSubscriber`, and call this
+ * helper. The Request now closes within seconds of the last child WI
+ * transitioning, instead of waiting for the heartbeat catch.
+ *
+ * @module services/v3/cascade-request-status
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import {
+  isValidRequestTransition,
+  type RequestStatus,
+  type Request,
+} from '../../types/v2/index.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+
+/**
+ * Minimal {@link RequestService} surface the cascade needs. Defining it
+ * explicitly keeps tests and alternate callers from being forced to
+ * mock the entire service.
+ */
+export interface CascadeRequestService {
+  getById(id: string): Promise<Request | null>;
+  update(id: string, patch: Partial<Request>): Promise<unknown>;
+}
+
+/**
+ * Minimal {@link TaskPoolService} surface — only `getAllItems` is used
+ * (the cascade re-reads pool state to make its decision rather than
+ * trusting the event payload, which may be stale after a rapid burst).
+ */
+export interface CascadeTaskPool {
+  getAllItems(): Promise<WorkItem[]>;
+}
+
+/**
+ * Optional sink for "Request status changed" notifications. The original
+ * V3DataService implementation emitted `v3:request_updated`; preserved
+ * here so existing internal subscribers (UI refresh, etc.) keep working
+ * even though the cascade no longer lives in V3DataService.
+ */
+export interface CascadeNotifier {
+  emit(event: 'v3:request_updated', payload: {
+    requestId: string;
+    status: RequestStatus;
+    previousStatus: RequestStatus;
+  }): void;
+}
+
+export interface CascadeDeps {
+  requestService: CascadeRequestService;
+  taskPool: CascadeTaskPool;
+  logger?: ComponentLogger;
+  notifier?: CascadeNotifier;
+}
+
+/**
+ * Recompute Request.status from the aggregate state of its child WIs
+ * and persist any change.
+ *
+ * Cascade rules — match the original V3DataService implementation so
+ * behaviour is unchanged for paths that already cascade correctly:
+ *
+ *   - All children done/verified/done_by_worker → done
+ *   - Any child running                          → running
+ *   - All children queued/scheduled              → no change
+ *     (work delegated, not started — Request keeps current status)
+ *   - Any child blocked, none running            → blocked
+ *   - All children failed/cancelled              → cancelled
+ *   - Some done, no running                      → running
+ *     (progress is happening; further events will cascade to done)
+ *   - Mixed                                       → no change
+ *
+ * Honours `REQUEST_TRANSITIONS`. Skips silently when the target is
+ * unreachable from the current status — the next event tick will try
+ * again with fresh state.
+ *
+ * Best-effort. Logs but does not throw — a failing cascade must not
+ * break the subscriber that called it.
+ *
+ * @param requestId - Parent Request ID. `undefined` is a no-op (the WI
+ *   wasn't part of a Request).
+ * @param deps - Service surface needed to read pool + write request.
+ */
+export async function cascadeRequestStatus(
+  requestId: string | undefined,
+  deps: CascadeDeps,
+): Promise<void> {
+  if (!requestId) return;
+
+  const logger =
+    deps.logger ?? LoggerService.getInstance().createComponentLogger('CascadeRequestStatus');
+
+  try {
+    const request = await deps.requestService.getById(requestId);
+    if (!request) return;
+    if (request.status === 'done' || request.status === 'cancelled') return;
+
+    const allItems = await deps.taskPool.getAllItems();
+    const childItems = allItems.filter((wi) => wi.requestId === requestId);
+    if (childItems.length === 0) return;
+
+    const statuses = childItems.map((wi) => wi.status);
+
+    let newStatus: RequestStatus;
+    const allQueued = statuses.every((s) => s === 'queued' || s === 'scheduled');
+    if (statuses.every((s) => s === 'done' || s === 'verified' || s === 'done_by_worker')) {
+      newStatus = 'done';
+    } else if (statuses.some((s) => s === 'running')) {
+      newStatus = 'running';
+    } else if (allQueued) {
+      return;
+    } else if (statuses.some((s) => s === 'blocked') && !statuses.some((s) => s === 'running')) {
+      newStatus = 'blocked';
+    } else if (statuses.every((s) => s === 'failed' || s === 'cancelled')) {
+      newStatus = 'cancelled';
+    } else if (statuses.some((s) => s === 'done' || s === 'verified' || s === 'done_by_worker')) {
+      newStatus = 'running';
+    } else {
+      return;
+    }
+
+    if (newStatus === request.status) return;
+
+    // Direct transition.
+    if (isValidRequestTransition(request.status, newStatus)) {
+      await deps.requestService.update(requestId, { status: newStatus });
+      logger.info('Request status cascaded from WorkItems', {
+        requestId,
+        previousStatus: request.status,
+        newStatus,
+        childStatuses: statuses,
+      });
+      deps.notifier?.emit('v3:request_updated', {
+        requestId,
+        status: newStatus,
+        previousStatus: request.status,
+      });
+      return;
+    }
+
+    // `ready → done` is illegal; hop via running. Same shape used by
+    // the heartbeat-driven closer in RequestStatusUpdateSubscriber so
+    // both paths converge on identical semantics.
+    if (
+      newStatus === 'done' &&
+      isValidRequestTransition(request.status, 'running') &&
+      isValidRequestTransition('running', 'done')
+    ) {
+      await deps.requestService.update(requestId, { status: 'running' });
+      await deps.requestService.update(requestId, { status: 'done' });
+      logger.info('Request status cascaded via running hop', {
+        requestId,
+        previousStatus: request.status,
+        newStatus,
+        childStatuses: statuses,
+      });
+      deps.notifier?.emit('v3:request_updated', {
+        requestId,
+        status: newStatus,
+        previousStatus: request.status,
+      });
+      return;
+    }
+
+    logger.debug('Cascade target not reachable from current status', {
+      requestId,
+      currentStatus: request.status,
+      targetStatus: newStatus,
+    });
+  } catch (err) {
+    logger.debug('cascadeRequestStatus failed (non-fatal)', {
+      requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/services/v3/request-cascade.subscriber.test.ts
+++ b/backend/src/services/v3/request-cascade.subscriber.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for RequestCascadeSubscriber.
+ *
+ * Verifies the subscriber resolves requestId from event payload (or
+ * by WI lookup when missing), routes through cascadeRequestStatus,
+ * and never lets a single failed dispatch break the rest of the
+ * subscription.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { RequestCascadeSubscriber } from './request-cascade.subscriber.js';
+import type {
+  CascadeRequestService,
+  CascadeNotifier,
+} from './cascade-request-status.js';
+import type { CascadeSubscriberTaskPool } from './request-cascade.subscriber.js';
+import type { Request } from '../../types/v2/request.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
+
+const SILENT_LOGGER = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+function makeRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 'req-1',
+    title: 'test',
+    sourceConversationItemId: 'slack-CTEST-1707000000.000001',
+    intentLevel: 'L2',
+    intentCategory: 'planning',
+    actionable: true,
+    status: 'running',
+    workItemIds: [],
+    createdAt: '2026-05-09T01:00:00.000Z',
+    updatedAt: '2026-05-09T01:00:00.000Z',
+    ...overrides,
+  } as Request;
+}
+
+function makeWI(overrides: Partial<WorkItem>): WorkItem {
+  return {
+    id: 'wi-1',
+    title: 'test wi',
+    description: '',
+    status: 'queued',
+    requestId: 'req-1',
+    target: '',
+    type: 'delegate',
+    createdAt: '2026-05-09T01:00:00.000Z',
+    updatedAt: '2026-05-09T01:00:00.000Z',
+    ...overrides,
+  } as WorkItem;
+}
+
+function makeEvent(opts: {
+  type: EventType;
+  workItemId?: string;
+  requestId?: string;
+}): AgentEvent {
+  return {
+    id: `${opts.type}:${opts.workItemId ?? 'x'}`,
+    type: opts.type,
+    timestamp: new Date().toISOString(),
+    teamId: '',
+    teamName: '',
+    memberId: '',
+    memberName: '',
+    sessionName: '',
+    previousValue: '',
+    newValue: '',
+    changedField: 'taskStatus',
+    workItemId: opts.workItemId,
+    requestId: opts.requestId,
+  } as AgentEvent;
+}
+
+/**
+ * Minimal in-memory EventBus stub. Keeps a Set of handlers per event
+ * type; `publish` invokes each one. Mirrors the surface
+ * RequestCascadeSubscriber uses (`onInProcess` + the unsubscribe
+ * callback).
+ */
+function makeFakeBus() {
+  const handlers = new Map<EventType, Set<(e: AgentEvent) => unknown>>();
+  const bus = {
+    onInProcess(types: EventType | EventType[], h: (e: AgentEvent) => unknown) {
+      const arr = Array.isArray(types) ? types : [types];
+      for (const t of arr) {
+        let s = handlers.get(t);
+        if (!s) {
+          s = new Set();
+          handlers.set(t, s);
+        }
+        s.add(h);
+      }
+      return () => {
+        for (const t of arr) handlers.get(t)?.delete(h);
+      };
+    },
+    publish(event: AgentEvent) {
+      const set = handlers.get(event.type);
+      if (!set) return;
+      for (const h of set) h(event);
+    },
+  };
+  return bus;
+}
+
+function makeFakeServices(opts: {
+  request?: Request;
+  pool?: WorkItem[];
+} = {}) {
+  const requestStore = new Map<string, Request>();
+  if (opts.request) requestStore.set(opts.request.id, opts.request);
+  const pool = opts.pool ?? [];
+  const updates: Array<[string, Partial<Request>]> = [];
+
+  const requestService: CascadeRequestService = {
+    getById: async (id: string) => requestStore.get(id) ?? null,
+    update: async (id: string, patch: Partial<Request>) => {
+      updates.push([id, patch]);
+      const existing = requestStore.get(id);
+      if (existing) requestStore.set(id, { ...existing, ...patch } as Request);
+      return null;
+    },
+  };
+
+  const taskPool: CascadeSubscriberTaskPool = {
+    findWorkItem: async (id: string) => pool.find((w) => w.id === id),
+    getAllItems: async () => pool,
+  };
+
+  const notified: Array<{ event: string; payload: unknown }> = [];
+  const notifier: CascadeNotifier = {
+    emit: (e, p) => notified.push({ event: e, payload: p }),
+  };
+
+  return { requestService, taskPool, requestStore, updates, notified, notifier };
+}
+
+describe('RequestCascadeSubscriber', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cascades on task:cancelled when event carries requestId directly', async () => {
+    // The end-to-end flow we care about: task-pool publishes
+    // task:cancelled with the requestId on the payload, subscriber
+    // closes the Request without needing a pool re-lookup.
+    const r = makeRequest({ status: 'ready' });
+    const wis = [
+      makeWI({ id: 'a', status: 'cancelled' }),
+      makeWI({ id: 'b', status: 'cancelled' }),
+    ];
+    const services = makeFakeServices({ request: r, pool: wis });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:cancelled', workItemId: 'a', requestId: 'req-1' }));
+    await sub.flushPending();
+
+    expect(services.updates).toEqual([['req-1', { status: 'cancelled' }]]);
+    expect(services.requestStore.get('req-1')!.status).toBe('cancelled');
+  });
+
+  it('cascades on task:cancelled via WI lookup when event lacks requestId', async () => {
+    // Older / hand-fired emitters don't always set requestId. The
+    // subscriber must fall back to findWorkItem to resolve it.
+    const r = makeRequest({ status: 'ready' });
+    const wis = [makeWI({ id: 'orphan', status: 'cancelled', requestId: 'req-1' })];
+    const services = makeFakeServices({ request: r, pool: wis });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:cancelled', workItemId: 'orphan' })); // no requestId
+    await sub.flushPending();
+
+    expect(services.updates).toEqual([['req-1', { status: 'cancelled' }]]);
+  });
+
+  it('cascades on task:done_by_worker (closes Request when all children done)', async () => {
+    // Live wiring of the success path — proves the subscriber doesn't
+    // ONLY handle cancellation. After the last child reports done,
+    // the Request closes automatically.
+    const r = makeRequest({ status: 'running' });
+    const wis = [
+      makeWI({ id: 'a', status: 'done' }),
+      makeWI({ id: 'b', status: 'done_by_worker' }),
+    ];
+    const services = makeFakeServices({ request: r, pool: wis });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:done_by_worker', workItemId: 'b', requestId: 'req-1' }));
+    await sub.flushPending();
+
+    expect(services.updates).toEqual([['req-1', { status: 'done' }]]);
+  });
+
+  it('no-ops when neither event nor WI lookup yields a requestId', async () => {
+    // Genuinely orphan event — nothing to cascade. Must not throw.
+    const services = makeFakeServices({});
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:cancelled', workItemId: 'unknown-wi' }));
+    await sub.flushPending();
+
+    expect(services.updates).toEqual([]);
+  });
+
+  it('does not throw when cascade itself fails (best-effort contract)', async () => {
+    // Subscriber MUST swallow errors from cascade so a single failing
+    // request doesn't break the bus dispatch loop.
+    const services = makeFakeServices({});
+    services.requestService.getById = async () => {
+      throw new Error('storage exploded');
+    };
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:failed', workItemId: 'x', requestId: 'req-1' }));
+    await expect(sub.flushPending()).resolves.toBeUndefined();
+  });
+
+  it('subscribes to all six lifecycle events on start', async () => {
+    // Regression gate: if a future refactor drops one of the event
+    // types from SUBSCRIBED_EVENTS, the cascade for that lifecycle
+    // path silently breaks. Trip it here.
+    const r = makeRequest({ status: 'running' });
+    const services = makeFakeServices({ request: r, pool: [makeWI({ status: 'running' })] });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    const onSpy = jest.spyOn(bus, 'onInProcess');
+    sub.start();
+
+    const subscribedTypes = onSpy.mock.calls.map((c) => c[0]);
+    expect(subscribedTypes).toEqual(
+      expect.arrayContaining([
+        'task:done_by_worker',
+        'task:verified',
+        'task:rejected',
+        'task:cancelled',
+        'task:failed',
+        'task:blocked',
+      ]),
+    );
+  });
+
+  it('start() is idempotent — calling twice does not double-subscribe', async () => {
+    const services = makeFakeServices({});
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    const onSpy = jest.spyOn(bus, 'onInProcess');
+    sub.start();
+    sub.start();
+    expect(onSpy.mock.calls.length).toBe(6); // 6 unique event types, one per type
+  });
+
+  it('stop() detaches handlers — subsequent events are ignored', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const services = makeFakeServices({
+      request: r,
+      pool: [makeWI({ status: 'cancelled' })],
+    });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+    sub.stop();
+
+    bus.publish(makeEvent({ type: 'task:cancelled', workItemId: 'wi-1', requestId: 'req-1' }));
+    await sub.flushPending();
+
+    expect(services.updates).toEqual([]);
+  });
+});

--- a/backend/src/services/v3/request-cascade.subscriber.ts
+++ b/backend/src/services/v3/request-cascade.subscriber.ts
@@ -1,0 +1,190 @@
+/**
+ * RequestCascadeSubscriber — keeps Request.status in sync with the
+ * aggregate state of its child WorkItems by reacting to live task
+ * lifecycle events on the central EventBus.
+ *
+ * **Why this exists.** 2026-05-09 dogfood: `cascadeRequestStatus` lives
+ * inside V3DataService, but the only callers are V3DataService's
+ * onTaskCompleted/onTaskFailed/onTaskBlocked handlers — and those
+ * handlers are wired to the **retired** `v3:task_*` events that nothing
+ * emits anymore (`mission-executor.service.ts:152` v1-cleanup comment).
+ * So the cascade hadn't fired for any task event in months.
+ *
+ * Symptom: a Slack-originated Request whose 4 child WIs all landed in
+ * `cancelled` stayed in `ready` for hours, generating misleading
+ * "0/4, 进行中 0..." heartbeats every sweep.
+ *
+ * **What this subscribes to.** Every live task lifecycle event that the
+ * central EventBus publishes:
+ *   - `task:done_by_worker`   — child finished, awaiting verification
+ *   - `task:verified`         — verifier accepted
+ *   - `task:rejected`         — verifier sent back for retry
+ *   - `task:cancelled`        — child cancelled (added in this PR)
+ *   - `task:failed`           — child failed terminally
+ *   - `task:blocked`          — child wedged
+ *
+ * Each handler resolves `requestId` from the event payload (or by
+ * looking up the WI if the event didn't carry it) and calls
+ * {@link cascadeRequestStatus}, which re-reads pool state and patches
+ * the parent Request to the right status.
+ *
+ * **What this is NOT.** This is not a notification service —
+ * `RequestStatusUpdateSubscriber` handles user-facing Slack updates.
+ * They share the event stream but have separate concerns. (The
+ * heartbeat-driven closer in `RequestStatusUpdateSubscriber` remains
+ * as a 30-min safety net for any cancellation that bypasses the
+ * publish path — e.g. direct storage mutation by an ops script.)
+ *
+ * @module services/v3/request-cascade.subscriber
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
+import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+import {
+  cascadeRequestStatus,
+  type CascadeRequestService,
+  type CascadeTaskPool,
+  type CascadeNotifier,
+} from './cascade-request-status.js';
+
+/**
+ * Events that may signal a Request needs re-cascading.
+ */
+const SUBSCRIBED_EVENTS: readonly EventType[] = [
+  'task:done_by_worker',
+  'task:verified',
+  'task:rejected',
+  'task:cancelled',
+  'task:failed',
+  'task:blocked',
+] as const;
+
+/**
+ * Minimal pool surface — needs both `findWorkItem` (resolve missing
+ * requestId from event payload) and `getAllItems` (the cascade itself
+ * re-reads pool state).
+ */
+export interface CascadeSubscriberTaskPool extends CascadeTaskPool {
+  findWorkItem(id: string): Promise<WorkItem | undefined | null>;
+}
+
+export interface RequestCascadeSubscriberDependencies {
+  eventBus: EventBusService;
+  requestService: CascadeRequestService;
+  taskPool: CascadeSubscriberTaskPool;
+  /** Optional notifier — production wiring passes the same EventBus so
+   * `v3:request_updated` reaches existing UI subscribers. */
+  notifier?: CascadeNotifier;
+  logger?: ComponentLogger;
+}
+
+export class RequestCascadeSubscriber {
+  private readonly eventBus: EventBusService;
+  private readonly requestService: CascadeRequestService;
+  private readonly taskPool: CascadeSubscriberTaskPool;
+  private readonly notifier?: CascadeNotifier;
+  private readonly logger: ComponentLogger;
+
+  private unsubscribers: InProcessUnsubscribe[] = [];
+  private started = false;
+  /** In-flight async dispatch promises — exposed via `flushPending` for tests. */
+  private readonly pendingDispatches: Set<Promise<void>> = new Set();
+
+  constructor(deps: RequestCascadeSubscriberDependencies) {
+    this.eventBus = deps.eventBus;
+    this.requestService = deps.requestService;
+    this.taskPool = deps.taskPool;
+    this.notifier = deps.notifier;
+    this.logger =
+      deps.logger ?? LoggerService.getInstance().createComponentLogger('RequestCascadeSubscriber');
+  }
+
+  /**
+   * Subscribe to bus events. Idempotent.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    for (const eventType of SUBSCRIBED_EVENTS) {
+      this.unsubscribers.push(
+        this.eventBus.onInProcess(eventType, (e) => this.safeDispatch(eventType, e)),
+      );
+    }
+
+    this.logger.info('RequestCascadeSubscriber subscribed', {
+      eventTypes: SUBSCRIBED_EVENTS,
+    });
+  }
+
+  /**
+   * Detach subscriptions. Safe to call repeatedly.
+   */
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    for (const unsub of this.unsubscribers) {
+      try {
+        unsub();
+      } catch (err) {
+        this.logger.warn('Unsubscribe failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    this.unsubscribers = [];
+  }
+
+  /**
+   * Test affordance — wait for any in-flight dispatch promises to settle.
+   */
+  async flushPending(): Promise<void> {
+    while (this.pendingDispatches.size > 0) {
+      await Promise.allSettled(Array.from(this.pendingDispatches));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+
+  private safeDispatch(eventType: EventType, event: AgentEvent): Promise<void> {
+    const dispatch = (async () => {
+      try {
+        await this.handleTaskEvent(eventType, event);
+      } catch (err) {
+        // Best-effort — never let a cascade failure poison the bus.
+        this.logger.warn('Cascade dispatch failed (non-fatal)', {
+          eventType,
+          workItemId: event.workItemId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    this.pendingDispatches.add(dispatch);
+    void dispatch.finally(() => this.pendingDispatches.delete(dispatch));
+    return dispatch;
+  }
+
+  private async handleTaskEvent(_eventType: EventType, event: AgentEvent): Promise<void> {
+    let requestId = event.requestId;
+
+    // Some emitters don't carry requestId on the event payload (older
+    // call sites, hand-fired test events). Resolve via the WI if we
+    // have a workItemId. If neither is present, there's nothing to
+    // cascade — quietly bail.
+    if (!requestId && event.workItemId) {
+      const wi = await this.taskPool.findWorkItem(event.workItemId);
+      if (wi) requestId = wi.requestId;
+    }
+
+    if (!requestId) return;
+
+    await cascadeRequestStatus(requestId, {
+      requestService: this.requestService,
+      taskPool: this.taskPool,
+      logger: this.logger,
+      notifier: this.notifier,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Closes the cascade gap that the heartbeat-driven catch in #533 was working around with a 30-min latency.

**Background.** `cascadeRequestStatus` lived in `V3DataService` and was only called from `V3DataService.onTaskCompleted` / `onTaskFailed` / `onTaskBlocked`. Those handlers subscribe to `v3:task_completed` / `v3:task_failed` / `v3:task_blocked`, all of which were retired in the v1-cleanup campaign (`mission-executor.service.ts:152` comment). Result: the cascade hadn't fired for any task event in months. Out-of-band cancellations left Requests orphaned in `ready` indefinitely; successful runs only closed because the heartbeat sweep eventually caught them.

## Changes

**1. Extract `cascadeRequestStatus` into a standalone helper** (`backend/src/services/v3/cascade-request-status.ts`)
- Pure function; injected `RequestService` / `TaskPool` / `Notifier` surfaces
- Adds the `ready → running → done` hop for Requests whose first lifecycle event is a successful verify (mirrors the closer added in #533)
- 12 unit tests covering all cascade rules + the hop + best-effort error swallowing

**2. Publish `task:cancelled` from TaskPoolService**
- New `publishTaskCancelled` private method, mirrors `publishTaskDoneByWorker` / `publishTaskRejected`
- Called from both `updateItemStatus` and `transitionStatus` after the storage write succeeds when `newStatus === 'cancelled'`

**3. New `RequestCascadeSubscriber`** subscribes to all six live task lifecycle events and calls cascade
- `task:done_by_worker`, `task:verified`, `task:rejected`, `task:cancelled`, `task:failed`, `task:blocked`
- Falls back to `findWorkItem` lookup when the event payload omits `requestId`
- Wired in `index.ts` alongside `RequestStatusUpdateSubscriber`
- 8 unit tests covering each event path + idempotent start/stop + bus dispatch resilience

## What is NOT touched

- `V3DataService.onTaskCompleted` and friends are still dead (subscribed to retired `v3:task_*`). Cleaning that up is its own PR — they're inert, just orphaned.
- The heartbeat-driven closer in `RequestStatusUpdateSubscriber` stays as a 30-min safety net for cancellations that bypass the publish path (e.g. a direct ops script writing storage).

## Test plan
- [x] 12 new tests in `cascade-request-status.test.ts` (helper)
- [x] 8 new tests in `request-cascade.subscriber.test.ts` (subscriber)
- [x] Existing 23 tests in `request-status-update.subscriber.test.ts` still pass
- [x] Existing tests in `task-pool.service.test.ts` still pass (164/164 across all four suites)
- [x] `tsc --noEmit` clean for touched files
- [x] `npm run build` succeeds
- [ ] Post-merge: live verify by cancelling a WI in the running pool and watching the parent Request close within seconds, not minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)