### PR TITLE
fix(reconciler): TTL rule picks state-machine-legal expiry target

### DIFF
--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -23,7 +23,7 @@ import {
 } from './reconcile-rules.js';
 import type { AgentHealth } from './reconcile-rules.js';
 import { createWorkItem, createRequest, createTaskClaim } from '../../types/v2/index.js';
-import type { WorkItem, Request, TaskClaim } from '../../types/v2/index.js';
+import type { WorkItem, WorkItemStatus, Request, TaskClaim } from '../../types/v2/index.js';
 import { WORK_ITEM_TRANSITIONS } from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
@@ -456,6 +456,48 @@ describe('detectTTLExpiredWorkItems', () => {
     });
     const { expiredIds } = detectTTLExpiredWorkItems([done]);
     expect(expiredIds).toHaveLength(0);
+  });
+
+  // 2026-05-12 dogfood: 10 done_by_worker WIs sat unreviewable for 86h
+  // because the TTL correction was illegal per WORK_ITEM_TRANSITIONS
+  // (`done_by_worker` only has edges to `verified` / `rejected`, not
+  // `cancelled`). Reconciler logged ERROR every minute, never cleaned up.
+  it('routes expired `done_by_worker` to `verified` (the legal terminal edge), not `cancelled`', () => {
+    const stale = makeWorkItem({
+      status: 'done_by_worker',
+      createdAt: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+    });
+
+    const { corrections, expiredIds } = detectTTLExpiredWorkItems([stale]);
+
+    expect(expiredIds).toContain(stale.id);
+    expect(corrections).toHaveLength(1);
+    expect(corrections[0].newState).toBe('verified');
+    expect(corrections[0].previousState).toBe('done_by_worker');
+  });
+
+  it('keeps `cancelled` as the default expiry target for non-done_by_worker statuses', () => {
+    // queued, running, blocked, scheduled, proposed, accepted, escalated
+    // — all of these have a `→ cancelled` edge in WORK_ITEM_TRANSITIONS,
+    // and `cancelled` is the right "abandoned work" semantic. Verify the
+    // picker doesn't accidentally over-generalise to other statuses.
+    const old = (status: WorkItemStatus) => makeWorkItem({
+      status,
+      createdAt: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+    });
+    const items = [
+      old('queued'),
+      old('running'),
+      old('blocked'),
+      old('scheduled'),
+    ];
+
+    const { corrections } = detectTTLExpiredWorkItems(items);
+
+    expect(corrections).toHaveLength(4);
+    for (const c of corrections) {
+      expect(c.newState).toBe('cancelled');
+    }
   });
 });
 

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -362,8 +362,47 @@ export function detectOrphanWorkItems(
 // ---------------------------------------------------------------------------
 
 /**
+ * Pick the legal terminal status for a TTL-expired WorkItem.
+ *
+ * The reconciler's TTL rule used to unconditionally issue
+ * `→ cancelled` corrections. That works for `queued` / `running` /
+ * `blocked` / etc. — they all permit `→ cancelled` per
+ * `WORK_ITEM_TRANSITIONS`. But `done_by_worker` only permits
+ * `→ verified` and `→ rejected` (the work IS done from the worker's
+ * point of view; auto-cancelling would lose audit trail). Same for
+ * `proposed` (auto-acceptance after timeout is the right semantic).
+ *
+ * Mirrors the `pickResolveTarget` helper in `request-sla.subscriber.ts`,
+ * which makes the identical choice for SLA-timeout-resolved WIs.
+ *
+ * Dogfood symptom 2026-05-12: 10 stale `done_by_worker` WIs sat in
+ * pool for 86+ hours. The TTL rule fired every minute, every attempt
+ * failed with `Invalid status transition for WorkItem ...:
+ * done_by_worker → cancelled`, the log filled with ERROR noise and
+ * the WIs never cleaned up. Fix routes through this picker so the
+ * correction target matches what the state machine accepts.
+ *
+ * @param current - Current non-terminal WI status
+ * @returns Legal terminal status for TTL expiry
+ */
+function pickTTLExpiryTarget(current: WorkItemStatus): WorkItemStatus {
+  // done_by_worker has no `→ cancelled` edge — auto-approve via
+  // `verified` instead. Treat 24h-of-no-objection as implicit
+  // acceptance. The worker reported done; nobody pushed back.
+  if (current === 'done_by_worker') return 'verified';
+  // running has both `→ done` and `→ cancelled` — prefer `cancelled`
+  // for TTL since `done` should only come from an explicit completion
+  // event, not a timeout.
+  return 'cancelled';
+}
+
+/**
  * Detects WorkItems that have exceeded their time-to-live.
  * Default TTL is 24 hours.
+ *
+ * Picks a state-machine-legal terminal target for each expired WI via
+ * {@link pickTTLExpiryTarget}, so the correction never fails with
+ * `Invalid status transition`.
  *
  * @param workItems - All non-terminal WorkItems to check
  * @param ttlMs - Maximum age before auto-cancel (default: 24h)
@@ -384,11 +423,12 @@ export function detectTTLExpiredWorkItems(
     const age = now - createdAt;
 
     if (age > ttlMs) {
+      const target = pickTTLExpiryTarget(wi.status);
       corrections.push(createCorrection({
         entityType: 'work_item',
         entityId: wi.id,
         previousState: wi.status,
-        newState: 'cancelled',
+        newState: target,
         reason: `WorkItem exceeded TTL of ${Math.round(ttlMs / 3600000)}h`,
         evidence: `Created at ${wi.createdAt}, age=${Math.round(age / 3600000)}h`,
       }));


### PR DESCRIPTION
## Summary

2026-05-12 dogfood: the reconciler has been spam-ERRORing every minute for 10 stale \`done_by_worker\` WIs:

\`\`\`
Invalid status transition for WorkItem ...: done_by_worker → cancelled
\`\`\`

\`detectTTLExpiredWorkItems\` unconditionally targets \`cancelled\` for every expired WI, but \`WORK_ITEM_TRANSITIONS\` forbids \`done_by_worker → cancelled\` — the only legal terminals from that state are \`verified\` and \`rejected\`. Result: 10 WIs sat in \`done_by_worker\` for 86+ hours, the reconciler tried + failed every minute for 3+ days, the log filled with ERROR noise, the zombies never cleaned up. To the operator: "the system isn't auto-progressing."

## Fix

Introduce \`pickTTLExpiryTarget(status)\`:

| From | TTL target | Why |
|---|---|---|
| \`done_by_worker\` | \`verified\` | 24h of no objection = implicit acceptance. Worker reported done, nobody pushed back. |
| everything else | \`cancelled\` | Canonical abandonment terminal — and \`WORK_ITEM_TRANSITIONS\` allows it from queued/running/blocked/scheduled/proposed/accepted/escalated. |

Mirrors \`pickResolveTarget\` in \`request-sla.subscriber.ts\` which makes the identical mapping for SLA-timeout-resolved WIs — both paths now agree on what an expired \`done_by_worker\` becomes.

## Test plan
- [x] 2 new tests in \`reconcile-rules.test.ts\`:
  - expired \`done_by_worker\` → \`verified\` (not \`cancelled\`)
  - expired queued/running/blocked/scheduled → \`cancelled\` (regression gate)
- [x] All 76 reconcile-rules tests pass
- [x] \`npm run build\` succeeds
- [ ] Post-merge: restart OSS, watch the reconciler clean up the 10 stale done_by_worker zombies within one TTL-sweep tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)