### PR TITLE
fix(slack): persist upload-file/image to chat-v2 + mark thread terminal

### DIFF
--- a/backend/src/controllers/slack/slack.controller.test.ts
+++ b/backend/src/controllers/slack/slack.controller.test.ts
@@ -595,6 +595,131 @@ describe('Slack Controller', () => {
         await fs.unlink(tmpFile).catch(() => {});
       }
     });
+
+    // Regression: 2026-05-15 — duplicate `agentic_explainer.mp4` posted by
+    // orchestrator after every backend restart. Root cause: /upload-file
+    // wrote to Slack but never persisted a chat-v2 turn / marked the
+    // thread-status terminal, so on context recovery orc concluded the
+    // file had not been sent and re-uploaded it.
+    it('marks thread-status replied_completed + records chat-v2 turn after successful upload', async () => {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+      const tmpFile = path.join(os.tmpdir(), 'test-upload-bookkeeping.pdf');
+      await fs.writeFile(tmpFile, 'fake pdf');
+
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'uploadFile').mockResolvedValue({ fileId: 'F-BOOK' });
+
+      mockChatV2EnsureChannel.mockClear();
+      mockChatV2RecordTurn.mockClear();
+
+      const channelId = 'CUPLOAD-1';
+      const threadTs = '1800.upload-1';
+
+      try {
+        await request(app).post('/api/slack/upload-file').send({
+          channelId,
+          filePath: tmpFile,
+          filename: 'agentic_explainer.mp4',
+          initialComment: 'here is the file',
+          threadTs,
+        });
+      } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+      }
+
+      // chat-v2 turn was recorded so orc's context recovery can see the upload.
+      expect(mockChatV2RecordTurn).toHaveBeenCalledTimes(1);
+      const turnCall = mockChatV2RecordTurn.mock.calls[0][0];
+      expect(turnCall.content).toContain('agentic_explainer.mp4');
+      expect(turnCall.metadata.source).toBe('reply-tool');
+      expect(turnCall.metadata.replyKind).toBe('file-upload');
+      expect(turnCall.metadata.slackChannelId).toBe(channelId);
+      expect(turnCall.metadata.slackThreadTs).toBe(threadTs);
+
+      // thread-status is terminal so recoverPendingThreads() skips it.
+      const { ThreadStatusQueueService } = await import(
+        '../../services/messaging/thread-status-queue.service.js'
+      );
+      const tsq = ThreadStatusQueueService.getInstance();
+      const entry = tsq.get(`${channelId}:${threadTs}`);
+      expect(entry?.status).toBe('replied_completed');
+      expect(entry?.repliedAt).toBeDefined();
+    });
+
+    it('skips bookkeeping when threadTs is absent (no thread to mark)', async () => {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+      const tmpFile = path.join(os.tmpdir(), 'test-upload-no-thread.pdf');
+      await fs.writeFile(tmpFile, 'fake pdf');
+
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'uploadFile').mockResolvedValue({ fileId: 'F-NT' });
+
+      mockChatV2EnsureChannel.mockClear();
+      mockChatV2RecordTurn.mockClear();
+
+      try {
+        const response = await request(app).post('/api/slack/upload-file').send({
+          channelId: 'C-NOTHREAD',
+          filePath: tmpFile,
+        });
+        expect(response.status).toBe(200);
+      } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+      }
+
+      // No threadTs → no conversationId can be synthesized → no chat-v2 turn.
+      expect(mockChatV2RecordTurn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/slack/upload-image — bookkeeping parity', () => {
+    it('marks thread-status replied_completed + records chat-v2 turn after successful upload', async () => {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+      const tmpFile = path.join(os.tmpdir(), 'test-upload-image-bookkeeping.png');
+      await fs.writeFile(tmpFile, 'fake png');
+
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'uploadImage').mockResolvedValue({ fileId: 'F-IMG' });
+
+      mockChatV2EnsureChannel.mockClear();
+      mockChatV2RecordTurn.mockClear();
+
+      const channelId = 'CIMG-1';
+      const threadTs = '1800.image-1';
+
+      try {
+        await request(app).post('/api/slack/upload-image').send({
+          channelId,
+          filePath: tmpFile,
+          filename: 'preview.png',
+          threadTs,
+        });
+      } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+      }
+
+      expect(mockChatV2RecordTurn).toHaveBeenCalledTimes(1);
+      const turnCall = mockChatV2RecordTurn.mock.calls[0][0];
+      expect(turnCall.content).toContain('preview.png');
+      expect(turnCall.metadata.source).toBe('reply-tool');
+      expect(turnCall.metadata.replyKind).toBe('image-upload');
+
+      const { ThreadStatusQueueService } = await import(
+        '../../services/messaging/thread-status-queue.service.js'
+      );
+      const tsq = ThreadStatusQueueService.getInstance();
+      const entry = tsq.get(`${channelId}:${threadTs}`);
+      expect(entry?.status).toBe('replied_completed');
+    });
   });
 
   describe('GET /api/slack/config', () => {

--- a/backend/src/controllers/slack/slack.controller.test.ts
+++ b/backend/src/controllers/slack/slack.controller.test.ts
@@ -649,6 +649,43 @@ describe('Slack Controller', () => {
       expect(entry?.repliedAt).toBeDefined();
     });
 
+    // PR #562 review: `initialComment` is caller-controlled and unbounded.
+    // Without a cap, a pathological 10KB comment would land in chat-v2
+    // verbatim. The controller slices to UPLOAD_MARKER_CONTENT_MAX (500).
+    it('caps chat-v2 content at 500 chars when initialComment is pathologically long', async () => {
+      const fs = await import('fs/promises');
+      const path = await import('path');
+      const os = await import('os');
+      const tmpFile = path.join(os.tmpdir(), 'test-upload-long-comment.pdf');
+      await fs.writeFile(tmpFile, 'fake pdf');
+
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'uploadFile').mockResolvedValue({ fileId: 'F-LONG' });
+
+      mockChatV2EnsureChannel.mockClear();
+      mockChatV2RecordTurn.mockClear();
+
+      const longComment = 'x'.repeat(10000);
+
+      try {
+        await request(app).post('/api/slack/upload-file').send({
+          channelId: 'CCAP-1',
+          filePath: tmpFile,
+          filename: 'big.pdf',
+          initialComment: longComment,
+          threadTs: '1800.cap-1',
+        });
+      } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+      }
+
+      expect(mockChatV2RecordTurn).toHaveBeenCalledTimes(1);
+      const turnCall = mockChatV2RecordTurn.mock.calls[0][0];
+      expect(turnCall.content.length).toBeLessThanOrEqual(500);
+      expect(turnCall.content.startsWith('[file uploaded: big.pdf]')).toBe(true);
+    });
+
     it('skips bookkeeping when threadTs is absent (no thread to mark)', async () => {
       const fs = await import('fs/promises');
       const path = await import('path');

--- a/backend/src/controllers/slack/slack.controller.test.ts
+++ b/backend/src/controllers/slack/slack.controller.test.ts
@@ -663,18 +663,46 @@ describe('Slack Controller', () => {
       mockChatV2EnsureChannel.mockClear();
       mockChatV2RecordTurn.mockClear();
 
+      // Spy on the SLA cascade to verify it does NOT fire without threadTs.
+      // The earlier version of this test only asserted recordTurn — which
+      // would silently pass even if the helper crashed mid-flight (all three
+      // bookkeeping steps are wrapped in try/catch). These extra spies pin
+      // the negative behavior explicitly.
+      const slaModule = await import('../../services/v3/request-sla.subscriber.js');
+      const slaSpy = jest.spyOn(slaModule, 'getRequestSlaSubscriber');
+
       try {
         const response = await request(app).post('/api/slack/upload-file').send({
           channelId: 'C-NOTHREAD',
           filePath: tmpFile,
         });
         expect(response.status).toBe(200);
+        expect(response.body.data.fileId).toBe('F-NT');
       } finally {
         await fs.unlink(tmpFile).catch(() => {});
       }
 
-      // No threadTs → no conversationId can be synthesized → no chat-v2 turn.
+      // No threadTs →
+      //   1. No conversationId synthesis path → no chat-v2 turn recorded.
+      //   2. Thread-status branch is gated on threadTs → no markReplied call
+      //      (we cannot directly assert that without leaking through the
+      //      singleton, but verifying tsq has no `C-NOTHREAD:*` entry is a
+      //      sufficient proxy because trackInbound would have left one).
+      //   3. SLA cascade is gated on threadTs → getRequestSlaSubscriber is
+      //      never invoked.
       expect(mockChatV2RecordTurn).not.toHaveBeenCalled();
+      expect(slaSpy).not.toHaveBeenCalled();
+
+      const { ThreadStatusQueueService } = await import(
+        '../../services/messaging/thread-status-queue.service.js'
+      );
+      const tsq = ThreadStatusQueueService.getInstance();
+      // Any threadKey starting with `C-NOTHREAD:` would have been created
+      // by trackInbound. There should be none.
+      const allEntries = tsq.getPendingThreads().concat(tsq.getByStatus('replied_completed'));
+      expect(allEntries.find((e) => e.threadKey.startsWith('C-NOTHREAD'))).toBeUndefined();
+
+      slaSpy.mockRestore();
     });
   });
 
