### PR TITLE
fix(browser): proxy path respects agent→tab binding (closes #384, P0)

### DIFF
--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -262,7 +262,7 @@ async function sendToolCommand(
 	// Path 1: If a specific instance is requested AND proxy is available, use proxy
 	if (instance && proxy.isAvailable()) {
 		try {
-			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName);
+			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession);
 			res.json(result);
 			return;
 		} catch (err) {
@@ -289,7 +289,7 @@ async function sendToolCommand(
 	// Path 3: Proxy relay (relay_to addressed messaging)
 	if (proxy.isAvailable()) {
 		try {
-			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName);
+			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession);
 			res.json(result);
 			return;
 		} catch (err) {

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -396,6 +396,114 @@ describe('BrowserProxyService', () => {
       await cmdPromise;
     });
 
+    // Issue #384 — per-tab dispatch on the proxy path.
+
+    it('injects bound tabId on the proxy path when agentSession has a binding (#384)', async () => {
+      setupConnectedProxy();
+      const proxy = BrowserProxyService.getInstance();
+
+      // Stub the BrowserBridgeService lazy-imported inside sendCommand.
+      // The proxy imports it dynamically; intercept via the singleton.
+      const { BrowserBridgeService } = await import('./browser-bridge.service.js');
+      const bridge = BrowserBridgeService.getInstance();
+      jest.spyOn(bridge, 'getBinding').mockReturnValue({
+        agentSession: 'crewly-product-leo',
+        tabId: 4242,
+        boundAt: new Date(),
+        lastActivityAt: new Date(),
+      } as any);
+
+      const cmdPromise = proxy.sendCommand(
+        'click',
+        { selector: '.foo' },
+        undefined,
+        5000,
+        undefined,
+        'crewly-product-leo',
+      );
+
+      // Drain the promise to allow the dynamic import + spy to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const sentMsg = JSON.parse(latestMockWs!.send.mock.lastCall![0] as string);
+      const payload = JSON.parse(sentMsg.payload as string);
+      expect(payload.params.tabId).toBe(4242);
+      expect(payload.params.selector).toBe('.foo');
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          payload: JSON.stringify({ id: payload.id, success: true, result: 'ok' }),
+        }),
+      );
+      await cmdPromise;
+    });
+
+    it('explicit tabId in params wins over the binding (#384)', async () => {
+      setupConnectedProxy();
+      const proxy = BrowserProxyService.getInstance();
+
+      const { BrowserBridgeService } = await import('./browser-bridge.service.js');
+      const bridge = BrowserBridgeService.getInstance();
+      const getBindingSpy = jest.spyOn(bridge, 'getBinding');
+
+      const cmdPromise = proxy.sendCommand(
+        'click',
+        { selector: '.foo', tabId: 99 },
+        undefined,
+        5000,
+        undefined,
+        'crewly-product-leo',
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Explicit tabId path: getBinding should NOT have been consulted.
+      expect(getBindingSpy).not.toHaveBeenCalled();
+
+      const sentMsg = JSON.parse(latestMockWs!.send.mock.lastCall![0] as string);
+      const payload = JSON.parse(sentMsg.payload as string);
+      expect(payload.params.tabId).toBe(99);
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          payload: JSON.stringify({ id: payload.id, success: true, result: 'ok' }),
+        }),
+      );
+      await cmdPromise;
+    });
+
+    it('forwards without tabId when no agentSession is supplied (legacy active-tab path)', async () => {
+      setupConnectedProxy();
+      const proxy = BrowserProxyService.getInstance();
+
+      const { BrowserBridgeService } = await import('./browser-bridge.service.js');
+      const bridge = BrowserBridgeService.getInstance();
+      const getBindingSpy = jest.spyOn(bridge, 'getBinding');
+
+      const cmdPromise = proxy.sendCommand('click', { selector: '.foo' });
+      await Promise.resolve();
+
+      // No agentSession → no binding lookup, no tabId injected.
+      expect(getBindingSpy).not.toHaveBeenCalled();
+      const sentMsg = JSON.parse(latestMockWs!.send.mock.lastCall![0] as string);
+      const payload = JSON.parse(sentMsg.payload as string);
+      expect(payload.params.tabId).toBeUndefined();
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'relay',
+          payload: JSON.stringify({ id: payload.id, success: true, result: 'ok' }),
+        }),
+      );
+      await cmdPromise;
+    });
+
     it('should route to explicit instance name', async () => {
       // Add two instances
       const proxy = BrowserProxyService.getInstance();

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -343,6 +343,7 @@ export class BrowserProxyService {
     instance?: string,
     timeoutMs: number = BROWSER_BRIDGE_CONSTANTS.COMMAND_TIMEOUT_MS,
     agentName?: string,
+    agentSession?: string,
   ): Promise<BrowserCommandResponse> {
     if (this.state !== 'connected' || !this.ws) {
       throw new Error('Browser proxy not connected to relay');
@@ -361,11 +362,51 @@ export class BrowserProxyService {
       );
     }
 
+    // Issue #384 — Per-tab dispatch was previously bypassed on the
+    // proxy path. The direct-WS path uses `BrowserBridgeService.
+    // sendCommandForAgent` which auto-injects `params.tabId` from the
+    // agentTabBindings map; the proxy path silently forwarded without
+    // tabId and the Chrome Extension fell back to `tabs.query({active:
+    // true})` (the user's focused tab — wrong tab when the user
+    // switched away). Steve's 2026-04-30 demo bug: Olivia's clicks
+    // "stopped registering" after a tab switch.
+    //
+    // Mirror sendCommandForAgent here: if agentSession is supplied AND
+    // params has no explicit tabId, look up the binding from the
+    // shared BrowserBridgeService.agentTabBindings map and inject the
+    // bound tabId before forwarding. Explicit tabId still wins.
+    let resolvedParams = params ?? {};
+    if (
+      agentSession &&
+      resolvedParams &&
+      typeof (resolvedParams as { tabId?: unknown }).tabId !== 'number'
+    ) {
+      // Lazy import to avoid a circular dep at module-load time.
+      // BrowserBridgeService and BrowserProxyService are wired together
+      // by the controller but neither service should import the other
+      // eagerly.
+      const { BrowserBridgeService } = await import('./browser-bridge.service.js');
+      const binding = BrowserBridgeService.getInstance().getBinding(agentSession);
+      if (binding) {
+        resolvedParams = { ...resolvedParams, tabId: binding.tabId };
+        this.logger.debug('Injected bound tabId on proxy path (#384)', {
+          agentSession,
+          tabId: binding.tabId,
+          tool,
+        });
+      } else {
+        this.logger.debug('No binding for agentSession on proxy path — Extension will fall back to active tab', {
+          agentSession,
+          tool,
+        });
+      }
+    }
+
     const id = `proxy-${++this.commandCounter}-${Date.now()}`;
     const payload = JSON.stringify({
       id,
       tool,
-      params: params ?? {},
+      params: resolvedParams,
       agentName,
     });
 


### PR DESCRIPTION
Closes #384 (P0 bug).

## Summary

Per-tab dispatch only worked on the direct WebSocket path. On the Cloud-Relay / proxy path, the binding map was silently bypassed — requests forwarded without `tabId`, so the Chrome Extension fell back to `chrome.tabs.query({active: true})` (the **user's** focused tab, not the agent's bound tab).

**Real impact**: Steve's 2026-04-30 customer demo — Olivia's clicks "stopped registering" on her bound tab after the user switched away.

## Fix

Mirror the direct-WS per-tab logic on the proxy path:

- `BrowserProxyService.sendCommand` gains an `agentSession?: string` param.
- When `agentSession` is supplied AND params lacks an explicit `tabId`, look up the binding from `BrowserBridgeService.agentTabBindings` (shared map, single source of truth) via the existing `getBinding()` accessor and inject `binding.tabId`. Lazy-imports the bridge service to avoid a circular dep.
- Explicit `params.tabId` still wins.
- No binding + no explicit tabId → falls through as before.
- `browser.controller.ts` Paths 1 + 3 forward `agentSession`.

## Test plan

- [x] 11/11 pass on sendCommand — existing 8 + 3 new (binding-injection / explicit-tabId-wins / no-agentSession-passthrough)
- [x] Quality gates passed (service was briefly down during commit; verified post-restart)
- [ ] After deploy: agent A binds tab T1, user switches to T2, agent A click without `--tab-id` lands on T1 (not T2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)