### PR TITLE
chore: follow-ups from PR #543 review (#5, #6, #7, #9, #10)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -595,6 +595,18 @@ export class CrewlyServer {
 			}
 		});
 
+		// Shared LiveReconcilerDataProvider instance used by both the
+		// Reconciler service and the TeamHealthWatchdog data provider.
+		// Sharing is required so the memory-pressure broadcast state
+		// (`consecutivePressureSkips` / `lastPressureNotifiedAt`) is
+		// counted ONCE per sustained pressure episode. Two separate
+		// instances would each cross the 5-skip threshold around the same
+		// time and publish two `system:memory_pressure` events with
+		// distinct `event.id` values (no debounce match), so orc would
+		// receive duplicates. See follow-up #5 from PR #543 review.
+		const liveDataProvider = new LiveReconcilerDataProvider();
+		liveDataProvider.setEventBus(this.eventBusService);
+
 		// Initialize Reconciler Service (V2 — system truth recomputation)
 		{
 			const reconcilerLogger = LoggerService.getInstance().createComponentLogger('ReconcilerInit');
@@ -602,11 +614,6 @@ export class CrewlyServer {
 			// Live data provider — connects Reconciler to Task Pool, Claim Service,
 			// Storage Service, and Agent Suspend for real reconciliation including
 			// Hybrid Wake (auto-rehydrating suspended agents when tasks go unclaimed).
-			const liveDataProvider = new LiveReconcilerDataProvider();
-			// Wire EventBus so the provider can broadcast `system:memory_pressure`
-			// when wake actions are sustained-skipped due to memory pressure.
-			liveDataProvider.setEventBus(this.eventBusService);
-
 			this.reconcilerService = new ReconcilerService(liveDataProvider);
 			setReconcilerService(this.reconcilerService);
 
@@ -657,10 +664,11 @@ export class CrewlyServer {
 				} else if (!this.reconcilerService) {
 					thwLogger.warn('Reconciler not available; skipping TeamHealthWatchdog init.');
 				} else {
-					const reconcilerProvider = new LiveReconcilerDataProvider();
-					reconcilerProvider.setEventBus(this.eventBusService);
+					// Reuse the shared LiveReconcilerDataProvider declared
+					// above (follow-up #5 from PR #543 review) — instantiating
+					// a second copy would double-broadcast memory-pressure.
 					const dataProvider = new LiveTeamHealthDataProvider({
-						reconcilerProvider,
+						reconcilerProvider: liveDataProvider,
 						getTeams: async () => StorageService.getInstance().getTeams(),
 						bootedAt: new Date(),
 					});

--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -121,6 +121,13 @@ jest.mock('../v3/request-sla.subscriber.js', () => ({
 	})),
 }));
 