@@ -819,6 +847,40 @@ describe('Slack Controller', () => {
       // inbound bridge (`persistSlackInbound`).
       const synthesized = `slack-${channelId}-${String(threadTs).replace('.', '-')}`;
       expect(synthesized).toBe('slack-D0AC7NF5N7L-1777760999-956969');
+    });
+
+    // Positive regression gate: the bookkeeping-helper refactor in
+    // PR #562 collapsed /send's inline chat-v2 + thread-status + SLA
+    // blocks into a shared `recordSlackReplyBookkeeping` call. The
+    // existing tests only verify the helper fires for uploads or that
+    // the dual-write is SKIPPED on error paths — neither catches a
+    // future regression where the helper is removed from /send or its
+    // metadata shape changes. Lock in the happy-path shape here.
+    it('records a chat-v2 turn with replyKind=text after a successful send', async () => {
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'sendMessage').mockResolvedValue('1707.send-1');
+
+      const channelId = 'CSEND-1';
+      const threadTs = '1707.thread-send-1';
+      const text = 'orc text reply';
+
+      await request(app).post('/api/slack/send').send({
+        channelId,
+        text,
+        threadTs,
+        senderSessionName: 'crewly-orc',
+      });
+
+      expect(mockChatV2RecordTurn).toHaveBeenCalledTimes(1);
+      const turnCall = mockChatV2RecordTurn.mock.calls[0][0];
+      expect(turnCall.senderType).toBe('agent');
+      expect(turnCall.senderId).toBe('crewly-orc');
+      expect(turnCall.content).toBe(text);
+      expect(turnCall.metadata.source).toBe('reply-tool');
+      expect(turnCall.metadata.replyKind).toBe('text');
+      expect(turnCall.metadata.slackChannelId).toBe(channelId);
+      expect(turnCall.metadata.slackThreadTs).toBe(threadTs);
     });
   });
 });

