### PR TITLE
fix(slack): encode thread root in sourceConversationItemId

### DIFF
--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -473,7 +473,32 @@ export class SlackOrchestratorBridge extends EventEmitter {
             try {
               const { RequestService } = await import('../v3/request.service.js');
               const svc = RequestService.getInstance();
-              const msgId = `slack-${message.channelId}-${message.ts}`;
+              // 2026-05-13 dogfood fix: encode BOTH thread root AND message
+              // ts in sourceConversationItemId. The previous form was
+              // `slack-{channel}-{message.ts}`, which made
+              // `extractSlackThreadTs(sourceConv)` return the per-message
+              // ts — never the actual Slack thread root. The SLA
+              // threadIndex therefore mapped per-message ts → requestId,
+              // but when orc replied via reply-slack → POST /api/slack/send
+              // → markResolvedByThread(realThreadRoot), the lookup missed
+              // and the Request never auto-closed (PR #538 hook was a
+              // no-op for thread-reply messages).
+              //
+              // New form:
+              //   Top-level message (msg.ts == thread root):
+              //     `slack-{channelId}-{ts}`              (unchanged)
+              //   Reply within an existing thread:
+              //     `slack-{channelId}-{threadRoot}-msg-{messageTs}`
+              //
+              // The `-msg-{...}` suffix preserves per-message uniqueness
+              // so `findBySourceConversationItemId` still works. The
+              // updated `parseSlackThreadContext` strips the suffix
+              // before extracting the threadTs, so the SLA's threadIndex
+              // now keys on the actual thread root for both shapes.
+              const threadRoot = message.threadTs || message.ts;
+              const msgId = message.threadTs && message.threadTs !== message.ts
+                ? `slack-${message.channelId}-${threadRoot}-msg-${message.ts}`
+                : `slack-${message.channelId}-${message.ts}`;
               const existing = await svc.findBySourceConversationItemId(msgId);
               if (existing) return;
 

--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -245,6 +245,23 @@ describe('extractSlackThreadTs / extractSlackChannelId', () => {
     expect(extractSlackThreadTs(undefined)).toBeNull();
     expect(extractSlackChannelId('')).toBeNull();
   });
+
+  // 2026-05-13 dogfood regression: when a user replies WITHIN an existing
+  // Slack thread, the bridge encodes sourceConversationItemId as
+  // `slack-{channel}-{threadRoot}-msg-{messageTs}` so the SLA threadIndex
+  // keys on the actual thread root (which is what orc replies to via
+  // reply-slack). Both extractors MUST strip the `-msg-{ts}` suffix.
+  it('strips the `-msg-{ts}` suffix for thread-reply encoding (extractSlackThreadTs)', () => {
+    expect(
+      extractSlackThreadTs('slack-D0AC7NF5N7L-1777130816.772509-msg-1778679615.696949'),
+    ).toBe('1777130816.772509');
+  });
+
+  it('strips the `-msg-{ts}` suffix for thread-reply encoding (extractSlackChannelId)', () => {
+    expect(
+      extractSlackChannelId('slack-D0AC7NF5N7L-1777130816.772509-msg-1778679615.696949'),
+    ).toBe('D0AC7NF5N7L');
+  });
 });
 
 describe('pickResolveTarget', () => {

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -334,11 +334,17 @@ const ORC_REPLY_GRACE_MS = 30_000;     // 30s second-pass deferral
  */
 export function extractSlackThreadTs(sourceId: string | undefined): string | null {
   if (!sourceId || !sourceId.startsWith('slack-')) return null;
+  // 2026-05-13 dogfood fix: thread-reply Requests use the encoding
+  // `slack-{channelId}-{threadRoot}-msg-{messageTs}` so the SLA index
+  // keys on the thread root (which is what orc replies to). Strip the
+  // optional `-msg-{ts}` suffix before extracting the trailing ts.
+  // Top-level message ids (`slack-{channelId}-{ts}`) are unchanged.
+  const stripped = sourceId.replace(/-msg-\d+\.\d+$/, '');
   // slack-${channelId}-${ts}; channelId may not contain dashes, but ts is
   // dotted-decimal. We split on '-' and take the last segment as ts.
-  const lastDash = sourceId.lastIndexOf('-');
-  if (lastDash < 0 || lastDash === sourceId.length - 1) return null;
-  const ts = sourceId.slice(lastDash + 1);
+  const lastDash = stripped.lastIndexOf('-');
+  if (lastDash < 0 || lastDash === stripped.length - 1) return null;
+  const ts = stripped.slice(lastDash + 1);
   // ts looks like 1772899923.865659 — at minimum digits + '.'
   if (!/^\d+\.\d+$/.test(ts)) return null;
   return ts;
@@ -352,7 +358,10 @@ export function extractSlackThreadTs(sourceId: string | undefined): string | nul
  */
 export function extractSlackChannelId(sourceId: string | undefined): string | null {
   if (!sourceId || !sourceId.startsWith('slack-')) return null;
-  const rest = sourceId.slice('slack-'.length);
+  // Strip the optional `-msg-{ts}` suffix (thread-reply encoding) so the
+  // channelId is sliced from the threadRoot form, not from the messageTs.
+  const stripped = sourceId.replace(/-msg-\d+\.\d+$/, '');
+  const rest = stripped.slice('slack-'.length);
   const lastDash = rest.lastIndexOf('-');
   if (lastDash < 1) return null;
   return rest.slice(0, lastDash);

--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -185,6 +185,30 @@ describe('parseSlackThreadContext', () => {
     expect(parseSlackThreadContext(undefined)).toBeNull();
     expect(parseSlackThreadContext('')).toBeNull();
   });
+
+  // 2026-05-13 dogfood regression: thread-reply user messages now encode
+  // sourceConversationItemId as `slack-{channel}-{threadRoot}-msg-{messageTs}`
+  // so the SLA index keys on the actual thread root (which is what orc
+  // replies to via reply-slack). The parser MUST strip the `-msg-{ts}`
+  // suffix before extracting threadTs, otherwise the lookup misses and
+  // the Request never auto-closes when orc replies.
+  it('extracts the THREAD ROOT (not the message ts) from thread-reply encoding', () => {
+    expect(
+      parseSlackThreadContext('slack-D0AC7NF5N7L-1777130816.772509-msg-1778679615.696949'),
+    ).toEqual({
+      channelId: 'D0AC7NF5N7L',
+      threadTs: '1777130816.772509',  // ← thread root, NOT 1778679615.696949
+    });
+  });
+
+  it('handles the top-level (no-thread) form identically — no `-msg-` suffix to strip', () => {
+    // Regression gate: the strip must be a no-op on top-level message ids.
+    // If the regex were too greedy and ate part of the ts, this test fails.
+    expect(parseSlackThreadContext('slack-D0AC7NF5N7L-1778679615.696949')).toEqual({
+      channelId: 'D0AC7NF5N7L',
+      threadTs: '1778679615.696949',
+    });
+  });
 });
 
 describe('RequestStatusUpdateSubscriber — event handling', () => {

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -212,7 +212,15 @@ export function computeStateFingerprint(childWIs: WorkItem[]): string {
 
 export function parseSlackThreadContext(scid: string | undefined): ParsedSlackContext | null {
   if (!scid || !scid.startsWith('slack-')) return null;
-  const m = scid.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
+  // 2026-05-13 dogfood fix: Slack thread-reply Requests use the
+  // `slack-{channelId}-{threadRoot}-msg-{messageTs}` encoding so that
+  // the SLA threadIndex keys on the actual thread root (which is what
+  // orc replies to via reply-slack). Strip the trailing `-msg-{ts}`
+  // before extracting threadTs so both shapes parse to the thread root.
+  // Top-level messages (`slack-{channelId}-{ts}`) are unaffected — the
+  // strip is a no-op on those.
+  const stripped = scid.replace(/-msg-\d+\.\d+$/, '');
+  const m = stripped.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
   if (!m) return null;
   const [, channelId, ts1, ts2] = m;
   return { channelId, threadTs: `${ts1}.${ts2}` };


### PR DESCRIPTION
## Summary

User reported on 2026-05-13: sent multiple follow-ups in an existing Slack thread; orc analyzed each and replied via reply-slack — but the parent Request never closed, heartbeat kept firing "排队 1", and the user couldn't see orc's reply correlated to their question.

## Root cause

\`sourceConversationItemId\` was always built from \`message.ts\` (the message's own timestamp), even for replies within an existing thread:

\`\`\`
User message:    ts=1778679615.696949, thread_ts=1777130816.772509
Old sourceConv:  slack-D0AC7NF5N7L-1778679615.696949   ← uses msg ts
\`\`\`

The SLA \`threadIndex\` keys on whatever \`extractSlackThreadTs\` returns, so it had \`{"1778679615.696949": reqId}\`. But orc replies to the actual Slack thread root \`1777130816.772509\` (which is what the \`[SLACK:...]\` marker injects). The hook added in #538 calls \`markResolvedByThread("1777130816.772509")\` — and misses, because the index has per-message ts values, not thread roots. Request never auto-closes.

## Fix

Encode BOTH thread root AND message ts in \`sourceConversationItemId\` when they differ:

| Case | New \`sourceConversationItemId\` |
|---|---|
| Top-level message (\`msg.ts == thread root\`) | \`slack-{channelId}-{ts}\` (unchanged) |
| Reply within an existing thread | \`slack-{channelId}-{threadRoot}-msg-{messageTs}\` |

The \`-msg-{ts}\` suffix preserves per-message uniqueness so \`findBySourceConversationItemId\` still works. Three parsers updated to strip the suffix before extracting threadTs/channelId:
- \`parseSlackThreadContext\` (request-status-update.subscriber.ts)
- \`extractSlackThreadTs\` (request-sla.subscriber.ts)
- \`extractSlackChannelId\` (request-sla.subscriber.ts)

Top-level form parses identically (strip is a no-op without a suffix) — no regression for fresh threads.

## Test plan
- [x] 4 new regression tests pin the new shape + assert top-level remains unchanged
- [x] 120/120 SLA + status-update tests pass
- [x] 124/124 bridge tests pass
- [x] \`tsc --noEmit\` clean for touched files
- [x] \`npm run build\` succeeds
- [ ] Post-merge: send a new follow-up Slack message; verify orc's reply correlates to the right thread AND the Request auto-closes within seconds (not 30-min heartbeat catch)

## Note
Doesn't unwind Requests that pre-date this commit — their \`sourceConversationItemId\` still uses the old form. New Slack messages route correctly going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)