### PR TITLE
fix(create-request): synthesize sourceConversationItemId for agent flows (closes #458)

### DIFF
--- a/config/skills/agent/core/create-request/SKILL.md
+++ b/config/skills/agent/core/create-request/SKILL.md
@@ -91,7 +91,7 @@ Use these to classify the complexity of the request:
 | `--intent-level` | Yes | -- | L0, L1, L2, or L3 |
 | `--intent-category` | Yes | -- | communication, query, code_change, planning, debugging, deployment, team_management, other |
 | `--priority` | No | normal | low, normal, high, urgent |
-| `--source-message-id` | No | -- | Original message ID (for dedup) |
+| `--source-message-id` | No | `agent-self-{session}-{epoch}` | Original message ID (for dedup). When omitted, the skill synthesizes `agent-self-{CREWLY_SESSION_NAME}-{epoch}` so agent-context callers (e.g. TL self-filing a child Request) don't 400 on the backend's required-field check. Issue #458. |
 | `--needs-mission` | No | false | Whether this L3 request should trigger Mission creation |
 
 ## Examples -- CLI Flags (preferred)

--- a/config/skills/agent/core/create-request/execute.sh
+++ b/config/skills/agent/core/create-request/execute.sh
@@ -155,9 +155,36 @@ if [ -n "$PRIORITY" ]; then
   BODY=$(printf '%s' "$BODY" | jq --arg p "$PRIORITY" '. + {priority: $p}')
 fi
 
-if [ -n "$SOURCE_MESSAGE_ID" ]; then
-  BODY=$(printf '%s' "$BODY" | jq --arg sid "$SOURCE_MESSAGE_ID" '. + {sourceConversationItemId: $sid}')
+# Issue #458: the backend validator at v2/request.types.ts:283 requires
+# `sourceConversationItemId` to be a non-empty string. The orc passes the
+# inbound Slack/chat message id when filing a Request, but agent-context
+# callers (e.g. a TL filing a child Request from a delegated task) have
+# no inbound message of their own. Auto-synthesize a stable
+# `agent-self-{session}-{epoch}-{nonce}` id so the request lands instead
+# of 400-ing.
+#
+# Notes:
+# - The synthetic shape is intentionally distinct from the `slack-{ch}-
+#   {ts}` / `chatv2-{ch}__{msg}` prefixes so downstream consumers
+#   (extractSlackThreadTs, extractChatV2ChannelId, SLA tracker, .md
+#   store) inert-skip it.
+# - The trailing `${RANDOM}` nonce prevents per-second collisions when
+#   two rapid create-request calls from the same session land in the
+#   same wall-clock second. `findBySourceConversationItemId` (the dedup
+#   path) keys on this string verbatim.
+# - When `CREWLY_SESSION_NAME` is unset (likely a misconfiguration, but
+#   not load-bearing), we warn to stderr and continue with
+#   `unknown-session` so the request still lands instead of failing
+#   silently. The warn surfaces the missing env in observability.
+if [ -z "$SOURCE_MESSAGE_ID" ]; then
+  AGENT_SESSION="${CREWLY_SESSION_NAME:-}"
+  if [ -z "$AGENT_SESSION" ]; then
+    echo "warn: CREWLY_SESSION_NAME unset; falling back to 'unknown-session' for synthesized sourceConversationItemId" >&2
+    AGENT_SESSION="unknown-session"
+  fi
+  SOURCE_MESSAGE_ID="agent-self-${AGENT_SESSION}-$(date +%s)-${RANDOM}"
 fi
+BODY=$(printf '%s' "$BODY" | jq --arg sid "$SOURCE_MESSAGE_ID" '. + {sourceConversationItemId: $sid}')
 
 # Call the API to create the Request
 RESULT=$(api_call POST "/requests" "$BODY")

--- a/config/skills/agent/core/create-request/execute.test.sh
+++ b/config/skills/agent/core/create-request/execute.test.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Co-located bash test for create-request skill.
+# Spins up a tiny python HTTP stub to capture the outgoing body, then
+# asserts that sourceConversationItemId is always present (synthesized
+# when missing) — Issue #458 regression gate.
+#
+# Usage: bash execute.test.sh  (exit 0 on pass)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL="${SCRIPT_DIR}/execute.sh"
+
+if [ ! -x "$SKILL" ]; then
+  echo "FAIL: skill not executable at $SKILL" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+PORT=18789
+
+# --- Start stub backend on a fixed test port ---
+STUB_LOG="$(mktemp)"
+export STUB_LOG
+export STUB_PORT="${PORT}"
+
+python3 -u <<'PY' >/tmp/create-request-stub.log 2>&1 &
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json, os, sys
+
+LOG_PATH = os.environ['STUB_LOG']
+PORT = int(os.environ['STUB_PORT'])
+
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('content-length', '0'))
+        body = self.rfile.read(length).decode('utf-8') if length else ''
+        log = {
+            'path': self.path,
+            'body': body,
+            'agentSession': self.headers.get('x-agent-session', ''),
+        }
+        with open(LOG_PATH, 'w') as f:
+            f.write(json.dumps(log))
+        self.send_response(201)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'success': True, 'data': {'id': 'req-stub-123'}}).encode('utf-8'))
+    def log_message(self, *a, **k):
+        pass
+
+srv = HTTPServer(('127.0.0.1', PORT), H)
+srv.serve_forever()
+PY
+STUB_PID=$!
+
+cleanup() { kill "$STUB_PID" >/dev/null 2>&1 || true; rm -f "$STUB_LOG" || true; }
+trap cleanup EXIT
+
+# Wait until the port actually accepts a connection
+for i in $(seq 1 30); do
+  if curl -s -o /dev/null -m 0.2 "http://127.0.0.1:${PORT}/__probe__" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  ✓ $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ $name (wanted: $needle)"
+    echo "    in: $haystack"
+  fi
+}
+
+run_skill() {
+  CREWLY_API_URL="http://127.0.0.1:${PORT}" \
+  CREWLY_SESSION_NAME="crewly-product-sam-TEST" \
+  bash "$SKILL" "$@"
+}
+
+# --- Test 1: Issue #458 — TL agent flow without --source-message-id ---
+echo "test 1: agent-self synthesis when --source-message-id is omitted"
+: > "$STUB_LOG"
+OUT=$(run_skill \
+  --title "Fix dogfood pipeline P0" \
+  --description "Fix the pipeline regression that blocked decomposition" \
+  --intent-level L1 \
+  --intent-category debugging \
+  2>&1 || true)
+LOG=$(cat "$STUB_LOG" 2>/dev/null || echo '{}')
+assert_contains "success echoed" "$OUT" '"success": true'
+assert_contains "sourceConversationItemId synthesized" "$LOG" 'sourceConversationItemId'
+assert_contains "synthesized id uses agent-self prefix" "$LOG" 'agent-self-crewly-product-sam-TEST-'
+assert_contains "path targets /requests" "$LOG" '/requests'
+
+# --- Test 2: --source-message-id provided is preserved ---
+echo "test 2: explicit --source-message-id passes through unchanged"
+: > "$STUB_LOG"
+OUT=$(run_skill \
+  --title "Inbound Slack request" \
+  --description "Some inbound user message routing through orc" \
+  --intent-level L2 \
+  --intent-category code_change \
+  --source-message-id "slack-D0AC7-1234567890.000001" \
+  2>&1 || true)
+LOG=$(cat "$STUB_LOG" 2>/dev/null || echo '{}')
+assert_contains "explicit sourceConversationItemId preserved" "$LOG" 'slack-D0AC7-1234567890.000001'
+if echo "$LOG" | grep -q 'agent-self-'; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ agent-self prefix wrongly added when explicit id present"
+else
+  PASS=$((PASS + 1))
+  echo "  ✓ explicit id is not overwritten by agent-self synthesis"
+fi
+
+# --- Test 3: legacy JSON form without sourceMessageId still gets synthesis ---
+echo "test 3: legacy JSON form falls back to agent-self synthesis"
+: > "$STUB_LOG"
+OUT=$(run_skill '{"title":"json form","description":"some description","intentLevel":"L1","intentCategory":"debugging"}' 2>&1 || true)
+LOG=$(cat "$STUB_LOG" 2>/dev/null || echo '{}')
+assert_contains "json-form synthesis works too" "$LOG" 'agent-self-crewly-product-sam-TEST-'
+
+# --- Test 4: explicit empty-string --source-message-id triggers synthesis ---
+echo "test 4: empty-string source-message-id treated as missing"
+: > "$STUB_LOG"
+OUT=$(run_skill \
+  --title "Empty id test" \
+  --description "Caller passed --source-message-id with an empty string" \
+  --intent-level L1 \
+  --intent-category debugging \
+  --source-message-id "" \
+  2>&1 || true)
+LOG=$(cat "$STUB_LOG" 2>/dev/null || echo '{}')
+assert_contains "empty-string id triggers synthesis" "$LOG" 'agent-self-crewly-product-sam-TEST-'
+
+# --- Test 5: two back-to-back synthesis calls produce distinct ids ---
+# Issue #458 review follow-up: the synthesis nonce ($RANDOM) must prevent
+# per-second collisions so `findBySourceConversationItemId` doesn't false-
+# positive on a second TL self-file in the same wall-clock second.
+echo "test 5: rapid synthesis produces distinct ids (no per-second collision)"
+: > "$STUB_LOG"
+run_skill --title "First" --description "Description one" --intent-level L1 --intent-category debugging >/dev/null 2>&1 || true
+ID_1=$(jq -r '.body | fromjson | .sourceConversationItemId' "$STUB_LOG" 2>/dev/null || echo '')
+: > "$STUB_LOG"
+run_skill --title "Second" --description "Description two" --intent-level L1 --intent-category debugging >/dev/null 2>&1 || true
+ID_2=$(jq -r '.body | fromjson | .sourceConversationItemId' "$STUB_LOG" 2>/dev/null || echo '')
+if [ -n "$ID_1" ] && [ -n "$ID_2" ] && [ "$ID_1" != "$ID_2" ]; then
+  PASS=$((PASS + 1))
+  echo "  ✓ two rapid syntheses produce distinct ids ($ID_1 vs $ID_2)"
+else
+  FAIL=$((FAIL + 1))
+  echo "  ✗ rapid syntheses collided or were empty: '$ID_1' '$ID_2'"
+fi
+
+echo
+echo "========================================"
+echo "create-request skill: PASS=$PASS  FAIL=$FAIL"
+echo "========================================"
+if [ "$FAIL" -gt 0 ]; then
+  echo "--- stub server log ---"
+  cat /tmp/create-request-stub.log 2>/dev/null | tail -40
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`create-request` skill 400s when an agent calls it without `--source-message-id` (only orc had one to pass). The backend validator at `v2/request.types.ts:283` requires non-empty.

Fix: skill auto-synthesizes `agent-self-${SESSION}-${EPOCH}-${RANDOM}` when missing. Prefix is intentionally distinct from `slack-*` / `chatv2-*` so all downstream consumers inert-skip it.

## Review fixes
- `${RANDOM}` nonce closes per-second collisions (verified by test 5)
- Missing `CREWLY_SESSION_NAME` warns to stderr before falling back

## Test plan
- [x] 9/9 bash test assertions pass (synthesis, explicit-preserved, JSON-form, empty-string, distinct-ids)
- [x] SKILL.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)