### PR TITLE
fix(skills): enrich MissingCredentialError with available creds (closes #324)

### DIFF
--- a/backend/src/services/skill/skill-executor.service.ts
+++ b/backend/src/services/skill/skill-executor.service.ts
@@ -515,7 +515,19 @@ export class SkillExecutorService {
 
       if (!bindingId) {
         if (req.required) {
-          throw new MissingCredentialError(req.slot, req.provider);
+          // Issue #324: include available credentials of the matching
+          // provider in the error so the caller can self-recover by
+          // re-invoking with credentialBindings: { slot: id }. Without
+          // this hint the agent has to grep ~/.crewly/credentials/ to
+          // figure out what's even registered.
+          const available = await store.findCredentialsByProvider(req.provider);
+          const hints = available.map((c) => ({
+            id: c.id,
+            name: c.name,
+            type: c.type,
+            status: c.status,
+          }));
+          throw new MissingCredentialError(req.slot, req.provider, hints);
         }
         continue;
       }

--- a/backend/src/types/credential.types.test.ts
+++ b/backend/src/types/credential.types.test.ts
@@ -25,6 +25,27 @@ describe('credential.types', () => {
       expect(err.message).toContain('gemini');
       expect(err).toBeInstanceOf(Error);
     });
+
+    // Issue #324: caller gets no way to discover available credentials
+    // from the bare error. The enriched message lists them so the agent
+    // can self-recover with `credentialBindings: { slot: id }`.
+    it('lists available credentials of the matching provider when supplied', () => {
+      const err = new MissingCredentialError('gmail', 'google', [
+        { id: 'cred-aaa', name: "Steve's Gmail", type: 'google-oauth', status: 'active' },
+        { id: 'cred-bbb', name: 'Service Account', type: 'google-oauth', status: 'active' },
+      ]);
+      expect(err.message).toContain('cred-aaa');
+      expect(err.message).toContain("name=\"Steve's Gmail\"");
+      expect(err.message).toContain('status=active');
+      expect(err.message).toContain('credentialBindings');
+      expect(err.available).toHaveLength(2);
+    });
+
+    it('surfaces a clear no-credentials-registered hint when the provider list is empty', () => {
+      const err = new MissingCredentialError('gmail', 'google');
+      expect(err.message).toContain('No google credentials registered');
+      expect(err.message).toContain('Settings → Credentials');
+    });
   });
 
   describe('InsufficientScopeError', () => {

--- a/backend/src/types/credential.types.ts
+++ b/backend/src/types/credential.types.ts
@@ -188,14 +188,38 @@ export type CredentialBindings = Record<string, string>;
 // ============================================================================
 
 /**
+ * One available credential, surfaced in MissingCredentialError so the
+ * caller can re-invoke with `credentialBindings: { [slot]: id }`.
+ */
+export interface AvailableCredentialHint {
+  id: string;
+  name: string;
+  type: CredentialType;
+  status: CredentialStatus;
+}
+
+/**
  * Thrown when a required slot has neither a binding nor a default.
+ *
+ * The error message now includes the list of available credentials of
+ * the matching provider so the caller can re-invoke with the right
+ * `credentialBindings` map without having to grep `~/.crewly/credentials/`
+ * by hand. Issue #324.
  */
 export class MissingCredentialError extends Error {
   constructor(
     public readonly slot: string,
     public readonly provider: string,
+    public readonly available: readonly AvailableCredentialHint[] = [],
   ) {
-    super(`No credential bound to required slot '${slot}' (provider: ${provider})`);
+    const base = `No credential bound to required slot '${slot}' (provider: ${provider}).`;
+    const hint =
+      available.length > 0
+        ? ` Available ${provider} credentials: ${available
+            .map((c) => `${c.id} (name="${c.name}", status=${c.status})`)
+            .join(', ')}. Re-invoke with credentialBindings: { ${slot}: "<id>" }.`
+        : ` No ${provider} credentials registered. Add one via the Settings → Credentials UI before invoking this skill.`;
+    super(base + hint);
     this.name = 'MissingCredentialError';
   }
 }


### PR DESCRIPTION
## Summary

`skill-gmail` (and every credential-bound skill) returned a bare `"No credential bound to required slot 'gmail'"` error with no way to discover what credentials existed in the store. Agents had to grep `~/.crewly/credentials/` by hand to find the id.

Fix scoped to discoverability: `MissingCredentialError` now carries `available` — a list of the matching-provider credentials with `id`, `name`, `type`, `status`. The agent sees an actionable error and can re-invoke with `credentialBindings: { slot: id }`.

## What's out of scope

- 30s hang on explicit `credentialBindings` (separate token-refresh issue)
- Auto-binding via session lookup so agents don't have to pass bindings at all (design work — needs schema + onboarding changes)

I'll file a follow-up issue for the auto-binding work after this lands.

## Test plan
- [x] 2 new credential.types tests (with-list + no-list message shapes)
- [x] 59/59 affected tests pass
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)