### PR TITLE
fix(v3): align closer's terminal-WI set with the validation gate

### DIFF
--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -577,6 +577,53 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
     expect(posts[0].text).toContain('取消/失败 2');
   });
 
+  it('does NOT close a Request whose child WI is done_by_worker (awaiting verification)', async () => {
+    // 2026-05-09 dogfood follow-up. The original closer treated
+    // `done_by_worker` as terminal, but `RequestService.update`'s
+    // child-validation gate only counts `{done, verified, cancelled}`
+    // — so the closer fired, the gate refused, and the Request logged
+    // a confusing "stale Request close failed" warning every sweep.
+    //
+    // Now the closer's terminal set is imported from work-item.types.ts
+    // (the canonical contract), so done_by_worker children short-circuit
+    // the all-terminal check and the closer skips entirely. The
+    // heartbeat post still fires (the user sees real progress: "1/2
+    // done, 0 in flight"), and the eventual verification → cascade
+    // path closes the Request properly.
+    const wis = [
+      makeWI({ id: 'wi-quinn', requestId: 'req-pending-verify', status: 'done_by_worker' }),
+      makeWI({ id: 'wi-canc',  requestId: 'req-pending-verify', status: 'cancelled' }),
+    ];
+    const r = makeRequest({ id: 'req-pending-verify', status: 'running' });
+    const { sub, posts, requestStore } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+
+    // Closer must NOT have fired.
+    expect(requestStore.get('req-pending-verify')!.status).toBe('running');
+    // But the heartbeat itself still posts (Request IS in flight, the
+    // user wants to know the verify WI is the bottleneck).
+    expect(posted).toBe(1);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].text).toContain('1/2');
+  });
+
+  it('does NOT close a Request whose child WI is failed (awaiting retry)', async () => {
+    // Same rationale as done_by_worker — `failed` is not in the
+    // canonical terminal set because BRIDGE-1 may re-queue it. The
+    // closer must defer to the recovery path.
+    const wis = [
+      makeWI({ id: 'wi-fail', requestId: 'req-fail', status: 'failed' }),
+      makeWI({ id: 'wi-done', requestId: 'req-fail', status: 'done' }),
+    ];
+    const r = makeRequest({ id: 'req-fail', status: 'running' });
+    const { sub, requestStore } = makeSubscriber({ request: r, pool: wis });
+
+    await sub.runHeartbeat();
+
+    expect(requestStore.get('req-fail')!.status).toBe('running');
+  });
+
   it('omits the 取消/失败 clause when no WIs are cancelled or failed', async () => {
     // Avoid noise — only show the bucket when it's actually non-zero.
     const wis = [

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -41,31 +41,37 @@ import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
 import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
 import type { Request, RequestStatus } from '../../types/v2/request.types.js';
-import type { WorkItem, WorkItemStatus } from '../../types/v2/work-item.types.js';
+import type { WorkItem } from '../../types/v2/work-item.types.js';
+import { TERMINAL_WORK_ITEM_STATUSES } from '../../types/v2/work-item.types.js';
 import { TERMINAL_REQUEST_STATUSES, isValidRequestTransition } from '../../types/v2/index.js';
 
 /**
  * WorkItem statuses that count as "terminal" for the heartbeat's
- * is-this-Request-actually-still-in-flight check. Includes both
- * success-shaped terminals (done/verified/done_by_worker) and
- * abandoned-shaped terminals (cancelled/failed/rejected).
+ * is-this-Request-actually-still-in-flight check.
  *
- * If every child WI of a Request lands in this set but the Request
- * itself is still non-terminal, something upstream skipped the cascade
- * (see 2026-05-09 dogfood bug: `cascadeRequestStatus` only fires from
- * the retired `v3:task_*` events on V3DataService, so out-of-band
- * cancellations leave the Request orphaned in `ready`). The heartbeat
- * sweep treats this as "close the Request" rather than firing a
- * misleading "still 0/4" ping.
+ * Imported from `work-item.types.ts` so the closer agrees with the
+ * canonical contract (`{done, verified, cancelled}`) used by
+ * `RequestService.update`'s child-validation gate. The previous shape
+ * of this constant was wider — it also included `done_by_worker`,
+ * `failed`, and `rejected` — which produced a real bug:
+ *
+ * 2026-05-09 dogfood: a Request with one `done_by_worker` child (verify
+ * WI cancelled out-of-band) and two `cancelled` children was deemed
+ * "all terminal" by the closer, but `RequestService.update` then refused
+ * the close because `done_by_worker` is not in the canonical terminal
+ * set. The closer logged a confusing "stale Request close failed"
+ * warning every 30 minutes and the Request stayed wedged in `running`.
+ *
+ * Aligning the closer's set with the validation gate keeps both views
+ * consistent. Trade-off: Requests with stuck-but-recoverable children
+ * (`done_by_worker` awaiting verification, `failed` awaiting BRIDGE-1
+ * retry, `rejected` awaiting re-queue) are NOT auto-closed by the
+ * sweep — they stay in flight until the recovery path completes or a
+ * human cancels them. That's the right call: the closer's job is to
+ * mop up genuinely-finished Requests, not to short-circuit pipelines
+ * that are merely paused.
  */
-const TERMINAL_WORKITEM_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>([
-  'done',
-  'verified',
-  'done_by_worker',
-  'cancelled',
-  'failed',
-  'rejected',
-]);
+const TERMINAL_WORKITEM_STATUSES = TERMINAL_WORK_ITEM_STATUSES;
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -546,8 +552,12 @@ export class RequestStatusUpdateSubscriber {
    * sweep must keep moving across other Requests.
    */
   private async closeStaleRequest(request: Request, childWIs: WorkItem[]): Promise<void> {
+    // `done_by_worker` is filtered out by the all-terminal guard
+    // upstream (it's not in TERMINAL_WORKITEM_STATUSES anymore — see
+    // the constant definition for the rationale). So success only
+    // comes from `done` or `verified` here.
     const hasSuccess = childWIs.some(
-      (wi) => wi.status === 'done' || wi.status === 'verified' || wi.status === 'done_by_worker',
+      (wi) => wi.status === 'done' || wi.status === 'verified',
     );
     const target: RequestStatus = hasSuccess ? 'done' : 'cancelled';
 


### PR DESCRIPTION
## Summary

PR #533's closer treated \`done_by_worker\`, \`failed\`, and \`rejected\` as terminal — but \`RequestService.update\`'s child-validation gate only counts \`{done, verified, cancelled}\` (the canonical set in \`work-item.types.ts\`). Two views, same word, different meanings.

## Bug shape (2026-05-09 dogfood)

Request \`8d8c241f\` had one \`done_by_worker\` child (verify WI cancelled out-of-band) and two \`cancelled\` children. The closer deemed it "all terminal" and tried to update the Request to \`done\`, but the gate refused:

\`\`\`
Request '8d8c241f-...' cannot transition to 'done': 1 child WorkItem still in non-terminal state. Terminal WI statuses are: done, verified, cancelled.
\`\`\`

The closer logged a confusing \`stale Request close failed\` warning every 30 minutes and the Request stayed wedged in \`running\` until manually cancelled via API.

## Fix

Import the canonical \`TERMINAL_WORK_ITEM_STATUSES\` from \`work-item.types.ts\` and use it in the all-terminal guard. Drops the custom set.

**Trade-off accepted:** Requests with stuck-but-recoverable children (\`done_by_worker\` awaiting verification, \`failed\` awaiting BRIDGE-1 retry, \`rejected\` awaiting re-queue) are NOT auto-closed by the sweep — they stay in flight until the recovery path completes or a human cancels them. That's the right call: the closer's job is to mop up genuinely-finished Requests, not to short-circuit pipelines that are merely paused.

Also tightens \`closeStaleRequest\`'s \`hasSuccess\` check — since \`done_by_worker\` children can no longer reach the closer, success is only \`done\` or \`verified\`.

## Test plan
- [x] 2 new regression tests in \`request-status-update.subscriber.test.ts\`:
  - Request with \`done_by_worker\` child stays \`running\` (closer skipped); heartbeat post still fires
  - Request with \`failed\` child stays \`running\` (BRIDGE-1 retry path owns it)
- [x] All 25 subscriber tests pass (existing 23 + 2 new)
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)