### PR TITLE
chore(tests): clarity + cleanup-on-throw (closes #462 #463; defers #464)

### DIFF
--- a/backend/src/services/v3/request-decompose-auto.integration.test.ts
+++ b/backend/src/services/v3/request-decompose-auto.integration.test.ts
@@ -78,75 +78,93 @@ interface IntegrationFixture {
 }
 
 async function buildFixture(): Promise<IntegrationFixture> {
+  // Issue #463 follow-up: wrap construction in try/catch so a partial
+  // failure (e.g. an awaitable subscriber init throws) doesn't leak the
+  // temp dir or the mutated CREWLY_HOME env var.
   const tmpRoot = await fs.mkdtemp(
     path.join(os.tmpdir(), 'pipeline-decompose-auto-int-'),
   );
-  const crewlyHome = path.join(tmpRoot, '.crewly');
-  await fs.mkdir(crewlyHome, { recursive: true });
   const previousCrewlyHome = process.env.CREWLY_HOME;
-  process.env.CREWLY_HOME = crewlyHome;
+  try {
+    const crewlyHome = path.join(tmpRoot, '.crewly');
+    await fs.mkdir(crewlyHome, { recursive: true });
+    process.env.CREWLY_HOME = crewlyHome;
 
-  // Reset singletons so we get clean instances scoped to this CREWLY_HOME.
-  RequestService.resetInstance();
-  TaskPoolService.resetInstance();
-  setRequestSlaSubscriber(null);
-  setRequestDecomposeSubscriber(null);
+    // Reset singletons so we get clean instances scoped to this CREWLY_HOME.
+    RequestService.resetInstance();
+    TaskPoolService.resetInstance();
+    setRequestSlaSubscriber(null);
+    setRequestDecomposeSubscriber(null);
 
-  const bus = new EventBusService();
-  const requestService = RequestService.getInstance(tmpRoot);
-  const taskPool = TaskPoolService.getInstance();
+    const bus = new EventBusService();
+    const requestService = RequestService.getInstance(tmpRoot);
+    const taskPool = TaskPoolService.getInstance();
 
-  // CRITICAL: wire the bus into both producers BEFORE starting subscribers.
-  // RequestService publishes `request:created` synchronously inside
-  // create(); without the bus wired the event never lands and the
-  // subscriber never fires.
-  setRequestServiceEventBus(bus);
-  taskPool.setEventBusService(bus);
+    // CRITICAL: wire the bus into both producers BEFORE starting subscribers.
+    // RequestService publishes `request:created` synchronously inside
+    // create(); without the bus wired the event never lands and the
+    // subscriber never fires.
+    setRequestServiceEventBus(bus);
+    taskPool.setEventBusService(bus);
 
-  // Start the SLA subscriber (PR #453 L4 fix — workitem:queued → linkWorkItem).
-  const slaSubscriber = new RequestSlaSubscriber({
-    eventBus: bus,
-    requestService,
-    taskPool,
-    orchestratorSession: 'test-orc',
-  });
-  slaSubscriber.start();
-  setRequestSlaSubscriber(slaSubscriber);
+    // Start the SLA subscriber (PR #453 L4 fix — workitem:queued → linkWorkItem).
+    const slaSubscriber = new RequestSlaSubscriber({
+      eventBus: bus,
+      requestService,
+      taskPool,
+      orchestratorSession: 'test-orc',
+    });
+    slaSubscriber.start();
+    setRequestSlaSubscriber(slaSubscriber);
 
-  // Start the auto-decompose subscriber under test.
-  const decomposeSubscriber = new RequestDecomposeSubscriber({
-    eventBus: bus,
-    requestService,
-    taskPool,
-  });
-  decomposeSubscriber.start();
-  setRequestDecomposeSubscriber(decomposeSubscriber);
+    // Start the auto-decompose subscriber under test.
+    const decomposeSubscriber = new RequestDecomposeSubscriber({
+      eventBus: bus,
+      requestService,
+      taskPool,
+    });
+    decomposeSubscriber.start();
+    setRequestDecomposeSubscriber(decomposeSubscriber);
 
-  return {
-    tmpRoot,
-    bus,
-    requestService,
-    taskPool,
-    slaSubscriber,
-    decomposeSubscriber,
-    cleanup: async () => {
-      decomposeSubscriber.stop();
-      slaSubscriber.stop();
-      setRequestDecomposeSubscriber(null);
-      setRequestSlaSubscriber(null);
-      setRequestServiceEventBus(null);
-      taskPool.setEventBusService(null);
-      RequestService.resetInstance();
-      TaskPoolService.resetInstance();
+    return {
+      tmpRoot,
+      bus,
+      requestService,
+      taskPool,
+      slaSubscriber,
+      decomposeSubscriber,
+      cleanup: async () => {
+        decomposeSubscriber.stop();
+        slaSubscriber.stop();
+        setRequestDecomposeSubscriber(null);
+        setRequestSlaSubscriber(null);
+        setRequestServiceEventBus(null);
+        taskPool.setEventBusService(null);
+        RequestService.resetInstance();
+        TaskPoolService.resetInstance();
 
-      if (previousCrewlyHome === undefined) {
-        delete process.env.CREWLY_HOME;
-      } else {
-        process.env.CREWLY_HOME = previousCrewlyHome;
-      }
-      await fs.rm(tmpRoot, { recursive: true, force: true });
-    },
-  };
+        if (previousCrewlyHome === undefined) {
+          delete process.env.CREWLY_HOME;
+        } else {
+          process.env.CREWLY_HOME = previousCrewlyHome;
+        }
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      },
+    };
+  } catch (err) {
+    // Symmetric env + dir rollback so a mid-construction throw doesn't
+    // leak. The temp dir is best-effort (might already partially exist);
+    // the env restore must run regardless.
+    if (previousCrewlyHome === undefined) {
+      delete process.env.CREWLY_HOME;
+    } else {
+      process.env.CREWLY_HOME = previousCrewlyHome;
+    }
+    await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {
+      /* best-effort */
+    });
+    throw err;
+  }
 }
 
 /**

--- a/backend/src/services/v3/request-decompose.subscriber.test.ts
+++ b/backend/src/services/v3/request-decompose.subscriber.test.ts
@@ -159,13 +159,17 @@ describe('RequestDecomposeSubscriber', () => {
   // -------------------------------------------------------------------------
 
   describe('filter rules', () => {
+    // Issue #462 follow-up: each category row pins the (L2 + category) gate,
+    // not "any intentLevel + category". The intentLevel is explicit so a
+    // future change to `makeRequest`'s default doesn't silently shift what
+    // the test pins.
     it.each<[string, Partial<Request>]>([
       ['intentLevel L0', { intentLevel: 'L0' as IntentLevel }],
       ['intentLevel L1', { intentLevel: 'L1' as IntentLevel }],
-      ['intentCategory communication', { intentCategory: 'communication' as IntentCategory }],
-      ['intentCategory query', { intentCategory: 'query' as IntentCategory }],
-      ['intentCategory other', { intentCategory: 'other' as IntentCategory }],
-      ['intentCategory review', { intentCategory: 'review' as IntentCategory }],
+      ['L2 + intentCategory communication', { intentLevel: 'L2' as IntentLevel, intentCategory: 'communication' as IntentCategory }],
+      ['L2 + intentCategory query', { intentLevel: 'L2' as IntentLevel, intentCategory: 'query' as IntentCategory }],
+      ['L2 + intentCategory other', { intentLevel: 'L2' as IntentLevel, intentCategory: 'other' as IntentCategory }],
+      ['L2 + intentCategory review', { intentLevel: 'L2' as IntentLevel, intentCategory: 'review' as IntentCategory }],
     ])('skips when %s', async (_label, overrides) => {
       const r = makeRequest(overrides);
       seed.set(r.id, r);


### PR DESCRIPTION
## Summary

Two PR #461 follow-ups landed; the third deferred after discovering it's a real bug.

**#462** — Parametric skip-suite labels now pin the L2 gate explicitly: `'L2 + intentCategory communication'` rows. Behavior byte-identical (makeRequest's default was already L2).

**#463** — `buildFixture` wraps construction in try/catch so a mid-flight throw restores `process.env.CREWLY_HOME` + unlinks the temp dir. Today wiring is straight-line; future awaitable subscriber init could turn this into a flaky test that grows `os.tmpdir()`.

**#464 deferred** → re-filed as **#565** (P1 bug). Implementing the suggested co-existence test surfaced that PR #461's claim "SLA seeds + decompose plans on the same Request" doesn't hold: SLA's `respond_to_user` WI lands in `workItemIds` first, decompose's `shouldDecompose` sees `length > 0` and silently skips. Every L2 inbound-Slack Request is being no-op'd in production. Investigation + repro filed at #565.

## Test plan

- [x] 34/34 affected tests pass (`request-decompose.subscriber.test.ts` + `request-decompose-auto.integration.test.ts`)
- [x] `tsc --noEmit` clean
- [x] Independent code review — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)