### PR TITLE
fix(slack): stop false-done cascade on every PTY delivery

### DIFF
--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -310,6 +310,29 @@ router.post('/send', async (req: Request, res: Response, next: NextFunction) => 
       }
     }
 
+    // 2026-05-12 dogfood: notify the V3 SLA tracker that this thread
+    // got a real orc reply. Without this hook, fixing the bridge's
+    // delivery-ack callback to no longer fire `fromOrcReply=true` (the
+    // 5-of-7-false-done bug) would leave Requests with no path at all
+    // to terminal — the respond_to_user WI would sit in `queued`
+    // forever after orc replies via this endpoint. Real orc replies
+    // come through here (reply-slack skill posts to /slack/send), so
+    // this is the right place to trigger the cascade.
+    //
+    // Best-effort: lazy import + try/catch so a subscriber-boot failure
+    // can never break the actual Slack reply.
+    if (threadTs) {
+      try {
+        const { getRequestSlaSubscriber } = await import('../../services/v3/request-sla.subscriber.js');
+        const sub = getRequestSlaSubscriber();
+        if (sub) {
+          await sub.markResolvedByThread(threadTs);
+        }
+      } catch {
+        // Slack delivery already succeeded; SLA hook is bookkeeping.
+      }
+    }
+
     res.json({
       success: true,
       data: { messageTs },

--- a/backend/src/services/slack/slack-orchestrator-bridge.test.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.test.ts
@@ -1300,6 +1300,63 @@ describe('SlackOrchestratorBridge', () => {
       const response = await messagePromise;
       expect(response).toContain('Failed to enqueue message');
     }, 30000);
+
+    // 2026-05-12 dogfood regression: QueueProcessor calls
+    // `slackResolve('')` on fire-and-forget PTY delivery (see
+    // queue-processor.service.ts:692). The previous bridge callback
+    // always returned `fromOrcReply: true`, so every Slack delivery
+    // triggered the SLA cascade-close → Request landed in `done` with
+    // `Auto-closed by SLA: orc_reply` before the user ever saw a reply.
+    // 5 of 7 Slack messages that day were falsely-done. Fix: gate on
+    // resp.length > 0 inside the bridge's slackResolve callback so
+    // the empty delivery ack stops short of the SLA cascade.
+    it('does NOT mark SLA resolved when slackResolve fires with empty resp (delivery ack only)', async () => {
+      const mockSubscriber = {
+        markResolvedByThread: jest.fn().mockResolvedValue(undefined),
+      };
+      const { setRequestSlaSubscriber } = await import('../v3/request-sla.subscriber.js');
+      setRequestSlaSubscriber(mockSubscriber as any);
+
+      try {
+        // Capture the slackResolve callback and fire it with EMPTY string
+        // (mirrors QueueProcessor's `routeResponse(message, '')` call).
+        mockQueueService.enqueue.mockImplementation((input: any) => {
+          setTimeout(() => input.sourceMetadata.slackResolve(''), 5);
+          return { id: 'q-empty' };
+        });
+
+        const bridge = new SlackOrchestratorBridge({ responseTimeoutMs: 5000 });
+        bridge.setMessageQueueService(mockQueueService);
+        await bridge.initialize();
+
+        const handled = new Promise<void>((resolve) => {
+          bridge.on('message_handled', () => resolve());
+        });
+
+        const slackService = (bridge as any).slackService;
+        jest.spyOn(slackService, 'sendMessage').mockResolvedValue(undefined);
+        jest.spyOn(slackService, 'addReaction').mockResolvedValue(undefined);
+        jest.spyOn(slackService, 'getConversationContext').mockReturnValue({
+          conversationId: 'conv-x', channelId: 'C-x', userId: 'U-x',
+        });
+
+        slackService.emit('message', {
+          text: 'I sent a request, expecting a reply',
+          channelId: 'C-x',
+          userId: 'U-x',
+          ts: '1778100000.000001',
+        });
+
+        await handled;
+
+        // The whole point: SLA cascade-close must not fire. The Request
+        // stays in flight until orc actually replies via reply-slack →
+        // respond_to_user WI transitions → cascade subscriber closes it.
+        expect(mockSubscriber.markResolvedByThread).not.toHaveBeenCalled();
+      } finally {
+        setRequestSlaSubscriber(null);
+      }
+    }, 15000);
   });
 
   describe('sendSlackResponse', () => {

--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -411,7 +411,10 @@ export class SlackOrchestratorBridge extends EventEmitter {
           // Strip the @mention prefix and send to the target agent
           const cleanMessage = enrichedText.replace(new RegExp(`^@${mentionTarget.name}\\s*`, 'i'), '').trim();
           const response = await this.sendToAgent(mentionTarget.sessionName, cleanMessage || enrichedText, context);
-          await this.sendSlackResponse(message, response);
+          // Same empty-response guard as the orchestrator route — an
+          // empty response is QueueProcessor's fire-and-forget delivery
+          // ack, not a real reply. Don't auto-resolve the SLA tracker.
+          await this.sendSlackResponse(message, response, response.length > 0);
           if (this.config.showTypingIndicator) {
             await this.markComplete(message);
           }
@@ -1040,8 +1043,35 @@ Just type naturally to chat with the orchestrator!`;
                 if (!resolved) {
                   resolved = true;
                   clearTimeout(timeoutId);
-                  // Real orc reply path — safe to auto-resolve the SLA tracker.
-                  resolve({ response: resp, fromOrcReply: true });
+                  // 2026-05-12 dogfood bug: the QueueProcessor fires
+                  // `routeResponse(message, '')` immediately after PTY
+                  // delivery to unblock this promise (see
+                  // queue-processor.service.ts:692 "fire-and-forget"
+                  // comment). That call carries an EMPTY response — orc
+                  // has only RECEIVED the message, not REPLIED. The
+                  // previous shape of this callback always returned
+                  // `fromOrcReply: true`, so every Slack delivery
+                  // triggered `markResolvedByThread('orc_reply')` →
+                  // `maybeCloseRequest` → Request cascaded to `done`
+                  // with `result: "Auto-closed by SLA: orc_reply"`
+                  // before the user ever saw a reply.
+                  //
+                  // Real orc replies (via the reply-slack skill) come
+                  // through a different route — the orc invokes
+                  // `POST /slack/send`, which posts to Slack directly;
+                  // the SLA tracker is resolved when the
+                  // `respond_to_user` WI transitions to `verified` and
+                  // the cascade subscriber picks it up. That path
+                  // produces a non-empty response payload only when
+                  // a worker explicitly drives reply text back through
+                  // the queue (rare; most orc replies are direct API).
+                  //
+                  // Gate: treat empty resp as a delivery ack ONLY
+                  // (fromOrcReply=false). Non-empty resp keeps the
+                  // legacy `true` semantics for any worker path that
+                  // does echo a reply through the queue.
+                  const fromOrcReply = resp.length > 0;
+                  resolve({ response: resp, fromOrcReply });
                 }
               },
               userId: context?.userId,


### PR DESCRIPTION
## Summary

User reported on 2026-05-12 that 7 Slack requests sent today never got a reply, yet the system showed 5 as \`done\`. **You were right — system is not actually progressing those requests.**

## Root cause

The bridge's \`slackResolve\` callback (in \`sendToOrchestrator\`) unconditionally resolved with \`fromOrcReply: true\`. But the QueueProcessor (per its "fire-and-forget" design at \`queue-processor.service.ts:692\`) calls \`routeResponse(message, '')\` on **every** successful PTY delivery to unblock the bridge's promise. orc has only RECEIVED the message at that point — the real reply comes later via reply-slack → \`/api/slack/send\`.

The unconditional \`fromOrcReply: true\` then triggered:

\`\`\`
sendSlackResponse(message, '', true)
  → markResolvedByThread(threadTs)
    → markResolved(rid, 'orc_reply')
      → maybeCloseRequest → cascade Request to \`done\`
\`\`\`

…all before orc had a chance to think, let alone reply.

Log evidence (one Request, every event today fits this pattern):

\`\`\`
[QueueProcessor]  Message delivered (fire-and-forget)
[RequestSlaSubscriber] SLA WorkItem auto-resolved | reason: orc_reply
  → fromStatus: cancelled, toStatus: cancelled
\`\`\`

## Two-part fix

**1. Bridge gates \`fromOrcReply\` on resp length.** Empty resp (delivery ack from QueueProcessor) → \`false\`. Non-empty resp → \`true\`. Applied to both the orchestrator route and the @mention-routing call site.

**2. \`POST /api/slack/send\` now triggers \`markResolvedByThread\` for real orc replies.** Without this, fixing the delivery callback would leave Requests with no path at all to terminal — \`respond_to_user\` WIs would sit in \`queued\` forever even after orc replies. Best-effort lazy-import + try/catch so subscriber failures can't break the Slack send.

## Test plan
- [x] New regression test \`does NOT mark SLA resolved when slackResolve fires with empty resp\` — exact reproduction of the dogfood symptom
- [x] All 124 bridge tests pass (existing 123 + 1 new)
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds
- [ ] Post-merge: restart OSS, send a Slack message, confirm the Request stays in \`open\`/\`running\` until orc actually replies via reply-slack

## Note
The 5 already-falsely-done Requests stay falsely-done — this fix prevents future occurrences but doesn't unwind history. They can be manually re-sent or have their respond_to_user WIs cleared if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)