--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -116,8 +116,11 @@ async function recordSlackReplyBookkeeping(params: {
         metadata: {
           source: 'reply-tool',
           replyKind,
-          slackChannelId: channelId,
-          slackThreadTs: threadTs,
+          // Mirror the pre-PR /send guards exactly. `req.body` destructure
+          // is `any`, so a non-string slip-through would persist as-is into
+          // chat-v2 metadata without these `typeof` checks.
+          slackChannelId: typeof channelId === 'string' ? channelId : undefined,
+          slackThreadTs: typeof threadTs === 'string' ? threadTs : undefined,
         },
       });
     } catch {

--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -22,6 +22,18 @@ const router = Router();
 const SLACK_MANIFEST_PATH = path.join(process.cwd(), 'config', 'slack-app-manifest.json');
 
 /**
+ * Cap for upload-marker content written to chat-v2.
+ *
+ * The marker is `[file uploaded: ${name}]${: comment}` — `initialComment`
+ * is caller-controlled and unbounded. Without this cap a 10KB comment
+ * would land in the chat history verbatim. Mirrors the bounded preview
+ * pattern used elsewhere (`THREAD_STATUS_CONSTANTS.MAX_PREVIEW_LENGTH`
+ * = 200 for inbound; 500 here so the file marker + a reasonable comment
+ * tail both fit). PR #562 review follow-up.
+ */
+const UPLOAD_MARKER_CONTENT_MAX = 500;
+
+/**
  * Handle Slack platform errors consistently across endpoints.
  * Returns true if the error was handled (422 sent), false otherwise.
  *
@@ -505,6 +517,27 @@ router.post('/upload-image', async (req: Request, res: Response, next: NextFunct
       threadTs,
     });
 
+    // F14 observability parity with /send — record `agent.action` so
+    // dashboards counting `send_slack` include attachment uploads.
+    // `details.kind` discriminates text vs file vs image when finer-
+    // grained queries are needed.
+    try {
+      getAgentBehaviorLogService()?.record({
+        type: 'agent.action',
+        agent: typeof senderSessionName === 'string' ? senderSessionName : '',
+        actionType: 'send_slack',
+        details: {
+          kind: 'image',
+          channelId,
+          threadTs: threadTs ?? null,
+          fileId: result.fileId ?? null,
+          fileSize: stat.size,
+        },
+      });
+    } catch {
+      /* observability is best-effort */
+    }
+
     // Mirror /send post-success bookkeeping so orc's context recovery sees
     // the image was already delivered. Content captures the file marker so
     // the chat history shows what was actually sent.
@@ -515,7 +548,7 @@ router.post('/upload-image', async (req: Request, res: Response, next: NextFunct
       threadTs,
       conversationId,
       senderSessionName,
-      content: `[image uploaded: ${displayName}]${commentSuffix}`,
+      content: `[image uploaded: ${displayName}]${commentSuffix}`.slice(0, UPLOAD_MARKER_CONTENT_MAX),
       replyKind: 'image-upload',
     });
 
