### PR TITLE
fix(task-pool): /add accepts minimal CreateWorkItemInput shape

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -15,6 +15,7 @@ import {
   revokeAndRelease,
   deleteItem,
   completeItem,
+  addItem,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
 // Express types used for mock helpers below
@@ -48,6 +49,8 @@ const mockService = {
   completeItem: jest.fn(),
   findWorkItem: jest.fn(),
   setOutput: jest.fn(),
+  addToPool: jest.fn(),
+  getAllItems: jest.fn().mockResolvedValue([]),
 };
 
 (TaskPoolService.getInstance as any) = jest.fn().mockReturnValue(mockService);
@@ -828,6 +831,192 @@ describe('TaskPoolController', () => {
           decision: 'strict',
         }),
       );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /add — addItem
+  //
+  // 2026-05-12 dogfood: the orchestrator's delegate-task shell skill (and 3
+  // sibling skills) all send a minimal `CreateWorkItemInput` shape — no id,
+  // no status, no createdAt. The previous validator required all of those
+  // and 400'd every shell-driven delegation. Fix: accept the minimal shape
+  // and let the server build the full WI via `createWorkItem`. Preserve
+  // legacy full-WI shape for callers that construct ids locally (e.g.
+  // `break-down-request`).
+  // -----------------------------------------------------------------------
+
+  describe('addItem', () => {
+    beforeEach(() => {
+      mockService.addToPool.mockResolvedValue(undefined);
+      mockService.getAllItems.mockResolvedValue([]);
+    });
+
+    it('accepts a minimal CreateWorkItemInput body and generates id + status + createdAt', async () => {
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          target: 'crewly-product-leo',
+          title: 'Implement feature X',
+          description: 'Short summary',
+          briefMarkdown: 'Long-form brief...',
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockService.addToPool).toHaveBeenCalledTimes(1);
+
+      const addedWI = mockService.addToPool.mock.calls[0][0];
+      expect(typeof addedWI.id).toBe('string');
+      expect(addedWI.id.length).toBeGreaterThan(0);
+      expect(addedWI.status).toBe('queued');
+      expect(typeof addedWI.createdAt).toBe('string');
+      expect(addedWI.retryCount).toBe(0);
+      expect(addedWI.maxRetries).toBeGreaterThan(0);
+      expect(addedWI.title).toBe('Implement feature X');
+      expect(addedWI.type).toBe('delegate');
+      expect(addedWI.owner).toBe('orchestrator');
+      expect(addedWI.target).toBe('crewly-product-leo');
+      expect(addedWI.briefMarkdown).toBe('Long-form brief...');
+
+      // Response must echo the generated id so the skill can record it.
+      const body = res.json.mock.calls[0][0];
+      expect(body.success).toBe(true);
+      expect(body.data.workItemId).toBe(addedWI.id);
+      expect(body.data.id).toBe(addedWI.id);
+      expect(body.data.status).toBe('queued');
+    });
+
+    it('rejects a minimal body missing required CreateWorkItemInput fields', async () => {
+      // No type, no owner, no title — three errors expected.
+      const req = mockReq({ body: { description: 'orphan' } });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      const body = res.json.mock.calls[0][0];
+      expect(body.success).toBe(false);
+      expect(Array.isArray(body.errors)).toBe(true);
+      expect(mockService.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legacy full-WorkItem body and preserves the client-supplied id', async () => {
+      // break-down-request constructs WIs locally with deterministic ids it
+      // then records in `Request.workItemIds[]`. This path must keep working.
+      const req = mockReq({
+        body: {
+          id: 'wi_locally_minted_42',
+          type: 'delegate',
+          owner: 'orchestrator',
+          target: 'crewly-product-leo',
+          title: 'Pre-built WI',
+          status: 'queued',
+          createdAt: '2026-05-12T00:00:00.000Z',
+          retryCount: 0,
+          maxRetries: 3,
+          inputTokens: 0,
+          outputTokens: 0,
+          cost: 0,
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const addedWI = mockService.addToPool.mock.calls[0][0];
+      expect(addedWI.id).toBe('wi_locally_minted_42');
+      expect(addedWI.status).toBe('queued');
+    });
+
+    it('rejects a duplicate id against the existing pool (legacy path)', async () => {
+      mockService.getAllItems.mockResolvedValue([
+        { id: 'wi-dup', status: 'running', requestId: undefined },
+      ]);
+
+      const req = mockReq({
+        body: {
+          id: 'wi-dup',
+          type: 'delegate',
+          owner: 'orchestrator',
+          title: 'Dup',
+          status: 'queued',
+          createdAt: '2026-05-12T00:00:00.000Z',
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      const body = res.json.mock.calls[0][0];
+      expect(body.errors.join(' ')).toMatch(/already exists/);
+      expect(mockService.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the parent Request already holds MAX active WIs (per-request cap)', async () => {
+      // 25 active WIs sharing a requestId is the documented cap. A 26th
+      // should be refused as an "infinite decomposition" guardrail.
+      const existing = Array.from({ length: 25 }, (_, i) => ({
+        id: `wi-existing-${i}`,
+        status: 'queued',
+        requestId: 'req-runaway',
+      }));
+      mockService.getAllItems.mockResolvedValue(existing);
+
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          title: 'one more',
+          requestId: 'req-runaway',
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      const body = res.json.mock.calls[0][0];
+      expect(body.errors.join(' ')).toMatch(/active WorkItems/);
+      expect(mockService.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 if body is not an object', async () => {
+      const req = mockReq({ body: 'not-an-object' });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockService.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('initial status for a minimal body with dependsOn is `blocked`, not `queued`', async () => {
+      // createWorkItem promotes dependency-gated items to `blocked`. The
+      // endpoint must propagate that — otherwise an item with unresolved
+      // deps would be claimable immediately, defeating the gate.
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          title: 'Has upstream deps',
+          dependsOn: ['wi-upstream-1', 'wi-upstream-2'],
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const addedWI = mockService.addToPool.mock.calls[0][0];
+      expect(addedWI.status).toBe('blocked');
+      expect(addedWI.dependsOn).toEqual(['wi-upstream-1', 'wi-upstream-2']);
     });
   });
 });

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -20,7 +20,14 @@ import { TaskProjectionService } from '../../services/v3/task-projection.service
 import { ServiceContractGate } from '../../services/v3/service-contract-gate.service.js';
 import { StorageService } from '../../services/core/storage.service.js';
 import type { TokenUsage } from '../../types/v3/task-record.types.js';
-import { WORK_ITEM_TYPES, isValidWorkItemType } from '../../types/v2/work-item.types.js';
+import {
+  WORK_ITEM_TYPES,
+  isValidWorkItemType,
+  createWorkItem,
+  validateCreateWorkItemInput,
+  type CreateWorkItemInput,
+  type WorkItem,
+} from '../../types/v2/work-item.types.js';
 import { formatError } from '../../utils/format-error.js';
 import { LoggerService } from '../../services/core/logger.service.js';
 
@@ -168,34 +175,91 @@ export async function maybeEnforceContract(
 /**
  * Adds a WorkItem to the Task Pool.
  *
- * This is the HTTP entry point for the V3 pull-mode task path.
- * Used by delegate-task and other orchestration flows to queue
- * execution-ready WorkItems.
+ * HTTP entry point for the V3 pull-mode task path. Used by delegate-task
+ * and other orchestration shell skills to queue execution-ready WorkItems.
  *
- * Request body: a WorkItem object (id, type, owner, title, status='queued', etc.)
+ * Accepts two body shapes:
+ *
+ * 1. **Minimal `CreateWorkItemInput`** (preferred) — `{type, owner, title,
+ *    target?, description?, briefMarkdown?, priority?, requestId?, ...}`.
+ *    The server fills `id` (uuid), `status` (`'queued'` or `'blocked'`
+ *    if `dependsOn` set), `createdAt`, `retryCount=0`, `maxRetries`,
+ *    `inputTokens=0`, `outputTokens=0`, `cost=0`.
+ *
+ * 2. **Legacy full `WorkItem`** — body carries `id` AND `status` AND
+ *    `createdAt`. The server passes through unchanged (subject to the
+ *    same shape validation as before). Preserved for callers that
+ *    construct WIs locally with deterministic ids (e.g. break-down-request,
+ *    decomposition pipelines that need to record id-references upfront).
+ *
+ * **Why both shapes.** 2026-05-12 dogfood: orc-side `delegate-task` shell
+ * skill and 3 sibling skills (`agent/core/create-task`,
+ * `team-leader/decompose-goal`, `team-leader/delegate-task`) all send
+ * the minimal shape. They were silently 400'd by the strict validator
+ * because they omit `id` / `status` / `createdAt` / `retryCount` etc.
+ * Result: every orc delegation failed — `task-pool/add` returned
+ * `WorkItem.id is required and must be a string`, the skill exited 1,
+ * the orc thought it had delegated but no WI ever entered the pool.
+ *
+ * Fix the endpoint, not 4 skills — the canonical creation primitive
+ * `createWorkItem(input)` already exists for internal callers; the
+ * HTTP surface should expose the same shape.
  *
  * @param req - Express request with WorkItem body
  * @param res - Express response
  */
 export async function addItem(req: Request, res: Response): Promise<void> {
   try {
-    const workItem = req.body;
+    const body = req.body;
 
-    if (!workItem || typeof workItem !== 'object') {
+    if (!body || typeof body !== 'object') {
       res.status(400).json({ success: false, error: 'Request body must be a WorkItem object' });
       return;
     }
 
-    // V3.1 Task Validator
-    const validationErrors = await validateWorkItem(workItem);
-    if (validationErrors.length > 0) {
-      res.status(400).json({ success: false, errors: validationErrors });
-      return;
+    const isLegacyFullShape =
+      typeof body.id === 'string' &&
+      typeof body.status === 'string' &&
+      typeof body.createdAt === 'string';
+
+    let workItem: WorkItem;
+
+    if (isLegacyFullShape) {
+      // Legacy path — body already carries a complete WorkItem. Validate
+      // and pass through. This preserves backward compat for skills
+      // that construct the full shape locally and want their
+      // client-side id to win.
+      const validationErrors = await validateLegacyFullWorkItem(body);
+      if (validationErrors.length > 0) {
+        res.status(400).json({ success: false, errors: validationErrors });
+        return;
+      }
+      workItem = body as WorkItem;
+    } else {
+      // Minimal-input path — body is a CreateWorkItemInput. Validate
+      // the lighter shape and let `createWorkItem` build the full WI
+      // with server-generated id, timestamps, and defaults.
+      const inputErrors = validateCreateWorkItemInput(body as CreateWorkItemInput);
+      if (inputErrors.length > 0) {
+        res.status(400).json({ success: false, errors: inputErrors });
+        return;
+      }
+      workItem = createWorkItem(body as CreateWorkItemInput);
+
+      // The minimal-shape path still needs the duplicate / per-Request-cap
+      // guards from the legacy validator. Run them against the freshly
+      // built WI (id is now present and unique-by-uuid, so the duplicate
+      // check is effectively a per-Request-cap check on its own).
+      const postBuildErrors = await checkPoolInvariants(workItem);
+      if (postBuildErrors.length > 0) {
+        res.status(400).json({ success: false, errors: postBuildErrors });
+        return;
+      }
     }
 
     // ServiceContract gate — only runs when the body carries cross-team
     // routing hints. Rejects before the item is enqueued.
-    const rejection = await maybeEnforceContract(workItem as Record<string, unknown>);
+    const rejection = await maybeEnforceContract(workItem as unknown as Record<string, unknown>);
     if (rejection) {
       res.status(rejection.status).json(rejection.payload);
       return;
@@ -219,7 +283,7 @@ export async function addItem(req: Request, res: Response): Promise<void> {
     res.status(201).json({
       success: true,
       message: `WorkItem ${workItem.id} added to pool`,
-      data: { workItemId: workItem.id },
+      data: { workItemId: workItem.id, id: workItem.id, status: workItem.status },
     });
   } catch (error) {
     handleServiceError(res, error);
@@ -999,18 +1063,20 @@ export async function appendItemNote(req: Request, res: Response): Promise<void>
 const MAX_WORK_ITEMS_PER_REQUEST = 20;
 
 /**
- * Validates a WorkItem before it enters the pool.
+ * Validate a body that claims to be a fully-formed WorkItem (legacy path).
  * Returns a list of validation error strings (empty = valid).
  *
  * Checks:
  * 1. Schema: required fields present, type is valid
- * 2. Quantity: no more than MAX_WORK_ITEMS_PER_REQUEST per requestId
- * 3. Duplicate: workItemId must not already exist in pool
+ * 2. Pool invariants: per-request cap, duplicate-id
+ *
+ * The minimal-input path (`CreateWorkItemInput`) bypasses this — see
+ * {@link validateCreateWorkItemInput} for that shape's checks.
  *
  * @param workItem - The WorkItem to validate
  * @returns Array of error strings
  */
-async function validateWorkItem(workItem: Record<string, unknown>): Promise<string[]> {
+async function validateLegacyFullWorkItem(workItem: Record<string, unknown>): Promise<string[]> {
   const errors: string[] = [];
 
   // 1. Schema Check
@@ -1031,44 +1097,64 @@ async function validateWorkItem(workItem: Record<string, unknown>): Promise<stri
 
   if (errors.length > 0) return errors; // Bail out early on schema errors
 
+  // 2. Pool invariants
+  const invariantErrors = await checkPoolInvariants({
+    id: workItem.id as string,
+    requestId: workItem.requestId as string | undefined,
+  });
+  return invariantErrors;
+}
+
+/**
+ * Pool-level invariant checks that run for BOTH the legacy full-shape
+ * path and the minimal-input path. Split out from
+ * {@link validateLegacyFullWorkItem} so the minimal path (which has
+ * already passed `validateCreateWorkItemInput`) can reuse them after
+ * `createWorkItem` generates the id.
+ *
+ * Invariants:
+ * - Per-`requestId` cap: no more than `MAX_WORK_ITEMS_PER_REQUEST` active
+ *   WIs share the same parent Request. Guards against runaway recursive
+ *   decomposition.
+ * - Duplicate-id: a WI with this id must not already exist in the pool.
+ *
+ * @param wi - `{id, requestId?}` minimum surface needed for the checks
+ * @returns Array of error strings (empty = invariants hold)
+ */
+async function checkPoolInvariants(wi: { id: string; requestId?: string }): Promise<string[]> {
+  const errors: string[] = [];
   try {
     const svc = getService();
     const allItems = await svc.getAllItems();
 
-    // Single pass: collect both the duplicate (if any) and the count of
-    // active items sharing the same requestId. A previous implementation
-    // ran two separate O(n) scans — redundant on a hot insert path during
-    // decomposition bursts.
-    const requestId = workItem.requestId as string | undefined;
     let duplicate: typeof allItems[number] | undefined;
     let sameRequestActiveCount = 0;
-    for (const wi of allItems) {
-      if (!duplicate && wi.id === workItem.id) {
-        duplicate = wi;
+    for (const existing of allItems) {
+      if (!duplicate && existing.id === wi.id) {
+        duplicate = existing;
       }
       if (
-        requestId &&
-        wi.requestId === requestId &&
-        wi.status !== 'done' &&
-        wi.status !== 'cancelled'
+        wi.requestId &&
+        existing.requestId === wi.requestId &&
+        existing.status !== 'done' &&
+        existing.status !== 'cancelled'
       ) {
         sameRequestActiveCount += 1;
       }
     }
 
     if (duplicate) {
-      errors.push(`WorkItem.id "${workItem.id}" already exists in pool (status: ${duplicate.status})`);
+      errors.push(`WorkItem.id "${wi.id}" already exists in pool (status: ${duplicate.status})`);
     }
 
-    if (requestId && sameRequestActiveCount >= MAX_WORK_ITEMS_PER_REQUEST) {
+    if (wi.requestId && sameRequestActiveCount >= MAX_WORK_ITEMS_PER_REQUEST) {
       errors.push(
-        `Request ${requestId} already has ${sameRequestActiveCount} active WorkItems (max ${MAX_WORK_ITEMS_PER_REQUEST}). Possible infinite decomposition loop.`,
+        `Request ${wi.requestId} already has ${sameRequestActiveCount} active WorkItems (max ${MAX_WORK_ITEMS_PER_REQUEST}). Possible infinite decomposition loop.`,
       );
     }
   } catch (err) {
-    logger.debug('WorkItem validation check failed (non-fatal)', { error: formatError(err) });
+    logger.debug('WorkItem invariant check failed (non-fatal)', { error: formatError(err) });
   }
-
   return errors;
 }
 


### PR DESCRIPTION
## Summary

**Every orc shell-driven delegation has been silently failing.** Direct probe:

\`\`\`
POST /api/task-pool/add {type, owner, target, title, ...}
→ 400 {"errors":["WorkItem.id is required and must be a string"]}
\`\`\`

Four skills hit this — \`orchestrator/delegate-task\`, \`team-leader/delegate-task\`, \`team-leader/decompose-goal\`, \`agent/core/create-task\` — all send the minimal shape. The skill exits 1, the shell wrapper silently swallows, orc thinks the task was queued but no WorkItem ever entered the pool. **Sam goes \`idle_exit\` and can't be woken because waking needs a \`target=Sam\` queued WI in the pool. Chicken-and-egg.**

Even minting an \`id\` client-side hits a second wall: \`TaskPoolService.addToPool\` calls \`isWorkItem(value)\` which requires \`id + type + owner + title + status + createdAt + retryCount + maxRetries\`. Skills had no way to know the full set.

## Root cause (architectural)

\`/add\` exposed the **internal pool contract** (a fully-formed WorkItem) instead of the **canonical creation primitive** (\`CreateWorkItemInput\`, used by every in-tree non-HTTP caller via \`createWorkItem(input)\`). Skills had to duplicate the factory logic in jq — and got it wrong.

## Fix

Expose the canonical primitive via HTTP. The endpoint now accepts two shapes:

| Shape | When | Behaviour |
|---|---|---|
| **Minimal** \`{type, owner, title, ...}\` | Shell skills | Server runs \`createWorkItem(input)\` → fills \`id\` (uuidv4), \`status\` (queued / blocked if deps), \`createdAt\`, retry counts, token counts |
| **Legacy full WorkItem** with \`id+status+createdAt\` | \`break-down-request\` | Pass-through; client-supplied id wins. Preserves backward compat for callers that record id-references upfront. |

- Validation split: \`validateCreateWorkItemInput\` for minimal, \`validateLegacyFullWorkItem\` for legacy
- Pool invariants (per-Request cap, duplicate-id) extracted into \`checkPoolInvariants\` and run in both paths
- Response now echoes \`id\` and \`status\` so skills can record them

**No skill changes needed.** They all already send the minimal shape that \`/add\` now accepts.

## Test plan
- [x] 7 new tests in \`task-pool.controller.test.ts\`:
  - minimal body → 201 + generated id/status/createdAt
  - missing fields → 400 with field-level errors
  - legacy full-WI body → preserves client-supplied id
  - duplicate id → 400 (legacy path)
  - per-Request cap (25 active WIs) → 400
  - non-object body → 400
  - \`dependsOn\` → initial status \`blocked\`, not \`queued\`
- [x] 50/50 controller tests pass
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds
- [ ] Post-merge: restart OSS, hit endpoint with the four broken skill bodies, confirm they all 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)