### PR TITLE
fix(cloud): device heartbeat no longer permanently stops on failure (closes #296)

### DIFF
--- a/backend/src/services/cloud/device-auto-discovery.service.test.ts
+++ b/backend/src/services/cloud/device-auto-discovery.service.test.ts
@@ -452,6 +452,44 @@ describe('DeviceAutoDiscoveryService', () => {
 
 			expect(service.getConsecutiveHeartbeatFailures()).toBe(0);
 		});
+
+		// Issue #296 regression gate: hitting MAX_CONSECUTIVE_HEARTBEAT_FAILURES
+		// previously permanently cleared the heartbeat timer. A transient blip
+		// would freeze `lastHeartbeatAt` in the Cloud registry indefinitely.
+		// The fix removes the hard stop — failures continue at the capped
+		// backoff so heartbeats resume the moment connectivity returns.
+		it('keeps re-arming the timer past MAX_CONSECUTIVE_HEARTBEAT_FAILURES, then recovers on success (#296)', async () => {
+			mockSuccessfulStart();
+			const service = DeviceAutoDiscoveryService.getInstance();
+			await service.start(mockConfig);
+
+			// Fire MAX_CONSECUTIVE_HEARTBEAT_FAILURES + 2 = 12 failures.
+			// After each, advance the (capped) backoff so the next attempt
+			// fires. If the bug were present, attempt 11 would never run
+			// because the timer would have been cleared at attempt 10.
+			for (let i = 0; i < DISCOVERY_CONSTANTS.MAX_CONSECUTIVE_HEARTBEAT_FAILURES + 2; i++) {
+				mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ devices: [] }) }); // poll
+				mockFetch.mockResolvedValueOnce({ ok: false, status: 503 }); // heartbeat fails
+				jest.advanceTimersByTime(DISCOVERY_CONSTANTS.BACKOFF_MAX_MS + 200);
+				await flushPromises();
+			}
+
+			expect(service.getConsecutiveHeartbeatFailures()).toBeGreaterThan(
+				DISCOVERY_CONSTANTS.MAX_CONSECUTIVE_HEARTBEAT_FAILURES,
+			);
+			// Direct assertion: timer must still be alive after the threshold.
+			// Pre-fix this was null because `handleHeartbeatFailure` had
+			// `clearTimeout(this.heartbeatTimer); this.heartbeatTimer = null;`.
+			expect((service as unknown as { heartbeatTimer: unknown }).heartbeatTimer).not.toBeNull();
+
+			// Now succeed — counter must reset, proving the timer was still alive.
+			mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ devices: [] }) }); // poll
+			mockFetch.mockResolvedValueOnce({ ok: true }); // heartbeat succeeds
+			jest.advanceTimersByTime(DISCOVERY_CONSTANTS.BACKOFF_MAX_MS + 200);
+			await flushPromises();
+
+			expect(service.getConsecutiveHeartbeatFailures()).toBe(0);
+		});
 	});
 
 	describe('DISCOVERY_CONSTANTS', () => {

--- a/backend/src/services/cloud/device-auto-discovery.service.ts
+++ b/backend/src/services/cloud/device-auto-discovery.service.ts
@@ -282,6 +282,11 @@ export class DeviceAutoDiscoveryService extends EventEmitter {
 		this.pollTimer = setTimeout(() => {
 			this.pollDevices().finally(() => this.schedulePoll());
 		}, delay);
+		// .unref() so a CLI invocation that never reaches `stop()` can
+		// still exit cleanly — the timer keeps re-arming forever now that
+		// the heartbeat hard-stop is gone (#296), and we don't want it
+		// holding the event loop open in test/CLI contexts.
+		this.pollTimer.unref?.();
 	}
 
 	/**
@@ -298,6 +303,9 @@ export class DeviceAutoDiscoveryService extends EventEmitter {
 		this.heartbeatTimer = setTimeout(() => {
 			this.sendHeartbeat().finally(() => this.scheduleHeartbeat());
 		}, delay);
+		// .unref() — see schedulePoll for rationale. The hard-stop removal
+		// in #296 makes this load-bearing for CLI / test process exit.
+		this.heartbeatTimer.unref?.();
 	}
 
 	// ---------------------------------------------------------------------------
@@ -508,11 +516,16 @@ export class DeviceAutoDiscoveryService extends EventEmitter {
 	/**
 	 * Send a heartbeat to the cloud to keep this device marked as online.
 	 * On failure, increments heartbeat failure counter and backs off.
-	 * After MAX_CONSECUTIVE_HEARTBEAT_FAILURES, stops sending heartbeats.
+	 * After MAX_CONSECUTIVE_HEARTBEAT_FAILURES, escalates the log level
+	 * from `warn` to `error` (one-shot edge event) but keeps retrying at
+	 * the capped backoff so heartbeats resume automatically when
+	 * connectivity returns. See issue #296.
 	 */
 	private async sendHeartbeat(): Promise<void> {
 		if (!this.config) return;
 
+		// Issue #296: heartbeats now retry indefinitely at the capped
+		// backoff. See `handleHeartbeatFailure` JSDoc for the rationale.
 		try {
 			const url = `${this.config.cloudUrl}${DISCOVERY_CONSTANTS.DEVICES_PATH}/heartbeat`;
 
@@ -541,8 +554,23 @@ export class DeviceAutoDiscoveryService extends EventEmitter {
 	}
 
 	/**
-	 * Handle a heartbeat failure: increment counter and stop heartbeats
-	 * if the max retry limit is exceeded.
+	 * Handle a heartbeat failure: increment counter and log a warning. The
+	 * timer is NOT stopped — heartbeats continue at the capped backoff
+	 * (`BACKOFF_MAX_MS`, currently 5 min) so that whenever the network
+	 * or Cloud server recovers, `lastHeartbeatAt` resumes updating
+	 * automatically.
+	 *
+	 * Issue #296 background: previously, hitting
+	 * `MAX_CONSECUTIVE_HEARTBEAT_FAILURES` (10) permanently cleared
+	 * `heartbeatTimer`. A transient network blip 24-48h ago would freeze
+	 * `lastHeartbeatAt` forever even after sync recovered — the Cloud
+	 * dashboard then showed the device as offline indefinitely. Removing
+	 * the hard stop trades a small (capped) ongoing log volume for
+	 * self-healing.
+	 *
+	 * After `MAX_CONSECUTIVE_HEARTBEAT_FAILURES` we still emit an `error`
+	 * log so persistent failures stay visible in observability, but the
+	 * timer keeps firing at the 5-min cap until something succeeds.
 	 *
 	 * @param reason - Human-readable failure reason
 	 */
@@ -550,20 +578,26 @@ export class DeviceAutoDiscoveryService extends EventEmitter {
 		this.consecutiveHeartbeatFailures++;
 		const nextDelay = DeviceAutoDiscoveryService.calculateBackoff(this.consecutiveHeartbeatFailures);
 
-		this.logger.warn('Heartbeat failed', {
+		const meta = {
 			reason,
 			consecutiveFailures: this.consecutiveHeartbeatFailures,
 			nextRetryMs: nextDelay,
-		});
+		};
 
-		if (this.consecutiveHeartbeatFailures >= DISCOVERY_CONSTANTS.MAX_CONSECUTIVE_HEARTBEAT_FAILURES) {
-			this.logger.error('Max heartbeat retries exceeded, stopping heartbeats', {
-				failures: this.consecutiveHeartbeatFailures,
-			});
-			if (this.heartbeatTimer) {
-				clearTimeout(this.heartbeatTimer);
-				this.heartbeatTimer = null;
-			}
+		const maxFails = DISCOVERY_CONSTANTS.MAX_CONSECUTIVE_HEARTBEAT_FAILURES;
+		if (this.consecutiveHeartbeatFailures < maxFails) {
+			this.logger.warn('Heartbeat failed', meta);
+			return;
+		}
+
+		// At or past the threshold — escalate once at the exact crossing,
+		// then drop to debug to avoid log-spam (~288/day per device at the
+		// 5-min cap). A persistent-failure dashboard alarm should watch
+		// the threshold-crossing error, not the every-cycle log.
+		if (this.consecutiveHeartbeatFailures === maxFails) {
+			this.logger.error('Heartbeat persistently failing (will keep retrying at capped backoff)', meta);
+		} else {
+			this.logger.debug('Heartbeat still failing (post-threshold)', meta);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`lastHeartbeatAt` in Cloud device registry was stuck at the last successful timestamp — sometimes days stale. Root: `handleHeartbeatFailure` permanently cleared `heartbeatTimer` after 10 consecutive failures. A transient blip would trip it, heartbeats never resumed.

Fix: remove hard stop. Heartbeats retry forever at the already-capped 5-min backoff. Self-heal on connectivity recovery.

## Review-driven hardening

- Log throttling: error once on threshold crossing, then debug. Prevents ~288/day error log spam per offline device.
- `.unref()` on poll + heartbeat timers so CLI/test process can exit cleanly (the hard stop used to do this implicitly).
- Stale JSDoc rewritten.
- Direct `expect(heartbeatTimer).not.toBeNull()` assertion in the regression test.

## Test plan
- [x] 28/28 tests pass (incl. new gate: 12 fails → counter resets on success + timer still alive)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)