+const mockBehaviorLogRecord = jest.fn();
+jest.mock('../observability/agent-behavior-log.singleton.js', () => ({
+	getAgentBehaviorLogService: jest.fn(() => ({
+		record: mockBehaviorLogRecord,
+	})),
+}));
+
 jest.mock('./oauth-relogin-monitor.service.js', () => ({
 	OAuthReloginMonitorService: {
 		getInstance: jest.fn().mockReturnValue({
@@ -3866,6 +3873,7 @@ describe('AgentRegistrationService', () => {
 			mockTsqTrackInbound.mockReset();
 			mockTsqMarkReplied.mockReset();
 			mockMarkResolvedByThread.mockReset().mockResolvedValue(undefined);
+			mockBehaviorLogRecord.mockReset();
 		});
 
 		const flushAsync = async (): Promise<void> => {
@@ -3969,6 +3977,51 @@ describe('AgentRegistrationService', () => {
 
 			expect(mockTsqTrackInbound).not.toHaveBeenCalled();
 			expect(mockTsqMarkReplied).toHaveBeenCalledTimes(1);
+		});
+
+		// Follow-up #9 from PR #543 review. /slack/send records an
+		// `agent.action` row on every successful send; the in-process
+		// auto-route was missing this, so audit views silently lost the
+		// auto-routed branch of agent replies.
+		it('records an agent.action behavior-log row after successful send', async () => {
+			invoke({ channelId: 'C-AUDIT', threadTs: '1700000000.000222' });
+			await flushAsync();
+
+			expect(mockBehaviorLogRecord).toHaveBeenCalledTimes(1);
+			const event = mockBehaviorLogRecord.mock.calls[0][0];
+			expect(event).toMatchObject({
+				type: 'agent.action',
+				agent: 'crewly-orc',
+				actionType: 'send_slack',
+			});
+			expect(event.details).toMatchObject({
+				channelId: 'C-AUDIT',
+				threadTs: '1700000000.000222',
+				source: 'in_process_auto_route',
+			});
+		});
+
+		it('does NOT record agent.action when the Slack send failed', async () => {
+			mockSlackSendMessage.mockRejectedValueOnce(new Error('slack 5xx'));
+
+			invoke();
+			await flushAsync();
+
+			expect(mockSlackSendMessage).toHaveBeenCalledTimes(1);
+			expect(mockBehaviorLogRecord).not.toHaveBeenCalled();
+		});
+
+		it('survives behavior-log record failure (audit is best-effort)', async () => {
+			mockBehaviorLogRecord.mockImplementationOnce(() => {
+				throw new Error('sqlite locked');
+			});
+
+			expect(() => invoke()).not.toThrow();
+			await flushAsync();
+
+			// Downstream SLA cascade still ran — the audit failure is
+			// non-fatal and must not break the bookkeeping chain.
+			expect(mockMarkResolvedByThread).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -449,6 +449,34 @@ export class AgentRegistrationService {
 					textLength: cleanText.length,
 				});
 
+				// Mirror /slack/send bookkeeping #3 — record `agent.action`
+				// with actionType='send_slack' so the auditor view and any
+				// V3 downstream analysis see the auto-routed reply. Without
+				// this entry the in-process auto-route is invisible in the
+				// behavior log (only `/slack/send`-originated replies show
+				// up). Follow-up #9 from PR #543 review.
+				try {
+					const { getAgentBehaviorLogService } = await import(
+						'../observability/agent-behavior-log.singleton.js'
+					);
+					getAgentBehaviorLogService()?.record({
+						type: 'agent.action',
+						agent: sessionName,
+						actionType: 'send_slack',
+						details: {
+							channelId: slackContext.channelId,
+							threadTs: slackContext.threadTs ?? null,
+							textLength: cleanText.length,
+							source: 'in_process_auto_route',
+						},
+					});
+				} catch (err) {
+					this.logger.debug('Failed to record send_slack agent.action (non-fatal)', {
+						sessionName,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
+
 				// Mirror /slack/send bookkeeping #1 — mark thread as
 				// replied_completed so the recovery loop on the next restart
 				// does not re-enqueue this inbound message. Without this, every

--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -1036,6 +1036,53 @@ describe('LiveReconcilerDataProvider', () => {
         // here. The contract is "must not throw".
       });
 
+      it('clears the skip counter on a successful wake under pressure (skip→wake→skip cannot accumulate)', async () => {
+        // Follow-up #6 from PR #543 review. Without this contract, a
+        // pressure episode that oscillates between "at floor → wake →
+        // back at floor" would let `consecutivePressureSkips` keep
+        // climbing across the wake events, producing an extra event
+        // each time the throttle window opens.
+        const publish = jest.fn();
+        provider.setEventBus({ publish } as any);
+
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+
+        // Phase 1: 4 skips at floor — below threshold, no fire yet.
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+        for (let i = 0; i < 4; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+        expect(publish).not.toHaveBeenCalled();
+
+        // Phase 2: active count drops below floor → one successful
+        // wake — this MUST reset the skip counter.
+        mockStorage.getTeams.mockResolvedValueOnce([
+          {
+            id: 't1',
+            members: [
+              { id: 'm1', sessionName: 's1', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            ],
+          },
+        ]);
+        mockSuspend.isSuspended.mockReturnValue(true);
+        mockSuspend.rehydrateAgent.mockResolvedValue(true);
+        await provider.executeWakeAction(buildAction());
+
+        // Phase 3: back at floor, 4 more skips. Pre-fix this would
+        // bring the running total to 8 (≥ threshold of 5) and trigger
+        // a publish. With the fix it's only 4 — still below threshold.
+        mockStorage.getTeams.mockResolvedValue(buildAtFloorTeams());
+        for (let i = 0; i < 4; i++) {
+          await provider.executeWakeAction(buildAction());
+        }
+        expect(publish).not.toHaveBeenCalled();
+
+        // Phase 4: 5th skip after the reset finally crosses threshold.
+        await provider.executeWakeAction(buildAction());
+        expect(publish).toHaveBeenCalledTimes(1);
+      });
+
       it('survives an EventBus publish failure without breaking the reconciler', async () => {
         mockTotalmem.mockReturnValue(16_000_000_000);
         mockFreemem.mockReturnValue(800_000_000);

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -30,6 +30,7 @@ import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { TokenUsageService } from '../monitoring/token-usage.service.js';
 import { isUnderMemoryPressure, getMemoryStats } from '../core/system-health.util.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
+import { WEB_CONSTANTS } from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -702,6 +703,13 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         activeAgents: activeCount,
         wakeFloor: WAKE_FLOOR_UNDER_PRESSURE,
       });
+      // Pressure persists but a wake is proceeding — clear the skip
+      // counter so the FIRST_FIRE_THRESHOLD must be crossed again
+      // before the next broadcast. Keep `lastPressureNotifiedAt` so
+      // the 5min refire throttle still applies — we don't want the
+      // skip→wake→skip oscillation to slip past the throttle window.
+      // (Follow-up #6 from PR #543 review.)
+      this.consecutivePressureSkips = 0;
     } else {
       // Pressure cleared — reset state so the next episode re-fires.
       this.resetMemoryPressureBroadcast();
@@ -729,9 +737,14 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         // The agent session creation is complex — use the team-member-start API endpoint.
         const { teamId, memberId } = action;
 
-        let url = `http://localhost:${process.env.PORT || 8787}/api/teams/members/start`;
+        // Follow-up #10 from PR #543 review: replace the hardcoded
+        // 8787 with the canonical backend port constant. `process.env.PORT`
+        // still wins when set so deployments overriding the default keep
+        // working unchanged.
+        const port = process.env.PORT || WEB_CONSTANTS.PORTS.BACKEND;
+        let url = `http://localhost:${port}/api/teams/members/start`;
         if (teamId && memberId) {
-          url = `http://localhost:${process.env.PORT || 8787}/api/teams/${teamId}/members/${memberId}/start`;
+          url = `http://localhost:${port}/api/teams/${teamId}/members/${memberId}/start`;
         }
 
         // Pass `workItemId` so the team-controller wake-gate can verify

--- a/cli/src/commands/start.test.ts
+++ b/cli/src/commands/start.test.ts
@@ -276,14 +276,26 @@ describe('shutdown handler — re-entry guard + child wait', () => {
 				}
 				waits.push(
 					new Promise<void>((resolve) => {
-						proc.once('exit', () => resolve());
+						let settled = false;
+						let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
+						let hardTimer: ReturnType<typeof setTimeout> | null = null;
+
+						const done = (): void => {
+							if (settled) return;
+							settled = true;
+							if (sigkillTimer) clearTimeout(sigkillTimer);
+							if (hardTimer) clearTimeout(hardTimer);
+							resolve();
+						};
+
+						proc.once('exit', done);
 						proc.kill('SIGTERM');
-						setTimeout(() => {
+						sigkillTimer = setTimeout(() => {
 							if (!proc.killed && proc.exitCode === null) {
 								proc.kill('SIGKILL');
 							}
 						}, 5000);
-						setTimeout(() => resolve(), 8000);
+						hardTimer = setTimeout(() => done(), 8000);
 					}),
 				);
 			}
@@ -347,6 +359,27 @@ describe('shutdown handler — re-entry guard + child wait', () => {
 
 		c1._exitHandlers.forEach((h) => h());
 		await Promise.all([p1, p2]);
+	});
+
+	it('registers exactly one "exit" listener per child (follow-up #7)', async () => {
+		// Previously the cleanup function called `proc.once('exit', ...)`
+		// twice per child (once to resolve the wait, once to clear the
+		// timers). That doubled listener registrations, which on a child
+		// with prior listeners can trip Node's MaxListenersExceededWarning.
+		// Now there is a single listener that handles both responsibilities.
+		const c1 = makeFakeChild();
+		const { cleanup } = buildCleanup([c1]);
+
+		const pending = cleanup();
+		await new Promise((r) => setImmediate(r));
+
+		const exitRegistrations = c1.once.mock.calls.filter(
+			(call: unknown[]) => call[0] === 'exit',
+		);
+		expect(exitRegistrations).toHaveLength(1);
+
+		c1._exitHandlers.forEach((h) => h());
+		await pending;
 	});
 
 	it('parent waits for child exit before resolving (no orphan window)', async () => {

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -419,9 +419,18 @@ function setupShutdownHandlers(activeProcesses: ChildProcess[]): void {
 			waits.push(
 				new Promise<void>((resolve) => {
 					let settled = false;
+					// Timers are declared in the outer closure so the
+					// single `exit` listener can clear them. Avoids the
+					// earlier double `proc.once('exit', ...)` registration
+					// pattern (follow-up #7 from PR #543 review).
+					let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
+					let hardTimer: ReturnType<typeof setTimeout> | null = null;
+
 					const done = (): void => {
 						if (settled) return;
 						settled = true;
+						if (sigkillTimer) clearTimeout(sigkillTimer);
+						if (hardTimer) clearTimeout(hardTimer);
 						resolve();
 					};
 
@@ -436,7 +445,7 @@ function setupShutdownHandlers(activeProcesses: ChildProcess[]): void {
 					}
 
 					// Escalate to SIGKILL after 5s if SIGTERM didn't take.
-					const sigkillTimer = setTimeout(() => {
+					sigkillTimer = setTimeout(() => {
 						if (!proc.killed && proc.exitCode === null) {
 							try {
 								proc.kill('SIGKILL');
@@ -447,17 +456,12 @@ function setupShutdownHandlers(activeProcesses: ChildProcess[]): void {
 					}, 5000);
 
 					// Hard cap on the wait so parent always exits eventually.
-					const hardTimer = setTimeout(() => {
+					hardTimer = setTimeout(() => {
 						console.warn(
 							chalk.red('Backend did not exit within 8s of SIGTERM; exiting parent anyway'),
 						);
 						done();
 					}, 8000);
-
-					proc.once('exit', () => {
-						clearTimeout(sigkillTimer);
-						clearTimeout(hardTimer);
-					});
 				}),
 			);
 		}


### PR DESCRIPTION
## Summary

Five non-blocking items from the code review of PR #543 (the idle-detection self-heal + reconciler memory-pressure event bundle). All small, all additive, organized into three commits by topic.

| # | What | Severity | Commit |
|---|---|---|---|
| #5 | Dedupe memory-pressure broadcast — share one `LiveReconcilerDataProvider` between Reconciler and TeamHealthWatchdog (was: two instances, two events per episode) | Medium | `7320c802` |
| #6 | Reset `consecutivePressureSkips` on a successful wake under pressure (was: counter could leak past throttle window via skip→wake→skip oscillation) | Low | `7320c802` |
| #9 | Emit `agent.action` behavior-log row in `routeInProcessResponseToSlack` (was: in-process auto-routed Slack replies invisible in auditor view; `/slack/send` always recorded one) | Low | `18cd4a8f` |
| #7 | Merge the two `proc.once('exit', ...)` listeners in CLI shutdown into one (was: 2 listeners/child — defensive against `MaxListenersExceededWarning` on children with prior listeners) | Low | `810fd9b8` |
| #10 | Replace hardcoded `8787` in `reconciler-data-provider.ts` with `WEB_CONSTANTS.PORTS.BACKEND` (pre-existing CLAUDE.md violation flagged in the review) | Low | `810fd9b8` |

## Test plan

- [x] `npx tsc --noEmit -p backend/tsconfig.json` clean
- [x] `npx tsc --noEmit -p cli/tsconfig.json` clean
- [x] `npm run build:backend` clean
- [x] `npm run build:cli` clean
- [x] `reconciler-data-provider.test.ts` system:memory_pressure subset — 7/7 pass (includes new "clears skip counter on successful wake under pressure" test for #6)
- [x] `agent-registration.service.test.ts` Slack auto-route subset — 9/9 pass (6 prior + 3 new for #9: records on success, NOT on send failure, survives record() throwing)
- [x] `start.test.ts` shutdown handler subset — 5/5 pass (4 prior + 1 new "exactly one exit listener per child" for #7)

## Notes

- No behavior change visible to end users beyond fewer duplicate `system:memory_pressure` events (#5) and the `agent.action` audit row appearing for in-process auto-routed replies (#9).
- #10 is unrelated to PR #543's scope but trivial enough to bundle; flagged it would be tidier to fold rather than leave a stranded TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)