### PR TITLE
fix(session): resume-sessions dialog excludes agents with no pool work

### DIFF
--- a/backend/src/controllers/session/session.controller.test.ts
+++ b/backend/src/controllers/session/session.controller.test.ts
@@ -13,6 +13,8 @@ import { RUNTIME_TYPES } from '../../constants.js';
 
 // Mock dependencies
 const mockSendMessage = jest.fn<any>();
+const mockGetAllItems = jest.fn<any>().mockResolvedValue([]);
+
 jest.mock('../../services/session/index.js', () => ({
 	getSessionBackendSync: jest.fn(),
 	getSessionBackend: jest.fn(),
@@ -20,6 +22,14 @@ jest.mock('../../services/session/index.js', () => ({
 	createSessionCommandHelper: jest.fn(() => ({
 		sendMessage: mockSendMessage,
 	})),
+}));
+
+jest.mock('../../services/task-pool/task-pool.service.js', () => ({
+	TaskPoolService: {
+		getInstance: () => ({
+			getAllItems: () => mockGetAllItems(),
+		}),
+	},
 }));
 
 jest.mock('../../services/core/logger.service.js', () => ({
@@ -96,7 +106,21 @@ describe('Session Controller - Previous Sessions', () => {
 	});
 
 	describe('getPreviousSessions', () => {
-		it('should return sessions with no active PTY', async () => {
+		beforeEach(() => {
+			// Reset pool mock between tests
+			mockGetAllItems.mockReset();
+			mockGetAllItems.mockResolvedValue([]);
+		});
+
+		it('should return sessions with no active PTY (pool-filter retains them when WI targets them)', async () => {
+			// Steve 2026-05-15: pool filter retains sessions that have
+			// at least one non-terminal WI targeting them. Both agents
+			// here have pool work — pass through.
+			mockGetAllItems.mockResolvedValue([
+				{ target: 'agent-1', status: 'queued' },
+				{ target: 'agent-2', status: 'running' },
+			]);
+
 			const sessionsMap = new Map([
 				['agent-1', { name: 'agent-1', role: 'dev', teamId: 'team-1', runtimeType: RUNTIME_TYPES.CLAUDE_CODE, claudeSessionId: 'abc-123' }],
 				['agent-2', { name: 'agent-2', role: 'qa', runtimeType: RUNTIME_TYPES.GEMINI_CLI }],
@@ -121,6 +145,11 @@ describe('Session Controller - Previous Sessions', () => {
 		});
 
 		it('should filter out sessions with active PTY', async () => {
+			mockGetAllItems.mockResolvedValue([
+				{ target: 'active-agent', status: 'running' },
+				{ target: 'stopped-agent', status: 'queued' },
+			]);
+
 			const sessionsMap = new Map([
 				['active-agent', { name: 'active-agent', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
 				['stopped-agent', { name: 'stopped-agent', role: 'qa', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
@@ -136,6 +165,71 @@ describe('Session Controller - Previous Sessions', () => {
 			const jsonCall = (res.json as jest.Mock).mock.calls[0][0] as PreviousSessionsResponse;
 			expect(jsonCall.data.sessions).toHaveLength(1);
 			expect(jsonCall.data.sessions[0].name).toBe('stopped-agent');
+		});
+
+		// Steve 2026-05-15 dogfood: Resume dialog listed 12 marketing/
+		// think-tank agents with zero pool work, then `startTeam` woke
+		// them all, then wake-gate rejected each member with "pool has
+		// no queued/blocked WorkItem with target=...". Filter now
+		// matches the wake-gate's contract.
+
+		it('filters out sessions with no active WI in the pool (Steve 2026-05-15)', async () => {
+			mockGetAllItems.mockResolvedValue([
+				{ target: 'agent-with-work', status: 'queued' },
+				{ target: 'agent-also-idle', status: 'done' }, // terminal — doesn't count
+			]);
+
+			const sessionsMap = new Map([
+				['agent-with-work', { name: 'agent-with-work', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+				['agent-idle', { name: 'agent-idle', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+				['agent-also-idle', { name: 'agent-also-idle', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+			]);
+			mockPersistence.getRegisteredSessionsMap.mockReturnValue(sessionsMap);
+			mockBackend.sessionExists.mockReturnValue(false);
+
+			const req = createMockReq();
+			const res = createMockRes();
+			await getPreviousSessions.call(undefined, req, res);
+
+			const jsonCall = (res.json as jest.Mock).mock.calls[0][0] as PreviousSessionsResponse;
+			expect(jsonCall.data.sessions).toHaveLength(1);
+			expect(jsonCall.data.sessions[0].name).toBe('agent-with-work');
+		});
+
+		it('always includes orchestrator sessions regardless of pool state', async () => {
+			mockGetAllItems.mockResolvedValue([]); // empty pool
+
+			const sessionsMap = new Map([
+				['crewly-orc', { name: 'crewly-orc', role: 'orchestrator', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+				['agent-x', { name: 'agent-x', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+			]);
+			mockPersistence.getRegisteredSessionsMap.mockReturnValue(sessionsMap);
+			mockBackend.sessionExists.mockReturnValue(false);
+
+			const req = createMockReq();
+			const res = createMockRes();
+			await getPreviousSessions.call(undefined, req, res);
+
+			const jsonCall = (res.json as jest.Mock).mock.calls[0][0] as PreviousSessionsResponse;
+			expect(jsonCall.data.sessions.map((s) => s.name)).toEqual(['crewly-orc']);
+		});
+
+		it('falls back to include-all behavior when pool read fails (graceful degradation)', async () => {
+			mockGetAllItems.mockRejectedValue(new Error('pool unavailable'));
+
+			const sessionsMap = new Map([
+				['agent-x', { name: 'agent-x', role: 'dev', runtimeType: RUNTIME_TYPES.CLAUDE_CODE }],
+			]);
+			mockPersistence.getRegisteredSessionsMap.mockReturnValue(sessionsMap);
+			mockBackend.sessionExists.mockReturnValue(false);
+
+			const req = createMockReq();
+			const res = createMockRes();
+			await getPreviousSessions.call(undefined, req, res);
+
+			const jsonCall = (res.json as jest.Mock).mock.calls[0][0] as PreviousSessionsResponse;
+			// Pool unavailable → fall back to legacy behavior, include all
+			expect(jsonCall.data.sessions.map((s) => s.name)).toEqual(['agent-x']);
 		});
 
 		it('should return empty array when no sessions registered', async () => {

--- a/backend/src/controllers/session/session.controller.ts
+++ b/backend/src/controllers/session/session.controller.ts
@@ -13,6 +13,7 @@ import { getSessionBackendSync, getSessionBackend, getSessionStatePersistence, c
 import { LoggerService } from '../../services/core/logger.service.js';
 import { OAuthReloginMonitorService } from '../../services/agent/oauth-relogin-monitor.service.js';
 import { RUNTIME_TYPES } from '../../constants.js';
+import { TaskPoolService } from '../../services/task-pool/task-pool.service.js';
 
 const logger = LoggerService.getInstance().createComponentLogger('SessionController');
 
@@ -280,6 +281,43 @@ export async function getPreviousSessions(
 		const sessions = persistence.getRegisteredSessionsMap();
 		const backend = getSessionBackendSync();
 
+		// Steve 2026-05-15 dogfood: the Resume Sessions dialog was
+		// listing every previously-running agent (12+ rows on a typical
+		// restart) including marketing/think-tank members with zero
+		// queued WorkItems. The wake-gate at startTeamMember rejects
+		// those wakes with "pool has no queued/blocked WorkItem with
+		// target=<session>" — so resuming them via the dialog burns
+		// compute and produces failed wake warnings. Filter the resume
+		// list to sessions that have a non-terminal WI in the pool
+		// targeting them; idle agents stay dismissed and the user can
+		// manually start them from the Teams page if they want.
+		let targetsWithWork: Set<string> | null = null;
+		try {
+			const items = await TaskPoolService.getInstance().getAllItems();
+			targetsWithWork = new Set(
+				items
+					.filter(
+						(w) =>
+							typeof w.target === 'string' &&
+							w.target.length > 0 &&
+							w.status !== 'done' &&
+							w.status !== 'verified' &&
+							w.status !== 'cancelled' &&
+							w.status !== 'failed' &&
+							w.status !== 'rejected',
+					)
+					.map((w) => w.target as string),
+			);
+		} catch (err) {
+			// Pool unavailable — fall back to the legacy include-all
+			// behavior so the dialog still helps the user resume after a
+			// crash where the pool can't be loaded.
+			logger.warn('getPreviousSessions: pool read failed, skipping pool-filter', {
+				error: err instanceof Error ? err.message : String(err),
+			});
+			targetsWithWork = null;
+		}
+
 		const previousSessions: Array<{
 			name: string;
 			role?: string;
@@ -290,15 +328,25 @@ export async function getPreviousSessions(
 
 		for (const [name, info] of sessions) {
 			// Only include sessions that don't have an active PTY
-			if (!backend?.sessionExists(name)) {
-				previousSessions.push({
-					name: info.name,
-					role: info.role,
-					teamId: info.teamId,
-					runtimeType: info.runtimeType,
-					hasResumeId: info.runtimeType === RUNTIME_TYPES.CLAUDE_CODE,
-				});
+			if (backend?.sessionExists(name)) continue;
+			// Pool-filter: skip sessions with no active WI targeting them.
+			// Orchestrator is excluded from the filter — it auto-starts
+			// independently of pool state and the frontend already filters
+			// it out of the dialog separately.
+			if (
+				targetsWithWork &&
+				info.role !== 'orchestrator' &&
+				!targetsWithWork.has(name)
+			) {
+				continue;
 			}
+			previousSessions.push({
+				name: info.name,
+				role: info.role,
+				teamId: info.teamId,
+				runtimeType: info.runtimeType,
+				hasResumeId: info.runtimeType === RUNTIME_TYPES.CLAUDE_CODE,
+			});
 		}
 
 		res.json({ success: true, data: { sessions: previousSessions } });


### PR DESCRIPTION
## Summary

Steve 2026-05-15 dogfood: the "Previous Sessions Detected" dialog listed 12 agents to resume after a restart — marketing/think-tank members with zero queued WorkItems in the pool. Auto-resume then fired `startTeam` for each team, which spawned every member, which each hit the wake-gate at `startTeamMember`:

```
WARN [TeamController] startTeamMember rejected by wake gate
reason: "Cannot wake '<session>': pool has no queued/blocked WorkItem with target=<session> ..."
```

Net effect: 12 wasted spawn attempts per restart + a steady drip of wake-gate WARNs. User's reasonable question: "为什么系统会启动这么多团队? workitem里没有他们的呀."

## Fix

`GET /api/sessions/previous` now filters the returned list to sessions that have at least one non-terminal WI (`queued | running | blocked | done_by_worker`) targeting them in the pool. Idle agents stay dismissed; user can still manually start them from the Teams page.

Edge cases preserved:
- Orchestrator always included (auto-starts independently; FE filters it separately anyway).
- Pool read failure → fall back to legacy include-all behavior (graceful degradation).

## Test plan

- [x] 7/7 pass on `getPreviousSessions` slice — 3 existing + 4 new (pool-filter retain / pool-filter skip / orc always-include / pool-error fallback)
- [x] Quality gates passed
- [ ] After restart: dialog only shows sessions with actual pool work

🤖 Generated with [Claude Code](https://claude.com/claude-code)