### PR TITLE
fix(reconciler): dedupe corrections sharing entity+newState in one tick

### DIFF
--- a/backend/src/services/reconciler/reconciler.service.test.ts
+++ b/backend/src/services/reconciler/reconciler.service.test.ts
@@ -450,6 +450,42 @@ describe('ReconcilerService', () => {
       expect(provider.applyCorrection).not.toHaveBeenCalled();
     });
 
+    it('dedupes corrections sharing entity+newState in one tick (Steve 2026-05-15)', async () => {
+      // Repro: WI 5afef18f at 21:55:49 — both `detectRecoverableWorkItems`
+      // (agent back online) AND `detectDependencyResolvedWorkItems`
+      // (dependencies satisfied) emitted blocked→queued for the same
+      // WI in the same tick. First requeueWorkItem succeeded; second
+      // threw "Cannot release ... got 'queued'" because the WI was no
+      // longer in `blocked`. Dedup must skip the second.
+      provider = createMockProvider({});
+      service = new ReconcilerService(provider);
+
+      const correction = {
+        entityType: 'work_item' as const,
+        entityId: 'wi-1',
+        previousState: 'blocked',
+        newState: 'queued',
+        reason: 'agent back online',
+        evidence: '',
+        timestamp: new Date().toISOString(),
+        id: 'c1',
+      };
+      const duplicate = { ...correction, id: 'c2', reason: 'deps resolved' };
+
+      await (service as any).applyCorrections([correction, duplicate], {
+        corrections: [],
+        workItemsRequeued: 0,
+        claimsRevoked: 0,
+        errors: [],
+        staleItemsCleaned: 0,
+        workItemsTimedOut: 0,
+      });
+
+      // Only ONE requeueWorkItem call despite two corrections — dedup wins.
+      expect(provider.requeueWorkItem).toHaveBeenCalledTimes(1);
+      expect(provider.requeueWorkItem).toHaveBeenCalledWith('wi-1');
+    });
+
     it('should handle correction application errors gracefully', async () => {
       const wi = makeWorkItem({
         status: 'running',

--- a/backend/src/services/reconciler/reconciler.service.ts
+++ b/backend/src/services/reconciler/reconciler.service.ts
@@ -387,7 +387,41 @@ export class ReconcilerService {
     corrections: ReconcileCorrection[],
     result: ReconcileResult,
   ): Promise<void> {
-    for (const correction of corrections) {
+    // Steve 2026-05-15 dogfood (WI 5afef18f, 21:55:49): TWO rules can
+    // both emit blocked→queued for the same WI in a single tick —
+    // `detectRecoverableWorkItems` (agent back online) and
+    // `detectDependencyResolvedWorkItems` (dependencies satisfied). The
+    // first requeueWorkItem call succeeds; the second throws "Cannot
+    // release WorkItem: status must be 'running' or 'blocked', got
+    // 'queued'" because the WI is already past blocked. Dedup before
+    // iterating so each entity gets at most one terminal-state
+    // correction per tick — first writer wins. Key by entity+newState
+    // to keep room for legitimate distinct corrections on the same
+    // entity (e.g. a separate cancelled correction after a queued
+    // one, which the matrix rejects anyway but we surface explicitly).
+    const seen = new Set<string>();
+    const deduped: ReconcileCorrection[] = [];
+    let dupCount = 0;
+    for (const c of corrections) {
+      const key = `${c.entityType}:${c.entityId}:${c.newState}`;
+      if (seen.has(key)) {
+        dupCount++;
+        continue;
+      }
+      seen.add(key);
+      deduped.push(c);
+    }
+    if (dupCount > 0) {
+      // ReconcilerService has no injected logger; the result.errors
+      // array is the surface here. A duplicate-correction skip is not
+      // an error per se, but we want it observable in the tick result
+      // so a `runFull()` caller can see it in returned diagnostics.
+      // No error pushed — duplicates are expected when rules overlap
+      // (Steve 2026-05-15: detectRecoverable + detectDependencyResolved
+      // both produced blocked→queued for the same WI).
+    }
+
+    for (const correction of deduped) {
       try {
         // Handle claim-specific corrections via ClaimService
         if (correction.entityType === 'claim') {


### PR DESCRIPTION
## Summary

Steve 2026-05-15 dogfood, WI `5afef18f` at 21:55:49: a single reconciler tick produced TWO blocked→queued corrections for the same WI — `detectRecoverableWorkItems` (agent back online) AND `detectDependencyResolvedWorkItems` (dependencies satisfied) both matched.

```
21:55:49.921 transitioned blocked → queued (first requeueWorkItem)
21:55:49.933 released back to pool (first releaseBack success)
21:55:49.933 INFO  Re-queued work item            (first call done)
21:55:49.933 ERROR Failed to re-queue work item   (second call fails)
     error: "Cannot release WorkItem: status must be 'running' or
            'blocked', got 'queued'"
```

PR #551 made the blocked→queued path call `requeueWorkItem` instead of `applyCorrection`+`requeueWorkItem` (correct) — but when TWO corrections target the same `(entityId, newState)`, the second inevitably finds the WI past `blocked`.

## Fix

Dedupe by `${entityType}:${entityId}:${newState}` before iterating. First writer wins; duplicates silently dropped. Handles any rule overlap, not just blocked→queued.

## Test plan

- [x] 3/3 pass on requeue + dedup slice
- [x] Quality gates passed
- [ ] After restart: 0 more `Failed to re-queue work item` ERRORs

🤖 Generated with [Claude Code](https://claude.com/claude-code)