### PR TITLE
feat(milestone): report-status milestone verb + MilestoneNotificationSubscriber (closes #435 #438 #428 #429)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -65,6 +65,7 @@ import { ThreadStatusQueueService } from './services/messaging/thread-status-que
 import { EventBusService } from './services/event-bus/index.js';
 import { EventToWorkItemBridge } from './services/event-bus/event-to-workitem-bridge.service.js';
 import { AutoLearningSubscriber } from './services/memory/auto-learning.subscriber.js';
+import { MilestoneNotificationSubscriber } from './services/notification/milestone-notification.subscriber.js';
 import {
 	RequestSlaSubscriber,
 	setRequestSlaSubscriber,
@@ -194,6 +195,9 @@ export class CrewlyServer {
 	private eventToWorkItemBridge: EventToWorkItemBridge | null = null;
 	/** LEARN-1: subscribes to terminal task / mission:replanned events and auto-records learnings. */
 	private autoLearningSubscriber: AutoLearningSubscriber | null = null;
+	// DF-1 #438 — symmetric to AutoLearningSubscriber; surfaces milestones
+	// to orc's chat queue.
+	private milestoneNotificationSubscriber: MilestoneNotificationSubscriber | null = null;
 	/** INBOUND-1: subscribes to request:created and tracks 5/10 min SLA on respond_to_user WIs. */
 	private requestSlaSubscriber: RequestSlaSubscriber | null = null;
 	/** Pipeline-#4 follow-up: subscribes to request:created and auto-decomposes actionable L2 Requests via plan() → addToPool. */
@@ -439,6 +443,20 @@ export class CrewlyServer {
 		// contract (V1) and the V7/V9 self-checks in the co-located test.
 		this.autoLearningSubscriber = AutoLearningSubscriber.boot(this.eventBusService);
 		this.autoLearningSubscriber.start();
+
+		// DF-1 #438: symmetric notification subscriber. Same architectural
+		// pattern as AutoLearningSubscriber — listens to terminal lifecycle
+		// events (`task:verified`, `mission:replanned`) and enqueues a
+		// `[MILESTONE]` envelope into orc's chat queue. The QW-3 row in
+		// `config/roles/orchestrator/prompt.md` (#436) handles the
+		// always-forward-to-owner rule on the orc side; this subscriber
+		// closes the gap where an agent ships work but forgets to call
+		// `report-status --status milestone` (the agent-side QW-1 path).
+		this.milestoneNotificationSubscriber = new MilestoneNotificationSubscriber({
+			eventBus: this.eventBusService,
+			messageQueueService: this.messageQueueService,
+		});
+		this.milestoneNotificationSubscriber.start();
 
 		// INBOUND-1 + Pipeline-#4 follow-up: wire RequestService → bus, then
 		// boot both v3 subscribers (SLA tracker + auto-decompose). Order
@@ -3031,6 +3049,12 @@ export class CrewlyServer {
 			if (this.autoLearningSubscriber) {
 				this.autoLearningSubscriber.stop();
 				this.autoLearningSubscriber = null;
+			}
+
+			// DF-1 #438: same shutdown window as auto-learning above.
+			if (this.milestoneNotificationSubscriber) {
+				this.milestoneNotificationSubscriber.stop();
+				this.milestoneNotificationSubscriber = null;
 			}
 
 			// INBOUND-1: stop the SLA subscriber and unset the module-level

--- a/backend/src/services/notification/milestone-notification.subscriber.test.ts
+++ b/backend/src/services/notification/milestone-notification.subscriber.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for MilestoneNotificationSubscriber (#438).
+ *
+ * @module services/notification/milestone-notification.subscriber.test
+ */
+
+import { EventBusService } from '../event-bus/event-bus.service.js';
+import {
+  MilestoneNotificationSubscriber,
+  MILESTONE_SUBSCRIBED_EVENTS,
+} from './milestone-notification.subscriber.js';
+import type { AgentEvent } from '../../types/event-bus.types.js';
+
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+function makeEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    id: `evt-${Math.random().toString(36).slice(2, 8)}`,
+    type: 'task:verified',
+    timestamp: new Date().toISOString(),
+    teamId: 'team-1',
+    teamName: 'Team',
+    memberId: 'm-1',
+    memberName: 'Worker',
+    sessionName: 'crewly-product-leo',
+    previousValue: 'done_by_worker',
+    newValue: 'verified',
+    changedField: 'taskStatus',
+    workItemId: 'wi-1',
+    ...overrides,
+  } as AgentEvent;
+}
+
+describe('MilestoneNotificationSubscriber', () => {
+  let bus: EventBusService;
+  let enqueue: jest.Mock;
+  let subscriber: MilestoneNotificationSubscriber;
+
+  beforeEach(() => {
+    bus = new EventBusService();
+    enqueue = jest.fn();
+    subscriber = new MilestoneNotificationSubscriber({
+      eventBus: bus,
+      messageQueueService: { enqueue },
+      orchestratorSession: 'crewly-orc',
+    });
+    subscriber.start();
+  });
+
+  afterEach(() => {
+    subscriber.stop();
+  });
+
+  it('subscribes to exactly the closed set', () => {
+    // Smoke: starting + immediately stopping doesn't throw, and the
+    // exported event list matches what we expect.
+    expect(MILESTONE_SUBSCRIBED_EVENTS).toEqual(['task:verified', 'mission:replanned']);
+  });
+
+  it('enqueues a [MILESTONE] envelope when task:verified fires with a meaningful summary', async () => {
+    bus.publish(
+      makeEvent({
+        type: 'task:verified',
+        sessionName: 'crewly-product-leo',
+        workItemId: 'wi-shipped-1',
+        // Cast through unknown for the extra `summary` field that AgentEvent doesn't formally declare.
+        ...({
+          summary: 'PR #420 merged — agent state file is now corruption-resistant + auto-snapshots every 30s',
+        } as unknown as Partial<AgentEvent>),
+      }),
+    );
+
+    await subscriber.flushPending();
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const call = enqueue.mock.calls[0][0];
+    expect(call.content).toContain('[MILESTONE]');
+    expect(call.content).toContain('PR #420 merged');
+    expect(call.targetSession).toBe('crewly-orc');
+    expect(call.source).toBe('system_event');
+  });
+
+  it('skips events with no summary (avoids spamming orc on bare lifecycle ticks)', async () => {
+    bus.publish(
+      makeEvent({
+        type: 'task:verified',
+        sessionName: 'crewly-product-leo',
+        workItemId: 'wi-no-summary',
+      }),
+    );
+    await subscriber.flushPending();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips trivially-short summaries (mirrors the agent-side ≥30-char gate)', async () => {
+    bus.publish(
+      makeEvent({
+        type: 'task:verified',
+        workItemId: 'wi-short',
+        ...({ summary: 'task done' } as unknown as Partial<AgentEvent>),
+      }),
+    );
+    await subscriber.flushPending();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('dedups identical events on the same workItemId', async () => {
+    const evt = makeEvent({
+      type: 'task:verified',
+      workItemId: 'wi-dup-1',
+      ...({
+        summary: 'A meaningful milestone summary that exceeds thirty characters.',
+      } as unknown as Partial<AgentEvent>),
+    });
+    bus.publish(evt);
+    bus.publish({ ...evt, id: 'evt-dup-2' }); // Same wiKey
+    await subscriber.flushPending();
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/notification/milestone-notification.subscriber.ts
+++ b/backend/src/services/notification/milestone-notification.subscriber.ts
@@ -1,0 +1,261 @@
+/**
+ * MilestoneNotificationSubscriber (DF-1, issue #438)
+ *
+ * Mirrors `auto-learning.subscriber.ts` exactly — same shape (subscribe
+ * to lifecycle events, dispatch idempotently, log on failure) but with a
+ * different action: enqueue a `[MILESTONE]` message into the orchestrator's
+ * chat queue so orc's Smart Notification Protocol can decide whether to
+ * forward to the owner. The QW-3 prompt change (#436, PR #581) adds a
+ * dedicated `[MILESTONE]` row to that priority table — always 🟡 Important,
+ * never downgraded to ⚪ Info.
+ *
+ * **Why a backend subscriber when the agent-side prompt path already exists?**
+ * The QW-1 prompt change (#434, PR #581) tells agents to call `report-status
+ * --status milestone` when they ship. But that only fires when the agent
+ * decides to call it. Some lifecycle events (TL `verifyItem(verified)`,
+ * `mission:replanned`) happen at the system level WITHOUT going through
+ * report-status. The subscriber here is the safety net: any time a
+ * verified/replanned event surfaces, the owner gets notified even if the
+ * worker forgot to self-surface.
+ *
+ * Subscribed events (closed-set, mirrors the same Arch Veto V7 + N1
+ * rationale as auto-learning):
+ *   - `task:verified`        — TL verified a worker's output (shipped artifact)
+ *   - `mission:replanned`    — strategy changed (rare, escalate)
+ *
+ * Idempotency (Arch Veto V1):
+ *   `${eventType}:${workItemId}` (or `${eventType}:${missionId}:${eventId}`
+ *   for mission events) against an in-memory bounded LRU.
+ *
+ * No new event types (Arch Veto V7):
+ *   Listens only to event types already in `EVENT_TYPES`.
+ *
+ * Fire-and-forget:
+ *   `enqueueNotification()` is async; each dispatch is wrapped so a thrown
+ *   error logs but doesn't break the publisher or other subscribers.
+ *
+ * @module services/notification/milestone-notification.subscriber
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import type { EventBusService, InProcessUnsubscribe } from '../event-bus/event-bus.service.js';
+import type { AgentEvent, EventType } from '../../types/event-bus.types.js';
+import { formatError } from '../../utils/format-error.js';
+import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
+
+/** Minimal MessageQueueService surface this subscriber depends on. */
+export interface IMessageQueueServiceLike {
+  enqueue(input: {
+    content: string;
+    conversationId: string;
+    source: string;
+    targetSession?: string;
+    sourceMetadata?: Record<string, unknown>;
+  }): unknown;
+}
+
+/**
+ * Events this subscriber listens to. Closed-set per the same Arch N1 rule
+ * `auto-learning.subscriber` follows — additions require explicit review.
+ */
+export const MILESTONE_SUBSCRIBED_EVENTS: readonly EventType[] = [
+  'task:verified',
+  'mission:replanned',
+] as const;
+
+/** Bounded LRU cap to keep the dedup set from growing indefinitely. */
+const DEDUP_LRU_CAPACITY = 1024;
+
+/** Minimal LRU-ish bounded set — same shape `auto-learning.subscriber` uses. */
+class BoundedSet {
+  private readonly capacity: number;
+  private readonly items: Set<string> = new Set();
+  constructor(capacity: number) {
+    this.capacity = Math.max(1, capacity);
+  }
+  has(key: string): boolean {
+    return this.items.has(key);
+  }
+  add(key: string): void {
+    if (this.items.has(key)) return;
+    if (this.items.size >= this.capacity) {
+      const first = this.items.values().next().value;
+      if (first !== undefined) this.items.delete(first);
+    }
+    this.items.add(key);
+  }
+  get size(): number {
+    return this.items.size;
+  }
+}
+
+export interface MilestoneNotificationDependencies {
+  eventBus: EventBusService;
+  /** Notification sink — typically the orchestrator's MessageQueueService. */
+  messageQueueService: IMessageQueueServiceLike;
+  /** Optional logger override (defaults to a fresh component logger). */
+  logger?: ComponentLogger;
+  /** Optional dedup LRU capacity (defaults to {@link DEDUP_LRU_CAPACITY}). */
+  dedupCapacity?: number;
+  /** Optional override for the orchestrator session name. */
+  orchestratorSession?: string;
+}
+
+/**
+ * MilestoneNotificationSubscriber — surfaces lifecycle milestones to the
+ * orchestrator's chat queue with a `[MILESTONE]` envelope.
+ */
+export class MilestoneNotificationSubscriber {
+  private readonly eventBus: EventBusService;
+  private readonly messageQueueService: IMessageQueueServiceLike;
+  private readonly logger: ComponentLogger;
+  private readonly dedup: BoundedSet;
+  private readonly orchestratorSession: string;
+  private unsubscribers: InProcessUnsubscribe[] = [];
+  private started = false;
+  private pendingDispatches: Set<Promise<void>> = new Set();
+
+  constructor(deps: MilestoneNotificationDependencies) {
+    this.eventBus = deps.eventBus;
+    this.messageQueueService = deps.messageQueueService;
+    this.logger =
+      deps.logger ??
+      LoggerService.getInstance().createComponentLogger('MilestoneNotificationSubscriber');
+    this.dedup = new BoundedSet(deps.dedupCapacity ?? DEDUP_LRU_CAPACITY);
+    this.orchestratorSession = deps.orchestratorSession ?? ORCHESTRATOR_SESSION_NAME;
+  }
+
+  /** Subscribe to all configured events. Idempotent. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    for (const eventType of MILESTONE_SUBSCRIBED_EVENTS) {
+      this.unsubscribers.push(
+        this.eventBus.onInProcess(eventType, (e) => this.safeDispatch(eventType, e)),
+      );
+    }
+    this.logger.info('MilestoneNotificationSubscriber subscribed', {
+      eventTypes: MILESTONE_SUBSCRIBED_EVENTS,
+      orchestratorSession: this.orchestratorSession,
+    });
+  }
+
+  /** Wait for every in-flight dispatch. Test affordance. */
+  async flushPending(): Promise<void> {
+    while (this.pendingDispatches.size > 0) {
+      const inFlight = Array.from(this.pendingDispatches);
+      await Promise.allSettled(inFlight);
+    }
+  }
+
+  /** Detach all subscriptions. */
+  stop(): void {
+    for (const u of this.unsubscribers) {
+      try {
+        u();
+      } catch (err) {
+        this.logger.warn('MilestoneNotification unsubscribe threw', { error: formatError(err) });
+      }
+    }
+    this.unsubscribers = [];
+    this.started = false;
+    this.logger.info('MilestoneNotificationSubscriber stopped');
+  }
+
+  /** Snapshot of the dedup state. Test affordance. */
+  get dedupSize(): number {
+    return this.dedup.size;
+  }
+
+  private safeDispatch(eventType: EventType, event: AgentEvent): Promise<void> {
+    const promise = (async () => {
+      try {
+        await this.dispatchOne(eventType, event);
+      } catch (err) {
+        this.logger.warn('MilestoneNotification dispatch threw — swallowed', {
+          eventType,
+          eventId: event.id,
+          error: formatError(err),
+        });
+      }
+    })();
+    this.pendingDispatches.add(promise);
+    promise.finally(() => this.pendingDispatches.delete(promise));
+    return promise;
+  }
+
+  private async dispatchOne(eventType: EventType, event: AgentEvent): Promise<void> {
+    // Idempotency key — `${type}:${workItemId}` for task events,
+    // `${type}:${missionId}:${eventId}` for mission events.
+    const wiKey = event.workItemId
+      ? `${eventType}:${event.workItemId}`
+      : `${eventType}:${event.missionId ?? ''}:${event.id}`;
+    if (this.dedup.has(wiKey)) {
+      this.logger.debug('MilestoneNotification deduped', { wiKey });
+      return;
+    }
+    this.dedup.add(wiKey);
+
+    // Trivial-event filter: a verified WI with no artifact / summary
+    // signal isn't milestone-worthy. The agent-side report-status path
+    // already filters via the ≥30-char summary gate (issue #435); this
+    // backend filter catches the case where lifecycle events fire
+    // without a corresponding agent surface.
+    const summary = this.extractSummary(event);
+    if (!summary || summary.length < 30) {
+      this.logger.debug('MilestoneNotification skipped — summary too short or absent', {
+        eventType,
+        workItemId: event.workItemId,
+      });
+      return;
+    }
+
+    const envelope = this.buildEnvelope(eventType, event, summary);
+    try {
+      this.messageQueueService.enqueue({
+        content: envelope,
+        conversationId: 'system_milestone',
+        source: 'system_event',
+        targetSession: this.orchestratorSession,
+        sourceMetadata: {
+          eventType,
+          workItemId: event.workItemId,
+          missionId: event.missionId,
+        },
+      });
+      this.logger.info('MilestoneNotification enqueued', {
+        eventType,
+        workItemId: event.workItemId,
+        summaryPreview: summary.slice(0, 80),
+      });
+    } catch (err) {
+      this.logger.warn('MilestoneNotification enqueue failed (non-fatal)', {
+        eventType,
+        workItemId: event.workItemId,
+        error: formatError(err),
+      });
+    }
+  }
+
+  /**
+   * Best-effort summary extraction from an event payload. Different event
+   * types stash human-readable text in different fields; this normalizes.
+   */
+  private extractSummary(event: AgentEvent): string | null {
+    const raw = (event as unknown as { summary?: string; result?: { summary?: string }; reason?: string })
+      .summary
+      ?? (event as unknown as { result?: { summary?: string } }).result?.summary
+      ?? (event as unknown as { reason?: string }).reason
+      ?? '';
+    return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null;
+  }
+
+  private buildEnvelope(eventType: EventType, event: AgentEvent, summary: string): string {
+    // `[MILESTONE] Source: ${who} | Event: ${eventType} | ${summary}`
+    // Matches the priority-table row in orchestrator/prompt.md (#436)
+    // verbatim, so the bypass-by-prompt rule fires correctly when this
+    // envelope arrives.
+    const who = event.sessionName || event.workItemId || 'system';
+    return `[MILESTONE] Source: ${who} | Event: ${eventType} | ${summary}`;
+  }
+}

--- a/config/skills/agent/core/report-status/SKILL.md
+++ b/config/skills/agent/core/report-status/SKILL.md
@@ -48,7 +48,7 @@ When `status` is `done` and a `taskPath` is provided, the task file is automatic
 | Flag | JSON Field | Required | Description |
 |------|-----------|----------|-------------|
 | `--session` / `-s` | `sessionName` | Yes | Your agent session name |
-| `--status` / `-S` | `status` | Yes | Status: `done`, `blocked`, `failed`, `in_progress`, `active` |
+| `--status` / `-S` | `status` | Yes | Status: `done`, `blocked`, `failed`, `in_progress`, `active`, `milestone`. `milestone` = a SHIPPED artifact inside an open goal (PR merged / spec finalized / build pass); emits a `[MILESTONE]` envelope that orc's Smart Notification Protocol always forwards to the owner. See `config/sops/common/mid-flight-milestone-surface.md` (#435). Summary must be ≥30 chars. |
 | `--summary` / `-m` | `summary` | Yes | Brief description (or pipe via stdin) |
 | `--summary-file` | — | No | Read summary from a file path |
 | `--project` / `-p` | `projectPath` | No | Project path for auto-remember on completion |
@@ -68,6 +68,13 @@ bash execute.sh --session dev-1 --status blocked --summary "Waiting on API crede
 
 # Report failure
 bash execute.sh --session dev-1 --status failed --summary "Build fails due to missing dependency"
+
+# Surface a milestone (#435) — a SHIPPED artifact inside an open goal.
+# Emits the [MILESTONE] envelope orc's Smart Notification table always
+# forwards to the owner. Summary must carry both WHAT shipped AND
+# WHAT-IT-MEANS-FOR-OWNER (≥30 chars).
+bash execute.sh --session dev-1 --status milestone \
+  --summary "PR #420 merged — agent state file is now corruption-resistant + auto-snapshots every 30s"
 
 # Multi-line summary via stdin (avoids shell escaping)
 echo "Fixed the bug — it's working now" | bash execute.sh --session dev-1 --status done --project /path

--- a/config/skills/agent/core/report-status/execute.sh
+++ b/config/skills/agent/core/report-status/execute.sh
@@ -22,7 +22,12 @@ Usage:
 
 Options:
   --session  | -s   Agent session name (required)
-  --status   | -S   Status: done, blocked, failed, in_progress, active (required)
+  --status   | -S   Status: done, blocked, failed, in_progress, active, milestone (required)
+                       milestone = a SHIPPED artifact inside an open goal (PR merged,
+                       spec finalized, build pass on a non-trivial change). Emits a
+                       [MILESTONE] envelope that orc's Smart Notification Protocol
+                       always forwards to the owner. See:
+                       config/sops/common/mid-flight-milestone-surface.md (issue #435)
   --summary  | -m   Status summary text (required unless piped via stdin)
   --summary-file    Read summary from file path
   --project  | -p   Project path for auto-remember on completion
@@ -151,6 +156,18 @@ require_param "sessionName (--session)" "$SESSION_NAME"
 require_param "status (--status)" "$STATUS"
 require_param "summary (--summary)" "$SUMMARY"
 
+# Gate: milestone summaries must carry a real "WHAT shipped + WHAT it means
+# for the owner" — see config/sops/common/mid-flight-milestone-surface.md
+# (issue #435). Reject anything that looks like "task done" boilerplate
+# (under 30 chars) so the [MILESTONE] envelope doesn't get diluted.
+if [ "$STATUS" = "milestone" ]; then
+  SUMMARY_LEN=${#SUMMARY}
+  if [ "$SUMMARY_LEN" -lt 30 ]; then
+    echo "{\"error\":\"milestone gate failed: summary too short (${SUMMARY_LEN} chars, minimum 30). Per the Mid-Flight Milestone Surface SOP, a milestone surface must carry both WHAT shipped AND WHAT-IT-MEANS-FOR-OWNER.\"}" >&2
+    error_exit "Summary must be at least 30 characters when reporting milestone (got ${SUMMARY_LEN})"
+  fi
+fi
+
 # Gate: before_mark_done — reject empty or trivially short summaries
 # This prevents agents from marking tasks done without meaningful output.
 if [ "$STATUS" = "done" ]; then
@@ -168,6 +185,11 @@ map_status_to_state() {
     blocked) echo "blocked" ;;
     failed) echo "failed" ;;
     in_progress|working) echo "working" ;;
+    # Issue #435: `milestone` is a SHIPPED artifact inside an open goal,
+    # not the outer goal's completion. It maps to its own state so the
+    # downstream consumer (auto-learning subscriber, milestone-notification
+    # subscriber #438, orc Smart Notification table row #436) can branch.
+    milestone) echo "milestone" ;;
     *) echo "$1" ;;
   esac
 }


### PR DESCRIPTION
Second half of EPIC #426. Adds milestone verb to report-status skill + new MilestoneNotificationSubscriber service mirroring AutoLearningSubscriber. Pairs with PR #581 (prompt rules). 5 new unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)