### PR TITLE
fix(slack): catch finity 'Unhandled event' throws to prevent engine crash (closes #548)

### DIFF
--- a/backend/src/services/slack/slack.service.test.ts
+++ b/backend/src/services/slack/slack.service.test.ts
@@ -608,6 +608,72 @@ describe('SlackService', () => {
       mockSocketClient.emit('close');
       expect(service.isConnected()).toBe(false);
     });
+
+    // Issue #548 — finity throws `Unhandled event 'server explicit
+    // disconnect' in state 'connecting'` synchronously inside the
+    // WebSocket message callback. Pre-fix this killed the process on
+    // v1 hosts. Wrapped `onWebSocketMessage` must catch the throw,
+    // log a WARN, schedule reconnect, and return cleanly.
+    it('catches finity Unhandled event throws and schedules reconnect (issue #548)', () => {
+      const service = new SlackService();
+      const { EventEmitter } = require('events');
+      class MockSocketClient extends EventEmitter {
+        onWebSocketMessage(_msg: unknown): void {
+          throw new Error(`Unhandled event 'server explicit disconnect' in state 'connecting'`);
+        }
+      }
+      const mockSocketClient = new MockSocketClient();
+
+      (service as any).app = {
+        receiver: { client: mockSocketClient },
+        message: jest.fn(),
+        event: jest.fn(),
+        error: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+      };
+      (service as any).status.connected = true;
+
+      const scheduleReconnectSpy = jest
+        .spyOn(service as any, 'scheduleReconnect')
+        .mockImplementation(() => {});
+
+      (service as any).setupConnectionMonitoring();
+
+      // Invoke the (now-wrapped) onWebSocketMessage — should NOT throw
+      expect(() => mockSocketClient.onWebSocketMessage('{"type": "disconnect"}')).not.toThrow();
+
+      // Reconnect was scheduled, status flipped to disconnected
+      expect(scheduleReconnectSpy).toHaveBeenCalledTimes(1);
+      expect(service.isConnected()).toBe(false);
+      expect(service.getStatus().lastError).toMatch(/Unhandled event/);
+
+      scheduleReconnectSpy.mockRestore();
+    });
+
+    it('lets non-Unhandled-event throws propagate (issue #548 guard is targeted)', () => {
+      const service = new SlackService();
+      const { EventEmitter } = require('events');
+      class MockSocketClient extends EventEmitter {
+        onWebSocketMessage(_msg: unknown): void {
+          throw new Error('some other error');
+        }
+      }
+      const mockSocketClient = new MockSocketClient();
+
+      (service as any).app = {
+        receiver: { client: mockSocketClient },
+        message: jest.fn(),
+        event: jest.fn(),
+        error: jest.fn(),
+        start: jest.fn(),
+        stop: jest.fn(),
+      };
+      (service as any).setupConnectionMonitoring();
+
+      // Non-finity throws must still surface
+      expect(() => mockSocketClient.onWebSocketMessage('msg')).toThrow('some other error');
+    });
   });
 
   describe('health check active ping', () => {

--- a/backend/src/services/slack/slack.service.ts
+++ b/backend/src/services/slack/slack.service.ts
@@ -504,6 +504,54 @@ export class SlackService extends EventEmitter {
         return;
       }
 
+      // Issue #548 — `@slack/socket-mode`'s finity state machine throws
+      // `Unhandled event 'server explicit disconnect' in state 'connecting'`
+      // when Slack sends a disconnect signal during the reconnect
+      // handshake window. The throw is SYNCHRONOUS inside the WebSocket
+      // message callback (WebSocket.onMessage → SocketModeClient.
+      // onWebSocketMessage → finity.handle → throw) so it surfaces as
+      // an uncaughtException that takes the process down on v1 hosts
+      // (no pm2/systemd to restart). CrewlyNode1 went dark for ~21
+      // hours on 2026-05-14 from exactly this.
+      //
+      // Wrap `onWebSocketMessage` with a synchronous try/catch that
+      // swallows the unhandled-event throw, logs it as a recoverable
+      // event, and triggers the reconnect path. Other throws still
+      // surface normally — we only suppress the specific finity
+      // "Unhandled event" signature.
+      const wrappedClient = socketClient as unknown as {
+        onWebSocketMessage?: (...args: unknown[]) => unknown;
+      };
+      const originalOnMessage = wrappedClient.onWebSocketMessage;
+      if (typeof originalOnMessage === 'function') {
+        wrappedClient.onWebSocketMessage = (...args: unknown[]) => {
+          try {
+            return originalOnMessage.apply(socketClient, args);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (/Unhandled event/.test(msg)) {
+              this.logger.warn(
+                'Suppressed finity unhandled-event from SocketModeClient (issue #548) — triggering reconnect',
+                {
+                  error: msg,
+                },
+              );
+              this.status.connected = false;
+              this.status.lastError = `SocketMode finity throw: ${msg}`;
+              this.status.lastErrorAt = new Date().toISOString();
+              this.scheduleReconnect();
+              return undefined;
+            }
+            throw err;
+          }
+        };
+        this.logger.info('SocketModeClient.onWebSocketMessage wrapped for #548 finity-throw recovery');
+      } else {
+        this.logger.warn(
+          'SocketModeClient.onWebSocketMessage not found — #548 finity-throw guard NOT installed',
+        );
+      }
+
       socketClient.on('disconnected', () => {
         this.status.connected = false;
         this.status.lastError = 'Socket Mode connection lost';


### PR DESCRIPTION
## Summary

Closes #548.

`@slack/socket-mode`'s finity state machine throws synchronously when Slack sends `server explicit disconnect` while in state `connecting`:

```
Unhandled event 'server explicit disconnect' in state 'connecting'
  at StateMachine.handleUnhandledEvent (finity/StateMachine.js:76:13)
  ...
  at SocketModeClient.onWebSocketMessage (...:608:31)
  at WebSocket.onMessage (...)
```

The throw is synchronous inside the WebSocket callback, so the engine's `unhandledRejection` handler does NOT catch it — it surfaces as `uncaughtException` and kills the engine. On v1-layout hosts (no pm2/systemd) the engine stays silently dead.

**Real impact**: CrewlyNode1 went silently down 2026-05-14 16:52Z → 2026-05-15 14:30Z (~21h). ESTestNode pm2 thrashing with `↺ counter=15+`.

## Fix (Path B from the issue)

In `setupConnectionMonitoring`, wrap `SocketModeClient.onWebSocketMessage` with a synchronous try/catch:
- Match the specific `Unhandled event` message signature
- Log WARN noting the #548 guard fired
- Flip `status.connected = false`, record `lastError`
- Trigger `scheduleReconnect()` so normal backoff resumes
- Return cleanly (no rethrow)

Non-finity throws propagate normally. The structural fix (Path A: register the missing transition in finity) requires upstream changes in `@slack/socket-mode` and stays as future work.

## Test plan

- [x] 4/4 pass on `setupConnectionMonitoring` slice — existing 2 + new finity-throw catch + non-finity passthrough
- [x] Quality gates passed
- [ ] After deploy to CrewlyNode1: 24h with zero `Unhandled event` traces and no supervisor restart
- [ ] After deploy to ESTestNode: pm2 `↺ counter` stops climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)