### PR TITLE
fix(ops): idle-detection self-heal + reconciler memory-pressure event + CLI shutdown timing (+ Slack auto-route)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -603,6 +603,9 @@ export class CrewlyServer {
 			// Storage Service, and Agent Suspend for real reconciliation including
 			// Hybrid Wake (auto-rehydrating suspended agents when tasks go unclaimed).
 			const liveDataProvider = new LiveReconcilerDataProvider();
+			// Wire EventBus so the provider can broadcast `system:memory_pressure`
+			// when wake actions are sustained-skipped due to memory pressure.
+			liveDataProvider.setEventBus(this.eventBusService);
 
 			this.reconcilerService = new ReconcilerService(liveDataProvider);
 			setReconcilerService(this.reconcilerService);
@@ -655,6 +658,7 @@ export class CrewlyServer {
 					thwLogger.warn('Reconciler not available; skipping TeamHealthWatchdog init.');
 				} else {
 					const reconcilerProvider = new LiveReconcilerDataProvider();
+					reconcilerProvider.setEventBus(this.eventBusService);
 					const dataProvider = new LiveTeamHealthDataProvider({
 						reconcilerProvider,
 						getTeams: async () => StorageService.getInstance().getTeams(),

--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -3058,6 +3058,123 @@ describe('AgentRegistrationService', () => {
 			routeSpy.mockRestore();
 		});
 
+		// Bug 6: in-process AI SDK runtime auto-route to Slack
+		// When the agent finishes with text-only output (toolCalls=0,
+		// finishReason=stop) and the message came from Slack, the response
+		// must be auto-routed back to Slack via SlackService. Without this
+		// hook, the response is silently dropped — the AI SDK runtime has no
+		// PTY stream the SlackBridge can tail.
+		//
+		// See: P0 KR3 demo-blocker, 2026-05-14 (Steve livewalk on Crewly Demo
+		// Slack workspace).
+		it('should auto-route response to Slack when agent finished without calling reply_slack', async () => {
+			mockReadFile.mockResolvedValue('System prompt');
+			mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+			await service.createAgentSession({
+				sessionName: 'crewly-orc',
+				role: 'orchestrator',
+				runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+			});
+
+			// Reproduce the production smoking-gun: 101-char reply, no tool calls.
+			mockCrewlyRuntime.handleMessage.mockResolvedValueOnce({
+				text: '你好！很高兴见到你。我是 Crewly 的协调员，请告诉我你想完成什么任务。',
+				steps: 1,
+				usage: { input: 7187, output: 56 },
+				toolCalls: [],
+				finishReason: 'stop',
+			});
+
+			const slackRouteSpy = jest.spyOn(service as any, 'routeInProcessResponseToSlack');
+
+			const sendResult = await service.sendMessageToAgent(
+				'crewly-orc',
+				'[CHAT:slack-D0B17U49LR4-ts1778721826748439] 你好 [SLACK:D0B17U49LR4:1778721826.748439]',
+				RUNTIME_TYPES.CREWLY_AGENT as any
+			);
+
+			expect(sendResult.success).toBe(true);
+
+			// Wait for fire-and-forget async callback to complete
+			await new Promise(r => setTimeout(r, 50));
+
+			expect(slackRouteSpy).toHaveBeenCalledTimes(1);
+			const [routedSession, routedText, routedSlack] = slackRouteSpy.mock.calls[0];
+			expect(routedSession).toBe('crewly-orc');
+			expect(routedText).toContain('你好');
+			expect(routedSlack).toEqual({
+				channelId: 'D0B17U49LR4',
+				threadTs: '1778721826.748439',
+			});
+			slackRouteSpy.mockRestore();
+		});
+
+		it('should NOT auto-route to Slack when agent already called reply_slack (prevent double-post)', async () => {
+			mockReadFile.mockResolvedValue('System prompt');
+			mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+			await service.createAgentSession({
+				sessionName: 'crewly-orc',
+				role: 'orchestrator',
+				runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+			});
+
+			mockCrewlyRuntime.handleMessage.mockResolvedValueOnce({
+				text: 'Reply sent via tool',
+				steps: 2,
+				usage: { input: 100, output: 50 },
+				toolCalls: [{ toolName: 'reply_slack', args: { channelId: 'C123', text: 'Reply sent via tool' } }],
+				finishReason: 'stop',
+			});
+
+			const slackRouteSpy = jest.spyOn(service as any, 'routeInProcessResponseToSlack');
+
+			await service.sendMessageToAgent(
+				'crewly-orc',
+				'[CHAT:slack-C123-ts456] Hello [SLACK:C123:1234567890.123]',
+				RUNTIME_TYPES.CREWLY_AGENT as any
+			);
+
+			await new Promise(r => setTimeout(r, 50));
+
+			expect(slackRouteSpy).not.toHaveBeenCalled();
+			slackRouteSpy.mockRestore();
+		});
+
+		it('should NOT auto-route to Slack for non-Slack-sourced messages', async () => {
+			mockReadFile.mockResolvedValue('System prompt');
+			mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+			await service.createAgentSession({
+				sessionName: 'crewly-orc',
+				role: 'orchestrator',
+				runtimeType: RUNTIME_TYPES.CREWLY_AGENT as any,
+			});
+
+			mockCrewlyRuntime.handleMessage.mockResolvedValueOnce({
+				text: 'Chat-only reply',
+				steps: 1,
+				usage: { input: 100, output: 50 },
+				toolCalls: [],
+				finishReason: 'stop',
+			});
+
+			const slackRouteSpy = jest.spyOn(service as any, 'routeInProcessResponseToSlack');
+
+			// Web-chat inbound — no [SLACK:] marker.
+			await service.sendMessageToAgent(
+				'crewly-orc',
+				'[CHAT:web-conv-123] Hello',
+				RUNTIME_TYPES.CREWLY_AGENT as any
+			);
+
+			await new Promise(r => setTimeout(r, 50));
+
+			expect(slackRouteSpy).not.toHaveBeenCalled();
+			slackRouteSpy.mockRestore();
+		});
+
 		// ──────────────────────────────────────────────────────────────────
 		// Orchestrator modelId resolution (P1 fix, cloud_pro_v2)
 		// ──────────────────────────────────────────────────────────────────

--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -87,6 +87,40 @@ jest.mock('./pty-activity-tracker.service.js', () => ({
 }));
 
 // Mock OAuthReloginMonitorService — no-op for tests
+// Mocks for the dynamic imports used by routeInProcessResponseToSlack.
+// Default behaviour matches a "Slack disconnected" environment so existing
+// happy-path tests (which let the real method run) bail out at the
+// `isConnected()` check exactly as they do in CI today. Error-path tests
+// override these per-case.
+const mockSlackSendMessage = jest.fn().mockResolvedValue('1234567890.000100');
+const mockSlackIsConnected = jest.fn().mockReturnValue(false);
+jest.mock('../slack/slack.service.js', () => ({
+	getSlackService: jest.fn(() => ({
+		isConnected: mockSlackIsConnected,
+		sendMessage: mockSlackSendMessage,
+	})),
+}));
+
+const mockTsqGet = jest.fn().mockReturnValue(null);
+const mockTsqTrackInbound = jest.fn();
+const mockTsqMarkReplied = jest.fn();
+jest.mock('../messaging/thread-status-queue.service.js', () => ({
+	ThreadStatusQueueService: {
+		getInstance: jest.fn(() => ({
+			get: mockTsqGet,
+			trackInbound: mockTsqTrackInbound,
+			markReplied: mockTsqMarkReplied,
+		})),
+	},
+}));
+
+const mockMarkResolvedByThread = jest.fn().mockResolvedValue(undefined);
+jest.mock('../v3/request-sla.subscriber.js', () => ({
+	getRequestSlaSubscriber: jest.fn(() => ({
+		markResolvedByThread: mockMarkResolvedByThread,
+	})),
+}));
+
 jest.mock('./oauth-relogin-monitor.service.js', () => ({
 	OAuthReloginMonitorService: {
 		getInstance: jest.fn().mockReturnValue({
@@ -3813,6 +3847,128 @@ describe('AgentRegistrationService', () => {
 			});
 
 			expect(result.sessionName).toBe('broken-session-xyz');
+		});
+	});
+
+	// ──────────────────────────────────────────────────────────────────
+	// routeInProcessResponseToSlack — error paths
+	// ──────────────────────────────────────────────────────────────────
+	// The function is fire-and-forget (returns void) and every branch is
+	// best-effort with a `try/catch` that swallows errors and logs at
+	// debug/warn. These tests pin that contract: a future refactor that
+	// converts a `try/catch` to an unhandled `throw` would break the
+	// caller's success return — these tests are the safety net.
+	describe('routeInProcessResponseToSlack — error paths', () => {
+		beforeEach(() => {
+			mockSlackIsConnected.mockReset().mockReturnValue(true);
+			mockSlackSendMessage.mockReset().mockResolvedValue('1234567890.000100');
+			mockTsqGet.mockReset().mockReturnValue(null);
+			mockTsqTrackInbound.mockReset();
+			mockTsqMarkReplied.mockReset();
+			mockMarkResolvedByThread.mockReset().mockResolvedValue(undefined);
+		});
+
+		const flushAsync = async (): Promise<void> => {
+			// The function chains `.then().catch()` over a dynamic import.
+			// We need to drain microtasks AND the macrotask queue for the
+			// inner awaits (sendMessage, markResolvedByThread).
+			for (let i = 0; i < 5; i++) {
+				await new Promise(resolve => setImmediate(resolve));
+			}
+		};
+
+		const invoke = (overrides: Partial<{ channelId: string; threadTs?: string }> = {}): void => {
+			(service as any).routeInProcessResponseToSlack('crewly-orc', 'hello', {
+				channelId: overrides.channelId ?? 'C123',
+				threadTs: overrides.threadTs ?? '1234567890.000200',
+			});
+		};
+
+		it('(a) bails without throwing when Slack is not connected', async () => {
+			mockSlackIsConnected.mockReturnValue(false);
+
+			invoke();
+			await flushAsync();
+
+			expect(mockSlackSendMessage).not.toHaveBeenCalled();
+			expect(mockTsqTrackInbound).not.toHaveBeenCalled();
+			expect(mockTsqMarkReplied).not.toHaveBeenCalled();
+			expect(mockMarkResolvedByThread).not.toHaveBeenCalled();
+		});
+
+		it('(b) swallows sendMessage failure and skips downstream bookkeeping', async () => {
+			mockSlackSendMessage.mockRejectedValueOnce(new Error('slack 5xx'));
+
+			// Must not throw — the function is fire-and-forget.
+			expect(() => invoke()).not.toThrow();
+			await flushAsync();
+
+			expect(mockSlackSendMessage).toHaveBeenCalledTimes(1);
+			// When sendMessage throws, the .then() chain rejects and the
+			// outer .catch() handles it — bookkeeping never runs.
+			expect(mockTsqTrackInbound).not.toHaveBeenCalled();
+			expect(mockTsqMarkReplied).not.toHaveBeenCalled();
+			expect(mockMarkResolvedByThread).not.toHaveBeenCalled();
+		});
+
+		it('(c) swallows markReplied failure but still fires the V3 SLA cascade', async () => {
+			// Send succeeds, then the thread-status bookkeeping crashes —
+			// the SLA cascade in the *next* try/catch block must still run.
+			// Without independent try/catches, one failing primitive would
+			// silently leak Requests stuck in `queued`.
+			mockTsqGet.mockReturnValue(null);
+			mockTsqMarkReplied.mockImplementation(() => {
+				throw new Error('tsq corruption');
+			});
+
+			expect(() => invoke()).not.toThrow();
+			await flushAsync();
+
+			expect(mockSlackSendMessage).toHaveBeenCalledTimes(1);
+			expect(mockTsqTrackInbound).toHaveBeenCalledTimes(1);
+			expect(mockMarkResolvedByThread).toHaveBeenCalledTimes(1);
+		});
+
+		it('(d) swallows markResolvedByThread failure (last in chain — must not propagate)', async () => {
+			mockMarkResolvedByThread.mockRejectedValueOnce(new Error('subscriber down'));
+
+			expect(() => invoke()).not.toThrow();
+			await flushAsync();
+
+			expect(mockSlackSendMessage).toHaveBeenCalledTimes(1);
+			expect(mockTsqMarkReplied).toHaveBeenCalledTimes(1);
+			expect(mockMarkResolvedByThread).toHaveBeenCalledTimes(1);
+		});
+
+		it('builds the thread-status entry on the fly when no inbound was tracked (race-protection)', async () => {
+			// This is the #1 fix from the code review: /slack/send has
+			// always populated the entry before marking replied; the
+			// in-process route used to short-circuit on a missing entry
+			// and leave the recovery loop free to re-fire the inbound.
+			mockTsqGet.mockReturnValue(null);
+
+			invoke({ channelId: 'C999', threadTs: '1700000000.000111' });
+			await flushAsync();
+
+			expect(mockTsqTrackInbound).toHaveBeenCalledTimes(1);
+			const trackedArgs = mockTsqTrackInbound.mock.calls[0][0];
+			expect(trackedArgs).toMatchObject({
+				threadKey: 'C999:1700000000.000111',
+				source: 'slack',
+			});
+			// conversationId fallback format: 'slack-<channel>-<ts with . → ->'
+			expect(trackedArgs.conversationId).toBe('slack-C999-1700000000-000111');
+			expect(mockTsqMarkReplied).toHaveBeenCalledWith('C999:1700000000.000111', 'replied_completed');
+		});
+
+		it('skips trackInbound when the entry already exists (idempotent path)', async () => {
+			mockTsqGet.mockReturnValue({ threadKey: 'C123:abc' });
+
+			invoke();
+			await flushAsync();
+
+			expect(mockTsqTrackInbound).not.toHaveBeenCalled();
+			expect(mockTsqMarkReplied).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -453,6 +453,15 @@ export class AgentRegistrationService {
 				// replied_completed so the recovery loop on the next restart
 				// does not re-enqueue this inbound message. Without this, every
 				// backend restart would cause orc to re-reply.
+				//
+				// Race-protection: build the thread-status entry on the fly if
+				// it isn't tracked yet. The Slack listener's `trackInbound` is
+				// what normally populates the entry, but in a startup-race
+				// scenario the agent finish event can land before the listener
+				// has persisted the inbound. Without this fallback,
+				// `markReplied` short-circuits and the recovery loop on the
+				// next boot still re-fires the inbound (the exact bug
+				// /slack/send already guards against — keep parity).
 				if (slackContext.threadTs) {
 					try {
 						const { ThreadStatusQueueService } = await import(
@@ -460,9 +469,15 @@ export class AgentRegistrationService {
 						);
 						const tsq = ThreadStatusQueueService.getInstance();
 						const threadKey = `${slackContext.channelId}:${slackContext.threadTs}`;
-						if (tsq.get(threadKey)) {
-							tsq.markReplied(threadKey, 'replied_completed');
+						if (!tsq.get(threadKey)) {
+							tsq.trackInbound({
+								threadKey,
+								conversationId: `slack-${slackContext.channelId}-${String(slackContext.threadTs).replace('.', '-')}`,
+								source: 'slack',
+								messagePreview: '[in-process auto-route — no inbound recorded]',
+							});
 						}
+						tsq.markReplied(threadKey, 'replied_completed');
 					} catch (err) {
 						this.logger.debug('Failed to update thread-status after auto-route (non-fatal)', {
 							sessionName,

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -377,6 +377,132 @@ export class AgentRegistrationService {
 	}
 
 	/**
+	 * Auto-route an in-process agent's text response back to Slack.
+	 *
+	 * Mirrors the post-send side effects of POST /slack/send so that the
+	 * Slack reply, thread-status bookkeeping, and V3 SLA cascade all stay in
+	 * sync. Used as a finish-event hook for the in-process Crewly Agent
+	 * runtime when:
+	 *   1. The inbound message carried a `[SLACK:channelId:threadTs]` marker
+	 *   2. The agent produced text output (`result.text` non-empty)
+	 *   3. The agent did NOT explicitly call the `reply_slack` tool
+	 *
+	 * Without this hook, AI SDK agents that finish with `toolCalls=0,
+	 * finishReason=stop` would drop their reply on the floor — unlike the
+	 * claude-code PTY path, the in-process runtime has no stdout stream the
+	 * SlackBridge can tail.
+	 *
+	 * Best-effort: a Slack-not-connected condition or a downstream
+	 * bookkeeping failure is logged and swallowed; never throws. The chat
+	 * route (`routeInProcessResponseToChat`) handles persistence to the chat
+	 * service separately.
+	 *
+	 * @param sessionName - Agent session that produced the response
+	 * @param text - Response text from the agent
+	 * @param slackContext - Slack channel + thread metadata captured from the
+	 *                       inbound `[SLACK:channelId:threadTs]` marker
+	 */
+	private routeInProcessResponseToSlack(
+		sessionName: string,
+		text: string,
+		slackContext: { channelId: string; threadTs?: string },
+	): void {
+		// Lazy import to avoid module-load circular dependency between
+		// agent-registration ↔ slack ↔ messaging ↔ v3.
+		import('../slack/slack.service.js')
+			.then(async ({ getSlackService }) => {
+				const slack = getSlackService();
+				if (!slack.isConnected()) {
+					this.logger.warn('Slack not connected — cannot auto-route in-process agent response', {
+						sessionName,
+						channelId: slackContext.channelId,
+						threadTs: slackContext.threadTs,
+						textLength: text.length,
+					});
+					return;
+				}
+
+				// Auto-prefix with the agent display name (mirrors reply_slack tool
+				// behavior) so the message is attributable in the Slack thread.
+				// Skip if the text already starts with `[` — the agent supplied its
+				// own prefix.
+				let cleanText = text;
+				if (sessionName && !cleanText.startsWith('[')) {
+					const parts = sessionName.split('-');
+					const namePart = parts.length >= 3 ? parts[2] : parts[parts.length - 1];
+					if (namePart) {
+						const capitalized = namePart.charAt(0).toUpperCase() + namePart.slice(1);
+						cleanText = `[${capitalized}] ${cleanText}`;
+					}
+				}
+
+				await slack.sendMessage({
+					channelId: slackContext.channelId,
+					text: cleanText,
+					threadTs: slackContext.threadTs,
+				});
+
+				this.logger.info('Auto-routed in-process agent response to Slack', {
+					sessionName,
+					channelId: slackContext.channelId,
+					threadTs: slackContext.threadTs,
+					textLength: cleanText.length,
+				});
+
+				// Mirror /slack/send bookkeeping #1 — mark thread as
+				// replied_completed so the recovery loop on the next restart
+				// does not re-enqueue this inbound message. Without this, every
+				// backend restart would cause orc to re-reply.
+				if (slackContext.threadTs) {
+					try {
+						const { ThreadStatusQueueService } = await import(
+							'../messaging/thread-status-queue.service.js'
+						);
+						const tsq = ThreadStatusQueueService.getInstance();
+						const threadKey = `${slackContext.channelId}:${slackContext.threadTs}`;
+						if (tsq.get(threadKey)) {
+							tsq.markReplied(threadKey, 'replied_completed');
+						}
+					} catch (err) {
+						this.logger.debug('Failed to update thread-status after auto-route (non-fatal)', {
+							sessionName,
+							error: err instanceof Error ? err.message : String(err),
+						});
+					}
+				}
+
+				// Mirror /slack/send bookkeeping #2 — fire the V3 SLA cascade so
+				// the matching Request transitions out of `queued`. Without
+				// this, requests whose acknowledgement came via this auto-route
+				// would never reach a terminal state.
+				if (slackContext.threadTs) {
+					try {
+						const { getRequestSlaSubscriber } = await import(
+							'../v3/request-sla.subscriber.js'
+						);
+						const sub = getRequestSlaSubscriber();
+						if (sub) {
+							await sub.markResolvedByThread(slackContext.threadTs);
+						}
+					} catch (err) {
+						this.logger.debug('Failed to fire SLA cascade after auto-route (non-fatal)', {
+							sessionName,
+							error: err instanceof Error ? err.message : String(err),
+						});
+					}
+				}
+			})
+			.catch((err) => {
+				this.logger.warn('Failed to auto-route in-process agent response to Slack', {
+					sessionName,
+					channelId: slackContext.channelId,
+					threadTs: slackContext.threadTs,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			});
+	}
+
+	/**
 	 * Find the project root by looking for package.json
 	 */
 	private findProjectRoot(): string {
@@ -3057,6 +3183,26 @@ Loop until done, blocked, or explicitly reassigned:
 							this.logger.debug('Skipping chat routing — agent already replied via reply_slack', {
 								sessionName, conversationId: incomingConversationId,
 							});
+						}
+
+						// Auto-route to Slack when the message originated from Slack and the
+						// agent finished with text-only output (toolCalls=0, finishReason=stop)
+						// without explicitly invoking the reply_slack tool. Without this hook,
+						// the in-process AI SDK runtime drops Slack replies silently — unlike
+						// claude-code PTY where TerminalGateway tails stdout into SlackBridge,
+						// the in-process runtime has no stream the bridge can listen to.
+						//
+						// Skipped when the agent already called reply_slack (which posts via
+						// /slack/send) to prevent double-posting on the same thread.
+						if (slackMetadata?.channelId && result.text && !agentAlreadyReplied) {
+							this.routeInProcessResponseToSlack(
+								sessionName,
+								result.text,
+								{
+									channelId: slackMetadata.channelId,
+									threadTs: slackMetadata.threadTs,
+								},
+							);
 						}
 					})
 					.catch(async (agentError) => {

--- a/backend/src/services/agent/idle-detection.service.test.ts
+++ b/backend/src/services/agent/idle-detection.service.test.ts
@@ -486,4 +486,93 @@ describe('IdleDetectionService', () => {
 			expect(mockKillSession).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('tick observability (re-entrancy guard + heartbeat)', () => {
+		it('should expose initial stats including new forcedResetCount field', () => {
+			const service = IdleDetectionService.getInstance();
+			expect(service.getStats()).toEqual({
+				isRunning: false,
+				isChecking: false,
+				lastTickStartedAt: null,
+				lastTickCompletedAt: null,
+				lastTickDurationMs: null,
+				consecutiveSkippedTicks: 0,
+				forcedResetCount: 0,
+			});
+		});
+
+		it('should skip overlapping ticks via re-entrancy guard (real exercise)', () => {
+			// Make performCheck hang so the first tick stays in flight.
+			let releaseHang: () => void = () => {};
+			mockGetTeams.mockReturnValue(
+				new Promise<unknown[]>(resolve => {
+					releaseHang = () => resolve([]);
+				}),
+			);
+
+			const service = IdleDetectionService.getInstance();
+			const runTick = (service as any).runTick.bind(service) as () => void;
+
+			// First call: starts a real tick, isChecking flips to true,
+			// and the hang holds it there.
+			runTick();
+			expect(service.getStats().isChecking).toBe(true);
+			expect(service.getStats().consecutiveSkippedTicks).toBe(0);
+
+			// Second call within the stuck-threshold: must short-circuit
+			// (not increment further into a new tick) AND must increment
+			// the skipped-tick counter — this is the assertion the
+			// previous test missed.
+			runTick();
+			expect(service.getStats().consecutiveSkippedTicks).toBe(1);
+			expect(service.getStats().isChecking).toBe(true);
+
+			// Third call still within threshold: counter keeps climbing.
+			runTick();
+			expect(service.getStats().consecutiveSkippedTicks).toBe(2);
+
+			// Cleanup so we don't leak the pending promise.
+			releaseHang();
+		});
+
+		it('should force-reset isChecking when a tick has been hung past the stuck threshold', () => {
+			// Hang the first tick indefinitely.
+			let releaseHang: () => void = () => {};
+			mockGetTeams.mockReturnValue(
+				new Promise<unknown[]>(resolve => {
+					releaseHang = () => resolve([]);
+				}),
+			);
+
+			const service = IdleDetectionService.getInstance();
+			const runTick = (service as any).runTick.bind(service) as () => void;
+
+			runTick();
+			expect(service.getStats().isChecking).toBe(true);
+
+			// Fast-forward perceived clock past 3× interval. We can't
+			// move `Date.now()` via fake timers without `modern` mode;
+			// instead we backdate `lastTickStartedAt` to simulate
+			// elapsed time.
+			const oldStart = service.getStats().lastTickStartedAt!;
+			const stuckBy = AGENT_SUSPEND_CONSTANTS.IDLE_CHECK_INTERVAL_MS * 3 + 1000;
+			(service as any).lastTickStartedAt = oldStart - stuckBy;
+
+			runTick();
+			// Watchdog fired: isChecking flipped to false (and a fresh
+			// tick was scheduled, which then re-set isChecking to true).
+			expect(service.getStats().forcedResetCount).toBe(1);
+
+			releaseHang();
+		});
+
+		it('should never let a thrown error in performCheck stop the timer', async () => {
+			mockGetTeams.mockRejectedValueOnce(new Error('boom'));
+			const service = IdleDetectionService.getInstance();
+
+			// performCheck swallows storage errors internally (returns void).
+			// The tick wrapper additionally catches anything that escapes.
+			await expect(service.performCheck()).resolves.toBeUndefined();
+		});
+	});
 });

--- a/backend/src/services/agent/idle-detection.service.ts
+++ b/backend/src/services/agent/idle-detection.service.ts
@@ -32,6 +32,15 @@ export class IdleDetectionService {
 	private timer: ReturnType<typeof setInterval> | null = null;
 	private agentRegistrationService: AgentRegistrationService | null = null;
 
+	// Observability: surfaces silent hangs that previously caused the
+	// loop to "stop" for hours with no log evidence (2026-05-14 incident).
+	private isChecking = false;
+	private lastTickStartedAt: number | null = null;
+	private lastTickCompletedAt: number | null = null;
+	private lastTickDurationMs: number | null = null;
+	private consecutiveSkippedTicks = 0;
+	private forcedResetCount = 0;
+
 	private constructor() {
 		this.logger = LoggerService.getInstance().createComponentLogger('IdleDetection');
 	}
@@ -81,12 +90,120 @@ export class IdleDetectionService {
 		});
 
 		this.timer = setInterval(() => {
-			this.performCheck().catch(err => {
+			this.runTick();
+		}, AGENT_SUSPEND_CONSTANTS.IDLE_CHECK_INTERVAL_MS);
+	}
+
+	/**
+	 * Wrapper around `performCheck` that adds re-entrancy guard, heartbeat
+	 * logging, and duration tracking. Defensive against silent hangs — if
+	 * `performCheck` ever stops resolving (e.g., dependency hangs), the
+	 * `isChecking` guard prevents overlapping invocations from piling up,
+	 * and `consecutiveSkippedTicks` makes the stuck state observable.
+	 *
+	 * Why: on 2026-05-14 the loop stopped producing logs for 21 hours while
+	 * the timer was still scheduled. Without a per-tick heartbeat the
+	 * regression was invisible.
+	 */
+	private runTick(): void {
+		if (this.isChecking) {
+			this.consecutiveSkippedTicks++;
+			const elapsedMs = this.lastTickStartedAt ? Date.now() - this.lastTickStartedAt : 0;
+
+			// Self-heal watchdog: if a tick has been "in flight" for
+			// significantly longer than the configured tick interval, the
+			// previous `performCheck` is almost certainly hung on an
+			// upstream dependency that never resolves (e.g., a
+			// `getWorkingStatusForSession` that silently never settles —
+			// the 2026-05-14 incident shape). Re-entrancy guard alone is
+			// insufficient: every subsequent tick is just dropped while
+			// the system makes zero progress.
+			//
+			// Threshold = 3 × IDLE_CHECK_INTERVAL_MS. Tight enough that a
+			// genuinely slow but eventual completion (e.g., 1.5×
+			// interval) is not falsely flagged; loose enough that a real
+			// hang surfaces within ~6 minutes at the 2-minute default.
+			//
+			// Recovery action: force-reset `isChecking` and log at error
+			// level. We accept the small risk that the still-running
+			// previous tick later resolves into stale stats — that's
+			// strictly better than wedging the loop indefinitely.
+			const stuckThresholdMs = AGENT_SUSPEND_CONSTANTS.IDLE_CHECK_INTERVAL_MS * 3;
+			if (elapsedMs > stuckThresholdMs) {
+				this.forcedResetCount++;
+				this.logger.error('Idle check tick appears hung — force-resetting guard', {
+					elapsedMs,
+					stuckThresholdMs,
+					consecutiveSkippedTicks: this.consecutiveSkippedTicks,
+					forcedResetCount: this.forcedResetCount,
+					lastTickStartedAt: this.lastTickStartedAt
+						? new Date(this.lastTickStartedAt).toISOString()
+						: null,
+				});
+				this.isChecking = false;
+				// Fall through to start a fresh tick this cycle.
+			} else {
+				this.logger.warn('Idle check skipped — previous tick still running', {
+					consecutiveSkippedTicks: this.consecutiveSkippedTicks,
+					lastTickStartedAt: this.lastTickStartedAt
+						? new Date(this.lastTickStartedAt).toISOString()
+						: null,
+					elapsedMs,
+				});
+				return;
+			}
+		}
+
+		this.isChecking = true;
+		this.consecutiveSkippedTicks = 0;
+		this.lastTickStartedAt = Date.now();
+		this.logger.debug('Idle check tick started');
+
+		this.performCheck()
+			.then(() => {
+				this.lastTickCompletedAt = Date.now();
+				this.lastTickDurationMs = this.lastTickCompletedAt - (this.lastTickStartedAt ?? this.lastTickCompletedAt);
+				this.logger.debug('Idle check tick completed', {
+					durationMs: this.lastTickDurationMs,
+				});
+			})
+			.catch((err: unknown) => {
+				this.lastTickCompletedAt = Date.now();
+				this.lastTickDurationMs = this.lastTickCompletedAt - (this.lastTickStartedAt ?? this.lastTickCompletedAt);
 				this.logger.error('Idle check cycle failed', {
 					error: err instanceof Error ? err.message : String(err),
+					durationMs: this.lastTickDurationMs,
 				});
+			})
+			.finally(() => {
+				this.isChecking = false;
 			});
-		}, AGENT_SUSPEND_CONSTANTS.IDLE_CHECK_INTERVAL_MS);
+	}
+
+	/**
+	 * Snapshot of recent tick activity. Used by health/status endpoints
+	 * to detect a silently stuck loop without parsing logs.
+	 *
+	 * @returns Tick observability stats. All timestamps in epoch ms.
+	 */
+	getStats(): {
+		isRunning: boolean;
+		isChecking: boolean;
+		lastTickStartedAt: number | null;
+		lastTickCompletedAt: number | null;
+		lastTickDurationMs: number | null;
+		consecutiveSkippedTicks: number;
+		forcedResetCount: number;
+	} {
+		return {
+			isRunning: this.isRunning(),
+			isChecking: this.isChecking,
+			lastTickStartedAt: this.lastTickStartedAt,
+			lastTickCompletedAt: this.lastTickCompletedAt,
+			lastTickDurationMs: this.lastTickDurationMs,
+			consecutiveSkippedTicks: this.consecutiveSkippedTicks,
+			forcedResetCount: this.forcedResetCount,
+		};
 	}
 
 	/**

--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -916,5 +916,144 @@ describe('LiveReconcilerDataProvider', () => {
       expect(mockSuspend.rehydrateAgent).toHaveBeenCalledWith('agent-max');
 
     });
+
+    describe('system:memory_pressure broadcast', () => {
+      // Sustained memory pressure should reach orc via EventBus so the
+      // user gets a "system memory critical" notice instead of silent
+      // stall (2026-05-14 incident: 20h, zero user-facing signal).
+
+      const buildAtFloorTeams = () => [
+        {
+          id: 't1',
+          members: [
+            { id: 'm1', sessionName: 's1', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            { id: 'm2', sessionName: 's2', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            { id: 'm3', sessionName: 's3', agentStatus: 'active', role: 'dev', updatedAt: '' },
+          ],
+        },
+      ];
+
+      const buildAction = (): WakeAction => ({
+        workItemId: 'wi-1',
+        agentSessionName: 'agent-max',
+        strategy: 'rehydrate',
+        score: 75,
+        scoreBreakdown: { skillMatch: 40, urgency: 15, contextFamiliarity: 20, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+      });
+
+      it('does NOT publish on the first few skips (transient pressure is silenced)', async () => {
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000); // 95% used
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+
+        const publish = jest.fn();
+        provider.setEventBus({ publish } as any);
+
+        // Below the FIRST_FIRE_THRESHOLD (5)
+        for (let i = 0; i < 4; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+
+        expect(publish).not.toHaveBeenCalled();
+      });
+
+      it('publishes once sustained pressure crosses the threshold', async () => {
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+
+        const publish = jest.fn();
+        provider.setEventBus({ publish } as any);
+
+        for (let i = 0; i < 5; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+
+        expect(publish).toHaveBeenCalledTimes(1);
+        const event = publish.mock.calls[0][0];
+        expect(event.type).toBe('system:memory_pressure');
+        expect(event.sessionName).toBe('system');
+        expect(event.newValue).toBe('critical');
+      });
+
+      it('throttles re-fire — does not republish within the refire window', async () => {
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+
+        const publish = jest.fn();
+        provider.setEventBus({ publish } as any);
+
+        // Cross the threshold, then keep skipping — only one event fires
+        for (let i = 0; i < 50; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+
+        expect(publish).toHaveBeenCalledTimes(1);
+      });
+
+      it('resets state when pressure clears, allowing a fresh first-fire on re-entry', async () => {
+        const publish = jest.fn();
+        provider.setEventBus({ publish } as any);
+
+        // Episode 1: pressure on, cross threshold → one event
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+        for (let i = 0; i < 5; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+        expect(publish).toHaveBeenCalledTimes(1);
+
+        // Pressure clears
+        mockFreemem.mockReturnValue(8_000_000_000); // 50% used
+        mockSuspend.isSuspended.mockReturnValue(true);
+        await provider.executeWakeAction(buildAction());
+
+        // Episode 2: pressure returns, must cross threshold again before firing
+        mockFreemem.mockReturnValue(800_000_000);
+        for (let i = 0; i < 4; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+        expect(publish).toHaveBeenCalledTimes(1); // still only episode 1
+
+        await provider.executeWakeAction(buildAction()); // 5th skip
+        expect(publish).toHaveBeenCalledTimes(2);
+      });
+
+      it('is a no-op when no EventBus has been wired', async () => {
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+
+        // No setEventBus call
+        for (let i = 0; i < 10; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+        // No throw, no crash — pure no-op observable only via the
+        // absence of additional logger warnings, which we don't assert
+        // here. The contract is "must not throw".
+      });
+
+      it('survives an EventBus publish failure without breaking the reconciler', async () => {
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+
+        const publish = jest.fn(() => {
+          throw new Error('bus down');
+        });
+        provider.setEventBus({ publish } as any);
+
+        for (let i = 0; i < 5; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+
+        // We attempted to publish (the throw was thrown) but the wake
+        // path still returned cleanly without surfacing the error.
+        expect(publish).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -29,6 +29,7 @@ import { AgentSuspendService } from '../agent/agent-suspend.service.js';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { TokenUsageService } from '../monitoring/token-usage.service.js';
 import { isUnderMemoryPressure, getMemoryStats } from '../core/system-health.util.js';
+import type { EventBusService } from '../event-bus/event-bus.service.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -102,16 +103,28 @@ function isStorageNotReadyError(error: unknown): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Minimum concurrent active agents allowed even under memory pressure.
+ * Cap on concurrent active agents while the system is under memory
+ * pressure. Named `WAKE_FLOOR` for historical reasons — the value
+ * acts as a CEILING on wake actions under pressure, not a guaranteed
+ * floor. The reconciler does not proactively bring the active count
+ * up to this value; it only permits wakes when `activeCount < N` and
+ * blocks them otherwise.
  *
- * When `isUnderMemoryPressure()` returns true, the reconciler previously
- * blocked every wake action — which wedged the entire system whenever
- * free RAM stayed low (2026-05-13 dogfood: 6+ hours stuck). New
- * behaviour: keep up to this many agents alive so something is always
- * making progress; only block wakes beyond the floor. Set low enough
- * that the OOM-prevention intent is preserved (3 active agents at
- * crisis pressure is far below the 90%-threshold tipping point that
- * blocks unbounded spawns).
+ * Behaviour:
+ *  - `activeCount <  N` AND memory pressure → wake allowed (keeps the
+ *    system minimally productive instead of fully wedged).
+ *  - `activeCount >= N` AND memory pressure → wake blocked (prevents
+ *    an OOM cascade by capping additional spawns during a crisis).
+ *  - No memory pressure → this gate is not consulted.
+ *
+ * History: an earlier implementation blocked EVERY wake under memory
+ * pressure, which wedged the system on 2026-05-13 (6+ hours, free RAM
+ * 16-33 MB, queued WIs piling up). On 2026-05-14 the system stalled
+ * again — this gate worked as designed, but `IdleDetectionService`
+ * silently stopped releasing idle agents, so `activeCount` stayed
+ * above N for ~20 hours. The cap itself is not the bug; the absence
+ * of forward progress when the cap is held is. See the heartbeat
+ * additions in `idle-detection.service.ts`.
  */
 export const WAKE_FLOOR_UNDER_PRESSURE = 3;
 
@@ -136,10 +149,30 @@ export const WAKE_FLOOR_UNDER_PRESSURE = 3;
 export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
   private readonly logger: ComponentLogger;
   private readonly storage: StorageService;
+  private eventBus: EventBusService | null = null;
+
+  // Memory-pressure broadcast state. Per-instance to keep counters
+  // isolated, but the publish throttle ensures we don't flood orc even
+  // if multiple providers exist (each will throttle independently and
+  // EventBus deduplicates on event id).
+  private consecutivePressureSkips = 0;
+  private lastPressureNotifiedAt = 0;
 
   constructor() {
     this.logger = LoggerService.getInstance().createComponentLogger('ReconcilerDataProvider');
     this.storage = StorageService.getInstance();
+  }
+
+  /**
+   * Inject the EventBus used to broadcast `system:memory_pressure` to
+   * orc. Optional — when not set, the reconciler still functions but
+   * no user-facing notification is emitted. Called once from the
+   * server bootstrap after both services are constructed.
+   *
+   * @param eventBus - The EventBusService singleton wired in `index.ts`
+   */
+  setEventBus(eventBus: EventBusService): void {
+    this.eventBus = eventBus;
   }
 
   /**
@@ -539,6 +572,91 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
     }
   }
 
+  /**
+   * Broadcast `system:memory_pressure` to the EventBus when wake actions
+   * have been skipped enough consecutive times to indicate a sustained
+   * stall. Throttled so a long pressure episode emits at most one event
+   * per `MEMORY_PRESSURE_REFIRE_MS` window — orc only needs to surface
+   * the condition once per stuck period, not on every reconciler tick.
+   *
+   * The 2026-05-14 incident skipped wakes ~4,200 times across 20 hours
+   * with zero user-visible signal. After this change, orc receives a
+   * critical event within ~50 seconds of the stall starting and every
+   * ~5 minutes thereafter until pressure clears.
+   *
+   * @param stats - Snapshot of memory stats at the skip moment
+   * @param activeCount - Current active agent count (already computed)
+   */
+  private maybeBroadcastMemoryPressure(
+    stats: { usedPercent: number; freeMB: number },
+    activeCount: number,
+  ): void {
+    this.consecutivePressureSkips += 1;
+
+    if (!this.eventBus) {
+      return;
+    }
+
+    // First-fire threshold: 5 consecutive skips (~50s at 10s reconciler
+    // tick). Picked so a transient pressure spike that resolves on its
+    // own doesn't page orc; sustained pressure does.
+    const FIRST_FIRE_THRESHOLD = 5;
+    // Re-fire window: don't re-broadcast more often than once per 5min
+    // while pressure persists. Matches the EventBus dedup window order
+    // of magnitude and avoids spamming orc's terminal.
+    const MEMORY_PRESSURE_REFIRE_MS = 5 * 60 * 1000;
+
+    if (this.consecutivePressureSkips < FIRST_FIRE_THRESHOLD) {
+      return;
+    }
+
+    const now = Date.now();
+    if (this.lastPressureNotifiedAt > 0 && now - this.lastPressureNotifiedAt < MEMORY_PRESSURE_REFIRE_MS) {
+      return;
+    }
+
+    try {
+      this.eventBus.publish({
+        id: `system-memory-pressure-${now}`,
+        type: 'system:memory_pressure',
+        timestamp: new Date(now).toISOString(),
+        teamId: '',
+        teamName: '',
+        memberId: '',
+        memberName: 'system',
+        sessionName: 'system',
+        previousValue: 'ok',
+        newValue: 'critical',
+        changedField: 'agentStatus',
+      });
+      this.lastPressureNotifiedAt = now;
+      this.logger.warn('Broadcast system:memory_pressure to EventBus', {
+        memoryUsedPercent: stats.usedPercent,
+        freeMemMB: stats.freeMB,
+        activeAgents: activeCount,
+        consecutiveSkips: this.consecutivePressureSkips,
+      });
+    } catch (err) {
+      // Failure isolation — never let a telemetry failure break the
+      // reconciler's primary control flow.
+      this.logger.warn('Failed to broadcast system:memory_pressure (non-fatal)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Reset the memory-pressure broadcast state. Called on every wake
+   * that runs without pressure so the next sustained episode re-fires
+   * the first-time threshold instead of being silenced by stale state.
+   */
+  private resetMemoryPressureBroadcast(): void {
+    if (this.consecutivePressureSkips > 0 || this.lastPressureNotifiedAt > 0) {
+      this.consecutivePressureSkips = 0;
+      this.lastPressureNotifiedAt = 0;
+    }
+  }
+
   async executeWakeAction(action: WakeAction): Promise<boolean> {
     const { agentSessionName, strategy } = action;
 
@@ -573,6 +691,7 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
           activeAgents: activeCount,
           wakeFloor: WAKE_FLOOR_UNDER_PRESSURE,
         });
+        this.maybeBroadcastMemoryPressure(stats, activeCount);
         return false;
       }
       this.logger.info('Memory pressure detected — allowing wake (under concurrency floor)', {
@@ -583,6 +702,9 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         activeAgents: activeCount,
         wakeFloor: WAKE_FLOOR_UNDER_PRESSURE,
       });
+    } else {
+      // Pressure cleared — reset state so the next episode re-fires.
+      this.resetMemoryPressureBroadcast();
     }
 
     this.logger.info('Executing wake action', {

--- a/backend/src/types/event-bus.types.ts
+++ b/backend/src/types/event-bus.types.ts
@@ -90,6 +90,15 @@ export const EVENT_TYPES = [
   // are wiped on every restart. Treated as CRITICAL because re-arm latency
   // determines coverage gap of every trigger-dependent watchdog in the system.
   'system:backend_restarted',
+
+  // Memory pressure broadcast (2026-05-14 follow-up): emitted by the
+  // reconciler when it has skipped wake actions due to memory pressure
+  // for long enough that the user-facing system has visibly stalled.
+  // Orc subscribes so it can surface "system memory critical, X agents
+  // frozen" in its next reply instead of silently spinning. The
+  // reconciler emits with built-in throttling (no more than once per
+  // sustained pressure episode + a re-fire cap) so this never floods.
+  'system:memory_pressure',
 ] as const;
 
 /**
@@ -143,6 +152,10 @@ export const CRITICAL_EVENT_TYPES: ReadonlySet<EventType> = new Set([
   // backend-restart broadcast must NOT be debounced — coverage of every
   // trigger-dependent watchdog depends on exactly-one delivery per restart.
   'system:backend_restarted',
+  // Memory pressure is user-facing — orc surfaces it in its next reply.
+  // Debouncing here would defeat the purpose; the reconciler already
+  // throttles the emission rate at the source.
+  'system:memory_pressure',
 ]);
 
 /**

--- a/cli/src/commands/start.test.ts
+++ b/cli/src/commands/start.test.ts
@@ -218,3 +218,155 @@ describe('dynamic heap size calculation', () => {
 		expect(calculateHeapSize(mem4GB)).toBe(1638);
 	});
 });
+
+/**
+ * Tests for shutdown handler semantics (re-entry guard + await-children-before-exit).
+ * Mirrors the inline-extraction pattern above: start.ts can't be imported directly
+ * (uses import.meta.url, incompatible with Jest CJS), so the core control flow of
+ * `setupShutdownHandlers` is re-implemented here against mock ChildProcess objects.
+ *
+ * Pins the regression that motivated the fix: on 2026-05-14 the previous handler
+ * exited the parent on a fixed 1s timer while scheduling SIGKILL at 5s — the SIGKILL
+ * timer died with the parent, orphaning a backend that needed >1s for graceful exit.
+ */
+describe('shutdown handler — re-entry guard + child wait', () => {
+	type FakeChild = {
+		killed: boolean;
+		exitCode: number | null;
+		kill: jest.Mock;
+		once: jest.Mock;
+		_exitHandlers: Array<() => void>;
+	};
+
+	function makeFakeChild(): FakeChild {
+		const child: FakeChild = {
+			killed: false,
+			exitCode: null,
+			kill: jest.fn(),
+			once: jest.fn(),
+			_exitHandlers: [],
+		};
+		child.once.mockImplementation((event: string, handler: () => void) => {
+			if (event === 'exit') {
+				child._exitHandlers.push(handler);
+			}
+			return child;
+		});
+		return child;
+	}
+
+	function buildCleanup(children: FakeChild[]): {
+		cleanup: () => Promise<void>;
+		invocationCount: () => number;
+	} {
+		let cleaningUp = false;
+		let invocations = 0;
+
+		const cleanup = async (): Promise<void> => {
+			invocations++;
+			if (cleaningUp) {
+				return;
+			}
+			cleaningUp = true;
+
+			const waits: Promise<void>[] = [];
+			for (const proc of children) {
+				if (!proc || proc.killed || proc.exitCode !== null) {
+					continue;
+				}
+				waits.push(
+					new Promise<void>((resolve) => {
+						proc.once('exit', () => resolve());
+						proc.kill('SIGTERM');
+						setTimeout(() => {
+							if (!proc.killed && proc.exitCode === null) {
+								proc.kill('SIGKILL');
+							}
+						}, 5000);
+						setTimeout(() => resolve(), 8000);
+					}),
+				);
+			}
+
+			await Promise.all(waits).catch(() => {
+				/* ignore */
+			});
+			// parent would call process.exit(0) here
+		};
+
+		return { cleanup, invocationCount: () => invocations };
+	}
+
+	it('sends SIGTERM to each non-killed child', async () => {
+		const c1 = makeFakeChild();
+		const c2 = makeFakeChild();
+		const { cleanup } = buildCleanup([c1, c2]);
+
+		const pending = cleanup();
+		// Drain microtasks so the kills run
+		await new Promise((r) => setImmediate(r));
+		expect(c1.kill).toHaveBeenCalledWith('SIGTERM');
+		expect(c2.kill).toHaveBeenCalledWith('SIGTERM');
+
+		// Resolve via child exit events
+		c1._exitHandlers.forEach((h) => h());
+		c2._exitHandlers.forEach((h) => h());
+		await pending;
+	});
+
+	it('skips children that have already exited (killed=true or exitCode set)', async () => {
+		const dead = makeFakeChild();
+		dead.killed = true;
+		const live = makeFakeChild();
+		const { cleanup } = buildCleanup([dead, live]);
+
+		const pending = cleanup();
+		await new Promise((r) => setImmediate(r));
+		expect(dead.kill).not.toHaveBeenCalled();
+		expect(live.kill).toHaveBeenCalledWith('SIGTERM');
+
+		live._exitHandlers.forEach((h) => h());
+		await pending;
+	});
+
+	it('re-entry guard: second cleanup invocation is a no-op (does not re-kill)', async () => {
+		const c1 = makeFakeChild();
+		const { cleanup, invocationCount } = buildCleanup([c1]);
+
+		const p1 = cleanup();
+		await new Promise((r) => setImmediate(r));
+		// SIGTERM sent exactly once
+		expect(c1.kill).toHaveBeenCalledTimes(1);
+
+		// Second signal arriving mid-shutdown must not re-kill or duplicate work
+		const p2 = cleanup();
+		await new Promise((r) => setImmediate(r));
+		expect(c1.kill).toHaveBeenCalledTimes(1);
+		expect(invocationCount()).toBe(2); // entered twice…
+		// …but the kill was only fired once — second invocation short-circuited.
+
+		c1._exitHandlers.forEach((h) => h());
+		await Promise.all([p1, p2]);
+	});
+
+	it('parent waits for child exit before resolving (no orphan window)', async () => {
+		const c1 = makeFakeChild();
+		const { cleanup } = buildCleanup([c1]);
+
+		const pending = cleanup();
+		let parentExited = false;
+		void pending.then(() => {
+			parentExited = true;
+		});
+
+		// 100ms of real time pass with no exit event — parent must still be waiting.
+		// This is the regression-pin: the old code would have exited at 1s wall-clock
+		// regardless of whether the child had exited.
+		await new Promise((r) => setTimeout(r, 50));
+		expect(parentExited).toBe(false);
+
+		c1._exitHandlers.forEach((h) => h());
+		await pending;
+		expect(parentExited).toBe(true);
+	});
+});

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -384,30 +384,92 @@ async function waitForServer(port: number, maxAttempts: number = 30): Promise<vo
  * Set up signal handlers for graceful shutdown.
  * Uses a mutable array so the restart loop can update the active process.
  *
+ * The parent process must outlive its children long enough for the SIGKILL
+ * escalation timer to actually fire. The previous implementation exited
+ * the parent after a fixed 1s while scheduling SIGKILL at 5s — when the
+ * parent exited, the timer died with it and any backend that hadn't
+ * fully shut down in 1s was left as an orphan with PPID=1 still
+ * consuming resources. We now await each child's 'exit' event and only
+ * exit the parent once every child is gone (or 8s elapsed, whichever
+ * comes first).
+ *
+ * Re-entry: once cleanup runs, repeated signals are ignored. Without
+ * this guard, a second SIGINT during shutdown would re-run the
+ * already-in-flight kill sequence and call `process.exit(0)` twice.
+ *
  * @param activeProcesses - Mutable array of processes to kill on shutdown
  */
 function setupShutdownHandlers(activeProcesses: ChildProcess[]): void {
-	const cleanup = () => {
+	let cleaningUp = false;
+
+	const cleanup = (): void => {
+		if (cleaningUp) {
+			return;
+		}
+		cleaningUp = true;
 		console.log(chalk.yellow('\n🛑 Shutting down Crewly...'));
 
-		activeProcesses.forEach((proc) => {
-			if (proc && !proc.killed) {
-				console.log(chalk.gray(`Stopping Backend server...`));
-				proc.kill('SIGTERM');
-
-				// Force kill after 5 seconds
-				setTimeout(() => {
-					if (!proc.killed) {
-						proc.kill('SIGKILL');
-					}
-				}, 5000);
+		const waits: Promise<void>[] = [];
+		for (const proc of activeProcesses) {
+			if (!proc || proc.killed || proc.exitCode !== null) {
+				continue;
 			}
-		});
+			console.log(chalk.gray(`Stopping Backend server...`));
 
-		setTimeout(() => {
-			console.log(chalk.green('✅ Crewly stopped'));
-			process.exit(0);
-		}, 1000);
+			waits.push(
+				new Promise<void>((resolve) => {
+					let settled = false;
+					const done = (): void => {
+						if (settled) return;
+						settled = true;
+						resolve();
+					};
+
+					proc.once('exit', done);
+
+					try {
+						proc.kill('SIGTERM');
+					} catch {
+						// Child already gone — fine.
+						done();
+						return;
+					}
+
+					// Escalate to SIGKILL after 5s if SIGTERM didn't take.
+					const sigkillTimer = setTimeout(() => {
+						if (!proc.killed && proc.exitCode === null) {
+							try {
+								proc.kill('SIGKILL');
+							} catch {
+								/* already dead */
+							}
+						}
+					}, 5000);
+
+					// Hard cap on the wait so parent always exits eventually.
+					const hardTimer = setTimeout(() => {
+						console.warn(
+							chalk.red('Backend did not exit within 8s of SIGTERM; exiting parent anyway'),
+						);
+						done();
+					}, 8000);
+
+					proc.once('exit', () => {
+						clearTimeout(sigkillTimer);
+						clearTimeout(hardTimer);
+					});
+				}),
+			);
+		}
+
+		Promise.all(waits)
+			.catch(() => {
+				/* individual exits resolve, never reject */
+			})
+			.finally(() => {
+				console.log(chalk.green('✅ Crewly stopped'));
+				process.exit(0);
+			});
 	};
 
 	process.on('SIGTERM', cleanup);


### PR DESCRIPTION
## Summary

Originally scoped as a single fix for in-process Slack auto-route (commit `4acba615`). Scope expanded after the 2026-05-14 dogfood incident where the OSS system silently stalled for ~20 hours despite agents being idle. PR now bundles four related fixes that surfaced during that incident's root-cause investigation + code review.

Four commits, all additive, each independently revertible:

1. **`27dd92e2` fix(idle-detection): self-heal silent hangs + tick observability**
   - Root cause of 2026-05-14: `IdleDetectionService` produced its last log at UTC 00:15 and went silent for 21h while the timer was still scheduled — a hung `performCheck` never resolved.
   - Adds: re-entrancy guard, per-tick debug heartbeat, `getStats()` accessor for health endpoints, **self-heal watchdog** that force-resets `isChecking` when a tick has been in flight past `3 × IDLE_CHECK_INTERVAL_MS`.

2. **`bc4cb11b` feat(reconciler): emit `system:memory_pressure` event when wake skips persist**
   - Companion to #1: even when IdleDetection works, the reconciler can refuse wakes for 4,000+ ticks across hours with zero user-visible signal.
   - New event type `system:memory_pressure` (CRITICAL, not debounced). Reconciler publishes after 5 consecutive skips (~50s), re-fires throttled to once per 5min, resets on pressure clear.
   - Also fixes the misleading `WAKE_FLOOR_UNDER_PRESSURE` docstring (was \"minimum allowed\" but the impl is a cap, not a floor).
   - **Follow-up #5 from code review** (acknowledged in commit body): two `LiveReconcilerDataProvider` instances may publish independently — to be deduplicated in a separate PR.

3. **`1994dbfe` fix(agent-runtime): mirror `/slack/send` `trackInbound` semantics in auto-route**
   - Follow-up code review of `4acba615` found the post-send bookkeeping was incomplete: `markReplied` only fired when the thread-status entry already existed, but the Slack listener's `trackInbound` can land *after* the agent finish event in a startup race. Without this fix the recovery loop re-fires the inbound on next restart.
   - 6 new error-path tests pin the swallow-and-continue contract on all 4 try/catch blocks.

4. **`0c0f773c` fix(cli): await child exit before parent exit on shutdown**
   - Observed during 2026-05-14 manual restart: backend hit 96% CPU after parent exited because the SIGKILL escalation timer was scheduled at 5s but the parent exited at 1s — the timer died with it, orphaning the backend with PPID=1.
   - Parent now awaits each child's `exit` event (8s hard cap). Re-entry guard prevents double cleanup.

## Test plan

- [x] `npx tsc --noEmit -p backend/tsconfig.json` clean
- [x] `npx tsc --noEmit -p cli/tsconfig.json` clean
- [x] `npm run build:backend` clean
- [x] `npm run build:cli` clean
- [x] `idle-detection.service.test.ts` — 29/29 pass (26 existing + 3 new for re-entrancy guard + watchdog)
- [x] `reconciler-data-provider.test.ts` — Slack-pressure suite 6/6 pass; 1 unrelated pre-existing failure (`workItemId` body assertion in `start` strategy test) not introduced by this PR
- [x] `agent-registration.service.test.ts` Slack-route subset — 9/9 pass (3 existing happy-path + 6 new error-path)
- [x] `start.test.ts` — 26/26 pass (22 existing + 4 new shutdown semantics)
- [x] OSS restart on local dev: backend boots clean, `[IdleDetection] Starting idle detection service` logged within 1s of boot, `system:backend_restarted` event published, no memory-pressure warnings post-restart.

## Known follow-ups (deferred to separate PRs)

From the code review:
- **#5** Two `LiveReconcilerDataProvider` instances in `index.ts` (Reconciler + TeamHealthWatchdog) maintain independent counters — sustained pressure may emit two events. Likely fix: share the provider instance.
- **#6** `consecutivePressureSkips` is not cleared on a successful wake within a pressure episode — current behavior produces correct throttling but is logically loose.
- **#7** Two `proc.once('exit', ...)` listeners on the same child in CLI cleanup — works, but should be merged for readability.
- **#9** Slack auto-route does not emit the `agent.action` behavior-log entry that `/slack/send` does — auditor view will be missing entries.
- **#10** Hardcoded `process.env.PORT || 8787` in `reconciler-data-provider.ts:732,734` — pre-existing, violates CLAUDE.md constants policy.

## Hard evidence (original demo-blocker, still applies to commit 4acba615)

\`\`\`
01:23:48.708 [SlackBridge] Received message       preview=\"你好\"
01:23:48.949 [AgentRegistrationService] Message dispatched to in-process Crewly Agent
01:23:52.660 [CrewlyAgentRuntimeService] Message processed | steps=1, toolCalls=0, finishReason=stop
01:23:52.662 [AgentRegistrationService] Crewly Agent finished processing message | responseLength=101
                                                       ← silence; no SlackBridge outbound
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)