### PR TITLE
fix(cron): resolve targetTeamId by UUID or name-slug (closes #307)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,6 +55,7 @@ import { getSettingsService } from './services/settings/index.js';
 import { MemoryService } from './services/memory/memory.service.js';
 import { getImprovementStartupService } from './services/orchestrator/improvement-startup.service.js';
 import { initializeSlackIfConfigured, shutdownSlack } from './services/slack/index.js';
+import { resolveTeamByIdOrSlug, slugifyTeamName } from './services/workflow/team-identifier-resolver.js';
 import { initializeWhatsAppIfConfigured, shutdownWhatsApp } from './services/whatsapp/index.js';
 import { initializeGoogleChatIfConfigured } from './services/messaging/google-chat-initializer.js';
 import { initializeTelegramIfConfigured, shutdownTelegram } from './services/telegram/index.js';
@@ -1541,6 +1542,16 @@ export class CrewlyServer {
 						`[CRON_TASK:${task.id}] ${task.taskDescription}`,
 					);
 				});
+				// Issue #307: cron tasks created with `targetTeamId` set to a
+				// name slug (e.g. "stock-ops-team") instead of the UUID would
+				// silently 404 on every fire — `teams.find(t => t.id === teamId)`
+				// returned undefined and both callbacks returned `false` with
+				// no log surface. `resolveTeamByIdOrSlug` (imported statically
+				// at the top of the file) tries UUID first, then falls back
+				// to a slug match against `name`. Misses now surface a distinct
+				// warn-log with the available slugs so the cause is visible
+				// instead of hiding behind the generic "agent offline" warn
+				// from cron-task.service.
 				cronTaskService.setAgentStatusCallback(async (sessionName, teamId) => {
 					// Handle orchestrator separately — it's not in regular teams
 					if (sessionName === CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME || teamId === 'orchestrator') {
@@ -1548,8 +1559,16 @@ export class CrewlyServer {
 						return orchStatus?.agentStatus === 'active' || orchStatus?.agentStatus === 'started';
 					}
 					const teams = await storageRef.getTeams();
-					const team = teams.find((t) => t.id === teamId);
-					if (!team) return false;
+					const team = resolveTeamByIdOrSlug(teams, teamId);
+					if (!team) {
+						this.logger.warn('CronTask: targetTeamId resolves to no team', {
+							sessionName,
+							targetTeamId: teamId,
+							availableSlugs: teams.slice(0, 10).map((t) => slugifyTeamName(t.name)),
+							hint: 'Set targetTeamId to either the team UUID or one of availableSlugs (lowercase, spaces→-)',
+						});
+						return false;
+					}
 					const member = team.members.find((m) => m.sessionName === sessionName);
 					if (!member) return false;
 					// #286 Root Cause C: treat both 'active' and 'started' as online
@@ -1558,14 +1577,24 @@ export class CrewlyServer {
 				cronTaskService.setAgentStartCallback(async (sessionName, teamId) => {
 					try {
 						const teams = await storageRef.getTeams();
-						const team = teams.find((t) => t.id === teamId);
-						if (!team) return false;
+						const team = resolveTeamByIdOrSlug(teams, teamId);
+						if (!team) {
+							this.logger.warn('CronTask auto-start: targetTeamId resolves to no team', {
+								sessionName,
+								targetTeamId: teamId,
+								availableSlugs: teams.slice(0, 10).map((t) => slugifyTeamName(t.name)),
+								hint: 'Set targetTeamId to either the team UUID or one of availableSlugs (lowercase, spaces→-)',
+							});
+							return false;
+						}
 						const member = team.members.find((m) => m.sessionName === sessionName);
 						if (!member) return false;
 						await registrationRef.createAgentSession({
 							sessionName: member.sessionName,
 							role: member.role,
-							teamId,
+							// Use the resolved team's UUID — not the user-supplied identifier
+							// — so downstream agent-registration always sees the canonical id.
+							teamId: team.id,
 							memberId: member.id,
 						});
 						return true;

--- a/backend/src/services/workflow/team-identifier-resolver.test.ts
+++ b/backend/src/services/workflow/team-identifier-resolver.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for resolveTeamByIdOrSlug — issue #307.
+ *
+ * @module services/workflow/team-identifier-resolver.test
+ */
+
+import { resolveTeamByIdOrSlug, slugifyTeamName } from './team-identifier-resolver.js';
+import type { Team } from '../../types/index.js';
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 'team-uuid-1',
+  name: 'Stock Ops Team',
+  members: [],
+  projectIds: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('resolveTeamByIdOrSlug', () => {
+  it('matches by canonical UUID (fast path)', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: 'Alpha Team' })];
+    expect(resolveTeamByIdOrSlug(teams, 'aaa-111')?.name).toBe('Alpha Team');
+  });
+
+  // Issue #307 root case: targetTeamId was set to "stock-ops-team" (a
+  // name-derived slug) instead of the UUID. Resolution previously fell
+  // through, both callbacks returned `false`, and `lastRunAt` never
+  // updated. The slug fallback fixes this.
+  it('matches by team-name slug when UUID lookup misses', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: 'Stock Ops Team' })];
+    const got = resolveTeamByIdOrSlug(teams, 'stock-ops-team');
+    expect(got?.id).toBe('aaa-111');
+  });
+
+  it('slug match is case-insensitive on both sides', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: 'Sales SECRET Team' })];
+    expect(resolveTeamByIdOrSlug(teams, 'sales-secret-team')?.id).toBe('aaa-111');
+    expect(resolveTeamByIdOrSlug(teams, 'SALES-SECRET-TEAM')?.id).toBe('aaa-111');
+  });
+
+  it('collapses multiple whitespace chars into a single hyphen', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: 'A   B  C' })];
+    expect(resolveTeamByIdOrSlug(teams, 'a-b-c')?.id).toBe('aaa-111');
+  });
+
+  it('UUID match wins even when a sibling team has a matching slug', () => {
+    // If someone names a team "uuid-of-other-team", the explicit UUID
+    // lookup should still resolve to the canonical row.
+    const teams = [
+      makeTeam({ id: 'aaa-111', name: 'aaa-111' }),
+      makeTeam({ id: 'bbb-222', name: 'sibling' }),
+    ];
+    expect(resolveTeamByIdOrSlug(teams, 'aaa-111')?.id).toBe('aaa-111');
+  });
+
+  it('returns undefined when neither UUID nor slug matches', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: 'Real Team' })];
+    expect(resolveTeamByIdOrSlug(teams, 'no-such-team')).toBeUndefined();
+  });
+
+  it('returns undefined on an empty teams list', () => {
+    expect(resolveTeamByIdOrSlug([], 'anything')).toBeUndefined();
+  });
+
+  // Review-feedback regression gate: an empty identifier previously
+  // matched any team with an empty `name` (both slugify to '').
+  it('returns undefined for an empty identifier', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: '' })];
+    expect(resolveTeamByIdOrSlug(teams, '')).toBeUndefined();
+  });
+
+  it('trims leading/trailing whitespace on both sides before slug comparison', () => {
+    const teams = [makeTeam({ id: 'aaa-111', name: '  Padded Team  ' })];
+    expect(resolveTeamByIdOrSlug(teams, '  padded-team  ')?.id).toBe('aaa-111');
+  });
+
+  it('first-match-wins on duplicate slugs (Array.find insertion order)', () => {
+    // Two teams whose names collapse to the same slug. Resolution is
+    // deterministic (first match) — operators should not rely on slug
+    // uniqueness; this test documents the order.
+    const teams = [
+      makeTeam({ id: 'aaa-111', name: 'Ops' }),
+      makeTeam({ id: 'bbb-222', name: 'Ops' }),
+    ];
+    expect(resolveTeamByIdOrSlug(teams, 'ops')?.id).toBe('aaa-111');
+  });
+});
+
+describe('slugifyTeamName', () => {
+  it('lowercases + collapses internal whitespace to single hyphen', () => {
+    expect(slugifyTeamName('Stock Ops Team')).toBe('stock-ops-team');
+    expect(slugifyTeamName('A   B  C')).toBe('a-b-c');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(slugifyTeamName('  Padded  ')).toBe('padded');
+  });
+});

