### PR TITLE
fix(heartbeat): suppress status update when only internal verify/review WIs remain in flight

### DIFF
--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -395,6 +395,52 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
     expect(posts[0].text).toContain('1');     // running
   });
 
+  it('suppresses heartbeat when all delegate WIs are user-terminal and only a Verify WI is in flight (Steve 2026-05-15)', async () => {
+    // Repro of the 智库 Request heartbeat that fired right after Grace
+    // turned in her Review — "5/7 完成, 进行中 1" where the "1" was
+    // orc's internal Verify WI for Grace's Review. From the owner's
+    // view the deliverable was done; the verify-WI is internal noise.
+    const wis = [
+      makeWI({ id: 'wi-plan', requestId: 'req-x', type: 'delegate', status: 'verified' }),
+      makeWI({ id: 'wi-exec', requestId: 'req-x', type: 'delegate', status: 'verified' }),
+      makeWI({ id: 'wi-review', requestId: 'req-x', type: 'delegate', status: 'done_by_worker' }),
+      // The internal Verify WI for the Review — type=review, running.
+      makeWI({
+        id: 'wi-review:verify:wi-review',
+        requestId: 'req-x',
+        type: 'review',
+        status: 'running',
+        target: 'crewly-orc',
+      }),
+    ];
+    const r = makeRequest({ id: 'req-x', status: 'running' });
+    const { sub, posts } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(0);
+  });
+
+  it('still emits heartbeat when at least one delegate WI is non-terminal (mixed state)', async () => {
+    // Counter-test: if a delegate WI is still genuinely in flight, the
+    // user DOES want the heartbeat. Filter must only suppress when
+    // every deliverable is terminal.
+    const wis = [
+      makeWI({ id: 'wi-1', requestId: 'req-y', type: 'delegate', status: 'verified' }),
+      makeWI({ id: 'wi-2', requestId: 'req-y', type: 'delegate', status: 'running', target: 'leo' }),
+      makeWI({ id: 'wi-3', requestId: 'req-y', type: 'review', status: 'queued', target: 'orc' }),
+    ];
+    const r = makeRequest({ id: 'req-y', status: 'running' });
+    const { sub, posts } = makeSubscriber({ request: r, pool: wis });
+
+    const posted = await sub.runHeartbeat();
+    expect(posted).toBe(1);
+    // Counts surface only deliverables (2 total): 1 done, 1 running.
+    // The review/verify WI does NOT inflate the "进行中" tally.
+    expect(posts[0].text).toContain('1/2');
+    expect(posts[0].text).toContain('进行中 1');
+  });
+
   it('skips Requests in terminal status', async () => {
     const r = makeRequest({ id: 'req-done', status: 'done' });
     const { sub, posts } = makeSubscriber({ request: r, pool: [makeWI({ requestId: 'req-done' })] });
@@ -608,12 +654,19 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
     // — so the closer fired, the gate refused, and the Request logged
     // a confusing "stale Request close failed" warning every sweep.
     //
-    // Now the closer's terminal set is imported from work-item.types.ts
+    // The closer's terminal set is now imported from work-item.types.ts
     // (the canonical contract), so done_by_worker children short-circuit
-    // the all-terminal check and the closer skips entirely. The
-    // heartbeat post still fires (the user sees real progress: "1/2
-    // done, 0 in flight"), and the eventual verification → cascade
-    // path closes the Request properly.
+    // the all-terminal check and the closer skips entirely.
+    //
+    // 2026-05-15 follow-up: the heartbeat is ALSO suppressed when every
+    // deliverable is at a user-terminal state (done/verified/done_by_worker/
+    // cancelled/failed/rejected) — the owner already saw the deliverable
+    // land; the verify path is internal and shouldn't ping them again
+    // with a confusing "0 in flight" message that reads as "what's the
+    // system waiting on?". Both arms still hold: the Request stays open
+    // (closer didn't fire), AND the user doesn't get a spurious
+    // heartbeat. The eventual verification → cascade path closes the
+    // Request properly without any owner-visible noise in between.
     const wis = [
       makeWI({ id: 'wi-quinn', requestId: 'req-pending-verify', status: 'done_by_worker' }),
       makeWI({ id: 'wi-canc',  requestId: 'req-pending-verify', status: 'cancelled' }),
@@ -625,11 +678,10 @@ describe('RequestStatusUpdateSubscriber — heartbeat sweep', () => {
 
     // Closer must NOT have fired.
     expect(requestStore.get('req-pending-verify')!.status).toBe('running');
-    // But the heartbeat itself still posts (Request IS in flight, the
-    // user wants to know the verify WI is the bottleneck).
-    expect(posted).toBe(1);
-    expect(posts).toHaveLength(1);
-    expect(posts[0].text).toContain('1/2');
+    // Heartbeat now also suppressed — both deliverables are at
+    // user-terminal states (done_by_worker + cancelled).
+    expect(posted).toBe(0);
+    expect(posts).toHaveLength(0);
   });
 
   it('does NOT close a Request whose child WI is failed (awaiting retry)', async () => {

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -404,6 +404,45 @@ export class RequestStatusUpdateSubscriber {
         continue;
       }
 
+      // Steve 2026-05-15 dogfood: heartbeat fired for the 智库 Request
+      // showing "5/7 完成, 进行中 1" right after Grace's user-visible
+      // Review landed. The "进行中 1" was orc's *internal Verify WI*
+      // for Grace's Review — internal bookkeeping the user can't act
+      // on. From the user's chat view this read as "system still
+      // pending on something" when in fact the deliverable was done.
+      //
+      // Filter to user-deliverable WIs (`type === 'delegate'`). Review
+      // / verify / cron_run / notify / reconcile / check / confirm
+      // are internal types — surfacing their pending status to the
+      // owner is noise. If every deliverable has reached a
+      // user-perceived terminal state (done / verified / done_by_worker
+      // / cancelled / failed / rejected), suppress the heartbeat — the
+      // owner already saw the deliverable land; the internal verify
+      // path will close the Request soon enough.
+      const deliverableWIs = childWIs.filter((wi) => wi.type === 'delegate');
+      const userTerminalStatuses = new Set<WorkItem['status']>([
+        'done',
+        'verified',
+        'done_by_worker',
+        'cancelled',
+        'failed',
+        'rejected',
+      ]);
+      if (
+        deliverableWIs.length > 0 &&
+        deliverableWIs.every((wi) => userTerminalStatuses.has(wi.status))
+      ) {
+        this.logger.debug(
+          'Heartbeat suppressed — all user-deliverable WIs reached terminal; only internal verify/review remains',
+          {
+            requestId: r.id,
+            deliverableCount: deliverableWIs.length,
+            internalInFlight: childWIs.length - deliverableWIs.length,
+          },
+        );
+        continue;
+      }
+
       const fingerprint = computeStateFingerprint(childWIs);
       const lastFp = this.lastHeartbeatFingerprint.get(r.id);
       if (lastFp === fingerprint) {
@@ -414,7 +453,14 @@ export class RequestStatusUpdateSubscriber {
         continue;
       }
 
-      const text = this.buildHeartbeatText(r, childWIs);
+      // Build heartbeat from deliverables only when we have any, so the
+      // count the owner sees matches what they care about (their actual
+      // work, not the system's verify bookkeeping). Falls back to the
+      // full childWIs only if the Request somehow has zero delegates —
+      // a malformed shape we should still report on rather than hide.
+      const heartbeatBasis =
+        deliverableWIs.length > 0 ? deliverableWIs : childWIs;
+      const text = this.buildHeartbeatText(r, heartbeatBasis);
       try {
         await this.slackPoster({ channelId: slackCtx.channelId, text, threadTs: slackCtx.threadTs });
         this.lastPostedAt.set(r.id, now);

--- a/scripts/backfill-stuck-verify.ts
+++ b/scripts/backfill-stuck-verify.ts
@@ -1,0 +1,259 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot backfill for two pre-#553 stall shapes:
+ *
+ * Shape A (default mode):
+ *   - Source WorkItem at `done_by_worker` (worker finished)
+ *   - Verify WorkItem (`metadata.verifyOf === source.id`) at `done` (TL verified)
+ *   - Source never moved to `verified`, so dependents stay `blocked` forever.
+ *   - Fix: flip source to `verified`. PR #553 prevents this going forward.
+ *
+ * Shape B (`--stale-cleanup`):
+ *   - Source WorkItem at `done_by_worker` for >2 hours, AND
+ *     - either no verify WI ever got created, OR
+ *     - the verify WI is in `cancelled` (SLA timeout, queue-stale, etc.)
+ *   - These will never reach `verified` through normal flow. The work was
+ *     done; nobody will review it. Mark as `cancelled` with a clear reason
+ *     so the UI/heartbeat sweep stops listing them as "in flight".
+ *   - State-machine note: `done_by_worker → cancelled` is NOT a legal edge
+ *     (matrix only allows → verified/rejected). The script bypasses
+ *     transitionStatus by editing pool.json directly while the server is
+ *     stopped — acceptable for one-shot offline cleanup.
+ *
+ * **Operates directly on `pool.json`** because the running server caches
+ * pool data in memory (`PoolStorage.load` short-circuits on a populated
+ * `this.cache`). Editing pool.json without bouncing the server is
+ * therefore ineffective. The script:
+ *   1. Requires the server to be stopped (warns and exits if reachable).
+ *   2. Atomically rewrites pool.json (temp + fsync + rename).
+ *   3. Caller restarts the server afterwards.
+ *
+ * Usage:
+ *   crewly service stop
+ *   tsx scripts/backfill-stuck-verify.ts                       # dry-run shape A
+ *   tsx scripts/backfill-stuck-verify.ts --apply               # apply shape A
+ *   tsx scripts/backfill-stuck-verify.ts --stale-cleanup       # dry-run shape B
+ *   tsx scripts/backfill-stuck-verify.ts --stale-cleanup --apply
+ *   crewly service start
+ *
+ * @module scripts/backfill-stuck-verify
+ */
+
+/* eslint-disable no-console */
+
+import { readFile, writeFile, rename } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const POOL_PATH =
+  process.env.POOL_PATH ?? join(homedir(), '.crewly', 'task-pool', 'pool.json');
+const API_BASE = process.env.CREWLY_API_URL ?? 'http://localhost:8787';
+
+interface WorkItem {
+  id: string;
+  status: string;
+  metadata?: Record<string, unknown>;
+  title?: string;
+  type?: string;
+  completedAt?: string;
+}
+
+interface PoolData {
+  workItems: WorkItem[];
+  claims: unknown[];
+  lastUpdatedAt?: string;
+}
+
+async function isServerRunning(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/health`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Stale threshold for the cleanup mode — done_by_worker WIs older than this
+ *  with a cancelled/missing verify WI are abandoned, no review will happen. */
+const STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+async function main(): Promise<number> {
+  const apply = process.argv.includes('--apply');
+  const cleanup = process.argv.includes('--stale-cleanup');
+  const mode = cleanup ? 'stale-cleanup' : 'verify-propagation';
+  console.log(
+    `[backfill-stuck-verify] mode=${mode} action=${apply ? 'apply' : 'dry-run'} pool=${POOL_PATH}`,
+  );
+
+  if (apply && (await isServerRunning())) {
+    console.error(
+      `\nERROR: server appears to be running at ${API_BASE}/health.\n` +
+        `The server caches pool data in memory; writing pool.json while it's\n` +
+        `running will be overwritten on next flush. Stop the service first:\n` +
+        `  crewly service stop\n` +
+        `then re-run this script.`,
+    );
+    return 1;
+  }
+
+  const raw = await readFile(POOL_PATH, 'utf-8');
+  const data = JSON.parse(raw) as PoolData;
+  console.log(`Loaded ${data.workItems.length} WorkItems`);
+
+  const sourceByDoneByWorker = new Map<string, WorkItem>();
+  for (const w of data.workItems) {
+    if (w.status === 'done_by_worker') sourceByDoneByWorker.set(w.id, w);
+  }
+  console.log(`Sources in done_by_worker: ${sourceByDoneByWorker.size}`);
+
+  // Index every verify WI by its source id (whatever its status).
+  const verifyBySource = new Map<string, WorkItem>();
+  for (const w of data.workItems) {
+    const verifyOf =
+      w.metadata && typeof w.metadata.verifyOf === 'string'
+        ? (w.metadata.verifyOf as string)
+        : undefined;
+    if (verifyOf) verifyBySource.set(verifyOf, w);
+  }
+
+  if (cleanup) {
+    return await runStaleCleanup({ data, sourceByDoneByWorker, verifyBySource, apply });
+  }
+  return await runVerifyPropagation({ data, sourceByDoneByWorker, verifyBySource, apply });
+}
+
+/** Shape A — flip stuck `done_by_worker` sources to `verified` when their
+ *  verify WI is already `done`. */
+async function runVerifyPropagation(args: {
+  data: PoolData;
+  sourceByDoneByWorker: Map<string, WorkItem>;
+  verifyBySource: Map<string, WorkItem>;
+  apply: boolean;
+}): Promise<number> {
+  const { data, sourceByDoneByWorker, verifyBySource, apply } = args;
+  const stuckPairs: Array<{ source: WorkItem; verifyId: string }> = [];
+  for (const [sourceId, source] of sourceByDoneByWorker) {
+    const verify = verifyBySource.get(sourceId);
+    if (!verify) continue;
+    if (verify.status !== 'done') continue;
+    stuckPairs.push({ source, verifyId: verify.id });
+  }
+
+  console.log(`\nStuck pairs (verify=done, source=done_by_worker): ${stuckPairs.length}`);
+  for (const { source, verifyId } of stuckPairs) {
+    const title = (source.title ?? '').slice(0, 70);
+    console.log(`  source=${source.id}  verify=${verifyId}  ${title}`);
+  }
+
+  if (stuckPairs.length === 0) {
+    console.log('\nNothing to backfill.');
+    return 0;
+  }
+
+  if (!apply) {
+    console.log('\n(dry-run — re-run with --apply to push these to verified)');
+    return 0;
+  }
+
+  const now = new Date().toISOString();
+  for (const { source } of stuckPairs) {
+    source.status = 'verified';
+    if (!source.completedAt) source.completedAt = now;
+  }
+  data.lastUpdatedAt = now;
+  await writePool(data);
+
+  console.log(`\nDone: ${stuckPairs.length} sources flipped to verified.`);
+  console.log(`Restart the service to pick up the change:`);
+  console.log(`  crewly service start`);
+  console.log(
+    `\nThe reconciler will then re-evaluate dependents on its next tick and unblock\n` +
+      `any Execute/Review WIs that were waiting on these sources.`,
+  );
+  return 0;
+}
+
+/** Shape B — mark stale `done_by_worker` WIs as `cancelled` when their
+ *  verify WI is `cancelled` or never got created. These will never reach
+ *  `verified` through normal flow, so they sit in the UI forever as
+ *  "in flight". */
+async function runStaleCleanup(args: {
+  data: PoolData;
+  sourceByDoneByWorker: Map<string, WorkItem>;
+  verifyBySource: Map<string, WorkItem>;
+  apply: boolean;
+}): Promise<number> {
+  const { data, sourceByDoneByWorker, verifyBySource, apply } = args;
+  const nowMs = Date.now();
+
+  const stalePairs: Array<{ source: WorkItem; verify: WorkItem | undefined; ageH: number }> = [];
+  for (const [sourceId, source] of sourceByDoneByWorker) {
+    const verify = verifyBySource.get(sourceId);
+    // Cleanup target: verify missing OR cancelled. (verify=done is shape A,
+    // verify=queued/running means a review is still pending — leave alone.)
+    const isCleanupCandidate =
+      !verify || verify.status === 'cancelled';
+    if (!isCleanupCandidate) continue;
+
+    // Age gate — only touch items older than the stale threshold so we
+    // don't race active work.
+    const createdMs = source.createdAt ? Date.parse(source.createdAt) : nowMs;
+    const ageMs = nowMs - createdMs;
+    if (ageMs < STALE_THRESHOLD_MS) continue;
+
+    stalePairs.push({ source, verify, ageH: Math.round(ageMs / 3_600_000) });
+  }
+
+  console.log(
+    `\nStale pairs (done_by_worker >${STALE_THRESHOLD_MS / 3_600_000}h, verify cancelled/missing): ${stalePairs.length}`,
+  );
+  for (const { source, verify, ageH } of stalePairs) {
+    const title = (source.title ?? '').slice(0, 60);
+    const verifyStatus = verify ? verify.status : '<no verify WI>';
+    console.log(`  ${ageH}h  verify=${verifyStatus}  ${source.id}  ${title}`);
+  }
+
+  if (stalePairs.length === 0) {
+    console.log('\nNothing to clean up.');
+    return 0;
+  }
+
+  if (!apply) {
+    console.log('\n(dry-run — re-run with --stale-cleanup --apply to mark as cancelled)');
+    return 0;
+  }
+
+  const now = new Date().toISOString();
+  for (const { source, verify } of stalePairs) {
+    source.status = 'cancelled';
+    const reason = verify
+      ? `Backfill: verify WI cancelled (id=${verify.id}), source abandoned pre-PR#553`
+      : 'Backfill: verify WI never created, source abandoned pre-PR#553';
+    (source as WorkItem & { cancelReason?: string }).cancelReason = reason;
+    // Note: matches the historical convention — cancelled WIs do NOT carry
+    // completedAt (see task-pool.service.ts:1751). Leave any prior
+    // completedAt as-is (rare on done_by_worker but harmless if present).
+  }
+  data.lastUpdatedAt = now;
+  await writePool(data);
+
+  console.log(`\nDone: ${stalePairs.length} sources marked as cancelled.`);
+  console.log(`Restart the service to pick up the change:`);
+  console.log(`  crewly service start`);
+  return 0;
+}
+
+async function writePool(data: PoolData): Promise<void> {
+  const tmpPath = `${POOL_PATH}.backfill.tmp`;
+  await writeFile(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+  await rename(tmpPath, POOL_PATH);
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error('Unhandled error:', err);
+    process.exit(2);
+  });


### PR DESCRIPTION
## Summary

Steve 2026-05-15 dogfood: 智库 Request triggered a 30-min heartbeat saying "5/7 完成, 进行中 1" right after Grace turned in the user-visible Review. The "进行中 1" was orc's **internal Verify WI** (`type: 'review'`) for Grace's Review — bookkeeping the owner cannot act on.

From Steve's chat view it read as "system still pending on something" → he asked: "为什么系统会出现这个status更新？在这个thread里我没有看到有任何需要更新或等待回复的内容啊".

## Fix

Heartbeat tally now filters to **user-deliverable WIs only** (`type === 'delegate'`). Internal types — review/verify/cron_run/notify/reconcile/check/confirm — are excluded from the count.

When **every delegate** has reached a user-perceived terminal state (`done | verified | done_by_worker | cancelled | failed | rejected`), the heartbeat is suppressed entirely. The owner already saw the deliverable; the internal verify path will close the Request without noise.

Mixed states still fire normally (e.g. 1 delegate verified + 1 delegate running → heartbeat surfaces the running one without inflating the count with the internal review WI).

## Bundled

`scripts/backfill-stuck-verify.ts` gained a `--stale-cleanup` mode (used live today to mark 4 stale `done_by_worker` WIs as `cancelled` — verify WI cancelled/missing, source 5h-6d old).

## Test plan

- [x] 29/29 in `request-status-update.subscriber.test.ts` (2 new suppress/mixed cases; updated 2026-05-09 done_by_worker test to reflect new suppression)
- [x] Quality gates passed
- [ ] After restart + next user Request flow: no spurious `进行中 N` heartbeats when only Verify WIs are in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)