### PR TITLE
feat(prompts): milestone-notification audit — prompt batch (closes #434 #436 #437 #427 #430 #432)

### DIFF
--- a/config/roles/auditor/prompt.md
+++ b/config/roles/auditor/prompt.md
@@ -43,6 +43,30 @@ Continuously monitor all active agents, detect problems early, and produce struc
 - Use `heartbeat` to check overall system status
 - Detect: API failures, queue backlogs, scheduling issues
 
+### 6. Silent Shipping Detection (#437)
+
+The auditor's blind spot before issue #432: an agent ships a real
+artifact (PR merged, spec finalized) but never emits a `[MILESTONE]`
+surface upstream. The owner finds out via `git log` 12 hours later —
+exact shape of the 2026-05-04 incident that opened EPIC #426.
+
+**How to monitor:**
+
+- Cross-reference `git log` (commits in the last 24h) and merged PRs
+  against `report-status` / `[MILESTONE]` events from the same window.
+- Flag any agent who authored a merged PR but did NOT emit a
+  `[MILESTONE]` surface within 30 minutes of merge.
+- Evidence to capture: PR URL, author session, merge timestamp, the
+  most recent `report-status` event for that author (so the gap is
+  visible — "last surface at 14:02; PR merged at 17:18; 3h16m gap").
+
+**Severity:** **medium** by default — silent shipping indicates a
+system gap, not an agent bug. If the same author silently ships 3+
+times across an audit cycle, escalate to **high**: the structural
+fix (the Mid-Flight Milestone Surface SOP at
+`config/sops/common/mid-flight-milestone-surface.md`) is not landing
+in practice and a prompt/role adjustment is overdue.
+
 ## How You Report
 
 When you find a problem, use the `write_audit_report` tool to append it to the audit log.

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -160,7 +160,8 @@ When I send you a task:
 2. **Codebase audit** — Before implementing any feature, search the codebase for existing implementations that overlap with the task. Use `grep`, `find`, and read relevant service files. If the feature (or parts of it) already exists, report back what's already there and propose incremental improvements instead of building from scratch.
 3. Write clean, tested code following project conventions
 4. Report blockers and issues promptly
-5. Let me know when done
+5. **Surface milestones the moment they ship** — see "Mid-Flight Milestone Surface" SOP at `config/sops/common/mid-flight-milestone-surface.md`. When a PR merges / a spec is finalized / a build passes on a non-trivial change, immediately call `report-status` with `status: "milestone"` and a plain-language summary. Do NOT wait for the next outcome-check tick. Issue #427 / EPIC #426 — the system was structurally silent on this path until now.
+6. Let me know when fully done.
 
 **CRITICAL**: Never assume a feature doesn't exist. Always verify by reading the codebase first. Building duplicate code wastes time and creates maintenance burden.
 

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -678,7 +678,15 @@ Not every event deserves a user notification. Use this priority system to decide
 |----------|---------------|----------|
 | 🔴 **Critical** — Notify IMMEDIATELY | Agent crash, task failure, blocked, error | Runtime exited, build failed, agent stuck >15min |
 | 🟡 **Important** — Notify within 1 min | Task completed, needs user decision, milestone reached | Agent finished feature, needs review approval |
+| 🟡 **`[MILESTONE]` envelope** (#436) — **ALWAYS notify, never downgrade to ⚪ Info** | Agent emitted an explicit `[MILESTONE]` via `report-status` `status: "milestone"` — see `config/sops/common/mid-flight-milestone-surface.md` | "PR #420 merged — agent state file is now corruption-resistant", "Spec finalized + handed off to Atlas" |
 | ⚪ **Info** — Log only, include in next summary | Agent started working, routine status change, heartbeat | idle→in_progress, scheduled check with no changes |
+
+**Rule at ALL trust levels (never skip)**: when an agent surfaces a
+`[MILESTONE]` envelope, you forward it to the owner. The agent
+already self-filtered using the Mid-Flight Milestone Surface SOP; do
+not re-litigate that decision by downgrading to ⚪ Info even if the
+outer outcome / OKR isn't fully met yet. Issue #427 / EPIC #426
+documented the system gap that this rule closes.
 
 ### Decision Rules for Events
 

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -203,6 +203,12 @@ Your verification approach adjusts based on the team's `templateId`:
 - All reports to the Orchestrator **must** include the `[TL_REPORT]` tag
 - All tasks delegated to workers **must** include explicit `acceptanceCriteria`
 - Status updates use `report-status` skill with clear summaries
+- **Mid-flight milestones must surface immediately** — when a worker
+  ships a PR / finalizes a spec / passes a non-trivial build, you
+  forward (or your worker emits directly) a `[MILESTONE]` envelope
+  via `report-status` with `status: "milestone"`. See
+  `config/sops/common/mid-flight-milestone-surface.md`. Do NOT wait
+  for the next outcome-check tick. Issue #427 / EPIC #426.
 
 ---
 

--- a/config/sops/common/mid-flight-milestone-surface.md
+++ b/config/sops/common/mid-flight-milestone-surface.md
@@ -1,0 +1,128 @@
+---
+id: common-mid-flight-milestone-surface
+version: 1
+createdAt: 2026-05-16T00:00:00Z
+updatedAt: 2026-05-16T00:00:00Z
+createdBy: system
+updatedBy: system
+role: common
+category: communication
+priority: 8
+title: Mid-Flight Milestone Surface
+description: When you ship a milestone inside an active goal, surface it upstream immediately — do not wait for the next outcome-check tick.
+triggers:
+  - milestone
+  - report-status
+  - PR merged
+  - spec finalized
+  - build pass
+  - deploy succeeded
+tags:
+  - communication
+  - proactive
+  - milestone
+  - silent-shipping
+---
+
+# Mid-Flight Milestone Surface
+
+When you ship a milestone INSIDE an active goal — a PR merged, a spec
+finalized, a build pass on a non-trivial change, a dependency
+unblocked, a deploy succeeded — do **NOT** wait for the next
+outcome-check tick or for someone to ask. Surface it now.
+
+This SOP is the **symmetric agent-side rule** to the orchestrator's
+periodic check-in cadence (PR #418). The orc surfaces upward to the
+owner on a 15-min cadence; agents surface upward to the orc the
+moment they have something concrete to report. Issue #427 / EPIC
+#426 documented that worker / TL prompts had **zero** "milestone"
+keyword across 21 role prompts — the system was structurally silent
+on this path.
+
+## The rule
+
+Immediately call the `report-status` skill with:
+
+- `status: "milestone"` — the explicit verb introduced by issue #435 /
+  PR adding `[MILESTONE]` envelope to `report-status`.
+- `summary` — plain-language **WHAT shipped** + **one-line
+  WHAT-IT-MEANS-FOR-OWNER**. Optimize for someone scanning Slack on
+  their phone.
+- `artifacts` — the canonical link (PR URL, spec path, deploy id).
+  If there's no artifact, the milestone probably isn't one.
+
+The orchestrator's Smart Notification Protocol has a dedicated
+`[MILESTONE]` row in the priority table (issue #436) that promotes
+the surface to 🟡 Important — always notify, never downgraded to
+⚪ Info even if the outer outcome isn't fully met yet.
+
+## What counts as a milestone
+
+- PR merged
+- Spec finalized + handed off
+- Build pass on a non-trivial change (e.g. cross-module refactor
+  that compiles for the first time)
+- Dependency unblocked (the thing you were waiting on now exists)
+- Deploy succeeded
+- Verification gate passed (e.g. an integration test you wrote went
+  green for the first time)
+
+## What does NOT count
+
+- "task done" without context (no `summary` body) — every dispatch
+  produces a "task done" event, those flow through the existing
+  task-pool path and don't need separate `[MILESTONE]` surfacing.
+- Internal progress checkpoints (40% of the way through, 80% of the
+  way through). Those are status updates, not milestones.
+- The same milestone re-surfaced. Once is enough.
+
+## Examples
+
+✅ **Good**:
+
+- "PR #420 merged — agent state file is now corruption-resistant +
+  auto-snapshots every 30s. Persistence-loss risk on crash drops from
+  'all session memory' to 'last 30s only'. No action needed."
+
+- "Onboarding cold-start state machine merged (PR #409). End-to-end
+  5-min activation path is now in code. Real-user dry-run still
+  pending."
+
+❌ **Bad — do not emit**:
+
+- "task done"
+- "Progress update: 80%"
+- "Working on it"
+- "Will continue tomorrow" (without specifying what shipped)
+
+## How orc handles it
+
+When the `[MILESTONE]` envelope arrives, the orchestrator:
+
+1. Recognizes the explicit `[MILESTONE]` marker from the priority
+   table (issue #436) — classified as 🟡 Important.
+2. Surfaces to the owner via the trust-adaptive channel (chat-v2
+   `[NOTIFY]` or Slack reply-thread, depending on origin).
+3. Never downgrades to ⚪ Info even if the outer outcome (OKR /
+   request) isn't yet fully complete.
+
+The auditor's "Silent Shipping Detection" monitor (issue #437)
+cross-references `git log` against `report-status` / `[MILESTONE]`
+events and flags any merged PR whose author did not emit a milestone
+surface within 30 minutes of merge.
+
+## Where this SOP applies
+
+All roles that ship artifacts: developer, frontend-developer,
+fullstack-dev, qa, qa-engineer, product-manager, tpm, designer,
+ux-designer, architect, team-leader, generalist. The orc and the
+auditor consume the surface; they don't emit it.
+
+## Refs
+
+- EPIC #426 — Proactive-followup gap audit
+- RC1 #427 — Worker/TL prompts contain zero milestone keyword
+- QW-1 #434 — This SOP
+- QW-2 #435 — `[MILESTONE]` envelope in `report-status` skill
+- QW-3 #436 — `[MILESTONE]` row in orc priority table
+- QW-4 #437 — Auditor Silent Shipping Detection monitor


### PR DESCRIPTION
First half of the EPIC #426 fix batch — all prompt-only changes. Adds the Mid-Flight Milestone Surface SOP + reference points in worker/TL prompts, adds [MILESTONE] row to orc Smart Notification priority table, adds Silent Shipping Detection monitor to auditor prompt. Closes 6 sub-issues.

Second half (skill envelope + MilestoneNotificationSubscriber + ralph-loop reframe) coming as PR-2. #440 (subscription-model framework) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)