### PR TITLE
fix(session-handoff): static-import filter dep + log on throw (resume-notification silent failure)

### DIFF
--- a/backend/src/services/session/session-handoff.service.test.ts
+++ b/backend/src/services/session/session-handoff.service.test.ts
@@ -11,6 +11,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { SessionHandoffService, type TeamDataReader, type AgentMessageSender, type ResumeThread, type PendingTaskInfo } from './session-handoff.service.js';
+import { ThreadStatusQueueService } from '../messaging/thread-status-queue.service.js';
 
 describe('SessionHandoffService', () => {
   let service: SessionHandoffService;
@@ -630,6 +631,62 @@ describe('SessionHandoffService', () => {
       await service.pushResumeNotification(mockSender, 'crewly-orc');
 
       expect(mockSender.sendMessageToAgent).not.toHaveBeenCalled();
+    });
+
+    // Regression gate (2026-05-16): pre-fix, the resume-notification
+    // filter dynamic-imported ThreadStatusQueueService inside a
+    // `catch {}` block. When the import or lookup threw silently, the
+    // filter never excluded any threads — orc was re-prompted to reply
+    // to threads already in `replied_completed` status, producing the
+    // duplicate `agentic_explainer.mp4` upload after restart. The fix
+    // switched to static imports + a logging catch.
+    it('excludes threads whose thread-status is replied_completed (filter regression gate)', async () => {
+      // Seed the queue with a terminal entry for the agentic_explainer thread.
+      ThreadStatusQueueService.resetInstance();
+      const tsq = new ThreadStatusQueueService();
+      tsq.trackInbound({
+        threadKey: 'D0AC7NF5N7L:1778816065.309289',
+        conversationId: 'slack-D0AC7NF5N7L-1778816065-309289',
+        source: 'slack',
+        messagePreview: 'inbound msg',
+      });
+      tsq.markReplied('D0AC7NF5N7L:1778816065.309289', 'replied_completed');
+
+      jest.spyOn(service, 'findRecentThreads').mockResolvedValue([
+        // Terminal — should be filtered OUT.
+        {
+          channelType: 'slack',
+          channelId: 'D0AC7NF5N7L',
+          threadId: '1778816065.309289',
+          filePath: '/x.md',
+          lastActiveAt: new Date().toISOString(),
+          recentMessages: [],
+        },
+        // Not in queue — should pass through (kept).
+        {
+          channelType: 'slack',
+          channelId: 'D0AC7NF5N7L',
+          threadId: '1778859267.970399',
+          filePath: '/y.md',
+          lastActiveAt: new Date().toISOString(),
+          recentMessages: [],
+        },
+      ]);
+
+      const mockSender: AgentMessageSender = {
+        sendMessageToAgent: jest.fn().mockResolvedValue({ success: true }),
+      };
+
+      await service.pushResumeNotification(mockSender, 'crewly-orc');
+
+      expect(mockSender.sendMessageToAgent).toHaveBeenCalledTimes(1);
+      const message = (mockSender.sendMessageToAgent as jest.Mock).mock.calls[0][1] as string;
+      // Terminal thread MUST NOT appear in the resume notification.
+      expect(message).not.toContain('1778816065.309289');
+      // Non-terminal thread MUST appear.
+      expect(message).toContain('1778859267.970399');
+
+      ThreadStatusQueueService.resetInstance();
     });
 
     it('should handle sendMessageToAgent failure gracefully', async () => {

--- a/backend/src/services/session/session-handoff.service.ts
+++ b/backend/src/services/session/session-handoff.service.ts
@@ -15,6 +15,19 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { LoggerService } from '../core/logger.service.js';
+// Issue: SessionHandoff's resume-notification filter previously dynamic-
+// imported the thread-status-queue + isTerminalStatus, with a catch
+// block that silently swallowed any error. When the import / lookup
+// path threw (verified empirically 2026-05-16: the `Filtered terminal
+// threads` log line was missing from the post-restart cycle), terminal-
+// status threads slipped through the filter and orc was prompted to
+// re-reply to already-answered threads.
+//
+// Switch to static imports so module-resolution errors surface at boot
+// (not at first filter-call), and the catch now logs warn-level so any
+// remaining runtime failure is visible.
+import { ThreadStatusQueueService } from '../messaging/thread-status-queue.service.js';
+import { isTerminalStatus } from '../../types/thread-status.types.js';
 import { CREWLY_CONSTANTS, SLACK_THREAD_CONSTANTS, GCHAT_THREAD_CONSTANTS } from '../../constants.js';
 import type { RuntimeType } from '../../constants.js';
 import { RUNTIME_TYPES } from '../../constants.js';
@@ -855,8 +868,9 @@ export class SessionHandoffService {
       // handled before the restart (e.g. email processing, answered questions).
       let threads = allThreads;
       try {
-        const { ThreadStatusQueueService } = await import('../messaging/thread-status-queue.service.js');
-        const { isTerminalStatus } = await import('../../types/thread-status.types.js');
+        // Static-imported above so module-resolution errors surface at
+        // boot. The catch below is now a real fail-loud signal, not a
+        // shrug-and-include-all.
         const tsq = ThreadStatusQueueService.getInstance();
 
         threads = allThreads.filter(thread => {
@@ -893,8 +907,20 @@ export class SessionHandoffService {
             filtered: allThreads.length - threads.length,
           });
         }
-      } catch {
-        // Thread status queue not available — include all threads
+      } catch (err) {
+        // Was previously a silent `catch {}` — empirically masked a real
+        // failure (2026-05-16: filter never executed at the 17:07 restart,
+        // and orc was prompted with 5 threads including one already in
+        // replied_completed status, leading to a duplicate file upload).
+        // Now surfaces the error and includes the thread count we
+        // would have filtered against so the next debug pass has a
+        // starting point.
+        this.logger.warn('SessionHandoff resume-notification filter threw — including all threads (potential duplicate-reply risk)', {
+          sessionName,
+          allThreadsCount: allThreads.length,
+          error: err instanceof Error ? err.message : String(err),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
       }
 
       if (threads.length === 0) {


### PR DESCRIPTION
Today's duplicate `agentic_explainer.mp4` upload — root cause: SessionHandoff filter dynamic-imported its deps inside a silent `catch {}`. When something threw, filter never ran and terminal threads slipped through, triggering orc to re-reply. Switched to static imports + logging catch. New regression test pins the filter behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)