### PR TITLE
fix(slack): append orc replies to slack-thread .md store on /send

### DIFF
--- a/backend/src/controllers/slack/slack.controller.test.ts
+++ b/backend/src/controllers/slack/slack.controller.test.ts
@@ -743,6 +743,57 @@ describe('Slack Controller', () => {
     });
   });
 
+  // PR follow-up (2026-05-16): orc reads the per-thread .md file at
+  // ~/.crewly/slack-threads/{channel}/{threadTs}.md on session wake-up,
+  // not chat-v2. Replies sent via /api/slack/send were chat-v2-persisted
+  // and thread-status-marked but never appended to the .md file, so orc
+  // saw only user messages on wake-up and re-replied to everything.
+  describe('POST /api/slack/send — slack-thread store append', () => {
+    it('appends the orchestrator reply to the slack-thread .md store', async () => {
+      const { SlackThreadStoreService, setSlackThreadStore, resetSlackThreadStore } = await import(
+        '../../services/slack/slack-thread-store.service.js'
+      );
+      const os = await import('os');
+      const fs = await import('fs/promises');
+      const path = await import('path');
+
+      // Spin up a temp-rooted store so we don't touch the real ~/.crewly/.
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'slack-thread-store-test-'));
+      const store = new SlackThreadStoreService(tmpRoot);
+      setSlackThreadStore(store);
+
+      const channelId = 'CSTORE-1';
+      const threadTs = '1900.store-1';
+
+      // Seed the thread file (appendOrchestratorReply is a no-op when the
+      // file doesn't exist — mirrors the inbound-bridge behavior).
+      await store.ensureThreadFile(channelId, threadTs, 'USTEVE');
+
+      const slackService = getSlackService();
+      jest.spyOn(slackService, 'isConnected').mockReturnValue(true);
+      jest.spyOn(slackService, 'sendMessage').mockResolvedValue('1900.reply-1');
+
+      try {
+        await request(app).post('/api/slack/send').send({
+          channelId,
+          text: 'orc here, working on it',
+          threadTs,
+        });
+
+        // Read the .md file and assert the reply landed.
+        // SlackThreadStoreService nests under `slack-threads/` inside the
+        // crewlyHome — the file path is the public surface, use it.
+        const filePath = store.getThreadFilePath(channelId, threadTs);
+        const contents = await fs.readFile(filePath, 'utf-8');
+        expect(contents).toContain('**Crewly**');
+        expect(contents).toContain('orc here, working on it');
+      } finally {
+        resetSlackThreadStore();
+        await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+  });
+
   describe('POST /api/slack/upload-image — bookkeeping parity', () => {
     it('marks thread-status replied_completed + records chat-v2 turn after successful upload', async () => {
       const fs = await import('fs/promises');

--- a/backend/src/controllers/slack/slack.controller.ts
+++ b/backend/src/controllers/slack/slack.controller.ts
@@ -73,8 +73,17 @@ function handleSlackPlatformError(error: unknown, res: Response): boolean {
  *  3. Fire the V3 SLA `markResolvedByThread` cascade so the matching Request
  *     auto-closes on file-only replies (it already worked for text replies
  *     via the same hook).
+ *  4. Append the reply to the slack-thread `.md` store (the file orc reads
+ *     directly on session restart). The legacy `slack-orchestrator-bridge.
+ *     sendSlackResponse` path already did this for its internal flow, but
+ *     replies coming through `/api/slack/send` (the reply-slack skill path
+ *     orc actually uses) never reached the .md file. Without this, orc's
+ *     wake-up read of the thread context shows only user messages and
+ *     re-replies to everything (regression observed 2026-05-16 — orc
+ *     re-replied to all 3 user messages on the CE thread after a session
+ *     restart, even though /send had already marked chat-v2 + thread-status).
  *
- * All three steps are best-effort. The Slack send itself has already
+ * All four steps are best-effort. The Slack send itself has already
  * succeeded; failures here are bookkeeping-only and must never throw.
  *
  * @param params.channelId - Slack channel the send hit
@@ -170,6 +179,21 @@ async function recordSlackReplyBookkeeping(params: {
       }
     } catch {
       // Non-fatal.
+    }
+  }
+
+  // 4. Append to the slack-thread .md store so orc's wake-up read of the
+  //    thread context file sees its own reply. Without this, orc reads the
+  //    file, sees only user messages, and re-replies to everything.
+  if (threadTs && channelId) {
+    try {
+      const { getSlackThreadStore } = await import('../../services/slack/slack-thread-store.service.js');
+      const store = getSlackThreadStore();
+      if (store) {
+        await store.appendOrchestratorReply(channelId, threadTs, content);
+      }
+    } catch {
+      // Non-fatal — Slack delivery succeeded.
     }
   }
 }

--- a/scripts/backfill-slack-thread-store.ts
+++ b/scripts/backfill-slack-thread-store.ts
@@ -1,0 +1,141 @@
+/**
+ * Backfill orchestrator replies into `~/.crewly/slack-threads/{ch}/{ts}.md`
+ * by reading them from the chat-v2 database.
+ *
+ * Background: prior to the PR that added step 4 of `recordSlackReplyBookkeeping`
+ * (slack.controller.ts), agent replies sent via `/api/slack/send` were
+ * persisted to chat-v2 but never appended to the slack-thread .md store.
+ * On session-restart, orc reads the .md file (not chat-v2) and concludes
+ * "no one replied" → re-replies to everything.
+ *
+ * This script reads the canonical reply history from chat-v2 and appends
+ * any missing `**Crewly** (...)` entries onto the corresponding .md file.
+ * It is idempotent — runs only insert lines that aren't already present
+ * (matched by content hash).
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-slack-thread-store.ts             # dry-run
+ *   npx tsx scripts/backfill-slack-thread-store.ts --apply     # write
+ *   npx tsx scripts/backfill-slack-thread-store.ts --apply --thread 1778859267.970399
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import Database from 'better-sqlite3';
+
+const apply = process.argv.includes('--apply');
+const threadFilter = (() => {
+  const idx = process.argv.indexOf('--thread');
+  return idx >= 0 ? process.argv[idx + 1] : null;
+})();
+
+const CREWLY_HOME = path.join(os.homedir(), '.crewly');
+const CHAT_DB = path.join(CREWLY_HOME, 'chat.db');
+const SLACK_THREADS_DIR = path.join(CREWLY_HOME, 'slack-threads');
+
+interface AgentMessage {
+  content: string;
+  createdAt: number; // epoch ms
+  channelId: string; // chat-v2 conversation id, e.g. slack-D0AC7NF5N7L-1778859267-970399
+}
+
+function chatChannelIdToSlackParts(chatChannelId: string): { slackChannel: string; threadTs: string } | null {
+  // Pattern: slack-{slackChannel}-{epoch}-{decimals}
+  // OR    : slack-{slackChannel}-{epoch}.{decimals}-msg-{...}  (thread-reply form)
+  const stripped = chatChannelId.replace(/-msg-\d+\.\d+$/, '');
+  const m = stripped.match(/^slack-(.+)-(\d+)[.-](\d+)$/);
+  if (!m) return null;
+  const [, slackChannel, t1, t2] = m;
+  return { slackChannel, threadTs: `${t1}.${t2}` };
+}
+
+function formatEntry(content: string, ts: Date): string {
+  const tsStr = ts.toISOString().replace('T', ' ').slice(0, 16);
+  return `\n**Crewly** (${tsStr}):\n${content}\n`;
+}
+
+async function main() {
+  console.log(`Mode: ${apply ? 'APPLY' : 'DRY-RUN'}`);
+  if (threadFilter) console.log(`Thread filter: ${threadFilter}`);
+
+  const db = new Database(CHAT_DB, { readonly: true });
+
+  // chat-v2 channels for Slack threads have channel.metadata.legacyConversationId
+  // formatted as `slack-{channelId}-{ts}`. The chat_channels table's `id` is the
+  // chat-v2 internal id, distinct from the legacy conversation id. We need to
+  // pull the agent messages then group by the original conversation id.
+  // For Slack-sourced channels the chat_channels.id IS the legacy
+  // conversation id (`slack-{channelId}-{tsWithHyphen}`); chat-v2's
+  // `ensureChannelForLegacyConversation` writes the legacy id as the
+  // primary key directly. See chat-v2.service.ts.
+  const rows = db.prepare(`
+    SELECT m.content, m.created_at as createdAt, c.id as channelId
+    FROM chat_messages m
+    JOIN chat_channels c ON c.id = m.channel_id
+    WHERE m.sender_type = 'agent'
+      AND c.id LIKE 'slack-%'
+    ORDER BY m.created_at ASC
+  `).all() as AgentMessage[];
+
+  // Group by slack thread
+  const byThread = new Map<string, AgentMessage[]>();
+  for (const row of rows) {
+    const parts = chatChannelIdToSlackParts(row.channelId);
+    if (!parts) continue;
+    if (threadFilter && parts.threadTs !== threadFilter) continue;
+    const key = `${parts.slackChannel}/${parts.threadTs}`;
+    if (!byThread.has(key)) byThread.set(key, []);
+    byThread.get(key)!.push(row);
+  }
+
+  console.log(`Found ${rows.length} agent messages across ${byThread.size} threads`);
+
+  let appendedTotal = 0;
+  let filesUpdated = 0;
+
+  for (const [key, msgs] of byThread.entries()) {
+    const filePath = path.join(SLACK_THREADS_DIR, `${key}.md`);
+    let existing: string;
+    try {
+      existing = await fs.readFile(filePath, 'utf-8');
+    } catch {
+      console.log(`SKIP: ${key} — no .md file (orc never had this thread mapped to disk)`);
+      continue;
+    }
+
+    const missing: string[] = [];
+    for (const msg of msgs) {
+      // De-dup: skip if the first 60 chars of the content already appears
+      // in the file (handles the rare case where the bridge path wrote it).
+      const probe = msg.content.slice(0, 60).trim();
+      if (probe.length === 0) continue;
+      if (existing.includes(probe)) continue;
+      missing.push(formatEntry(msg.content, new Date(msg.createdAt)));
+    }
+
+    if (missing.length === 0) {
+      console.log(`OK:   ${key} — already in sync (${msgs.length} agent msgs)`);
+      continue;
+    }
+
+    console.log(`DIFF: ${key} — ${missing.length} missing agent entries`);
+
+    if (apply) {
+      await fs.appendFile(filePath, missing.join(''), 'utf-8');
+      filesUpdated++;
+      appendedTotal += missing.length;
+    }
+  }
+
+  db.close();
+
+  console.log('');
+  console.log(`Summary: ${appendedTotal} entries ${apply ? 'appended' : 'would append'} across ${filesUpdated} file(s)`);
+  if (!apply) console.log('Run with --apply to write changes.');
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Sibling bug to #562. The orc reads `~/.crewly/slack-threads/{ch}/{ts}.md` on session restart for context. That file gets user inbound messages appended automatically, but bot replies sent via the `reply-slack` skill → `POST /api/slack/send` were never written back — so on wake-up orc saw "8 user messages, 0 bot replies" and re-replied to everything.

## Bug evidence

2026-05-16 user reported orc re-replied to all 3 user messages from yesterday on the CE thread (`D0AC7NF5N7L:1778859267.970399`) after a session restart. Confirmed:
- `chat.db` shows orc replied to each user message ✓
- `thread-status-queue.json` shows the thread `replied_completed` ✓
- `.crewly/slack-threads/D0AC7NF5N7L/1778859267.970399.md` shows **8 user messages, 0 `**Crewly**` entries** ✗

Three parallel bookkeeping stores; the .md file was the only one orc actually reads.

## Changes

- `slack.controller.ts` — `recordSlackReplyBookkeeping` gains a 4th step: call `getSlackThreadStore()?.appendOrchestratorReply(channelId, threadTs, content)`. Best-effort, gated on threadTs. Now all three endpoints (`/send`, `/upload-file`, `/upload-image`) hit the same four sinks.
- `slack.controller.test.ts` — new regression gate spins up a temp-rooted `SlackThreadStoreService`, fires `/send`, asserts the reply landed in the `.md` file.
- `scripts/backfill-slack-thread-store.ts` — backfills missing `**Crewly**` entries onto existing `.md` files from chat-v2's canonical history. Idempotent, `--apply`-gated, `--thread`-filterable. **Already run on local install** (74 entries across 5 threads).

## Test plan

- [x] 49 controller tests pass (was 48 — +1 thread-store gate)
- [x] `tsc --noEmit` clean
- [x] Local backfill ran cleanly: `Summary: 74 entries appended across 5 file(s)`
- [ ] Manual: after merge + rebuild + restart, confirm orc does not re-reply to the CE thread on next session-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)