@@ -607,6 +640,25 @@ router.post('/upload-file', async (req: Request, res: Response, next: NextFuncti
       threadTs,
     });
 
+    // F14 observability parity with /send — see /upload-image for the
+    // shared rationale.
+    try {
+      getAgentBehaviorLogService()?.record({
+        type: 'agent.action',
+        agent: typeof senderSessionName === 'string' ? senderSessionName : '',
+        actionType: 'send_slack',
+        details: {
+          kind: 'file',
+          channelId,
+          threadTs: threadTs ?? null,
+          fileId: result.fileId ?? null,
+          fileSize: stat.size,
+        },
+      });
+    } catch {
+      /* observability is best-effort */
+    }
+
     // Mirror /send post-success bookkeeping. Without this the orchestrator
     // re-uploads the same file after every restart (regression 2026-05-15:
     // duplicate agentic_explainer.mp4 in D0AC7NF5N7L:1778816065.309289 thread).
@@ -617,7 +669,7 @@ router.post('/upload-file', async (req: Request, res: Response, next: NextFuncti
       threadTs,
       conversationId,
       senderSessionName,
-      content: `[file uploaded: ${displayName}]${commentSuffix}`,
+      content: `[file uploaded: ${displayName}]${commentSuffix}`.slice(0, UPLOAD_MARKER_CONTENT_MAX),
       replyKind: 'file-upload',
     });
 

--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -47,6 +47,119 @@ function handleSlackPlatformError(error: unknown, res: Response): boolean {
 }
 
 /**
+ * Post-Slack-send bookkeeping shared by /send, /upload-image, and /upload-file.
+ *
+ * After a successful Slack write, mirror the side-effects the orchestrator
+ * relies on for restart-safety and request lifecycle:
+ *
+ *  1. Persist a turn to chat-v2 so the agent's context-recovery sees the
+ *     action and does not re-send. The orchestrator was previously re-uploading
+ *     attached files after restart because file uploads landed in Slack but
+ *     never in chat-v2 (regression observed 2026-05-15 — dup `agentic_explainer.mp4`).
+ *  2. Mark the thread-status queue entry as `replied_completed` so
+ *     `recoverPendingThreads()` does not re-fire the inbound on the next boot.
+ *  3. Fire the V3 SLA `markResolvedByThread` cascade so the matching Request
+ *     auto-closes on file-only replies (it already worked for text replies
+ *     via the same hook).
+ *
+ * All three steps are best-effort. The Slack send itself has already
+ * succeeded; failures here are bookkeeping-only and must never throw.
+ *
+ * @param params.channelId - Slack channel the send hit
+ * @param params.threadTs - Optional Slack thread root timestamp
+ * @param params.conversationId - Optional caller-supplied conversation id
+ * @param params.senderSessionName - Optional agent session that initiated the send
+ * @param params.content - The turn content to persist (text or file marker)
+ * @param params.source - Marker for the chat-v2 metadata.source field
+ */
+async function recordSlackReplyBookkeeping(params: {
+  channelId: string;
+  threadTs?: string;
+  conversationId?: string;
+  senderSessionName?: string;
+  content: string;
+  /**
+   * Audit sub-kind for the chat-v2 metadata, recorded alongside the
+   * canonical `source: 'reply-tool'`. Keeps the closed `RECORD_TURN_SOURCES`
+   * enum intact while still letting downstream consumers distinguish text
+   * replies from attachment uploads.
+   */
+  replyKind: 'text' | 'file-upload' | 'image-upload';
+}): Promise<void> {
+  const { channelId, threadTs, conversationId, senderSessionName, content, replyKind } = params;
+
+  // 1. Persist agent turn into chat-v2 so context recovery sees the reply.
+  const resolvedConversationId: string | undefined =
+    (typeof conversationId === 'string' && conversationId.length > 0
+      ? conversationId
+      : undefined) ??
+    (typeof channelId === 'string' && typeof threadTs === 'string'
+      ? synthesizeSlackConversationId(channelId, threadTs)
+      : undefined);
+  if (resolvedConversationId) {
+    try {
+      const { getChatV2Service } = await import('../../services/chat-v2/chat-v2.singleton.js');
+      const chatV2 = getChatV2Service();
+      const agentSession =
+        typeof senderSessionName === 'string' && senderSessionName.length > 0
+          ? senderSessionName
+          : 'crewly-orc';
+      const channel = chatV2.ensureChannelForLegacyConversation({
+        conversationId: resolvedConversationId,
+        agentSession,
+      });
+      chatV2.recordTurn({
+        channelId: channel.id,
+        senderType: 'agent',
+        senderId: agentSession,
+        content,
+        metadata: {
+          source: 'reply-tool',
+          replyKind,
+          slackChannelId: channelId,
+          slackThreadTs: threadTs,
+        },
+      });
+    } catch {
+      // Non-fatal — Slack delivery succeeded.
+    }
+  }
+
+  // 2. Mark thread-status replied_completed (idempotent — creates entry if missing).
+  if (threadTs && channelId) {
+    try {
+      const { ThreadStatusQueueService } = await import('../../services/messaging/thread-status-queue.service.js');
+      const tsq = ThreadStatusQueueService.getInstance();
+      const threadKey = `${channelId}:${threadTs}`;
+      if (!tsq.get(threadKey)) {
+        tsq.trackInbound({
+          threadKey,
+          conversationId: resolvedConversationId ?? synthesizeSlackConversationId(channelId, threadTs),
+          source: 'slack',
+          messagePreview: '[reply-only — no inbound recorded]',
+        });
+      }
+      tsq.markReplied(threadKey, 'replied_completed');
+    } catch {
+      // Non-fatal.
+    }
+  }
+
+  // 3. SLA cascade — closes the matching Request when orc replies in-thread.
+  if (threadTs) {
+    try {
+      const { getRequestSlaSubscriber } = await import('../../services/v3/request-sla.subscriber.js');
+      const sub = getRequestSlaSubscriber();
+      if (sub) {
+        await sub.markResolvedByThread(threadTs);
+      }
+    } catch {
+      // Non-fatal.
+    }
+  }
+}
+
+/**
  * GET /api/slack/status
  *
  * Get Slack integration status including connection state and message counts.
@@ -237,128 +350,17 @@ router.post('/send', async (req: Request, res: Response, next: NextFunction) => 
       /* observability is best-effort */
     }
 
