### PR TITLE
fix(v3): decompose runs alongside SLA on inbound-Slack Requests (closes #565)

### DIFF
--- a/backend/src/services/event-bus/event-bus.service.ts
+++ b/backend/src/services/event-bus/event-bus.service.ts
@@ -218,21 +218,33 @@ export class EventBusService extends EventEmitter {
    * @param event - The agent lifecycle event to publish
    */
   publish(event: AgentEvent): void {
+    const nowMs = Date.now();
+
     // Dedup: ignore duplicate events for the same (type, sessionName) within
     // the debounce window. This prevents redundant notifications when both
     // the file watcher and ActivityMonitor detect the same status transition.
-    const dedupKey = `${event.type}:${event.sessionName}`;
-    const nowMs = Date.now();
-    const lastPublished = this.recentPublishMap.get(dedupKey);
-    if (lastPublished && nowMs - lastPublished < EVENT_BUS_CONSTANTS.EVENT_DEBOUNCE_WINDOW_MS) {
-      this.logger.debug('Duplicate event suppressed within debounce window', {
-        type: event.type,
-        sessionName: event.sessionName,
-        msSinceLast: nowMs - lastPublished,
-      });
-      return;
+    //
+    // Issue #565: system-level events (sessionName === '') — `workitem:queued`,
+    // `task:done_by_worker`, etc. — are distinct work items, not duplicate
+    // observations of the same agent state. Collapsing them under a single
+    // `${type}:` dedup key drops every event after the first within 5s, so
+    // decomposition fan-outs lost N-1 of N `workitem:queued` events and the
+    // `linkWorkItem` cascade never fired for those WIs. Skip dedup when
+    // sessionName is empty — the publisher's event.id already encodes
+    // uniqueness for these (e.g. `workitem:queued:${workItemId}`).
+    if (event.sessionName !== '') {
+      const dedupKey = `${event.type}:${event.sessionName}`;
+      const lastPublished = this.recentPublishMap.get(dedupKey);
+      if (lastPublished && nowMs - lastPublished < EVENT_BUS_CONSTANTS.EVENT_DEBOUNCE_WINDOW_MS) {
+        this.logger.debug('Duplicate event suppressed within debounce window', {
+          type: event.type,
+          sessionName: event.sessionName,
+          msSinceLast: nowMs - lastPublished,
+        });
+        return;
+      }
+      this.recentPublishMap.set(dedupKey, nowMs);
     }
-    this.recentPublishMap.set(dedupKey, nowMs);
 
     // Clean up old entries periodically (keep map small)
     if (this.recentPublishMap.size > EVENT_BUS_CONSTANTS.DEDUP_MAP_CLEANUP_THRESHOLD) {

--- a/backend/src/services/v3/request-decompose-auto.integration.test.ts
+++ b/backend/src/services/v3/request-decompose-auto.integration.test.ts
@@ -207,6 +207,57 @@ describe('Request auto-decompose pipeline (Option C subscriber, end-to-end)', ()
   // Acceptance criteria #1 — POST creates Request with WorkItems within 5s
   // -------------------------------------------------------------------------
 
+  // Issue #565 regression gate. The decompose subscriber's
+  // `shouldDecompose` previously rejected any Request whose
+  // `workItemIds.length > 0` — including the housekeeping
+  // `:respond_to_user` WI seeded synchronously by the SLA subscriber
+  // for inbound-Slack Requests. Every L2 inbound-Slack Request thus
+  // silently skipped decomposition. PR-B (#566) tried to add this test
+  // and discovered the bug; the fix here filters housekeeping WIs out
+  // of the gate.
+  it('co-existence: an L2 inbound-Slack Request produces SLA respond_to_user + ≥1 decomposition WI', async () => {
+    const created = await fx.requestService.create({
+      title: 'Build feature X for SLA co-existence test',
+      description: 'Build a comprehensive feature with auth, persistence, and end-to-end tests',
+      sourceConversationItemId: 'slack-CCOEX565-1.000001',
+      priority: 'normal',
+      // `tags: ['slack']` is what the SLA subscriber gates on for
+      // seeding the respond_to_user WI.
+      tags: ['slack'],
+      intentLevel: 'L2' as IntentLevel,
+      intentCategory: 'code_change' as IntentCategory,
+    });
+
+    // Loop multiple flush rounds — both subscribers may schedule more
+    // work in response to each other's events.
+    for (let i = 0; i < 5; i++) {
+      await fx.decomposeSubscriber.flushPending();
+      await fx.slaSubscriber.flushPending();
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    // Confirm decompose actually ran. If this fails, the bug isn't the
+    // SLA-WI gate — it's something earlier in the subscriber chain.
+    const decomposed = fx.decomposeSubscriber.getDecomposedRequestIdsSnapshot();
+    expect(decomposed.has(created.id)).toBe(true);
+
+    const refreshed = await fx.requestService.getById(created.id);
+    expect(refreshed).not.toBeNull();
+
+    // ≥2 decomposition WIs must exist — proves BOTH root causes are fixed:
+    //   1. shouldDecompose's housekeeping-WI filter (SLA's :respond_to_user
+    //      WI no longer falsely trips the "already decomposed" gate).
+    //   2. EventBus type+sessionName dedup no longer collapses N workitem:
+    //      queued events to 1 for system-level events (sessionName='').
+    //      Pre-fix the second WI's event was silently dropped.
+    // The plan() heuristic returns ≥3 tasks for the build-style description
+    // used here, so requiring ≥2 in workItemIds is a tighter gate that
+    // catches dedup regressions specifically.
+    const slaWiId = `request:${created.id}:respond_to_user`;
+    const decompositionWis = refreshed!.workItemIds.filter((id) => id !== slaWiId);
+    expect(decompositionWis.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('an L2 code_change Request lands with WorkItems linked end-to-end', async () => {
     const created = await fx.requestService.create({
       title: 'Build a feature for X',

--- a/backend/src/services/v3/request-decompose.subscriber.ts
+++ b/backend/src/services/v3/request-decompose.subscriber.ts
@@ -87,6 +87,7 @@ import type { Request, IntentCategory } from '../../types/v2/request.types.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import { createWorkItem } from '../../types/v2/work-item.types.js';
 import type { PlannedTask } from './v3-data.service.js';
+import { SLA_TRACKER_ID_PATTERN } from './workitem-dispatch.subscriber.js';
 
 // ---------------------------------------------------------------------------
 // Filter rules
@@ -463,10 +464,27 @@ export class RequestDecomposeSubscriber {
     // Request manually. Don't double-add. The check is on the persisted
     // workItemIds (cross-process safe) — distinct from the in-memory
     // decomposedRequestIds dedupe (within-process redelivery).
-    if (request.workItemIds.length > 0) {
-      this.logger.debug('skip auto-decompose — Request already has linked WorkItems', {
+    //
+    // Issue #565: filter out the SLA-side `:respond_to_user` WI before
+    // counting. That WI is created by `RequestSlaSubscriber` for every
+    // inbound-Slack Request and lands in `workItemIds` BEFORE this
+    // handler runs. Treating it as evidence of "already decomposed"
+    // made every L2 inbound-Slack Request silently skip auto-decompose
+    // — confirmed in production via PR-B test (closed as #566). The
+    // gate now counts only non-housekeeping WIs.
+    //
+    // Use the canonical `SLA_TRACKER_ID_PATTERN` regex (exported by
+    // `workitem-dispatch.subscriber`) rather than a `endsWith` check so
+    // a user-named WI like `foo:respond_to_user` can't accidentally
+    // match the filter.
+    const decompositionWiCount = request.workItemIds.filter(
+      (id) => !SLA_TRACKER_ID_PATTERN.test(id),
+    ).length;
+    if (decompositionWiCount > 0) {
+      this.logger.debug('skip auto-decompose — Request already has linked decomposition WorkItems', {
         requestId: request.id,
-        existingCount: request.workItemIds.length,
+        decompositionWiCount,
+        totalWiCount: request.workItemIds.length,
       });
       return false;
     }


### PR DESCRIPTION
## Summary

P1 bug. Every L2 inbound-Slack Request silently skipped auto-decomposition. Two root causes, both required:

1. **shouldDecompose workItemIds gate** counted SLA's housekeeping `:respond_to_user` WI as "already decomposed". Fix: filter using `SLA_TRACKER_ID_PATTERN`.
2. **EventBus dedup collision** dropped most `workitem:queued` events because all share `sessionName: ''`. Fix: skip dedup when sessionName is empty (system events encode uniqueness in `event.id`).

## Test plan
- [x] 183/183 tests pass across 4 affected suites
- [x] New regression gate asserts ≥2 decomposition WIs on L2+slack-tag+actionable Request (catches both root causes)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)