### PR TITLE
fix(cron): wait for agent readiness after auto-start + record skip reason (closes #305)

### DIFF
--- a/backend/src/services/workflow/cron-task.service.test.ts
+++ b/backend/src/services/workflow/cron-task.service.test.ts
@@ -355,6 +355,107 @@ describe('CronTaskService', () => {
 			await service.evaluateTasks();
 			expect(executedTasks).toHaveLength(0);
 		});
+
+		// Issue #305 regression gate: an offline agent that auto-start
+		// successfully wakes up must be allowed to receive the cron task
+		// once it reports ready. Previously the executionCallback fired
+		// immediately after the start callback returned, before the agent
+		// had fully booted, and the message was lost.
+		it('waits for agent to become ready after auto-start before executing', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+
+			// Agent starts offline, then becomes online on the 2nd status check.
+			let statusCheckCount = 0;
+			service.setAgentStatusCallback(async () => {
+				statusCheckCount++;
+				return statusCheckCount >= 2;
+			});
+			let startCalled = false;
+			service.setAgentStartCallback(async () => {
+				startCalled = true;
+				return true;
+			});
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-readiness-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: pastTime,
+						createdBy: 'user', createdAt: '2026-01-01',
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			await service.evaluateTasks();
+
+			expect(startCalled).toBe(true);
+			expect(executedTasks).toHaveLength(1);
+			expect(executedTasks[0].id).toBe('cron-readiness-1');
+		});
+
+		// Issue #305: when the agent never reports ready within the wait
+		// window, the task must be skipped with `lastSkippedAt` set and
+		// a `lastSkipReason` distinguishable from "never ran" — not
+		// silently dropped.
+		it('skips with lastSkipReason="agent_offline_not_ready" when readiness wait expires', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+
+			// Agent never reports ready, status callback always returns false.
+			service.setAgentStatusCallback(async () => false);
+			service.setAgentStartCallback(async () => true); // kicks off, never becomes ready
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-stuck-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: pastTime,
+						createdBy: 'user', createdAt: '2026-01-01',
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			// Patch the timeout to keep the test fast — the real value is 15s.
+			// We rely on the readiness poll loop honoring the deadline; reducing
+			// it via a module-level patch isn't necessary because the test
+			// already exits via the polling loop with status=false repeatedly
+			// until deadline. To keep this test fast, mock setTimeout to no-op
+			// the inter-poll delay and override Date.now to fast-forward.
+			const realNow = Date.now;
+			let fakeNow = realNow();
+			jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+			const origSetTimeout = global.setTimeout;
+			(global as any).setTimeout = (cb: () => void) => {
+				fakeNow += 500; // each poll fast-forwards 500ms
+				cb();
+				return 0 as any;
+			};
+
+			try {
+				await service.evaluateTasks();
+			} finally {
+				(global as any).setTimeout = origSetTimeout;
+				(Date.now as jest.Mock).mockRestore();
+			}
+
+			expect(executedTasks).toHaveLength(0);
+			// Confirm the persisted task carries the skip reason.
+			const writeCall = mockWriteFile.mock.calls.find(c => String(c[0]).includes('team-a'));
+			expect(writeCall).toBeDefined();
+			const written = JSON.parse(writeCall![1] as string);
+			expect(written.tasks[0].lastSkippedAt).toBeTruthy();
+			expect(written.tasks[0].lastSkipReason).toBe('agent_offline_not_ready');
+			expect(written.tasks[0].lastRunAt).toBeNull();
+		});
 	});
 
 	describe('migrateGlobalToTeamScoped', () => {

--- a/backend/src/services/workflow/cron-task.service.ts
+++ b/backend/src/services/workflow/cron-task.service.ts
@@ -29,6 +29,20 @@ import type {
  */
 const CRON_CHECK_INTERVAL_MS = 60_000;
 
+/**
+ * Issue #305: when a cron task fires against an offline agent, we
+ * kick off auto-start, then poll the agent's online status until it
+ * reports ready or this deadline fires.
+ *
+ * 15s covers a cold tmux + Claude-Code init (~5-10s typically) with
+ * some headroom. Tasks that miss this window are skipped with
+ * `lastSkipReason: 'agent_offline_not_ready'`.
+ */
+const CRON_AUTO_START_READY_TIMEOUT_MS = 15_000;
+
+/** How often to re-check the agent's status during the readiness wait. */
+const CRON_AUTO_START_READY_POLL_MS = 500;
+
 /** Name of the per-team cron task file */
 const CRON_TASKS_FILENAME = 'cron-tasks.json';
 
@@ -732,19 +746,27 @@ export class CronTaskService {
 			}
 		}
 
-		// Auto-start offline agent if callback is available
+		// Auto-start offline agent if callback is available. Issue #305:
+		// the callback returns immediately when it kicks off the registration
+		// flow, but the agent takes a few seconds to actually report
+		// `active` / `started`. Without a readiness wait, the execution
+		// callback fires while the agent is still booting and the message
+		// is lost. We now poll `agentStatusCallback` up to the configured
+		// wait window before proceeding.
+		let skipReason: CronTask['lastSkipReason'] | null = null;
 		if (!agentOnline && this.agentStartCallback) {
 			this.logger.info('Agent offline for cron task, attempting auto-start', {
 				id: task.id,
 				target: task.targetAgent,
 			});
+			let kicked = false;
 			try {
-				const started = await this.agentStartCallback(task.targetAgent, task.targetTeamId);
-				if (started) {
-					agentOnline = true;
-					this.logger.info('Agent auto-started successfully', {
+				kicked = await this.agentStartCallback(task.targetAgent, task.targetTeamId);
+				if (kicked) {
+					this.logger.info('Agent auto-start kicked off, waiting for ready', {
 						id: task.id,
 						target: task.targetAgent,
+						maxWaitMs: CRON_AUTO_START_READY_TIMEOUT_MS,
 					});
 				}
 			} catch (error) {
@@ -753,14 +775,54 @@ export class CronTaskService {
 					target: task.targetAgent,
 					error: error instanceof Error ? error.message : String(error),
 				});
+				skipReason = 'agent_offline_start_failed';
 			}
+
+			if (kicked && this.agentStatusCallback) {
+				// Poll until ready or timeout. The status callback already
+				// treats both `active` and `started` as online (#286).
+				const deadline = Date.now() + CRON_AUTO_START_READY_TIMEOUT_MS;
+				while (Date.now() < deadline) {
+					try {
+						if (await this.agentStatusCallback(task.targetAgent, task.targetTeamId)) {
+							agentOnline = true;
+							break;
+						}
+					} catch {
+						// Transient — keep retrying until deadline.
+					}
+					await new Promise((res) => setTimeout(res, CRON_AUTO_START_READY_POLL_MS));
+				}
+				if (!agentOnline) {
+					skipReason = 'agent_offline_not_ready';
+					this.logger.warn('Agent did not become ready before cron auto-start deadline', {
+						id: task.id,
+						target: task.targetAgent,
+						maxWaitMs: CRON_AUTO_START_READY_TIMEOUT_MS,
+					});
+				} else {
+					this.logger.info('Agent auto-started and ready', {
+						id: task.id,
+						target: task.targetAgent,
+					});
+				}
+			} else if (!kicked && skipReason === null) {
+				skipReason = 'agent_offline_start_failed';
+			}
+		} else if (!agentOnline) {
+			skipReason = 'agent_offline_no_callback';
 		}
 
 		if (!agentOnline) {
 			this.logger.warn('Skipping cron task — agent offline and auto-start unavailable', {
 				id: task.id,
 				target: task.targetAgent,
+				skipReason,
 			});
+			// Mark the skip distinctly from "never ran" so the user can tell
+			// from API surfaces why `lastRunAt` is still null. Issue #305.
+			task.lastSkippedAt = now.toISOString();
+			task.lastSkipReason = skipReason ?? 'agent_offline_no_callback';
 			// Still advance nextRunAt to prevent re-evaluating the same missed slot
 			task.nextRunAt = getNextRunTime(task.cronExpression, task.timezone, now);
 			return true;

--- a/backend/src/types/cron-task.types.ts
+++ b/backend/src/types/cron-task.types.ts
@@ -33,6 +33,23 @@ export interface CronTask {
 	lastRunAt: string | null;
 	/** ISO timestamp of next scheduled run */
 	nextRunAt: string | null;
+	/**
+	 * ISO timestamp of the most recent fire-slot that was skipped because
+	 * the target agent was offline AND auto-start could not bring it back
+	 * online within the wait window. Distinct from `lastRunAt: null`
+	 * which means "never ran" — `lastSkippedAt` set + `lastRunAt: null`
+	 * means "tried but couldn't deliver." Issue #305.
+	 */
+	lastSkippedAt?: string | null;
+	/**
+	 * Human-readable reason the last fire-slot was skipped. One of:
+	 *   - `agent_offline_no_callback` — auto-start wasn't configured
+	 *   - `agent_offline_start_failed` — callback threw or returned false
+	 *   - `agent_offline_not_ready` — callback succeeded but agent
+	 *     didn't come online within the wait window
+	 * Issue #305.
+	 */
+	lastSkipReason?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Cron tasks against offline agents were silently dropped: `agentStartCallback` returned immediately, but the agent took 5-10s to actually boot. The execution callback fired against a still-booting agent and the message was lost. `lastRunAt: null` was indistinguishable from "never ran."

Fix:
1. After `agentStartCallback` returns true, poll `agentStatusCallback` every 500ms until ready or 15s timeout.
2. New `lastSkippedAt` + `lastSkipReason` fields on `CronTask` so skipped fire-slots are distinguishable from never-ran (one of: `agent_offline_no_callback`, `agent_offline_start_failed`, `agent_offline_not_ready`).

## Test plan
- [x] 37/37 cron-task tests pass (incl. 2 new gates: ready-in-time + timeout-skip)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)