-    // Persist orchestrator/agent replies to the chat store so they appear
-    // in the Chat UI. Phase 6c of unified-chat-message-store spec: the
-    // call site now invokes the canonical `ChatV2Service.recordTurn`
-    // directly (the legacy `ChatService.addDirectMessage` façade has
-    // been retired).
-    //
-    // 2026-05-15 follow-up: the reply-slack skill only sends
-    // `{channelId, text, threadTs}` (no `conversationId`), so an
-    // earlier `if (conversationId)` guard silently dropped every
-    // tool-driven reply on the floor. Synthesize a conversationId
-    // from `channelId + threadTs` using the same format the inbound
-    // bridge writes (`slack-${channelId}-${threadTs}`) so the agent
-    // reply and the user inbound land on the same chat-v2 channel.
-    const resolvedConversationId: string | undefined =
-      (typeof conversationId === 'string' && conversationId.length > 0
-        ? conversationId
-        : undefined) ??
-      (typeof channelId === 'string' && typeof threadTs === 'string'
-        ? synthesizeSlackConversationId(channelId, threadTs)
-        : undefined);
-    if (resolvedConversationId) {
-      try {
-        const { getChatV2Service } = await import('../../services/chat-v2/chat-v2.singleton.js');
-        const chatV2 = getChatV2Service();
-        const agentSession =
-          typeof senderSessionName === 'string' && senderSessionName.length > 0
-            ? senderSessionName
-            : 'crewly-orc';
-        const channel = chatV2.ensureChannelForLegacyConversation({
-          conversationId: resolvedConversationId,
-          agentSession,
-        });
-        chatV2.recordTurn({
-          channelId: channel.id,
-          senderType: 'agent',
-          senderId: agentSession,
-          content: typeof text === 'string' ? text : String(text),
-          metadata: {
-            source: 'reply-tool',
-            slackChannelId: typeof channelId === 'string' ? channelId : undefined,
-            slackThreadTs: typeof threadTs === 'string' ? threadTs : undefined,
-          },
-        });
-      } catch {
-        // Non-fatal — Slack delivery succeeded, chat persistence is best-effort
-      }
-    }
-
-    // Mark the thread as replied_completed in the thread-status queue.
-    //
-    // Bug from 2026-05-08 dogfood: every backend restart re-enqueued the
-    // user's original Slack message via the
-    // `ThreadStatusQueueService.recoverPendingThreads` → message-queue
-    // `[RECOVERY]` path. orc would then "re-reply" to the same message
-    // multiple times after each restart, even though the user only sent
-    // one message and orc had already replied.
-    //
-    // Root cause: when orc invoked `reply-slack` skill → `POST /slack/send`,
-    // we sent to Slack + persisted to chat, but we never updated the
-    // thread-status entry. The entry stayed in `received` (or
-    // `replied_waiting_actions`) status, so the recovery loop on the
-    // next boot considered it unreplied and re-fired it.
-    //
-    // Fix: mark the thread as `replied_completed` here, atomically with
-    // the actual Slack send. Now the next restart sees a terminal status
-    // and skips re-enqueue.
-    //
-    // Why `replied_completed` and not `replied_to_follow_up`: orc has
-    // produced its user-facing acknowledgement; whatever async work
-    // continues downstream (Request → WIs → workers) is tracked by the
-    // pool, not by the thread-status queue. Conflating "user got a reply"
-    // with "all downstream work resolved" was the original architectural
-    // mistake — they belong in different queues.
-    //
-    // Best-effort: if the threadKey isn't tracked yet (rare race where
-    // the trackInbound call hasn't landed) or the markReplied throws,
-    // we log and continue — Slack delivery is the primary success
-    // criterion, thread-status is bookkeeping.
-    if (threadTs && channelId) {
-      try {
-        const { ThreadStatusQueueService } = await import('../../services/messaging/thread-status-queue.service.js');
-        const tsq = ThreadStatusQueueService.getInstance();
-        const threadKey = `${channelId}:${threadTs}`;
-        // Create the entry if it isn't tracked yet, then mark replied.
-        // The trackInbound is idempotent — if the entry exists, this is
-        // a no-op via `get(threadKey)` short-circuit.
-        if (!tsq.get(threadKey)) {
-          tsq.trackInbound({
-            threadKey,
-            conversationId: conversationId || synthesizeSlackConversationId(channelId, threadTs),
-            source: 'slack',
-            messagePreview: '[reply-only — no inbound recorded]',
-          });
-        }
-        tsq.markReplied(threadKey, 'replied_completed');
-      } catch {
-        // Non-fatal — Slack delivery succeeded, thread bookkeeping is best-effort
-      }
-    }
-
-    // 2026-05-12 dogfood: notify the V3 SLA tracker that this thread
-    // got a real orc reply. Without this hook, fixing the bridge's
-    // delivery-ack callback to no longer fire `fromOrcReply=true` (the
-    // 5-of-7-false-done bug) would leave Requests with no path at all
-    // to terminal — the respond_to_user WI would sit in `queued`
-    // forever after orc replies via this endpoint. Real orc replies
-    // come through here (reply-slack skill posts to /slack/send), so
-    // this is the right place to trigger the cascade.
-    //
-    // Best-effort: lazy import + try/catch so a subscriber-boot failure
-    // can never break the actual Slack reply.
-    if (threadTs) {
-      try {
-        const { getRequestSlaSubscriber } = await import('../../services/v3/request-sla.subscriber.js');
-        const sub = getRequestSlaSubscriber();
-        if (sub) {
-          await sub.markResolvedByThread(threadTs);
-        }
-      } catch {
-        // Slack delivery already succeeded; SLA hook is bookkeeping.
-      }
-    }
+    // Post-send bookkeeping (chat-v2 persist + thread-status terminal mark +
+    // SLA cascade). The same helper is used by /upload-image and /upload-file
+    // so the orchestrator never has to re-derive "did I already reply here?".
+    await recordSlackReplyBookkeeping({
+      channelId,
+      threadTs,
+      conversationId,
+      senderSessionName,
+      content: typeof text === 'string' ? text : String(text),
+      replyKind: 'text',
+    });
 
     res.json({
       success: true,
@@ -431,7 +433,7 @@ router.post('/notify', async (req: Request, res: Response, next: NextFunction) =
  */
 router.post('/upload-image', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { channelId, filePath, filename, title, initialComment, threadTs } = req.body;
+    const { channelId, filePath, filename, title, initialComment, threadTs, conversationId, senderSessionName } = req.body;
 
     if (!channelId || !filePath) {
       res.status(400).json({
@@ -500,6 +502,20 @@ router.post('/upload-image', async (req: Request, res: Response, next: NextFunct
       threadTs,
     });
 
+    // Mirror /send post-success bookkeeping so orc's context recovery sees
+    // the image was already delivered. Content captures the file marker so
+    // the chat history shows what was actually sent.
+    const displayName = typeof filename === 'string' && filename.length > 0 ? filename : path.basename(filePath);
+    const commentSuffix = typeof initialComment === 'string' && initialComment.length > 0 ? `: ${initialComment}` : '';
+    await recordSlackReplyBookkeeping({
+      channelId,
+      threadTs,
+      conversationId,
+      senderSessionName,
+      content: `[image uploaded: ${displayName}]${commentSuffix}`,
+      replyKind: 'image-upload',
+    });
+
     res.json({
       success: true,
       data: { fileId: result.fileId },
@@ -528,7 +544,7 @@ router.post('/upload-image', async (req: Request, res: Response, next: NextFunct
  */
 router.post('/upload-file', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { channelId, filePath, filename, title, initialComment, threadTs } = req.body;
+    const { channelId, filePath, filename, title, initialComment, threadTs, conversationId, senderSessionName } = req.body;
 
     if (!channelId || !filePath) {
       res.status(400).json({
@@ -586,6 +602,20 @@ router.post('/upload-file', async (req: Request, res: Response, next: NextFuncti
       title,
       initialComment,
       threadTs,
+    });
+
+    // Mirror /send post-success bookkeeping. Without this the orchestrator
+    // re-uploads the same file after every restart (regression 2026-05-15:
+    // duplicate agentic_explainer.mp4 in D0AC7NF5N7L:1778816065.309289 thread).
+    const displayName = typeof filename === 'string' && filename.length > 0 ? filename : path.basename(filePath);
+    const commentSuffix = typeof initialComment === 'string' && initialComment.length > 0 ? `: ${initialComment}` : '';
+    await recordSlackReplyBookkeeping({
+      channelId,
+      threadTs,
+      conversationId,
+      senderSessionName,
+      content: `[file uploaded: ${displayName}]${commentSuffix}`,
+      replyKind: 'file-upload',
     });
 
     res.json({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1434,17 +1434,23 @@ export class CrewlyServer {
 			// resume notification won't re-send already-answered conversations.
 			try {
 				const { RequestService } = await import('./services/v3/request.service.js');
+				const { extractSlackChannelId, extractSlackThreadTs } = await import('./services/v3/request-sla.subscriber.js');
 				const reqSvc = RequestService.getInstance();
 				const allReqs = await reqSvc.listAll();
 				let backfilled = 0;
 				for (const req of allReqs) {
 					if (req.status !== 'done') continue;
 					const scid = req.sourceConversationItemId || '';
-					if (!scid.startsWith('slack-')) continue;
-					const m = scid.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
-					if (!m) continue;
-					const [, channelId, t1, t2] = m;
-					const threadKey = `${channelId}:${t1}.${t2}`;
+					// `extractSlack*` strips the optional `-msg-{ts}` thread-reply
+					// suffix before parsing, so both top-level and in-thread
+					// Requests resolve to the canonical `{channelId}:{threadRoot}`.
+					// Previously a local regex was used here and its greedy `.+`
+					// swallowed the suffix, producing a malformed threadKey that
+					// missed the dedup check and bloated the persistence file.
+					const channelId = extractSlackChannelId(scid);
+					const threadTs = extractSlackThreadTs(scid);
+					if (!channelId || !threadTs) continue;
+					const threadKey = `${channelId}:${threadTs}`;
 					if (this.threadStatusQueueService.get(threadKey)) continue;
 					this.threadStatusQueueService.trackInbound({
 						threadKey,
@@ -2781,14 +2787,13 @@ export class CrewlyServer {
 					if (req.sourceConversationItemId.startsWith('slack-')) {
 						try {
 							const { ThreadStatusQueueService } = await import('./services/messaging/thread-status-queue.service.js');
+							const { extractSlackChannelId, extractSlackThreadTs } = await import('./services/v3/request-sla.subscriber.js');
 							const tsq = ThreadStatusQueueService.getInstance();
-							// sourceConversationItemId format: "slack-{channelId}-{messageTs}"
-							// messageTs format in the ID uses hyphens: "1775935980-197679"
-							// Slack threadTs uses dots: "1775935980.197679"
-							const match = req.sourceConversationItemId.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
-							if (match) {
-								const channelId = match[1];
-								const threadTs = `${match[2]}.${match[3]}`;
+							// Use the canonical parser (handles both `slack-{ch}-{ts}` and
+							// the thread-reply `slack-{ch}-{root}-msg-{msgTs}` shapes).
+							const channelId = extractSlackChannelId(req.sourceConversationItemId);
+							const threadTs = extractSlackThreadTs(req.sourceConversationItemId);
+							if (channelId && threadTs) {
 								const threadKey = `${channelId}:${threadTs}`;
 								// Create entry if not tracked, then mark terminal
 								if (!tsq.get(threadKey)) {

--- a/backend/src/services/v3/request-status-update.subscriber.test.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.test.ts
@@ -172,11 +172,14 @@ describe('parseSlackThreadContext', () => {
     });
   });
 
-  it('parses a hyphen-separated thread id (the underscore-friendly variant)', () => {
-    expect(parseSlackThreadContext('slack-CTEST123-1707000000-123456')).toEqual({
-      channelId: 'CTEST123',
-      threadTs: '1707000000.123456',
-    });
+  // PR #562 follow-up: the hyphen-between-digits form
+  // `slack-CH-1707000000-123456` is no longer accepted. Confirmed across
+  // the codebase that no producer emits this shape (slack-orchestrator-bridge
+  // always interpolates Slack-API dotted-decimal ts). The old `[.-]` regex
+  // flexibility was dead defense; canonicalizing on dot-only via the
+  // request-sla.subscriber helpers eliminates a maintenance hazard.
+  it('rejects the legacy hyphen-between-digits ts form (no producer emits it)', () => {
+    expect(parseSlackThreadContext('slack-CTEST123-1707000000-123456')).toBeNull();
   });
 
   it('returns null for non-slack ids', () => {

--- a/backend/src/services/v3/request-status-update.subscriber.ts
+++ b/backend/src/services/v3/request-status-update.subscriber.ts
@@ -44,6 +44,7 @@ import type { Request, RequestStatus } from '../../types/v2/request.types.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import { TERMINAL_WORK_ITEM_STATUSES } from '../../types/v2/work-item.types.js';
 import { TERMINAL_REQUEST_STATUSES, isValidRequestTransition } from '../../types/v2/index.js';
+import { extractSlackChannelId, extractSlackThreadTs } from './request-sla.subscriber.js';
 
 /**
  * WorkItem statuses that count as "terminal" for the heartbeat's
@@ -211,19 +212,22 @@ export function computeStateFingerprint(childWIs: WorkItem[]): string {
 }
 
 export function parseSlackThreadContext(scid: string | undefined): ParsedSlackContext | null {
-  if (!scid || !scid.startsWith('slack-')) return null;
-  // 2026-05-13 dogfood fix: Slack thread-reply Requests use the
-  // `slack-{channelId}-{threadRoot}-msg-{messageTs}` encoding so that
-  // the SLA threadIndex keys on the actual thread root (which is what
-  // orc replies to via reply-slack). Strip the trailing `-msg-{ts}`
-  // before extracting threadTs so both shapes parse to the thread root.
-  // Top-level messages (`slack-{channelId}-{ts}`) are unaffected — the
-  // strip is a no-op on those.
-  const stripped = scid.replace(/-msg-\d+\.\d+$/, '');
-  const m = stripped.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
-  if (!m) return null;
-  const [, channelId, ts1, ts2] = m;
-  return { channelId, threadTs: `${ts1}.${ts2}` };
+  // Delegate to the canonical helpers in `request-sla.subscriber`. They
+  // already handle both the top-level `slack-{ch}-{ts}` and the
+  // thread-reply `slack-{ch}-{root}-msg-{msgTs}` shapes (suffix-strip)
+  // and reject anything that isn't dot-decimal. Keeping a separate inline
+  // regex here was a maintenance hazard — PR #562 review.
+  //
+  // Behavior change vs the prior inline regex: hyphen-between-digits
+  // ts form (e.g. `slack-CH-1707000000-123456`) is no longer accepted.
+  // No production producer emits that shape (verified across the
+  // codebase — slack-orchestrator-bridge always interpolates the
+  // Slack-API-supplied dotted-decimal ts), so this strictly removes
+  // dead defense.
+  const channelId = extractSlackChannelId(scid);
+  const threadTs = extractSlackThreadTs(scid);
+  if (!channelId || !threadTs) return null;
+  return { channelId, threadTs };
 }
 
 export class RequestStatusUpdateSubscriber {


### PR DESCRIPTION
## Summary

- `/api/slack/upload-file` and `/api/slack/upload-image` now mirror `/send`'s post-success bookkeeping (chat-v2 turn + thread-status terminal mark + SLA cascade). Without these, orc had no record of the file send and re-uploaded after every OSS restart.
- Drive-by: replace the greedy regex in `index.ts:1444` and `:2788` with the canonical `extractSlackChannelId`/`extractSlackThreadTs` helpers so thread-reply ids parse correctly.

## Bug context (2026-05-15 dogfood)

User reported orc re-uploaded `agentic_explainer.mp4` to a Slack thread after each restart. Chat history showed:

- user: "可以把 agentic_explainer.mp4 给我给我看"
- orc: "找一下，稍等。"
- [chat-v2 had no further record — but Slack thread had the file sent]

On context recovery, orc reconstructed "I haven't finished" and re-uploaded. The `reply-slack --file` skill hits `/upload-file`, which (unlike `/send`) wrote to Slack but never persisted a chat-v2 turn or marked the thread terminal.

## Changes

- New private helper `recordSlackReplyBookkeeping` extracted from `/send`, shared by all three endpoints.
- `metadata.replyKind` (text|file-upload|image-upload) distinguishes attachment vs text replies while `source` remains the closed `reply-tool` enum value.
- Backfill path at `index.ts:1444` and auto-close path at `:2788` switched from local regex to the canonical helpers that already handle the `-msg-{ts}` thread-reply form (and are tested in `request-sla.subscriber.test.ts`).

## Test plan

- [x] `slack.controller.test.ts` — 46 tests pass, including 3 new regression gates on the upload endpoints
- [x] `request-sla.subscriber.test.ts` + `index.test.ts` — 115 tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual: after merge, restart OSS, confirm orc does not re-upload a file it already sent on a prior session

🤖 Generated with [Claude Code](https://claude.com/claude-code)