### PR TITLE
chore(chat-v2): pickTeamLead rule-4 warn + dispatchToAgent @deprecated (closes #332 #334)

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
@@ -317,6 +317,17 @@ export class ChatV2DispatcherService {
    * Messages where `senderType !== "user"` are a no-op — we never loop an
    * agent's own reply back into its own PTY.
    *
+   * @deprecated Issue #334 — `dispatchToAgent` is the legacy 1:1 entry
+   * point. New callers MUST go through `dispatchMessage`, which routes
+   * type='dm' messages here and adds the type='channel' (@mentions /
+   * @team) path. Direct callers of `dispatchToAgent` silently bypass
+   * the mention-resolution layer.
+   *
+   * Conversion: replace `dispatchToAgent(channel, message)` with
+   * `dispatchMessage(channel, message)` and read the `dmResult` field
+   * of the returned object. See chat-v2.dispatcher.service.ts:dispatchMessage
+   * for the contract.
+   *
    * @param channel - Channel DTO (provides `agentSession` + display name)
    * @param message - Persisted message DTO
    */

--- a/backend/src/utils/team.utils.test.ts
+++ b/backend/src/utils/team.utils.test.ts
@@ -63,6 +63,56 @@ describe('pickTeamLead', () => {
     expect(pickTeamLead(team)?.id).toBe('m1');
   });
 
+  // Issue #332: rule-4 fallback must emit a warn so missing hierarchy
+  // data surfaces in observability. Rules 1-3 must stay silent.
+  describe('observability (#332)', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    function countTeamUtilsWarns(): number {
+      return warnSpy.mock.calls.filter(([msg]) =>
+        typeof msg === 'string' && msg.includes('pickTeamLead falling back to first member'),
+      ).length;
+    }
+
+    it('rule-1 (hierarchy TL) does NOT warn', () => {
+      const tl = baseMember({ id: 'tl', hierarchyLevel: 1, canDelegate: true });
+      const other = baseMember({ id: 'dev' });
+      const team = mkTeam([other, tl]);
+      pickTeamLead(team);
+      expect(countTeamUtilsWarns()).toBe(0);
+    });
+
+    it('rule-2 (canDelegate) does NOT warn', () => {
+      const tl = baseMember({ id: 'tl', canDelegate: true });
+      const team = mkTeam([tl]);
+      pickTeamLead(team);
+      expect(countTeamUtilsWarns()).toBe(0);
+    });
+
+    it('rule-3 (role=team-leader) does NOT warn', () => {
+      const tl = baseMember({ id: 'tl', role: 'team-leader' });
+      const team = mkTeam([tl]);
+      pickTeamLead(team);
+      expect(countTeamUtilsWarns()).toBe(0);
+    });
+
+    it('rule-4 (first member fallback) DOES warn', () => {
+      const m1 = baseMember({ id: 'm1' });
+      const m2 = baseMember({ id: 'm2' });
+      const team = mkTeam([m1, m2]);
+      pickTeamLead(team);
+      expect(countTeamUtilsWarns()).toBe(1);
+    });
+  });
+
   it('returns null when team has no members', () => {
     const team = mkTeam([]);
     expect(pickTeamLead(team)).toBeNull();

--- a/backend/src/utils/team.utils.ts
+++ b/backend/src/utils/team.utils.ts
@@ -10,6 +10,9 @@
  */
 
 import type { Team, TeamMember } from '../types/index.js';
+import { LoggerService } from '../services/core/logger.service.js';
+
+const logger = LoggerService.getInstance().createComponentLogger('TeamUtils');
 
 /**
  * Choose the TL (Team Lead) responder for a team.
@@ -23,7 +26,9 @@ import type { Team, TeamMember } from '../types/index.js';
  *      didn't fill in `canDelegate` still resolve correctly.
  *   4. First member: deterministic last resort — better to dispatch to
  *      _someone_ than silently drop a `@team` ping. Tests cover this
- *      case.
+ *      case. **Emits a warn-log (#332)** so operators see when team
+ *      hierarchy data is incomplete — silent rule-4 hits were
+ *      previously invisible.
  *
  * Returns `null` only when the team has no members at all.
  *
@@ -40,10 +45,25 @@ export function pickTeamLead(team: Team): TeamMember | null {
   const members = team.members ?? [];
   if (members.length === 0) return null;
 
-  return (
-    members.find((m) => m.hierarchyLevel === 1 && m.canDelegate === true) ??
-    members.find((m) => m.canDelegate === true) ??
-    members.find((m) => m.role === 'team-leader') ??
-    members[0]
-  );
+  const hierarchyTl = members.find((m) => m.hierarchyLevel === 1 && m.canDelegate === true);
+  if (hierarchyTl) return hierarchyTl;
+
+  const anyDelegator = members.find((m) => m.canDelegate === true);
+  if (anyDelegator) return anyDelegator;
+
+  const roleTl = members.find((m) => m.role === 'team-leader');
+  if (roleTl) return roleTl;
+
+  // Issue #332: rule-4 fallback — emit a warn so the missing hierarchy
+  // data surfaces in observability instead of being invisible. The
+  // resolver still returns a member so `@team` pings don't silently
+  // drop, but the team owner should fix the underlying hierarchy gap.
+  logger.warn('pickTeamLead falling back to first member — team has no canDelegate / team-leader marker', {
+    teamId: team.id,
+    teamName: team.name,
+    chosenMemberId: members[0].id,
+    memberCount: members.length,
+    reason: 'no TL markers — falling back to first member',
+  });
+  return members[0];
 }


### PR DESCRIPTION
Two small chat-v2 cleanups from PR #331 review. (1) pickTeamLead rule-4 fallback now emits logger.warn so missing hierarchy data is visible in observability. (2) Legacy dispatchToAgent marked @deprecated pointing callers at dispatchMessage. 10/10 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)