### PR TITLE
fix(agent): alias common role synonyms to canonical directory names (tech-lead → team-leader)

### DIFF
--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -3817,6 +3817,35 @@ describe('AgentRegistrationService', () => {
 				(service as any).getPromptFileForRole('')
 			).rejects.toThrow(InvalidAgentRoleError);
 		});
+
+		// Steve 2026-05-15 dogfood: CE team config used `role: "tech-lead"`
+		// while the canonical directory is `team-leader`, producing a
+		// steady drip of "Could not load prompt from config" warns on
+		// every member start.
+		it('resolves "tech-lead" alias → team-leader directory', async () => {
+			const result = await (service as any).getPromptFileForRole('tech-lead');
+			expect(result).toContain('config/roles/team-leader/prompt.md');
+		});
+
+		it('resolves "Tech Lead" (mixed case + space) → team-leader', async () => {
+			const result = await (service as any).getPromptFileForRole('Tech Lead');
+			expect(result).toContain('config/roles/team-leader/prompt.md');
+		});
+
+		it('resolves "tl" alias → team-leader', async () => {
+			const result = await (service as any).getPromptFileForRole('tl');
+			expect(result).toContain('config/roles/team-leader/prompt.md');
+		});
+
+		it('resolves "team-lead" alias → team-leader (synonym normalization)', async () => {
+			const result = await (service as any).getPromptFileForRole('team-lead');
+			expect(result).toContain('config/roles/team-leader/prompt.md');
+		});
+
+		it('does not alias a role that already matches a directory (no regression)', async () => {
+			const result = await (service as any).getPromptFileForRole('developer');
+			expect(result).toContain('config/roles/developer/prompt.md');
+		});
 	});
 
 	describe('createAgentSession role validation (Bug #1 fail-fast)', () => {

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -739,6 +739,27 @@ export class AgentRegistrationService {
 	}
 
 	/**
+	 * Role aliases — common synonyms users naturally type in team configs
+	 * mapped to the canonical directory name under `config/roles/`. Without
+	 * these, a team-config role like `"tech-lead"` would fall through to a
+	 * non-existent directory and trigger the ENOENT fallback path on every
+	 * agent registration (Steve 2026-05-15 dogfood: CE team config used
+	 * `role: "tech-lead"` while the canonical directory is `team-leader`,
+	 * producing a steady drip of "Could not load prompt from config" warns
+	 * for every member-start with no actionable resolution short of editing
+	 * user data).
+	 *
+	 * Keep keys lowercased + dash-normalized (matches the post-normalization
+	 * shape used by `getPromptFileForRole`).
+	 */
+	private static readonly ROLE_DIR_ALIASES: ReadonlyMap<string, string> = new Map([
+		['tech-lead', 'team-leader'],
+		['techlead', 'team-leader'],
+		['tl', 'team-leader'],
+		['team-lead', 'team-leader'],
+	]);
+
+	/**
 	 * Get prompt file path for a specific role
 	 * Uses the unified config/roles/{role}/prompt.md structure
 	 */
@@ -748,7 +769,11 @@ export class AgentRegistrationService {
 		// and trigger the silent fallback path that left agents with empty prompts (Bug #1).
 		validateAgentRole(role, 'getPromptFileForRole');
 		// Normalize role name to directory name format
-		const roleName = role.toLowerCase().replace(/\s+/g, '-');
+		const normalized = role.toLowerCase().replace(/\s+/g, '-');
+		// Resolve aliases (e.g. tech-lead → team-leader). Falls through for
+		// any role that already matches its directory name.
+		const roleName =
+			AgentRegistrationService.ROLE_DIR_ALIASES.get(normalized) ?? normalized;
 		return path.join(process.cwd(), 'config', 'roles', roleName, 'prompt.md');
 	}
 


### PR DESCRIPTION
## Summary

Steve 2026-05-15 dogfood: CE team config uses `role: "tech-lead"` for Owen, but the canonical directory under `config/roles/` is `team-leader`. Every agent registration in that team logs:

```
WARN [AgentRegistrationService] Could not load prompt from config, using fallback
     role: "tech-lead", error: ENOENT ...config/roles/tech-lead/prompt.md
```

PR #550 already dropped this from ERROR to WARN, but the warning keeps firing on every member start with no actionable resolution short of asking the user to rename their team config.

## Fix

Small role-alias map at the path resolver level:
- `tech-lead` → `team-leader`
- `techlead` → `team-leader`
- `tl` → `team-leader`
- `team-lead` → `team-leader`

Roles that already match a directory name fall through unchanged (no regression). Keys are normalized (lower + dash-replace) so caller-side casing differences (`"Tech Lead"`) hit the alias too.

## Test plan

- [x] 10/10 pass on `getPromptFileForRole` describe — 5 new alias cases + 5 existing
- [x] Quality gates passed
- [ ] After restart: no more "Could not load prompt" WARNs for the CE team

🤖 Generated with [Claude Code](https://claude.com/claude-code)