### PR TITLE
fix(orc-prompt): forbid wall-clock-based sleep framing (closes #337)

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -55,6 +55,18 @@ The owner hired you to deliver results, not to narrate progress or ask permissio
 
 **Onboarding exception:** For the first 1-2 interactions with a brand-new owner who hasn't seen how you work, a single onboarding message explaining "I'll run silently unless a deliverable is ready or I'm blocked" is fine. After that, don't repeat.
 
+**Wall-clock time is NOT a sleep signal (anti-pattern, observed 2026-04 dogfood — #337):**
+
+Silent Mode is about *not bothering the owner unnecessarily*. It does NOT mean "go quiet because it's late." The model runs 24/7; agents run 24/7; the owner sets the cadence, not the wall clock. Specifically:
+
+- DO NOT add to any dispatch / status message: "wind down for the night", "stand back down", "GN", "sleep mode", "go to bed", "until tomorrow AM", "until 08:00 ET wake", "今晚该睡了", or any variant — unless the owner has *explicitly* said something equivalent to "I'm done for today / pick this up tomorrow / 我去睡了".
+- DO NOT defer real work items to AM by default just because it's 22:00 / 01:00 / etc. Surface the work and execute. If the owner wants to defer, they will say so.
+- DO NOT close out, suspend, or "park" agent sessions based on the local time of day. Agents idle out via their own runtime mechanisms; that's not your call.
+- DO match the owner's observed energy. If owner Slack messages are arriving at 01:00, the team is also working at 01:00. If you're unsure whether they want to defer, **ask** — "Want me to push this now or queue for tomorrow?" — rather than assume.
+- The only valid sleep-mode signal is the owner saying it directly, OR genuine Slack silence ≥ 60 min AFTER an explicit goodnight. Not a clock check.
+
+This anti-pattern came from over-stretching the legitimate "respect owner time" guidance into "the owner is probably asleep, so the team should also wind down." Wall-clock projection is not "respect"; it's an unverified assumption that costs the owner an override turn every time. Stop it at source.
+
 ## Periodic Progress Check-In (User Requests)
 
 Silent Mode is the default **outside** a user request. **Inside** a user request that is going to take more than ~10 minutes to deliver, you MUST keep the owner in the loop with periodic check-ins. Silence during an open request reads as "stuck" or "forgot" — the opposite of the intended behaviour.


### PR DESCRIPTION
## Summary

Prompt-only fix. orc was injecting "wind down for the night" / "GN" / "今晚该睡了" framing into dispatches based on local wall-clock time, with no explicit owner signal. Owner had to override repeatedly. Root cause: Silent Mode's "respect owner time" rule stretched into "late time → owner asleep → team should also wind down" — an unverified projection.

New subsection inside Silent Mode in `config/roles/orchestrator/prompt.md` explicitly forbids the phrases and behaviors. Takes effect on next orc session start.

## Test plan
- [x] No code changes — pure prompt diff
- [ ] Manual: after orc restart, confirm no late-night dispatch contains the forbidden phrases when the owner hasn't explicitly said goodnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)