### PR TITLE
fix(reconciler): wake-floor under memory pressure (allow up to 3 active)

### DIFF
--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -783,10 +783,29 @@ describe('LiveReconcilerDataProvider', () => {
       globalThis.fetch = originalFetch;
     });
 
-    it('should skip wake action under memory pressure (>=90%)', async () => {
-      // Simulate >=90% memory usage
-      mockTotalmem.mockReturnValue(16_000_000_000); // 16GB
-      mockFreemem.mockReturnValue(800_000_000);      // 800MB free = 95% used
+    // 2026-05-13 dogfood: previously this gate UNCONDITIONALLY blocked
+    // every wake action whenever memory pressure tripped (>=90%), which
+    // wedged the entire system for hours when free RAM stayed low.
+    // New behaviour: allow wakes up to WAKE_FLOOR_UNDER_PRESSURE
+    // concurrent active agents so something keeps making progress;
+    // block additional wakes beyond that floor. Tests now pin both
+    // halves of the contract.
+    it('skips wake under memory pressure when active-agent count is at/above the floor', async () => {
+      // 95% used
+      mockTotalmem.mockReturnValue(16_000_000_000);
+      mockFreemem.mockReturnValue(800_000_000);
+
+      // 3 active agents = floor reached
+      mockStorage.getTeams.mockResolvedValue([
+        {
+          id: 't1',
+          members: [
+            { id: 'm1', sessionName: 's1', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            { id: 'm2', sessionName: 's2', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            { id: 'm3', sessionName: 's3', agentStatus: 'started', role: 'dev', updatedAt: '' },
+          ],
+        },
+      ]);
 
       mockSuspend.isSuspended.mockReturnValue(true);
       mockSuspend.rehydrateAgent.mockResolvedValue(true);
@@ -802,10 +821,75 @@ describe('LiveReconcilerDataProvider', () => {
 
       const result = await provider.executeWakeAction(action);
 
-      // Should return false without calling rehydrate because of memory pressure
       expect(result).toBe(false);
       expect(mockSuspend.rehydrateAgent).not.toHaveBeenCalled();
+    });
 
+    it('allows wake under memory pressure when active-agent count is BELOW the floor', async () => {
+      // 95% used (would have skipped pre-fix)
+      mockTotalmem.mockReturnValue(16_000_000_000);
+      mockFreemem.mockReturnValue(800_000_000);
+
+      // Only 1 active agent → 2 slots under floor → wake should go through
+      mockStorage.getTeams.mockResolvedValue([
+        {
+          id: 't1',
+          members: [
+            { id: 'm1', sessionName: 's1', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            { id: 'm2', sessionName: 's2', agentStatus: 'inactive', role: 'dev', updatedAt: '' },
+            { id: 'm3', sessionName: 's3', agentStatus: 'suspended', role: 'dev', updatedAt: '' },
+          ],
+        },
+      ]);
+
+      mockSuspend.isSuspended.mockReturnValue(true);
+      mockSuspend.rehydrateAgent.mockResolvedValue(true);
+
+      const action: WakeAction = {
+        workItemId: 'wi-1',
+        agentSessionName: 'agent-max',
+        strategy: 'rehydrate',
+        score: 75,
+        scoreBreakdown: { skillMatch: 40, urgency: 15, contextFamiliarity: 20, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+      };
+
+      const result = await provider.executeWakeAction(action);
+
+      expect(result).toBe(true);
+      expect(mockSuspend.rehydrateAgent).toHaveBeenCalledWith('agent-max');
+    });
+
+    it('counts `starting` and `started` toward the floor (in-flight wakes consume RAM too)', async () => {
+      mockTotalmem.mockReturnValue(16_000_000_000);
+      mockFreemem.mockReturnValue(800_000_000);
+
+      // 3 in-flight = floor reached even though none are fully active yet
+      mockStorage.getTeams.mockResolvedValue([
+        {
+          id: 't1',
+          members: [
+            { id: 'm1', sessionName: 's1', agentStatus: 'starting', role: 'dev', updatedAt: '' },
+            { id: 'm2', sessionName: 's2', agentStatus: 'started', role: 'dev', updatedAt: '' },
+            { id: 'm3', sessionName: 's3', agentStatus: 'starting', role: 'dev', updatedAt: '' },
+          ],
+        },
+      ]);
+
+      mockSuspend.isSuspended.mockReturnValue(true);
+      const action: WakeAction = {
+        workItemId: 'wi-1',
+        agentSessionName: 'agent-max',
+        strategy: 'rehydrate',
+        score: 75,
+        scoreBreakdown: { skillMatch: 40, urgency: 15, contextFamiliarity: 20, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+      };
+
+      const result = await provider.executeWakeAction(action);
+
+      expect(result).toBe(false);
+      expect(mockSuspend.rehydrateAgent).not.toHaveBeenCalled();
     });
 
     it('should proceed with wake action when memory usage is below 90%', async () => {

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -98,6 +98,24 @@ function isStorageNotReadyError(error: unknown): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum concurrent active agents allowed even under memory pressure.
+ *
+ * When `isUnderMemoryPressure()` returns true, the reconciler previously
+ * blocked every wake action — which wedged the entire system whenever
+ * free RAM stayed low (2026-05-13 dogfood: 6+ hours stuck). New
+ * behaviour: keep up to this many agents alive so something is always
+ * making progress; only block wakes beyond the floor. Set low enough
+ * that the OOM-prevention intent is preserved (3 active agents at
+ * crisis pressure is far below the 90%-threshold tipping point that
+ * blocks unbounded spawns).
+ */
+export const WAKE_FLOOR_UNDER_PRESSURE = 3;
+
+// ---------------------------------------------------------------------------
 // LiveReconcilerDataProvider
 // ---------------------------------------------------------------------------
 
@@ -484,21 +502,87 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
    * @param action - The wake action to execute
    * @returns True if the wake was initiated successfully
    */
+  /**
+   * Count agent sessions currently in an alive state. Used by the
+   * memory-pressure gate in {@link executeWakeAction} to decide whether
+   * a new wake would push us past the concurrency floor.
+   *
+   * Counts `'active'`, `'started'`, and `'starting'` — anything that
+   * has a live process consuming RAM. `started` and `starting` cover
+   * in-flight wakes from prior reconciler ticks that haven't fully
+   * promoted to active yet. `suspended` / `inactive` are NOT alive and
+   * don't contribute (suspended drops the runtime; inactive never had
+   * one).
+   *
+   * @returns The number of agent sessions currently alive
+   */
+  private async countActiveAgentSessions(): Promise<number> {
+    try {
+      const teams = await this.storage.getTeams();
+      let count = 0;
+      for (const team of teams) {
+        for (const member of team.members || []) {
+          const s = member.agentStatus;
+          if (s === 'active' || s === 'started' || s === 'starting') {
+            count += 1;
+          }
+        }
+      }
+      return count;
+    } catch (err) {
+      // Storage hiccup → fail closed (assume floor reached, skip wake).
+      // Better to defer a wake than to overshoot under crisis pressure.
+      this.logger.debug('countActiveAgentSessions failed — assuming floor reached', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return WAKE_FLOOR_UNDER_PRESSURE;
+    }
+  }
+
   async executeWakeAction(action: WakeAction): Promise<boolean> {
     const { agentSessionName, strategy } = action;
 
-    // Skip wake action under system memory pressure (>90% used).
-    // Prevents spawning new agent processes when the system is already low on memory,
-    // which would cause OOM → kill → reconciler wakes again → OOM loop.
+    // Memory-pressure gate with a concurrency floor.
+    //
+    // Previous behaviour (unconditional skip on >=90% used) wedged the
+    // system in the 2026-05-13 dogfood scenario: free RAM hovered at
+    // 16-33 MB for hours, the reconciler refused EVERY wake, and the
+    // user saw orc/think-tank/marketing all stuck inactive with queued
+    // WIs piling up. Nothing made progress until manual intervention.
+    //
+    // New behaviour: under memory pressure, still allow wakes up to
+    // `WAKE_FLOOR_UNDER_PRESSURE` concurrent active agents so the
+    // system stays minimally productive. Wakes beyond that cap are
+    // still blocked — we don't want to spawn an unbounded number of
+    // agents under crisis pressure and trigger an OOM cascade.
+    //
+    // The count includes 'active' and 'started' sessions (counting
+    // 'started' covers an in-flight wake from a prior reconciler tick
+    // that hasn't fully promoted to 'active' yet). Slight overshoot
+    // is possible across concurrent pass executions; acceptable
+    // because the cap is a SAFETY FLOOR, not a hard limit.
     if (isUnderMemoryPressure()) {
       const stats = getMemoryStats();
-      this.logger.warn('Skipping wake action due to memory pressure', {
+      const activeCount = await this.countActiveAgentSessions();
+      if (activeCount >= WAKE_FLOOR_UNDER_PRESSURE) {
+        this.logger.warn('Skipping wake action — memory pressure AND at concurrency floor', {
+          agent: agentSessionName,
+          strategy,
+          memoryUsedPercent: stats.usedPercent,
+          freeMemMB: stats.freeMB,
+          activeAgents: activeCount,
+          wakeFloor: WAKE_FLOOR_UNDER_PRESSURE,
+        });
+        return false;
+      }
+      this.logger.info('Memory pressure detected — allowing wake (under concurrency floor)', {
         agent: agentSessionName,
         strategy,
         memoryUsedPercent: stats.usedPercent,
         freeMemMB: stats.freeMB,
+        activeAgents: activeCount,
+        wakeFloor: WAKE_FLOOR_UNDER_PRESSURE,
       });
-      return false;
     }
 
     this.logger.info('Executing wake action', {


### PR DESCRIPTION
## Summary

User reported on 2026-05-13: free RAM stayed at 16-33 MB for hours. The reconciler's memory-pressure gate **unconditionally** blocked every wake action — orc / think-tank / marketing all sat inactive with queued WIs piling up, nothing made progress.

The gate's original intent (OOM prevention) is sound, but "block everything" overshoots — the system can't tell you what's happening if NO agent is alive to think. A minimal concurrency floor (~3 active agents) is the right safety net: enough to keep work moving, far below the runaway-spawn limit the unconditional block was guarding against.

## New behaviour

| Memory pressure? | Active agent count | Wake action |
|---|---|---|
| ✅ Yes | < 3 (\`WAKE_FLOOR_UNDER_PRESSURE\`) | **Allow** |
| ✅ Yes | ≥ 3 | Skip (existing OOM-guard) |
| ❌ No | any | Allow (unchanged) |

"Active" counts \`'active' | 'started' | 'starting'\` — anything with a live process consuming RAM. \`started\` and \`starting\` cover in-flight wakes from prior reconciler ticks so the same wake isn't double-counted across overlapping passes. The counting helper fails closed on storage hiccup (returns the floor) so an unreadable \`teams.json\` never accidentally unblocks unbounded wakes.

## Test plan
- [x] 3 new regression tests:
  - pressure + count ≥ floor → skip (regression gate for the original OOM guard)
  - pressure + count < floor → allow (the new behaviour)
  - \`starting\`/\`started\` count toward the floor (in-flight RAM included)
- [x] All other reconciler-data-provider tests still pass
- [x] \`tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [ ] Post-merge: restart and watch the reconciler bring up 3 agents within a couple of ticks even with free RAM <100MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)