### PR TITLE
fix(v3): 5 dogfood findings from 2026-05-15 log review

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -620,16 +620,19 @@ export class CrewlyServer {
 			// Subscribe EventBus events for targeted reconciliation
 			if (this.reconcilerService) {
 				const reconciler = this.reconcilerService;
-				const eventTypes = ['agent:idle', 'task:completed', 'task:failed', 'agent:inactive'] as const;
-				for (const eventType of eventTypes) {
-					this.eventBusService.subscribe({
-						eventType,
-						filter: {},
-						subscriberSession: '__reconciler__',
-						oneShot: false,
-						ttlMinutes: 525_600, // 1 year — permanent subscription
-					});
-				}
+
+				// 2026-05-15 Steve dogfood: the prior `subscribe({ subscriberSession:
+				// '__reconciler__' })` loop here was redundant AND wrong. The
+				// subscribe path routes critical events through
+				// `MessageQueueService.enqueue` keyed by `targetSession`, which
+				// then fails noisily because `__reconciler__` is not a PTY
+				// session ("Session '__reconciler__' does not exist", every
+				// reconciler tick). The in-process `event_published` listener
+				// below already drives the reconciler — no second wiring needed.
+				// Removed the subscribe-block; if a future change needs persistent
+				// metadata for the reconciler subscription, attach it as a real
+				// in-process subscriber via `onInProcess` rather than the
+				// session-targeted `subscribe` API.
 
 				// Listen for all published events and trigger targeted reconciliation
 				this.eventBusService.on('event_published', (payload: { eventType: string; sessionName: string }) => {

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -1529,6 +1529,30 @@ describe('TaskPoolService', () => {
       await expect(service.updateItemStatus(wi.id, 'done'))
         .rejects.toThrow('Invalid status transition');
     });
+
+    it('silently no-ops on same-state update (idempotent, Steve 2026-05-15)', async () => {
+      // Reproduces the dogfood race where reconciler stale-pickup and
+      // SLA close both attempt `→ cancelled` on the same WI within ms.
+      // Before this guard, the second call threw "Invalid status
+      // transition: cancelled → cancelled" because WORK_ITEM_TRANSITIONS
+      // for `cancelled` is the empty set; with the guard it should be a
+      // silent no-op so callers can be resilient.
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.updateItemStatus(wi.id, 'cancelled', 'system', 'first cancel');
+
+      // Second call same-state — must NOT throw
+      await expect(
+        service.updateItemStatus(wi.id, 'cancelled', 'system', 'second cancel'),
+      ).resolves.toBeUndefined();
+
+      // cancelReason should be preserved from the first call (mutator
+      // doesn't re-run on the no-op path)
+      const items = await service.getAllItems();
+      const after = items.find((i) => i.id === wi.id);
+      expect(after!.status).toBe('cancelled');
+      expect(after!.cancelReason).toBe('first cancel');
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -2074,11 +2098,8 @@ describe('TaskPoolService', () => {
 
   describe('cancelReason persistence (2026-05-15)', () => {
     it('persists the reason when transitioning to cancelled', async () => {
-      const wi = await service.addToPool({
-        type: 'delegate',
-        owner: 'orchestrator',
-        title: 'cancel-reason test',
-      });
+      const wi = makeWorkItem({ title: 'cancel-reason test', owner: 'orchestrator' });
+      await service.addToPool(wi);
 
       await service.updateItemStatus(
         wi.id,
@@ -2094,11 +2115,8 @@ describe('TaskPoolService', () => {
     });
 
     it('leaves cancelReason undefined when caller passes no reason', async () => {
-      const wi = await service.addToPool({
-        type: 'delegate',
-        owner: 'orchestrator',
-        title: 'no-reason cancel',
-      });
+      const wi = makeWorkItem({ title: 'no-reason cancel', owner: 'orchestrator' });
+      await service.addToPool(wi);
 
       await service.updateItemStatus(wi.id, 'cancelled', 'system');
 
@@ -2107,11 +2125,8 @@ describe('TaskPoolService', () => {
     });
 
     it('ignores the reason argument on non-cancel transitions', async () => {
-      const wi = await service.addToPool({
-        type: 'delegate',
-        owner: 'orchestrator',
-        title: 'reason-on-non-cancel',
-      });
+      const wi = makeWorkItem({ title: 'reason-on-non-cancel', owner: 'orchestrator' });
+      await service.addToPool(wi);
 
       // running is a valid transition target and is not 'cancelled' —
       // a reason passed in must NOT spuriously populate cancelReason.
@@ -2124,11 +2139,8 @@ describe('TaskPoolService', () => {
     // Code-review P0 follow-up (2026-05-15) — transitionStatus is the
     // path V3 SLA subscriber uses, and was missing reason propagation.
     it('transitionStatus persists cancelReason when target is cancelled', async () => {
-      const wi = await service.addToPool({
-        type: 'delegate',
-        owner: 'orchestrator',
-        title: 'transitionStatus-cancel-reason',
-      });
+      const wi = makeWorkItem({ title: 'transitionStatus-cancel-reason', owner: 'orchestrator' });
+      await service.addToPool(wi);
 
       await service.transitionStatus(
         wi.id,
@@ -2143,11 +2155,8 @@ describe('TaskPoolService', () => {
     });
 
     it('transitionStatus mutator can override cancelReason (escape hatch)', async () => {
-      const wi = await service.addToPool({
-        type: 'delegate',
-        owner: 'orchestrator',
-        title: 'mutator-override',
-      });
+      const wi = makeWorkItem({ title: 'mutator-override', owner: 'orchestrator' });
+      await service.addToPool(wi);
 
       await service.transitionStatus(
         wi.id,

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1584,6 +1584,22 @@ export class TaskPoolService {
       throw new Error(`WorkItem not found: ${workItemId}`);
     }
 
+    // Idempotent same-state no-op: the reconciler's stale-pickup rule
+    // and the SLA close path can both race to apply the same terminal
+    // status. Silently no-op here instead of throwing or logging a
+    // misleading "transitioned cancelled → cancelled" entry. (Steve
+    // 2026-05-15 dogfood — see the duplicate "Work item status
+    // updated from cancelled to cancelled" rows in
+    // crewly-2026-05-15.log around 15:48:56 / 16:05:55.)
+    if (item.status === newStatus) {
+      this.logger.debug('Skipped idempotent same-state status update', {
+        workItemId,
+        status: newStatus,
+        actorRole,
+      });
+      return;
+    }
+
     if (!isValidWorkItemTransition(item.status, newStatus)) {
       throw new Error(
         `Invalid status transition for WorkItem ${workItemId}: ${item.status} → ${newStatus}`,
@@ -1701,6 +1717,18 @@ export class TaskPoolService {
     const item = await this.storage.findWorkItem(workItemId);
     if (!item) {
       throw new Error(`WorkItem not found: ${workItemId}`);
+    }
+
+    // Idempotent same-state no-op (matches updateItemStatus behavior).
+    // Return the current item so callers chaining on the result don't
+    // see a spurious null. Steve 2026-05-15.
+    if (item.status === newStatus) {
+      this.logger.debug('Skipped idempotent same-state transition', {
+        workItemId,
+        status: newStatus,
+        actorRole,
+      });
+      return item;
     }
 
     if (!isValidWorkItemTransition(item.status, newStatus)) {

--- a/backend/src/services/v3/cascade-request-status.test.ts
+++ b/backend/src/services/v3/cascade-request-status.test.ts
@@ -138,6 +138,86 @@ describe('cascadeRequestStatus', () => {
     expect(updates).toEqual([['req-1', { status: 'cancelled' }]]);
   });
 
+  it('does NOT cascade-cancel when the only cancelled child was SLA-resolved by orc_reply (Steve 2026-05-15)', async () => {
+    // Reproduces the dogfood race: a Slack Request with one
+    // respond_to_user SLA tracker. Orc replies in-window → markResolved
+    // transitions the tracker queued→cancelled with
+    // metadata.slaResolvedReason='orc_reply'. Cascade fires on
+    // task:cancelled; without this guard it overwrites Request.status
+    // to 'cancelled' just before RequestSlaSubscriber.maybeCloseRequest
+    // moves it to 'done'.
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({
+          id: 'request:req-1:respond_to_user',
+          status: 'cancelled',
+          metadata: { slaResolvedReason: 'orc_reply' },
+        }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('honors verified-reply tags for chatv2_reply and workitem_decompose too', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({
+          id: 'a',
+          status: 'cancelled',
+          metadata: { slaResolvedReason: 'chatv2_reply' },
+        }),
+        makeWI({
+          id: 'b',
+          status: 'cancelled',
+          metadata: { slaResolvedReason: 'workitem_decompose' },
+        }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([]);
+  });
+
+  it('still cascades to cancelled when SLA-resolved children sit alongside other genuine cancellations', async () => {
+    // Mixed: 1 SLA-resolved (orc_reply) + 1 real cancellation. The SLA
+    // tracker is filtered out, leaving ['cancelled'] → cascade fires.
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({
+          id: 'sla',
+          status: 'cancelled',
+          metadata: { slaResolvedReason: 'orc_reply' },
+        }),
+        makeWI({ id: 'real-cancel', status: 'cancelled' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'cancelled' }]]);
+  });
+
+  it('still cascades to running when SLA-resolved cancellation coexists with a running sibling', async () => {
+    const r = makeRequest({ status: 'ready' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({
+          id: 'sla',
+          status: 'cancelled',
+          metadata: { slaResolvedReason: 'orc_reply' },
+        }),
+        makeWI({ id: 'live', status: 'running' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    expect(updates).toEqual([['req-1', { status: 'running' }]]);
+  });
+
   it('cascades to running when any child is running, regardless of other state', async () => {
     const r = makeRequest({ status: 'ready' });
     const { deps, updates } = makeDeps({

--- a/backend/src/services/v3/cascade-request-status.ts
+++ b/backend/src/services/v3/cascade-request-status.ts
@@ -74,6 +74,39 @@ export interface CascadeDeps {
 }
 
 /**
+ * Verified-reply SLA resolution reasons — these tags appear in
+ * `WorkItem.metadata.slaResolvedReason` when
+ * `RequestSlaSubscriber.markResolved` deliberately cancels the
+ * respond_to_user tracker because the orchestrator answered the user.
+ * Such cancellations are NOT abandonments and should not propagate
+ * a `cancelled` status to the parent Request; the SLA subscriber's
+ * own `maybeCloseRequest` owns that transition.
+ *
+ * Keep in sync with `request-sla.subscriber.ts:VERIFIED_REPLY_REASONS`.
+ */
+const VERIFIED_SLA_REPLY_REASONS = new Set([
+  'orc_reply',
+  'orc_reply_recheck',
+  'chatv2_reply',
+  'workitem_decompose',
+]);
+
+/**
+ * Returns true when a WorkItem's metadata indicates the cancellation
+ * came from a verified-reply SLA auto-resolve (orc replied to the
+ * user, or chat-v2 saw an agent reply, or the WI was retired because
+ * the Request was decomposed into new WIs).
+ *
+ * @param metadata - WorkItem.metadata bag (may be undefined)
+ * @returns true if the cancellation should be ignored for parent
+ *   Request cascade purposes
+ */
+function isSlaResolvedByVerifiedReply(metadata: Record<string, unknown> | undefined): boolean {
+  const reason = metadata?.slaResolvedReason;
+  return typeof reason === 'string' && VERIFIED_SLA_REPLY_REASONS.has(reason);
+}
+
+/**
  * Recompute Request.status from the aggregate state of its child WIs
  * and persist any change.
  *
@@ -116,8 +149,33 @@ export async function cascadeRequestStatus(
     if (request.status === 'done' || request.status === 'cancelled') return;
 
     const allItems = await deps.taskPool.getAllItems();
-    const childItems = allItems.filter((wi) => wi.requestId === requestId);
-    if (childItems.length === 0) return;
+    const allChildItems = allItems.filter((wi) => wi.requestId === requestId);
+    if (allChildItems.length === 0) return;
+
+    // 2026-05-15 dogfood (Steve): Slack Requests with a single
+    // respond_to_user SLA tracker were ending up in `cancelled` →
+    // overwritten to `done` by RequestSlaSubscriber.maybeCloseRequest
+    // in a ~10ms race window. Root cause: `markResolved(orc_reply)`
+    // transitions the SLA tracker `queued → cancelled`, the
+    // `task:cancelled` event fires here, and the cascade sees
+    // `statuses=['cancelled']` → newStatus='cancelled'. Then SLA's
+    // own auto-close (next tick) flips it to `done` and the Request
+    // ends with inconsistent status events in its log.
+    //
+    // Filter out children that were cancelled by a verified-reply
+    // SLA resolution — those aren't real abandonments, the SLA
+    // closer owns the parent Request transition. If after filtering
+    // nothing remains, let the SLA path drive the close.
+    const childItems = allChildItems.filter(
+      (wi) => wi.status !== 'cancelled' || !isSlaResolvedByVerifiedReply(wi.metadata),
+    );
+    if (childItems.length === 0) {
+      logger.debug('Cascade skipped — only SLA-resolved cancellations remain', {
+        requestId,
+        slaResolvedCount: allChildItems.length,
+      });
+      return;
+    }
 
     const statuses = childItems.map((wi) => wi.status);
 

--- a/backend/src/services/v3/workitem-dispatch.subscriber.test.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.test.ts
@@ -134,6 +134,43 @@ describe('WorkItemDispatchSubscriber', () => {
       const [url] = mockedAxios.post.mock.calls[0];
       expect(url).toContain(encodeURIComponent('agent name with space'));
     });
+
+    it('re-dispatches the same WI to a different target (Steve 2026-05-15 dogfood)', async () => {
+      // Concrete repro: WI 20a778bc was dispatched to ethan (claim
+      // expired without ethan starting work, WI requeued), then
+      // AutoClaim reassigned it to crewly-orc. Before this fix the
+      // dispatched-set short-circuited on workItemId alone and orc
+      // never received the [CREWLY-DISPATCH] message. Composite key
+      // restores the second dispatch.
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-reassigned', target: 'agent-ethan' });
+
+      const first = await svc.dispatchTo(wi);
+      expect(first).toBe(true);
+
+      // Same WI, NEW target (reassignment scenario)
+      const reassigned = { ...wi, target: 'crewly-orc' };
+      const second = await svc.dispatchTo(reassigned);
+      expect(second).toBe(true);
+
+      // Confirm BOTH targets received the message
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+      const [url1] = mockedAxios.post.mock.calls[0];
+      const [url2] = mockedAxios.post.mock.calls[1];
+      expect(url1).toContain('agent-ethan');
+      expect(url2).toContain('crewly-orc');
+    });
+
+    it('still dedups within (workItemId, target) — a third call to the SAME target is a no-op', async () => {
+      const svc = WorkItemDispatchSubscriber.getInstance();
+      const wi = makeWorkItem({ id: 'wi-target-dedup', target: 'agent-foo' });
+
+      await svc.dispatchTo(wi);
+      await svc.dispatchTo(wi);
+      const third = await svc.dispatchTo(wi);
+      expect(third).toBe(false);
+      expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('event subscription', () => {

--- a/backend/src/services/v3/workitem-dispatch.subscriber.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.ts
@@ -82,10 +82,29 @@ export class WorkItemDispatchSubscriber {
   private eventBusService: { on: (event: string, handler: (...args: unknown[]) => void) => void } | null = null;
 
   /**
-   * WI ids already dispatched in this process lifetime. Reset on restart —
+   * Dispatch dedup keyed by `${workItemId}::${target}`. Reset on restart —
    * which is intentional, the startup backfill re-reads the pool.
+   *
+   * 2026-05-15 Steve dogfood: previously keyed by `workItemId` alone, which
+   * silently dropped re-dispatches after a WI was reassigned to a different
+   * target. Concrete repro from crewly-2026-05-15.log:
+   *   - 14:55:26 WI 20a778bc dispatched to strategy-ethan-c36c18bd
+   *   - ethan never started work, claim expired, WI requeued
+   *   - 15:36:55 AgentAutoClaim reassigned to crewly-orc
+   *   - dispatchTo short-circuited (dispatched.has('20a778bc') === true)
+   *   - orc never saw [CREWLY-DISPATCH], claim expired 13min later
+   *   - loop repeated
+   * The composite key fixes this: a re-target gets a fresh dispatch.
+   * Within a (workItemId, target) pair the dedup still holds, so the
+   * `workitem:queued` event and the AutoClaim post-claim hand-off don't
+   * double-fire on the same target.
    */
   private readonly dispatched = new Set<string>();
+
+  /** Composite dedup key — workItem id alone is not enough (see above). */
+  private dispatchKey(workItemId: string, target: string): string {
+    return `${workItemId}::${target}`;
+  }
 
   private constructor() {
     this.logger = LoggerService.getInstance().createComponentLogger(SERVICE_NAME);
@@ -170,7 +189,8 @@ export class WorkItemDispatchSubscriber {
   async dispatchTo(workItem: WorkItem): Promise<boolean> {
     if (!workItem.target) return false;
     if (SLA_TRACKER_ID_PATTERN.test(workItem.id)) return false;
-    if (this.dispatched.has(workItem.id)) return false;
+    const key = this.dispatchKey(workItem.id, workItem.target);
+    if (this.dispatched.has(key)) return false;
 
     const message = this.buildDispatchMessage(workItem);
 
@@ -183,7 +203,7 @@ export class WorkItemDispatchSubscriber {
           timeout: 5_000,
         },
       );
-      this.dispatched.add(workItem.id);
+      this.dispatched.add(key);
       this.logger.info('Dispatched WorkItem to target session', {
         workItemId: workItem.id,
         target: workItem.target,

--- a/backend/src/websocket/terminal.gateway.test.ts
+++ b/backend/src/websocket/terminal.gateway.test.ts
@@ -271,6 +271,75 @@ describe('TerminalGateway', () => {
 
 			expect(mockSession.resize).toHaveBeenCalledWith(120, 40);
 		});
+
+		it('logs a missing-session resize failure at debug, not error (Steve 2026-05-15)', () => {
+			// Frontend reconnect race: a resize event lands for a session
+			// that has already exited. The PTY backend throws "Session 'X'
+			// does not exist". This is normal lifecycle noise and should
+			// not surface as ERROR (314 such rows in one day's prod log).
+			const errorSpy = jest
+				.spyOn((gateway as any).logger, 'error')
+				.mockImplementation(() => {});
+			const debugSpy = jest
+				.spyOn((gateway as any).logger, 'debug')
+				.mockImplementation(() => {});
+
+			mockSessionBackend.resizeSession = jest.fn(() => {
+				throw new Error("Session 'crewly-orc' does not exist");
+			});
+
+			if (connectionCallback) {
+				connectionCallback(mockSocket as Socket);
+			}
+			const onMock = mockSocket.on as jest.Mock;
+			const resizeHandler = onMock.mock.calls.find(
+				(call: any[]) => call[0] === 'terminal_resize'
+			)?.[1];
+			resizeHandler({ sessionName: 'crewly-orc', cols: 80, rows: 24 });
+
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(debugSpy).toHaveBeenCalledWith(
+				'Error resizing terminal',
+				expect.objectContaining({
+					sessionName: 'crewly-orc',
+					error: expect.stringMatching(/does not exist/),
+				}),
+			);
+
+			errorSpy.mockRestore();
+			debugSpy.mockRestore();
+			delete mockSessionBackend.resizeSession;
+		});
+
+		it('still logs at ERROR for non-missing-session resize failures', () => {
+			const errorSpy = jest
+				.spyOn((gateway as any).logger, 'error')
+				.mockImplementation(() => {});
+
+			mockSessionBackend.resizeSession = jest.fn(() => {
+				throw new Error('PTY ioctl failed: EIO');
+			});
+
+			if (connectionCallback) {
+				connectionCallback(mockSocket as Socket);
+			}
+			const onMock = mockSocket.on as jest.Mock;
+			const resizeHandler = onMock.mock.calls.find(
+				(call: any[]) => call[0] === 'terminal_resize'
+			)?.[1];
+			resizeHandler({ sessionName: 'test-session', cols: 80, rows: 24 });
+
+			expect(errorSpy).toHaveBeenCalledWith(
+				'Error resizing terminal',
+				expect.objectContaining({
+					sessionName: 'test-session',
+					error: expect.stringMatching(/EIO/),
+				}),
+			);
+
+			errorSpy.mockRestore();
+			delete mockSessionBackend.resizeSession;
+		});
 	});
 
 	describe('request_terminal_state', () => {

--- a/backend/src/websocket/terminal.gateway.ts
+++ b/backend/src/websocket/terminal.gateway.ts
@@ -656,9 +656,17 @@ export class TerminalGateway {
 				rows,
 			});
 		} catch (error) {
-			this.logger.error('Error resizing terminal', {
+			// Distinguish "session genuinely gone" (frontend reconnect
+			// race — common, expected, drop to debug) from other resize
+			// failures (PTY backend issue — keep at error). Steve
+			// 2026-05-15: 314 ERROR entries from `Session 'X' does not
+			// exist` across one day was overwhelming the log without
+			// indicating any actionable problem.
+			const msg = error instanceof Error ? error.message : String(error);
+			const isMissingSession = /does not exist/.test(msg);
+			this.logger[isMissingSession ? 'debug' : 'error']('Error resizing terminal', {
 				sessionName,
-				error: error instanceof Error ? error.message : String(error),
+				error: msg,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary

5 root-cause fixes from the 2026-05-15 dogfood log review (`~/.crewly/logs/crewly-2026-05-15.log`). All committed; quality gates passed on each commit.

| # | User-visible symptom | Root cause | Files |
|---|---|---|---|
| **A** | Request shows "done" while its WorkItems are cancelled (`Request auto-closed by SLA cascade … from:"ready", path:["running","done"]` immediately after `Request status cascaded from WorkItems … newStatus:"cancelled"`) | ~10ms race between `RequestCascadeSubscriber` and `RequestSlaSubscriber.maybeCloseRequest`. The SLA tracker WI was cancelled by `markResolved(orc_reply)`, cascade then propagated `cancelled` to the parent, and SLA close overwrote it to `done`. | `cascade-request-status.ts` + tests |
| **B** | 42 ERROR rows/day: `Session '__reconciler__' does not exist` | `index.ts` was wiring the reconciler via the session-targeted `subscribe()` path with `subscriberSession: '__reconciler__'`. The in-process `event_published` listener below already drove `reconciler.runFast()` — the subscribe block was pure noise. | `index.ts` |
| **C** | `WorkItem transitioned from cancelled to cancelled` log noise (and same-state for `queued`/`running`) | Idempotent same-state writes (reconciler stale-pickup + SLA close racing on the same terminal status) succeeded with misleading log entries. Now silently no-op. | `task-pool.service.ts` + tests |
| **D** | "orc seems active but WorkItems finish slowly" (issue #3) — WI `20a778bc` cycled through orc claims every 13min, never executed | `WorkItemDispatchSubscriber.dispatched` was keyed by `workItemId` alone. After a WI was reassigned to a different target, `dispatchTo` short-circuited and the new target never got the `[CREWLY-DISPATCH]` message → claim expired → loop. Now keyed by `${workItemId}::${target}`. | `workitem-dispatch.subscriber.ts` + tests |
| **E** | 314 ERROR rows/day: `Error resizing terminal … Session 'crewly-orc' does not exist` | Frontend reconnect race — common, expected, but logged at ERROR level. Now routed to `debug` when the message is "does not exist"; other resize failures still go to ERROR. | `terminal.gateway.ts` + tests |

Out of scope but flagged for the user:
- 228 `Chat DB opened :memory:` rows are jest test runs leaking into the prod log file (test process reuses `~/.crewly/logs/crewly-{date}.log` because `enableFileLogging` defaults to true). Cosmetic; not a prod issue.
- 1139 "Skipping wake — memory pressure" rows: user's laptop running at 99.7% RAM with 9 active agents. Real constraint, no code fix.
- 27 "Orchestrator stuck in_progress for 30min" warnings: orc actually was in a long thought stream. Unrelated to the fixes here.

## Test plan

- [x] `cascade-request-status.test.ts`: 16/16 (4 new SLA-filter cases)
- [x] `task-pool.service.test.ts` (cancelReason + same-state slice): 6/6
- [x] `workitem-dispatch.subscriber.test.ts`: 15/15 (2 new — reassign re-dispatch + same-target dedup)
- [x] `terminal.gateway.test.ts` (resize slice): 5/5 (2 new — missing-session→debug, other failures→error)
- [x] All quality gates passed on each commit
- [ ] Manual smoke (after restart): Slack a single-WI request, confirm orc reply closes Request to `done` cleanly (no cascade-cancelled→done flip); reassign a WI mid-flight, confirm new target receives `[CREWLY-DISPATCH]`

**Restart required to take effect** — these are running-server code changes, not hot-reloadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)