### PR TITLE
fix(autoclaim): skip SLA tracker WIs so they stop trapping orc

### DIFF
--- a/backend/src/services/v3/agent-auto-claim.service.test.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.test.ts
@@ -113,6 +113,64 @@ describe('AgentAutoClaimService', () => {
       expect(result).toBeNull();
     });
 
+    // 2026-05-12 dogfood regression: AutoClaim happily claimed
+    // `request:<rid>:respond_to_user` tracker WIs for crewly-orc, then
+    // `WorkItemDispatchSubscriber.dispatchTo` short-circuited on the
+    // SLA tracker pattern — WI stuck `running`, SLA breach in 5/10 min,
+    // claim revoked, infinite re-claim loop. User saw "Request never
+    // progresses." Filter these out at the source of `availableItems`.
+    it('skips SLA tracker WIs (request:*:respond_to_user) — they are not dispatchable', async () => {
+      const service = AgentAutoClaimService.getInstance();
+
+      const trackerWI = {
+        id: 'request:3e6b984f-80e8-4473-b6c9-a19a4c1240ba:respond_to_user',
+        title: 'Respond to user: [Fix] ...',
+        type: 'review',
+        status: 'queued',
+        target: 'crewly-orc',
+        createdAt: new Date().toISOString(),
+      };
+      mockGetAvailableItems.mockResolvedValueOnce([trackerWI]);
+
+      const result = await service.tryAutoClaimForAgent('crewly-orc');
+
+      expect(result).toBeNull();
+      expect(mockClaimSpecificItem).not.toHaveBeenCalled();
+    });
+
+    it('still claims a real delegate WI when an SLA tracker is also present', async () => {
+      // Mixed pool: one tracker (skip), one real work item (claim).
+      // Asserts the filter is targeted, not over-broad.
+      const service = AgentAutoClaimService.getInstance();
+
+      const tracker = {
+        id: 'request:abc:respond_to_user',
+        title: 'tracker',
+        type: 'review',
+        status: 'queued',
+        target: 'crewly-orc',
+        createdAt: new Date().toISOString(),
+      };
+      const real = {
+        id: 'wi-real-1',
+        title: 'Real task',
+        type: 'delegate',
+        status: 'queued',
+        target: 'crewly-orc',
+        createdAt: new Date().toISOString(),
+      };
+      mockGetAvailableItems.mockResolvedValueOnce([tracker, real]);
+      mockClaimSpecificItem.mockResolvedValueOnce({
+        workItem: real,
+        claim: { id: 'claim-real', agentId: 'crewly-orc' },
+      });
+
+      const result = await service.tryAutoClaimForAgent('crewly-orc');
+
+      expect(result?.workItemId).toBe('wi-real-1');
+      expect(mockClaimSpecificItem).toHaveBeenCalledWith('crewly-orc', 'wi-real-1');
+    });
+
     it('should skip items below score threshold', async () => {
       const service = AgentAutoClaimService.getInstance();
 

--- a/backend/src/services/v3/agent-auto-claim.service.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.ts
@@ -21,6 +21,7 @@ import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import { computeAgentScore, type AgentHealth } from '../reconciler/reconcile-rules.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
+import { SLA_TRACKER_ID_PATTERN } from './workitem-dispatch.subscriber.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -219,8 +220,17 @@ export class AgentAutoClaimService {
   async tryAutoClaimForAgent(agentSessionName: string): Promise<{ workItemId: string; score: number } | null> {
     const taskPool = TaskPoolService.getInstance();
 
-    // Get available unclaimed items
-    const availableItems = await taskPool.getAvailableItems();
+    // Get available unclaimed items, excluding SLA tracker WIs.
+    // 2026-05-12 dogfood: AutoClaim happily claimed `respond_to_user`
+    // tracker WIs for crewly-orc, then `WorkItemDispatchSubscriber.dispatchTo`
+    // short-circuited on the SLA tracker id pattern — leaving the WI
+    // stuck in `running` with no PTY delivery, SLA breaching at 5/10 min,
+    // claim revoked, infinite re-claim loop. From the user's perspective:
+    // "Slack request never progresses; orc never replies." Skip these
+    // here so the trackers stay claimable only by the SLA resolve path.
+    const availableItems = (await taskPool.getAvailableItems()).filter(
+      (wi) => !SLA_TRACKER_ID_PATTERN.test(wi.id),
+    );
     if (availableItems.length === 0) return null;
 
     // Build agent health info for scoring
@@ -353,8 +363,13 @@ export class AgentAutoClaimService {
     const taskPool = TaskPoolService.getInstance();
     const availableItems = await taskPool.getAvailableItems();
 
-    // Find queued items with a specific target
-    const targetedItems = availableItems.filter((wi) => wi.target);
+    // Find queued items with a specific target. Skip SLA tracker WIs —
+    // they're not dispatchable work, so waking an offline agent for one
+    // would just trap the WI in a re-claim loop (see the comment in
+    // `tryAutoClaimForAgent` for the full bug shape).
+    const targetedItems = availableItems.filter(
+      (wi) => wi.target && !SLA_TRACKER_ID_PATTERN.test(wi.id),
+    );
     if (targetedItems.length === 0) return;
 
     // Get all known agent sessions from teams

--- a/backend/src/services/v3/workitem-dispatch.subscriber.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.ts
@@ -50,9 +50,20 @@ const API_BASE = 'http://localhost:8787';
 /**
  * SLA tracker WIs use a deterministic id pattern `request:<rid>:respond_to_user`
  * (see `request-sla.subscriber.ts`). They're internal bookkeeping items, not
- * dispatchable work, so we always skip them.
+ * dispatchable work — the orc never "claims and executes" one; the WI is
+ * passively tracked and resolved by the SLA path when orc actually replies
+ * via the reply-slack skill.
+ *
+ * Exported so {@link AgentAutoClaimService} can apply the same filter when
+ * scoring claimable WIs. Before that fix (2026-05-12), AutoClaim would
+ * happily claim a `respond_to_user` WI for crewly-orc, then call
+ * `dispatchTo` which short-circuits here on the same regex — leaving the
+ * WI stuck in `running` with no PTY delivery. 5/10-min SLA breach fired,
+ * claim revoked, WI cycled back to `queued`, AutoClaim re-claimed it,
+ * loop repeated indefinitely. From the user's perspective: "Request never
+ * progresses, only heartbeats and SLA-breach DMs."
  */
-const SLA_TRACKER_ID_PATTERN = /^request:.+:respond_to_user$/;
+export const SLA_TRACKER_ID_PATTERN = /^request:.+:respond_to_user$/;
 
 /** Per-WI delay between backfill pushes — keeps the burst polite. */
 const BACKFILL_THROTTLE_MS = 200;


### PR DESCRIPTION
## Summary

User reported that the system isn't progressing recent Slack requests — Slack thread filled with heartbeat + SLA-breach DMs, orc never replied. Direct log trace exposed an infinite re-claim loop:

\`\`\`
[AutoClaim]   Auto-claimed WorkItem for idle agent
              workItemId=request:3e6b984f-...:respond_to_user
              agentSessionName=crewly-orc
(NO WorkItemDispatch log — task never delivered to orc's PTY)
[SLA]         breach level=5
[SLA]         breach level=10 → orphan WI auto-failed
[Reconciler]  failed → queued (auto-retry 1/3)
[Claim]       revoked: grace period exceeded
(next AutoClaim tick re-claims, loop repeats forever)
\`\`\`

## Root cause

\`WorkItemDispatchSubscriber.dispatchTo\` short-circuits on the SLA tracker id pattern (\`request:*:respond_to_user\`) — these WIs are passive bookkeeping items resolved by the SLA path when orc actually replies via reply-slack, NOT dispatchable work.

But \`AgentAutoClaimService\` had no equivalent filter. It scored & claimed tracker WIs like any queued WI. The claim flipped status to \`running\` but the dispatch step silently no-op'd on the same regex. orc never saw a task. SLA fired. Claim died. Repeat.

## Fix

- Export \`SLA_TRACKER_ID_PATTERN\` from \`workitem-dispatch.subscriber.ts\`
- Apply the same filter inside both \`tryAutoClaimForAgent\` and \`recoverPendingTasks\` (the startup wake-offline path)

The respond_to_user WI now stays in \`queued\` (claimable only by the SLA resolve path) until orc actually replies via reply-slack → \`POST /api/slack/send\` → \`markResolvedByThread\` (added in #538) → WI transitions to \`verified\` → cascade subscriber closes the Request.

## Test plan
- [x] 2 new regression tests in \`agent-auto-claim.service.test.ts\`:
  - tracker WI alone → no claim
  - tracker mixed with real WI → real WI claimed, tracker skipped
- [x] 10/10 AutoClaim tests pass
- [x] 13/13 dispatch tests still pass (export didn't break anything)
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds
- [ ] Post-merge: restart, send Slack message, watch the respond_to_user WI stay claimable-only-by-SLA-path until orc actually replies (no more re-claim loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)