--- a/backend/src/services/workflow/team-identifier-resolver.ts
+++ b/backend/src/services/workflow/team-identifier-resolver.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolves a cron task's `targetTeamId` to a `Team` row.
+ *
+ * Background: `targetTeamId` is user-supplied and historically expected a
+ * UUID, but operators frequently pass a name-derived slug
+ * (`"stock-ops-team"` instead of `team.id`). The old `teams.find(t =>
+ * t.id === identifier)` lookup returned `undefined` for those, both
+ * cron auto-start callbacks silently returned `false`, and `lastRunAt`
+ * stayed `null` forever with no error surface (issue #307).
+ *
+ * Lookup order:
+ *   1. Exact UUID match against `team.id` (canonical, fast-path).
+ *   2. Slug match against `team.name` — lowercased, all whitespace runs
+ *      collapsed to `-`.
+ *
+ * The slug derivation MUST mirror whatever the UI / docs tell operators
+ * to type. The current operator-facing pattern is "lowercase + spaces→
+ * hyphens"; if that ever diverges, update this function in lockstep.
+ *
+ * @module services/workflow/team-identifier-resolver
+ */
+
+import type { Team } from '../../types/index.js';
+
+/**
+ * Try UUID lookup, then slug lookup. Returns the matched team or
+ * `undefined`. Callers MUST log a distinct warn on `undefined` so the
+ * misconfiguration is visible (issue #307 root cause was the missing
+ * warn-log, not the lookup itself).
+ *
+ * @param teams - All known teams (e.g. from `storage.getTeams()`)
+ * @param identifier - The user-supplied `targetTeamId` (UUID or slug)
+ * @returns The matched team, or `undefined` if neither lookup hits
+ */
+export function resolveTeamByIdOrSlug(
+  teams: readonly Team[],
+  identifier: string,
+): Team | undefined {
+  // Empty identifier matches an empty team name and accidentally resolves
+  // to whichever team happens to have a falsy `name`. Reject up front.
+  if (!identifier) return undefined;
+  const byId = teams.find((t) => t.id === identifier);
+  if (byId) return byId;
+  const wanted = identifier.trim().toLowerCase();
+  if (!wanted) return undefined;
+  return teams.find(
+    (t) => t.name.trim().toLowerCase().replace(/\s+/g, '-') === wanted,
+  );
+}
+
+/**
+ * Produce the canonical slug for a team name, matching the rule
+ * `resolveTeamByIdOrSlug` uses on the lookup side. Exported so the
+ * cron init can include the list of available slugs in its
+ * "team not found" warn-log for operator debuggability.
+ *
+ * @param name - The team display name (`team.name`)
+ * @returns The lowercase, hyphen-collapsed slug
+ */
+export function slugifyTeamName(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, '-');
+}


### PR DESCRIPTION
## Summary

Cron tasks created with `targetTeamId` set to a name-derived slug (e.g. `stock-ops-team`) silently failed every fire — both `setAgentStatusCallback` and `setAgentStartCallback` did strict UUID lookup and returned `false` with no log surface.

Fix: new resolver tries UUID first, then a slug match against `team.name`. Misses now emit a distinct warn with the original identifier + a capped list of available slugs so operators can see exactly what to type. Auto-start also substitutes the resolved canonical UUID into `createAgentSession` so downstream code always sees `team.id`.

## Test plan
- [x] 11 new resolver test cases (UUID/slug/case/whitespace/empty/duplicate)
- [x] index.test.ts (22) still passes
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)