### PR TITLE
fix(task-pool): log pre-write status correctly + drop ENOENT prompt to WARN

### DIFF
--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -1963,11 +1963,20 @@ export class AgentRegistrationService {
 			// Fallback to inline prompt if file doesn't exist
 			const attemptedPath = await this.getPromptFileForRole(role);
 
-			this.logger.error('Could not load prompt from config, using fallback', {
+			// Distinguish "role prompt simply absent" (team-config uses a
+			// custom role string, fallback covers it) from genuine read
+			// failures (permission denied, corrupt file). ENOENT is a
+			// common case — e.g. CE team config currently uses
+			// `role: "tech-lead"` while the filesystem canonical is
+			// `team-leader`. The fallback inline prompt is functionally
+			// sufficient; ERROR-level noise just buries real issues.
+			const msg = error instanceof Error ? error.message : String(error);
+			const isMissingFile = /ENOENT/.test(msg);
+			this.logger[isMissingFile ? 'warn' : 'error']('Could not load prompt from config, using fallback', {
 				role,
 				promptPath: attemptedPath,
-				error: error instanceof Error ? error.message : String(error),
-				stack: error instanceof Error ? error.stack : undefined,
+				error: msg,
+				...(isMissingFile ? {} : { stack: error instanceof Error ? error.stack : undefined }),
 			});
 
 			const memberIdJson = memberId ? `,"teamMemberId":"${memberId}"` : '';

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -1553,6 +1553,37 @@ describe('TaskPoolService', () => {
       expect(after!.status).toBe('cancelled');
       expect(after!.cancelReason).toBe('first cancel');
     });
+
+    it('logs the pre-write status as `from` even when storage mutates in place (Steve 2026-05-15)', async () => {
+      // pool-storage returns the in-memory object by reference, so the
+      // mutator's `wi.status = newStatus` also mutates the local `item`
+      // captured at the top of updateItemStatus. Without `const fromStatus
+      // = item.status` before the write, the post-write log reads
+      // `from: <newStatus>` (i.e. `cancelled → cancelled` for an actual
+      // `queued → cancelled` transition). Verified against the
+      // 17:48:29.328 log entry for request:4917f0c9:respond_to_user.
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+
+      const infoSpy = jest
+        .spyOn((service as any).logger, 'info')
+        .mockImplementation(() => {});
+      try {
+        await service.updateItemStatus(wi.id, 'cancelled', 'system', 'reason');
+
+        const updateCalls = infoSpy.mock.calls.filter(
+          (c) => c[0] === 'Work item status updated',
+        );
+        expect(updateCalls).toHaveLength(1);
+        expect(updateCalls[0][1]).toMatchObject({
+          workItemId: wi.id,
+          from: 'queued',   // NOT 'cancelled'
+          to: 'cancelled',
+        });
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1614,6 +1614,13 @@ export class TaskPoolService {
       );
     }
 
+    // Capture pre-write status. See transitionStatus's identical block
+    // for the writeup — storage.updateWorkItem mutates in place, so
+    // reading item.status after the write yields newStatus and the
+    // "Work item status updated" log reads like "X → X" for every
+    // valid transition.
+    const fromStatus = item.status;
+
     await this.storage.updateWorkItem(workItemId, (wi) => {
       wi.status = newStatus;
       // P1 1ffffb84 component (b): mirror the transitionStatus
@@ -1642,7 +1649,7 @@ export class TaskPoolService {
 
     this.logger.info('Work item status updated', {
       workItemId,
-      from: item.status,
+      from: fromStatus,
       to: newStatus,
       actorRole,
       ...(newStatus === 'cancelled' && reason ? { reason } : {}),
@@ -1653,7 +1660,7 @@ export class TaskPoolService {
     // {@link publishTaskCancelled} for the full bug writeup.
     if (newStatus === 'cancelled') {
       const post = await this.storage.findWorkItem(workItemId);
-      if (post) this.publishTaskCancelled(post, item.status);
+      if (post) this.publishTaskCancelled(post, fromStatus);
     }
   }
 
@@ -1744,6 +1751,15 @@ export class TaskPoolService {
       );
     }
 
+    // Capture the pre-write status into a local. `storage.updateWorkItem`
+    // mutates the same in-memory object that `findWorkItem` returned, so
+    // reading `item.status` AFTER the write yields the new value — which
+    // makes the "transitioned X → Y" log read like "Y → Y" and hides the
+    // real `previousValue` on the task:cancelled EventBus payload.
+    // (Steve 2026-05-15 dogfood: `from:cancelled, to:cancelled` showing
+    // for transitions that were actually `queued → cancelled`.)
+    const fromStatus = item.status;
+
     const ok = await this.storage.updateWorkItem(workItemId, (wi) => {
       wi.status = newStatus;
       // Atomic timestamp side-effects enforce the invariant
@@ -1801,7 +1817,7 @@ export class TaskPoolService {
 
     this.logger.info('WorkItem transitioned', {
       workItemId,
-      from: item.status,
+      from: fromStatus,
       to: newStatus,
       actorRole,
     });
@@ -1816,7 +1832,7 @@ export class TaskPoolService {
     // Request without waiting for the heartbeat catch. See
     // {@link publishTaskCancelled} for the full bug writeup.
     if (newStatus === 'cancelled' && post) {
-      this.publishTaskCancelled(post, item.status);
+      this.publishTaskCancelled(post, fromStatus);
     }
 
     return post;


### PR DESCRIPTION
## Summary

Post-restart dogfood monitoring (2026-05-15 17:40+) confirmed the SLA cascade race fix from PR #549 is working — Request `4917f0c9` closed cleanly to `done` without the previous `cancelled → done` overwrite pattern. While verifying, the log surfaced two remaining log-fidelity issues that masked the actual transitions:

### Fix 1: `WorkItem transitioned cancelled → cancelled` was misleading

`pool-storage.findWorkItem` returns the in-memory WI object by reference. `storage.updateWorkItem`'s mutator does `wi.status = newStatus`, which also mutates the local `item` captured at the top of `transitionStatus` / `updateItemStatus`. The subsequent log reads `item.status` and sees `newStatus`, so a real `queued → cancelled` transition logs as `cancelled → cancelled`. Same bug fed `previousValue: cancelled` into the `task:cancelled` EventBus payload.

Captured `const fromStatus = item.status` before the storage write; threaded `fromStatus` through to the logger and `publishTaskCancelled`. Concrete repro: `17:48:29.328` entry in today's log.

### Fix 2: ENOENT for missing role prompts no longer logs at ERROR

The CE team's config has `role: "tech-lead"` while the filesystem canonical directory is `team-leader`. Every agent registration in that team logs an ERROR with stack trace ("Could not load prompt from config, using fallback"), even though the fallback inline prompt works correctly.

Routed `ENOENT` through `logger.warn` (no stack trace); other read failures (permission, corruption) still go to error. The fallback path is unchanged.

## Test plan

- [x] `task-pool.service.test.ts`: 7/7 pass on the cancelReason + same-state + new pre-write log assertion
- [x] Quality gates passed on the commit
- [ ] After restart: confirm 0 `cancelled → cancelled` rows in fresh log; ENOENT prompt warnings are at WARN level

🤖 Generated with [Claude Code](https://claude.com/claude-code)