### PR TITLE
chore(intent): trimmed charCount + consolidate types (closes #473 #474)

### DIFF
--- a/backend/src/types/intent-task.types.test.ts
+++ b/backend/src/types/intent-task.types.test.ts
@@ -163,6 +163,23 @@ describe('classifyIntentLevel', () => {
     const longIntent = Array(40).fill('word').join(' ');
     expect(classifyIntentLevel(longIntent)).toBe('L2');
   });
+
+  // Issue #473: charCount must be measured AFTER trim so leading/trailing
+  // whitespace doesn't falsely trip the §2.7 length floor for L2.
+  it('measures char count on the trimmed string (whitespace must not count toward the L2 length floor)', () => {
+    // Body that is intentionally short enough (sub-80 chars) to fall BELOW
+    // the L2 §2.7 length-floor escalation. Should classify as L1.
+    const body = 'Fix the login bug in auth service';
+    expect(body.length).toBeLessThan(80);
+    expect(classifyIntentLevel(body)).toBe('L1');
+
+    // Same body padded with leading + trailing whitespace pushing the raw
+    // length over 80. With trimming, the meaningful content is unchanged
+    // and the classification must stay L1.
+    const padded = '   '.repeat(20) + body + '   '.repeat(20);
+    expect(padded.length).toBeGreaterThan(80);
+    expect(classifyIntentLevel(padded)).toBe(classifyIntentLevel(body));
+  });
 });
 
 // =============================================================================

--- a/backend/src/types/intent-task.types.ts
+++ b/backend/src/types/intent-task.types.ts
@@ -19,30 +19,17 @@
 // =============================================================================
 
 /**
- * Intent complexity levels:
- * - L0: Simple query — single agent, no tool calls (e.g., "what time is it?")
- * - L1: Standard task — single agent, may use tools (e.g., "fix this bug")
- * - L2: Complex task — multi-agent, multi-step orchestration (e.g., "build a feature")
- * - L3: OKR/sprint-scoped initiative — multi-day, multi-PR, multi-team. ORC owns
- *   the plan personally; success measured against KR/sprint gate, not artifact.
- *   Routed identically to L2 in v0 (Mia §5 Q1 default); the label is preserved so
- *   the L3-specific routing-split can land without retro-classifying.
+ * Intent classification types are owned by `v2/request.types.ts` — it's
+ * the domain-shape file and `IntentLevel` / `IntentCategory` are properties
+ * of `Request`. Re-exported here so existing import paths from this module
+ * keep working. Issue #474.
+ *
+ * Imported locally below because subsequent type declarations in this
+ * module reference these aliases; `export type {}` alone only re-exports
+ * and doesn't bring the names into local scope.
  */
-export type IntentLevel = 'L0' | 'L1' | 'L2' | 'L3';
-
-/**
- * Intent classification labels for categorizing user requests
- */
-export type IntentCategory =
-  | 'query'
-  | 'code_change'
-  | 'debugging'
-  | 'deployment'
-  | 'research'
-  | 'review'
-  | 'planning'
-  | 'communication'
-  | 'other';
+import type { IntentLevel, IntentCategory } from './v2/request.types.js';
+export type { IntentLevel, IntentCategory };
 
 // =============================================================================
 // Task Status
@@ -535,7 +522,10 @@ export function isActionableIntent(text: string): boolean {
 export function classifyIntentLevel(intent: string): IntentLevel {
   const lower = intent.toLowerCase();
   const wordCount = intent.split(/\s+/).filter(Boolean).length;
-  const charCount = intent.length;
+  // Issue #473: trim before measuring so leading/trailing whitespace
+  // doesn't trip the §2.7 length floor. The wordCount axis is already
+  // trim-equivalent via `.filter(Boolean)` — charCount should match.
+  const charCount = intent.trim().length;
 
   // ---------------------------------------------------------------------
   // L0 — read-only / status / lookup (no state change).


### PR DESCRIPTION
## Summary

Two PR #471 follow-up nits:

- **#473** — `classifyIntentLevel` measures charCount on `.trim()`ed length. Pads a sub-80 L1 body with 60+60 spaces (153 raw) and asserts classification unchanged.
- **#474** — Consolidate `IntentLevel` + `IntentCategory` to `v2/request.types.ts` (the canonical domain-shape file). `intent-task.types.ts` now re-exports + locally imports them.

Independent code review: clean, ship both.

## Test plan
- [x] 54/54 intent-task.types.test pass (incl. new whitespace gate)
- [x] 129/129 intent-task + intent-classifier suites pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)