### PR TITLE
fix(scripts): cleanup-stale-pool ESM named-import interop (closes #478)

### DIFF
--- a/backend/src/scripts/cleanup-stale-pool.runtime.test.ts
+++ b/backend/src/scripts/cleanup-stale-pool.runtime.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Runtime-validity smoke test for `scripts/cleanup-stale-pool.ts`.
+ *
+ * Issue #478: the script's `import { DEFAULT_KEEP_IDS, ... } from
+ * './cleanup-stale-pool.lib.js'` resolved to a CJS-namespace-as-default
+ * shape under tsx + Node 22 ESM and threw SyntaxError at module-
+ * instantiation time. The error fired BEFORE any flag parsing — even
+ * `--help` was broken. The lib's unit tests passed (jest's resolver
+ * papers over the interop quirk) — only a runtime-validity test would
+ * have caught the regression.
+ *
+ * This test lives in `backend/src/scripts/` (covered by jest's test
+ * roots) rather than next to the script under `scripts/` (which is
+ * not). It runs `npx tsx scripts/cleanup-stale-pool.ts --help` via
+ * child_process and asserts:
+ *   1. exit code 0 (no SyntaxError; module loaded cleanly)
+ *   2. stdout contains a recognizable help string
+ *
+ * It does NOT hit the backend — `--help` prints and exits before any
+ * fetch runs. Total wall time on a warm tsx cache is ~1.5s.
+ */
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'scripts', 'cleanup-stale-pool.ts');
+
+describe('scripts/cleanup-stale-pool.ts — runtime module-load smoke', () => {
+  it('loads via tsx and runs --help without throwing (issue #478 regression gate)', () => {
+    let output: string;
+    try {
+      output = execFileSync('npx', ['tsx', SCRIPT_PATH, '--help'], {
+        cwd: REPO_ROOT,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30_000,
+      });
+    } catch (err: unknown) {
+      const e = err as { status?: number; stdout?: string; stderr?: string };
+      // Surface stderr in the test report so the next regression is
+      // easy to diagnose — without this the only signal is "exit !== 0".
+      throw new Error(
+        `cleanup-stale-pool.ts failed to load: exit=${e.status}\n` +
+          `stdout:\n${e.stdout ?? ''}\n` +
+          `stderr:\n${e.stderr ?? ''}`,
+      );
+    }
+    expect(output).toMatch(/Usage|usage|--apply|--dry-run/);
+  }, 60_000);
+});

--- a/scripts/cleanup-stale-pool.ts
+++ b/scripts/cleanup-stale-pool.ts
@@ -49,13 +49,28 @@
  * @module scripts/cleanup-stale-pool
  */
 
-import {
+// Issue #478: the lib's named exports are bundled inside `default` when
+// tsx transpiles for this `"type": "module"` package — Node's strict ESM
+// loader then refuses any named-import specifier (the symptom was
+// SyntaxError "does not provide an export named 'DEFAULT_KEEP_IDS'").
+// Workaround: import the namespace as default, then destructure at
+// runtime. Types come from a separate `import type` line, which tsc /
+// tsx erases entirely so the runtime resolution is unaffected.
+import libDefault from '../backend/src/scripts/cleanup-stale-pool.lib.js';
+import type {
+  CleanupClassification,
+  MinimalWorkItem,
+} from '../backend/src/scripts/cleanup-stale-pool.lib.js';
+
+const {
   classifyPoolForCleanup,
   DEFAULT_KEEP_IDS,
   DEFAULT_KEEP_PARENT_REQUEST_IDS,
-  type CleanupClassification,
-  type MinimalWorkItem,
-} from '../backend/src/scripts/cleanup-stale-pool.lib.js';
+} = libDefault as unknown as {
+  classifyPoolForCleanup: typeof import('../backend/src/scripts/cleanup-stale-pool.lib.js').classifyPoolForCleanup;
+  DEFAULT_KEEP_IDS: typeof import('../backend/src/scripts/cleanup-stale-pool.lib.js').DEFAULT_KEEP_IDS;
+  DEFAULT_KEEP_PARENT_REQUEST_IDS: typeof import('../backend/src/scripts/cleanup-stale-pool.lib.js').DEFAULT_KEEP_PARENT_REQUEST_IDS;
+};
 
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:8787';
 const STALE_CUTOFF = process.env.STALE_CUTOFF || '2026-05-06T00:00:00Z';


### PR DESCRIPTION
## Summary

`npx tsx scripts/cleanup-stale-pool.ts --dry-run` fails at module-load with `SyntaxError: ... does not provide an export named 'DEFAULT_KEEP_IDS'`. Root cause: under tsx + Node 22 + `"type": "module"`, the lib's named exports materialize as a CJS-namespace-as-default. Node's strict ESM loader rejects named imports against it.

Fix: default-import the namespace + destructure at runtime. Typed `typeof import(...)` cast preserves rename-safety.

Plus a new `cleanup-stale-pool.runtime.test.ts` smoke that runs `tsx --help` and asserts exit 0 — this would have caught #478 in CI.

## Investigation note

The issue suggested 3 fixes (rename `.js`→`.ts`, add `scripts/` to tsconfig, change `moduleResolution`). First two were tested and did NOT resolve. The actual interop bug is shape-not-extension.

## Test plan

- [x] `npx tsx scripts/cleanup-stale-pool.ts --dry-run` returns valid output (`fetched 167 WIs from pool`)
- [x] New runtime smoke test passes
- [x] Existing lib tests pass (10/10)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)