### PR TITLE
fix(task-pool): claimFromPool returns existing claim (alreadyHeld=true) instead of null (closes #513)

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -489,15 +489,28 @@ describe('TaskPoolService', () => {
       expect(result).toBeNull();
     });
 
-    it('prevents agent from claiming when they already have a claim', async () => {
+    it('returns the existing claim with alreadyHeld=true when agent already has one (issue #513)', async () => {
+      // Steve 2026-05-08 incident: an agent that already held an
+      // active claim called accept-task and got a 404 "No available
+      // WorkItem". Misleading — there WAS a WI for them (the one
+      // they already claimed). Now we return the held claim+WI with
+      // alreadyHeld=true so the skill output is honest.
       const wi1 = makeWorkItem({ title: 'First' });
       const wi2 = makeWorkItem({ title: 'Second' });
       await service.addToPool(wi1);
       await service.addToPool(wi2);
 
-      await service.claimFromPool('agent-leo');
+      const first = await service.claimFromPool('agent-leo');
+      expect(first).not.toBeNull();
+      expect(first!.alreadyHeld).toBeFalsy();
+      expect(first!.workItem.id).toBe(wi1.id);
+
       const second = await service.claimFromPool('agent-leo');
-      expect(second).toBeNull();
+      // Now returns the existing claim, not null.
+      expect(second).not.toBeNull();
+      expect(second!.alreadyHeld).toBe(true);
+      expect(second!.workItem.id).toBe(wi1.id);   // same WI as first
+      expect(second!.claim.id).toBe(first!.claim.id); // same claim
     });
 
     it('filters by type', async () => {

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -132,12 +132,21 @@ export interface PoolSnapshot {
 
 /**
  * Result returned when claiming a work item.
+ *
+ * `alreadyHeld` (Steve 2026-05-15, issue #513): true when the caller
+ * already had an active claim — we return that claim + its WorkItem
+ * instead of returning null. Callers (skill scripts, controller) can
+ * distinguish "fresh claim" from "you already own this" and route
+ * accordingly. Default `false` for new claims so existing callers
+ * stay source-compat.
  */
 export interface ClaimResult {
   /** The claimed work item */
   workItem: WorkItem;
   /** The claim object tracking the lease */
   claim: TaskClaim;
+  /** Set when the caller already held an active claim before this call */
+  alreadyHeld?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -634,12 +643,31 @@ export class TaskPoolService {
       // Check if agent already has an active claim
       const existingClaim = await this.storage.findActiveClaimByAgent(agentId);
       if (existingClaim) {
-        this.logger.warn('Agent already has an active claim', {
+        // Issue #513 — Steve 2026-05-15. Previously this returned
+        // null, which the controller mapped to 404 "No available
+        // WorkItem matching filters". That was misleading: the caller
+        // DOES have a WorkItem (the one they already claimed), they
+        // just couldn't see it without grepping pool.json. Return the
+        // held claim + its WorkItem with `alreadyHeld: true` so the
+        // skill / agent can recognize the situation.
+        this.logger.info('Agent already has an active claim — returning existing', {
           agentId,
           existingClaimId: existingClaim.id,
           existingWorkItemId: existingClaim.workItemId,
         });
-        return null;
+        const heldWorkItem = await this.storage.findWorkItem(existingClaim.workItemId);
+        if (!heldWorkItem) {
+          // Held claim exists but WI is missing — orphan state. Best we
+          // can do is fall through to the empty-pool null so the agent
+          // doesn't think they own a phantom item. Log so we notice.
+          this.logger.warn('Orphan claim — claim exists but WorkItem missing', {
+            agentId,
+            existingClaimId: existingClaim.id,
+            existingWorkItemId: existingClaim.workItemId,
+          });
+          return null;
+        }
+        return { workItem: heldWorkItem, claim: existingClaim, alreadyHeld: true };
       }
 
       const workItems = await this.storage.getWorkItems();


### PR DESCRIPTION
Closes #513. Returns the held claim + its WorkItem with `alreadyHeld: true` when an agent calls claimFromPool while already holding an active claim — instead of returning null (which the controller mapped to HTTP 404 "No available WorkItem matching filters" — misleading because there WAS work). `claimSpecificItem` deliberately keeps null-return (AutoClaim's contract). Orphan-claim safety: WI missing → null + WARN. Tests: 1/1 pass on new alreadyHeld case.