### PR TITLE
feat(agents): wire /agents page to real backend with per-agent DM channels

### DIFF
--- a/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
@@ -496,6 +496,182 @@ describe('chat-v2 controller (REST)', () => {
       }
     });
   });
+
+  // -------------------------------------------------------------------------
+  // /agents directory + /presence + /channels/dm/ensure (Phase F)
+  // -------------------------------------------------------------------------
+
+  describe('Phase F — /agents page endpoints', () => {
+    /**
+     * Builder that injects `directory` + `presence` providers along with
+     * the chat-v2 service. Each test gets its own in-memory DB.
+     */
+    function buildAppWithProviders(opts: {
+      directoryTeams?: Awaited<
+        ReturnType<
+          NonNullable<
+            Parameters<typeof createChatV2Router>[1]
+          >['directory'] extends infer T
+            ? T extends { getTeams(): infer R }
+              ? () => R
+              : never
+            : never
+        >
+      >;
+      presence?: (sess: string) => Promise<{
+        agentSession: string;
+        status: 'online' | 'busy' | 'offline' | 'starting';
+        lastSeenAt: number | null;
+      }>;
+    } = {}) {
+      const db = openChatDatabase({
+        dbPath: ':memory:',
+        inMemory: true,
+        skipIntegrityCheck: true,
+      });
+      const service = new ChatV2Service({
+        config: loadChatV2Config({}),
+        db,
+        getPresence: () => ({ status: 'online', lastSeenAt: 111 }),
+        now: () => 1000,
+      });
+      const directory = opts.directoryTeams
+        ? { async getTeams() { return opts.directoryTeams!; } }
+        : undefined;
+      const presence = opts.presence
+        ? { async getPresence(s: string) { return opts.presence!(s); } }
+        : undefined;
+      const app = express();
+      app.use(express.json());
+      app.use(
+        '/api/chat',
+        createChatV2Router(service, { directory, presence }),
+      );
+      return { app, service };
+    }
+
+    it('POST /channels/dm/ensure — creates a new DM channel on first call (201)', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app)
+          .post('/api/chat/channels/dm/ensure')
+          .send({ agentSession: 'sess-leo', name: 'Leo' });
+        expect(res.status).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.agentSession).toBe('sess-leo');
+        expect(res.body.data.name).toBe('Leo');
+        expect(res.body.data.type).toBe('dm');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('POST /channels/dm/ensure — returns the same channel on second call (200)', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const first = await request(app)
+          .post('/api/chat/channels/dm/ensure')
+          .send({ agentSession: 'sess-leo', name: 'Leo' });
+        expect(first.status).toBe(201);
+        const second = await request(app)
+          .post('/api/chat/channels/dm/ensure')
+          .send({ agentSession: 'sess-leo', name: 'Leo' });
+        expect(second.status).toBe(200);
+        expect(second.body.data.id).toBe(first.body.data.id);
+      } finally {
+        service.close();
+      }
+    });
+
+    it('POST /channels/dm/ensure — 400 on empty agentSession', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app)
+          .post('/api/chat/channels/dm/ensure')
+          .send({ name: 'Ghost' });
+        expect(res.status).toBe(400);
+        expect(res.body.error.code).toBe('validation_error');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('GET /agents — returns flattened directory entries when wired', async () => {
+      const { app, service } = buildAppWithProviders({
+        directoryTeams: [
+          {
+            id: 't-orc',
+            name: 'Orchestrator Team',
+            members: [
+              {
+                sessionName: 'crewly-orc',
+                name: 'Orc',
+                role: 'orchestrator',
+                agentStatus: 'active',
+                workingStatus: 'idle',
+              },
+            ],
+          },
+        ],
+      });
+      try {
+        const res = await request(app).get('/api/chat/agents');
+        expect(res.status).toBe(200);
+        expect(res.body.data.agents).toHaveLength(1);
+        expect(res.body.data.agents[0]).toMatchObject({
+          agentSession: 'crewly-orc',
+          name: 'Orc',
+          teamId: 't-orc',
+          teamName: 'Orchestrator Team',
+        });
+      } finally {
+        service.close();
+      }
+    });
+
+    it('GET /agents — 503 when directory provider is not wired', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app).get('/api/chat/agents');
+        expect(res.status).toBe(503);
+        expect(res.body.error.code).toBe('directory_unavailable');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('GET /presence/:agentId — returns presence when wired', async () => {
+      const { app, service } = buildAppWithProviders({
+        presence: async (sess) => ({
+          agentSession: sess,
+          status: 'busy',
+          lastSeenAt: 1_700_000_000,
+        }),
+      });
+      try {
+        const res = await request(app).get('/api/chat/presence/crewly-orc');
+        expect(res.status).toBe(200);
+        expect(res.body.data).toEqual({
+          agentSession: 'crewly-orc',
+          status: 'busy',
+          lastSeenAt: 1_700_000_000,
+        });
+      } finally {
+        service.close();
+      }
+    });
+
+    it('GET /presence/:agentId — 503 when presence provider is not wired', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app).get('/api/chat/presence/crewly-orc');
+        expect(res.status).toBe(503);
+        expect(res.body.error.code).toBe('presence_unavailable');
+      } finally {
+        service.close();
+      }
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -243,15 +243,94 @@ export interface ChatV2ControllerHandlers {
   archiveChannel: (req: Request, res: Response) => void;
   listMessages: (req: Request, res: Response) => void;
   sendMessage: (req: Request, res: Response) => void | Promise<void>;
+  ensureDmChannel: (req: Request, res: Response) => void;
+  listAgents: (req: Request, res: Response) => void | Promise<void>;
+  getAgentPresence: (req: Request, res: Response) => void | Promise<void>;
+}
+
+/**
+ * Minimal directory entry surfaced by `GET /api/chat/agents`.
+ *
+ * Lives on the wire as-is; the /agents page renders one row per entry,
+ * grouped by team. The fields match the join the controller performs
+ * between {@link IAgentDirectoryProvider} (teams + members) and the
+ * presence provider, with no extra denormalization.
+ */
+export interface ChatAgentDirectoryEntry {
+  /** Member's `sessionName` — the agent's wire id, matches `Channel.agentSession`. */
+  agentSession: string;
+  /** Member display name (e.g. "Leo"). */
+  name: string;
+  /** Member role (e.g. "team-leader"). */
+  role: string;
+  /** Owning team id. */
+  teamId: string;
+  /** Owning team display name. */
+  teamName: string;
+  /** Stored agentStatus from the team file. */
+  agentStatus: string;
+  /** Stored workingStatus from the team file. */
+  workingStatus: string;
+  /** Optional emoji / avatar surfaced by the team file. */
+  avatar?: string;
+}
+
+/**
+ * Minimal storage surface the controller needs to enumerate agents.
+ * Decoupled from `StorageService` so tests can pass a fixture without
+ * spinning up SQLite + the team-file watcher.
+ */
+export interface IAgentDirectoryProvider {
+  /**
+   * Return all teams + members visible to the caller. The controller
+   * filters/flattens; no need to pre-shape the response.
+   */
+  getTeams(): Promise<
+    Array<{
+      id: string;
+      name: string;
+      members: Array<{
+        sessionName: string;
+        name: string;
+        role: string;
+        agentStatus: string;
+        workingStatus: string;
+        avatar?: string;
+      }>;
+    }>
+  >;
+}
+
+/** Wire shape returned by `GET /api/chat/presence/:agentId`. */
+export interface ChatAgentPresenceDTO {
+  agentSession: string;
+  status: 'online' | 'busy' | 'offline' | 'starting';
+  lastSeenAt: number | null;
+}
+
+/**
+ * Presence resolver. Returns the live status + last-seen timestamp for
+ * an agent session. Default implementation (`createDefaultPresenceProvider`)
+ * delegates to the orchestrator-status helper; tests inject a stub.
+ */
+export interface IAgentPresenceProvider {
+  getPresence(agentSession: string): Promise<ChatAgentPresenceDTO>;
 }
 
 /**
  * Optional wiring for real-time fan-out + agent dispatch. Leave undefined
  * in REST-only tests; supply both in the live server.
+ *
+ * Phase F — `directory` + `presence` providers are needed only by the
+ * new `/agents`, `/presence/:id`, and `/channels/dm/ensure` endpoints.
+ * When omitted, those endpoints return HTTP 503 `directory_unavailable`
+ * so REST-only tests can keep mounting the router without wiring storage.
  */
 export interface ChatV2ControllerDeps {
   gateway?: ChatV2Gateway;
   dispatcher?: ChatV2DispatcherService;
+  directory?: IAgentDirectoryProvider;
+  presence?: IAgentPresenceProvider;
 }
 
 /**
@@ -276,6 +355,11 @@ export function createChatV2Controller(
     return {
       gateway: live.gateway ?? deps.gateway,
       dispatcher: live.dispatcher ?? deps.dispatcher,
+      // `directory` + `presence` are constructor-only (not realtime); pass
+      // them through unchanged so the holder fallback path still surfaces
+      // them to the agents/presence handlers.
+      directory: deps.directory,
+      presence: deps.presence,
     };
   };
 
@@ -464,6 +548,132 @@ export function createChatV2Controller(
         notifyChatV2AgentReply(persisted);
       } catch {
         // INBOUND-2 hooks must never break the ack
+      }
+    },
+
+    /**
+     * POST /channels/dm/ensure
+     *
+     * Find-or-create a DM channel for the caller bound to `agentSession`.
+     * Idempotent: repeated calls for the same (owner, agentSession) return
+     * the same channel row, so the /agents page can map "click agent" →
+     * "active channel" without leaking duplicate DMs on reloads.
+     *
+     * Status code:
+     *  - 200 when the channel already existed
+     *  - 201 when a new channel was created
+     */
+    ensureDmChannel: (req, res) =>
+      runHandler(res, () => {
+        const principal = principalFromRequest(req);
+        const body = req.body ?? {};
+        const { channel, created } = service.ensureDmChannel({
+          agentSession: body.agentSession,
+          name: body.name,
+          purpose: body.purpose,
+          principal,
+        });
+        res.status(created ? 201 : 200).json({ success: true, data: channel });
+      }),
+
+    /**
+     * GET /agents
+     *
+     * Directory of all agents reachable from the configured teams.
+     * Returns one entry per (team × member), with cached
+     * agentStatus/workingStatus from the team file. The /agents page
+     * uses this to render the left rail; presence freshness comes from
+     * the per-agent `GET /presence/:agentId` endpoint, not from this list
+     * (intentional — the list is cheap; presence is per-row + on focus).
+     *
+     * Returns HTTP 503 `directory_unavailable` when the controller was
+     * wired without a `directory` provider (REST-only tests, etc.).
+     */
+    listAgents: async (req, res) => {
+      try {
+        // principalFromRequest enforces auth; the returned principal is
+        // intentionally unused here because the directory is global
+        // within a single OSS instance (no per-user filtering yet).
+        principalFromRequest(req);
+        const { directory } = resolveDeps();
+        if (!directory) {
+          res.status(503).json({
+            success: false,
+            error: {
+              code: 'directory_unavailable',
+              message: 'agent directory provider is not wired',
+            },
+          });
+          return;
+        }
+        const teams = await directory.getTeams();
+        const entries: ChatAgentDirectoryEntry[] = [];
+        for (const team of teams) {
+          for (const member of team.members) {
+            const sessionName = (member.sessionName ?? '').trim();
+            if (sessionName.length === 0) continue;
+            entries.push({
+              agentSession: sessionName,
+              name: member.name,
+              role: member.role,
+              teamId: team.id,
+              teamName: team.name,
+              agentStatus: member.agentStatus,
+              workingStatus: member.workingStatus,
+              avatar: member.avatar,
+            });
+          }
+        }
+        res.json({ success: true, data: { agents: entries } });
+      } catch (err) {
+        if (err instanceof ChatError) {
+          sendChatError(res, err);
+        } else {
+          sendInternalError(res, err);
+        }
+      }
+    },
+
+    /**
+     * GET /presence/:agentId
+     *
+     * Returns the agent's current presence + last-seen timestamp. Backs
+     * the chat-ui `getAgentPresence(agentId)` client call so the message
+     * thread can surface a live `online/busy/offline` badge per agent.
+     *
+     * Returns HTTP 503 `presence_unavailable` when the controller was
+     * wired without a `presence` provider (REST-only tests).
+     */
+    getAgentPresence: async (req, res) => {
+      try {
+        principalFromRequest(req);
+        const agentId = (req.params.agentId ?? '').trim();
+        if (agentId.length === 0) {
+          throw new ChatError(
+            CHAT_ERROR_CODES.VALIDATION,
+            400,
+            'agentId is required',
+          );
+        }
+        const { presence } = resolveDeps();
+        if (!presence) {
+          res.status(503).json({
+            success: false,
+            error: {
+              code: 'presence_unavailable',
+              message: 'presence provider is not wired',
+            },
+          });
+          return;
+        }
+        const result = await presence.getPresence(agentId);
+        res.json({ success: true, data: result });
+      } catch (err) {
+        if (err instanceof ChatError) {
+          sendChatError(res, err);
+        } else {
+          sendInternalError(res, err);
+        }
       }
     },
   };

--- a/backend/src/controllers/chat-v2/chat-v2.routes.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.routes.ts
@@ -22,10 +22,13 @@ import {
  * Routes (mounted under `/api/chat`):
  * - `GET    /channels`
  * - `POST   /channels`
+ * - `POST   /channels/dm/ensure` — find-or-create DM channel for an agent
  * - `GET    /channels/:id`
  * - `DELETE /channels/:id`
  * - `GET    /channels/:id/messages`
  * - `POST   /channels/:id/messages`
+ * - `GET    /agents` — directory of agents across all teams
+ * - `GET    /presence/:agentId` — live presence for one agent
  *
  * @param service - Configured ChatV2Service
  * @param deps    - Optional gateway + dispatcher for realtime wiring
@@ -40,11 +43,17 @@ export function createChatV2Router(
 
   router.get('/channels', requireAuth, handlers.listChannels);
   router.post('/channels', requireAuth, handlers.createChannel);
+  // `/channels/dm/ensure` must precede `/channels/:id` matchers so Express
+  // doesn't bind `:id = 'dm'` here.
+  router.post('/channels/dm/ensure', requireAuth, handlers.ensureDmChannel);
   router.get('/channels/:id', requireAuth, handlers.getChannel);
   router.delete('/channels/:id', requireAuth, handlers.archiveChannel);
 
   router.get('/channels/:id/messages', requireAuth, handlers.listMessages);
   router.post('/channels/:id/messages', requireAuth, handlers.sendMessage);
+
+  router.get('/agents', requireAuth, handlers.listAgents);
+  router.get('/presence/:agentId', requireAuth, handlers.getAgentPresence);
 
   return router;
 }

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -51,6 +51,10 @@ import { createActiveWorkRouter } from '../controllers/active-work/active-work.c
 import { createChatV2Router } from '../controllers/chat-v2/index.js';
 import { getChatV2Service } from '../services/chat-v2/chat-v2.singleton.js';
 import { createOssTeamMembershipValidator } from '../services/chat-v2/chat-v2.team-membership.js';
+import {
+  createOssAgentDirectoryProvider,
+  createOssAgentPresenceProvider,
+} from '../services/chat-v2/chat-v2.providers.js';
 
 /**
  * Creates API routes using the new organized controller structure
@@ -199,12 +203,22 @@ export function createApiRoutes(apiController: ApiController): Router {
   // first construction so type='channel' creates are gated by team
   // existence (single-user OSS treats existence === membership; Cloud
   // Portal Phase E swaps in a tenant-aware validator).
+  //
+  // Phase F (/agents page): inject `directory` + `presence` providers so
+  // the new `/agents` + `/presence/:agentId` + `/channels/dm/ensure`
+  // endpoints can resolve real team data and live agent status. Providers
+  // live in `chat-v2.providers.ts` so this wire-up doesn't bloat the
+  // route table or pull controller code into the routes module.
   router.use(
     '/chat',
     createChatV2Router(
       getChatV2Service({
         validateTeamMembership: createOssTeamMembershipValidator(),
       }),
+      {
+        directory: createOssAgentDirectoryProvider(apiController.storageService),
+        presence: createOssAgentPresenceProvider(apiController.storageService),
+      },
     ),
   );
 

--- a/backend/src/services/chat-v2/chat-v2.providers.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.providers.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the agent-directory + presence providers backing /agents.
+ *
+ * @module services/chat-v2/chat-v2.providers.test
+ */
+
+import {
+  createOssAgentDirectoryProvider,
+  createOssAgentPresenceProvider,
+  resolvePresenceStatus,
+  type IStorageServiceLike,
+} from './chat-v2.providers.js';
+
+const sampleTeams: Awaited<ReturnType<IStorageServiceLike['getTeams']>> = [
+  {
+    id: 'orchestrator',
+    name: 'Orchestrator Team',
+    members: [
+      {
+        sessionName: 'crewly-orc',
+        name: 'Orc',
+        role: 'orchestrator',
+        agentStatus: 'active',
+        workingStatus: 'idle',
+        avatar: ':robot:',
+      },
+      {
+        sessionName: '',
+        name: 'Ghost member with no session',
+        role: 'worker',
+        agentStatus: 'inactive',
+        workingStatus: 'idle',
+      },
+    ],
+  },
+  {
+    id: 't-marketing',
+    name: 'Marketing',
+    members: [
+      {
+        sessionName: 'crewly-marketing-ella',
+        name: 'Ella',
+        role: 'team-leader',
+        agentStatus: 'starting',
+        workingStatus: 'idle',
+      },
+      {
+        sessionName: 'crewly-marketing-luna',
+        name: 'Luna',
+        role: 'worker',
+        agentStatus: 'active',
+        workingStatus: 'in_progress',
+      },
+    ],
+  },
+];
+
+function makeStorageStub(
+  teams: Awaited<ReturnType<IStorageServiceLike['getTeams']>>,
+): IStorageServiceLike {
+  return {
+    async getTeams() {
+      return teams;
+    },
+  };
+}
+
+describe('resolvePresenceStatus', () => {
+  it('returns "offline" when not active and agentStatus !== starting', () => {
+    expect(resolvePresenceStatus(false, 'inactive', 'idle')).toBe('offline');
+    expect(resolvePresenceStatus(false, 'active', 'idle')).toBe('offline');
+    expect(resolvePresenceStatus(false, 'suspended', 'in_progress')).toBe('offline');
+  });
+
+  it('returns "starting" when not active and agentStatus === starting', () => {
+    expect(resolvePresenceStatus(false, 'starting', 'idle')).toBe('starting');
+  });
+
+  it('returns "busy" when active and workingStatus === in_progress', () => {
+    expect(resolvePresenceStatus(true, 'active', 'in_progress')).toBe('busy');
+  });
+
+  it('returns "online" when active and idle', () => {
+    expect(resolvePresenceStatus(true, 'active', 'idle')).toBe('online');
+  });
+});
+
+describe('createOssAgentDirectoryProvider', () => {
+  it('flattens teams + members and drops empty sessionNames', async () => {
+    const provider = createOssAgentDirectoryProvider(
+      makeStorageStub(sampleTeams),
+      { resolveOrchestratorStatus: async () => null },
+    );
+    const result = await provider.getTeams();
+    expect(result).toHaveLength(2);
+    const orcMembers = result[0].members.map((m) => m.sessionName);
+    expect(orcMembers).toEqual(['crewly-orc']);
+    const marketingMembers = result[1].members.map((m) => m.sessionName);
+    expect(marketingMembers).toEqual([
+      'crewly-marketing-ella',
+      'crewly-marketing-luna',
+    ]);
+  });
+
+  it('preserves avatar / role / status fields', async () => {
+    const provider = createOssAgentDirectoryProvider(
+      makeStorageStub(sampleTeams),
+      { resolveOrchestratorStatus: async () => null },
+    );
+    const result = await provider.getTeams();
+    expect(result[0].members[0]).toEqual({
+      sessionName: 'crewly-orc',
+      name: 'Orc',
+      role: 'orchestrator',
+      agentStatus: 'active',
+      workingStatus: 'idle',
+      avatar: ':robot:',
+    });
+  });
+
+  it('passes through an empty team list as-is when no orchestrator status', async () => {
+    const provider = createOssAgentDirectoryProvider(makeStorageStub([]), {
+      resolveOrchestratorStatus: async () => null,
+    });
+    expect(await provider.getTeams()).toEqual([]);
+  });
+
+  it('prepends a synthetic Orchestrator Team when status resolves', async () => {
+    const provider = createOssAgentDirectoryProvider(makeStorageStub([]), {
+      resolveOrchestratorStatus: async () => ({
+        agentStatus: 'active',
+        workingStatus: 'idle',
+      }),
+    });
+    const result = await provider.getTeams();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'orchestrator',
+      name: 'Orchestrator Team',
+      members: [
+        {
+          sessionName: 'crewly-orc',
+          name: 'Orchestrator',
+          role: 'orchestrator',
+          agentStatus: 'active',
+          workingStatus: 'idle',
+          avatar: undefined,
+        },
+      ],
+    });
+  });
+
+  it('orchestrator team comes first when other teams exist', async () => {
+    // Production-realistic fixture: storage.getTeams() filters out the
+    // orchestrator directory, so only the regular team is present here.
+    const provider = createOssAgentDirectoryProvider(
+      makeStorageStub([sampleTeams[1]]),
+      {
+        resolveOrchestratorStatus: async () => ({
+          agentStatus: 'inactive',
+          workingStatus: 'idle',
+        }),
+      },
+    );
+    const result = await provider.getTeams();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('orchestrator');
+    expect(result[1].id).toBe('t-marketing');
+  });
+});
+
+describe('createOssAgentPresenceProvider', () => {
+  it('returns "online" + stamped lastSeenAt for an active idle agent', async () => {
+    const provider = createOssAgentPresenceProvider(makeStorageStub(sampleTeams), {
+      isAgentActive: async () => true,
+      now: () => 1_700_000_000,
+    });
+    expect(await provider.getPresence('crewly-orc')).toEqual({
+      agentSession: 'crewly-orc',
+      status: 'online',
+      lastSeenAt: 1_700_000_000,
+    });
+  });
+
+  it('returns "busy" when the member is active and workingStatus=in_progress', async () => {
+    const provider = createOssAgentPresenceProvider(makeStorageStub(sampleTeams), {
+      isAgentActive: async () => true,
+      now: () => 1_700_000_000,
+    });
+    expect(await provider.getPresence('crewly-marketing-luna')).toEqual({
+      agentSession: 'crewly-marketing-luna',
+      status: 'busy',
+      lastSeenAt: 1_700_000_000,
+    });
+  });
+
+  it('returns "starting" + null lastSeenAt when not active and agentStatus=starting', async () => {
+    const provider = createOssAgentPresenceProvider(makeStorageStub(sampleTeams), {
+      isAgentActive: async () => false,
+      now: () => 1_700_000_000,
+    });
+    expect(await provider.getPresence('crewly-marketing-ella')).toEqual({
+      agentSession: 'crewly-marketing-ella',
+      status: 'starting',
+      lastSeenAt: null,
+    });
+  });
+
+  it('returns "offline" with null lastSeenAt for unknown agentSession', async () => {
+    const provider = createOssAgentPresenceProvider(makeStorageStub(sampleTeams), {
+      isAgentActive: async () => false,
+    });
+    expect(await provider.getPresence('unknown-session')).toEqual({
+      agentSession: 'unknown-session',
+      status: 'offline',
+      lastSeenAt: null,
+    });
+  });
+
+  it('degrades gracefully when storage.getTeams throws', async () => {
+    const brokenStorage: IStorageServiceLike = {
+      async getTeams() {
+        throw new Error('boom');
+      },
+    };
+    const provider = createOssAgentPresenceProvider(brokenStorage, {
+      isAgentActive: async () => false,
+    });
+    const result = await provider.getPresence('crewly-orc');
+    expect(result.status).toBe('offline');
+    expect(result.lastSeenAt).toBeNull();
+  });
+
+  it('degrades gracefully when isAgentActive throws', async () => {
+    const provider = createOssAgentPresenceProvider(makeStorageStub(sampleTeams), {
+      isAgentActive: async () => {
+        throw new Error('liveness probe failed');
+      },
+    });
+    const result = await provider.getPresence('crewly-orc');
+    expect(result.status).toBe('offline');
+    expect(result.lastSeenAt).toBeNull();
+  });
+});

--- a/backend/src/services/chat-v2/chat-v2.providers.ts
+++ b/backend/src/services/chat-v2/chat-v2.providers.ts
@@ -1,0 +1,251 @@
+/**
+ * Provider factories backing the chat-v2 controller's `/agents` and
+ * `/presence/:agentId` endpoints.
+ *
+ * These are intentionally kept separate from the controller + service so
+ * tests can inject a fixture (`IAgentDirectoryProvider` / `IAgentPresenceProvider`
+ * stubs) without spinning up StorageService or the orchestrator-status
+ * helper. The production wiring in `api.routes.ts` instantiates them
+ * once per request stack and passes them as `ChatV2ControllerDeps`.
+ *
+ * Why a thin adapter layer over StorageService.getTeams + isAgentActive?
+ *   - StorageService.getTeams returns the full `Team[]` shape including
+ *     fields the directory doesn't need (templates, hierarchy graphs,
+ *     project bindings). The controller's `IAgentDirectoryProvider`
+ *     contract is intentionally narrow so the route handler stays
+ *     decoupled from the storage shape.
+ *   - `isAgentActive` returns a boolean only; the controller's wire DTO
+ *     wants a `status` union + `lastSeenAt`. We do that mapping here.
+ *
+ * @module services/chat-v2/chat-v2.providers
+ */
+
+import type {
+  IAgentDirectoryProvider,
+  IAgentPresenceProvider,
+  ChatAgentPresenceDTO,
+} from '../../controllers/chat-v2/chat-v2.controller.js';
+
+/**
+ * Minimal storage surface the providers need. Decoupled from the full
+ * `StorageService` so a fixture team list is enough to test.
+ */
+export interface IStorageServiceLike {
+  getTeams(): Promise<
+    Array<{
+      id: string;
+      name: string;
+      members: Array<{
+        sessionName?: string;
+        name: string;
+        role: string;
+        agentStatus: string;
+        workingStatus: string;
+        avatar?: string;
+      }>;
+    }>
+  >;
+}
+
+/**
+ * Minimal agent-liveness probe. Defaults to `isAgentActive` from
+ * `orchestrator-status.service`; tests pass a synchronous stub.
+ */
+export type IsAgentActiveFn = (sessionName: string) => Promise<boolean>;
+
+/**
+ * Optional hook for surfacing the virtual "Orchestrator Team". The OSS
+ * orchestrator is not a row in any teams.json (it lives in
+ * `teams/orchestrator/config.json` and is *filtered out* by
+ * StorageService.getTeams), but the user expects to chat with it from
+ * the /agents page. The provider synthesizes the team on top of
+ * `getTeams()` so the rail always lists the orchestrator first.
+ *
+ * Tests can override the resolver to return null + skip the virtual
+ * team, or to inject a synthetic status without touching storage.
+ */
+export type OrchestratorStatusResolver = () => Promise<{
+  agentStatus: string;
+  workingStatus: string;
+} | null>;
+
+/**
+ * Build the production `IAgentDirectoryProvider`. Flattens
+ * `StorageService.getTeams()` into the narrow controller-facing shape,
+ * filtering out members without a `sessionName` (incomplete team
+ * entries, deleted-but-not-purged rows).
+ *
+ * Also prepends a synthetic Orchestrator Team so the user can DM the
+ * orchestrator from /agents without setting up a regular team. This
+ * mirrors team.controller's `buildOrchestratorTeam` virtual-team
+ * synthesis on the /api/teams endpoint.
+ *
+ * @param storage - The StorageService instance (or a fixture stub)
+ * @param opts.resolveOrchestratorStatus - Optional override for the
+ *   orchestrator's stored status. Defaults to a lazy import of
+ *   `StorageService.getOrchestratorStatus()` so tests can inject a stub.
+ *   Returning null skips the virtual-team prepend entirely.
+ * @returns Provider satisfying {@link IAgentDirectoryProvider}
+ */
+export function createOssAgentDirectoryProvider(
+  storage: IStorageServiceLike,
+  opts: {
+    resolveOrchestratorStatus?: OrchestratorStatusResolver;
+  } = {},
+): IAgentDirectoryProvider {
+  const resolveOrc =
+    opts.resolveOrchestratorStatus ??
+    (async () => {
+      try {
+        // `StorageService.getInstance` is exposed via the same module
+        // path used by every other caller (e.g. team.controller). Lazy
+        // import keeps the test-only dep optional and avoids a circular
+        // resolution when the chat-v2 module loads at boot time.
+        const mod = await import('../core/storage.service.js');
+        const status = await mod.StorageService.getInstance().getOrchestratorStatus();
+        if (!status) return null;
+        return {
+          agentStatus: status.agentStatus,
+          workingStatus: status.workingStatus,
+        };
+      } catch {
+        return null;
+      }
+    });
+
+  return {
+    async getTeams() {
+      const teams = await storage.getTeams();
+      const flat = teams.map((t) => ({
+        id: t.id,
+        name: t.name,
+        members: t.members
+          .filter((m) => typeof m.sessionName === 'string' && m.sessionName.length > 0)
+          .map((m) => ({
+            sessionName: m.sessionName as string,
+            name: m.name,
+            role: m.role,
+            agentStatus: m.agentStatus,
+            workingStatus: m.workingStatus,
+            avatar: m.avatar,
+          })),
+      }));
+
+      const orcStatus = await resolveOrc();
+      if (orcStatus) {
+        flat.unshift({
+          id: 'orchestrator',
+          name: 'Orchestrator Team',
+          members: [
+            {
+              sessionName: 'crewly-orc',
+              name: 'Orchestrator',
+              role: 'orchestrator',
+              agentStatus: orcStatus.agentStatus,
+              workingStatus: orcStatus.workingStatus,
+              avatar: undefined,
+            },
+          ],
+        });
+      }
+      return flat;
+    },
+  };
+}
+
+/**
+ * Map the stored `(agentStatus, workingStatus, isActive)` tuple to the
+ * presence wire status. The chat-ui client expects the closed set:
+ *   - `online`   : agent is up and idle (ready for a new message)
+ *   - `busy`     : agent is up and working on something
+ *   - `starting` : agent is registered but session not yet alive
+ *   - `offline`  : everything else (inactive, suspended, crash, …)
+ *
+ * Single source of truth — exported for tests + presence-aware UI bits.
+ *
+ * @param isActive - True when the PTY/in-process session is alive
+ * @param agentStatus - Stored `agentStatus` from team file
+ * @param workingStatus - Stored `workingStatus` from team file
+ * @returns Wire-level presence status
+ */
+export function resolvePresenceStatus(
+  isActive: boolean,
+  agentStatus: string,
+  workingStatus: string,
+): ChatAgentPresenceDTO['status'] {
+  if (!isActive) {
+    if (agentStatus === 'starting') return 'starting';
+    return 'offline';
+  }
+  if (workingStatus === 'in_progress') return 'busy';
+  return 'online';
+}
+
+/**
+ * Build the production `IAgentPresenceProvider`. Uses
+ * {@link IsAgentActiveFn} (defaulting to `isAgentActive` from
+ * orchestrator-status) for liveness and falls back to the stored
+ * agentStatus/workingStatus for unknown sessions.
+ *
+ * @param storage - StorageService for member lookups
+ * @param opts.isAgentActive - Optional override (tests pass a stub)
+ * @param opts.now - Optional clock override (tests freeze the
+ *   `lastSeenAt` timestamp)
+ * @returns Provider satisfying {@link IAgentPresenceProvider}
+ */
+export function createOssAgentPresenceProvider(
+  storage: IStorageServiceLike,
+  opts: {
+    isAgentActive?: IsAgentActiveFn;
+    now?: () => number;
+  } = {},
+): IAgentPresenceProvider {
+  const isActiveFn =
+    opts.isAgentActive ??
+    (async (sessionName: string) => {
+      const { isAgentActive } = await import(
+        '../orchestrator/orchestrator-status.service.js'
+      );
+      return isAgentActive(sessionName);
+    });
+  const now = opts.now ?? Date.now;
+
+  return {
+    async getPresence(agentSession: string): Promise<ChatAgentPresenceDTO> {
+      let agentStatus = 'inactive';
+      let workingStatus = 'idle';
+      try {
+        const teams = await storage.getTeams();
+        for (const team of teams) {
+          const member = team.members.find((m) => m.sessionName === agentSession);
+          if (member) {
+            agentStatus = member.agentStatus;
+            workingStatus = member.workingStatus;
+            break;
+          }
+        }
+      } catch {
+        // Storage failure — treat as offline below. Don't throw; the
+        // /presence endpoint should degrade gracefully when the team
+        // file is being rewritten under us.
+      }
+
+      let active = false;
+      try {
+        active = await isActiveFn(agentSession);
+      } catch {
+        active = false;
+      }
+
+      return {
+        agentSession,
+        status: resolvePresenceStatus(active, agentStatus, workingStatus),
+        // Only stamp `lastSeenAt` when we have a positive liveness signal.
+        // The chat-ui surface treats null as "never seen" / "unknown" and
+        // hides the timestamp; offline agents would otherwise show a
+        // misleading "last seen just now".
+        lastSeenAt: active ? now() : null,
+      };
+    },
+  };
+}

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -1141,6 +1141,74 @@ describe('ChatV2Service', () => {
   });
 
   // -------------------------------------------------------------------------
+  // ensureDmChannel — find-or-create for the /agents page
+  // -------------------------------------------------------------------------
+
+  describe('ensureDmChannel', () => {
+    it('creates a fresh DM channel when none exists', () => {
+      const { channel, created } = service.ensureDmChannel({
+        agentSession: 'sess-x',
+        name: 'Leo',
+        principal: owner,
+      });
+      expect(created).toBe(true);
+      expect(channel.agentSession).toBe('sess-x');
+      expect(channel.name).toBe('Leo');
+      expect(channel.type).toBe('dm');
+    });
+
+    it('returns the existing channel on a second call (idempotent)', () => {
+      const first = service.ensureDmChannel({
+        agentSession: 'sess-x',
+        name: 'Leo',
+        principal: owner,
+      });
+      const second = service.ensureDmChannel({
+        agentSession: 'sess-x',
+        name: 'Leo (renamed)',
+        principal: owner,
+      });
+      expect(second.created).toBe(false);
+      expect(second.channel.id).toBe(first.channel.id);
+      // We don't auto-rename — the existing row's name wins.
+      expect(second.channel.name).toBe('Leo');
+    });
+
+    it('scopes find-or-create by ownerUserId — other users get a separate channel', () => {
+      // F2b: this matters for Cloud Portal where multiple users share the
+      // singleton ChatV2Service. In OSS we always have one user, but the
+      // scoping invariant must hold so the same code path works in both.
+      const first = service.ensureDmChannel({
+        agentSession: 'sess-x',
+        name: 'Leo',
+        principal: owner,
+      });
+      const otherOwnerChan = service.ensureDmChannel({
+        agentSession: 'sess-x',
+        name: 'Leo',
+        principal: otherUser,
+      });
+      expect(otherOwnerChan.created).toBe(true);
+      expect(otherOwnerChan.channel.id).not.toBe(first.channel.id);
+    });
+
+    it('rejects empty agentSession', () => {
+      expect(() =>
+        service.ensureDmChannel({ agentSession: '   ', principal: owner }),
+      ).toThrow(/agentSession is required/);
+    });
+
+    it('falls back to the agentSession as the channel name when no name is provided', () => {
+      const { channel, created } = service.ensureDmChannel({
+        agentSession: 'sess-y',
+        principal: owner,
+      });
+      expect(created).toBe(true);
+      expect(channel.name).toBe('sess-y');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // importLegacyConversation
   // Spec: 2026-05-14-unified-chat-message-store.md Phase 5
   // -------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -486,6 +486,60 @@ export class ChatV2Service extends EventEmitter {
   }
 
   /**
+   * Idempotent DM channel lookup-or-create for the /agents page.
+   *
+   * Returns the most-recent active DM channel owned by `principal.userId`
+   * and bound to `agentSession`; creates a new one when none exists. The
+   * caller is the human owner (auth principal), unlike
+   * {@link ensureChannelForLegacyConversation} which runs as `'system'`
+   * for server-internal bridge paths.
+   *
+   * Used by `POST /api/chat/channels/dm/ensure` so the /agents page can
+   * map "user clicked an agent in the directory" → "send/receive messages
+   * on this channel" without leaking duplicate DMs every time the page
+   * is reloaded.
+   *
+   * @param args - Lookup-or-create args
+   * @returns The channel DTO plus a `created` flag (true when a new row
+   *   was inserted; false when an existing row was reused).
+   * @throws {ChatError} `validation_error` (400) on empty `agentSession`
+   *   or oversize `name` / `purpose`.
+   */
+  ensureDmChannel(args: {
+    agentSession: string;
+    name?: string;
+    purpose?: string;
+    principal: ChatPrincipal;
+  }): { channel: ChatChannelDTO; created: boolean } {
+    const agentSession = (args.agentSession ?? '').trim();
+    if (agentSession.length === 0) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        'agentSession is required',
+      );
+    }
+    const existing = this.channels.findActiveDmByOwnerAndAgent(
+      args.principal.userId,
+      agentSession,
+    );
+    if (existing) {
+      return { channel: this.toChannelDTO(existing), created: false };
+    }
+    // Fall through to createChannel so the full validation + tenant
+    // checks (purpose length, name length, etc.) run consistently with
+    // the public POST /channels endpoint.
+    const channel = this.createChannel({
+      agentSession,
+      name: (args.name ?? agentSession).trim(),
+      purpose: args.purpose,
+      principal: args.principal,
+      type: 'dm',
+    });
+    return { channel, created: true };
+  }
+
+  /**
    * Server-internal idempotent helper used by migration / bridge code to
    * map a legacy conversationId (e.g. `slack-D0AC7-1234`, `web-conv-abc`)
    * onto a chat-v2 channel row with the conversationId as the primary key.

--- a/backend/src/services/chat-v2/sqlite/channel.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.test.ts
@@ -184,6 +184,72 @@ describe('ChannelStore', () => {
     });
   });
 
+  describe('findActiveDmByOwnerAndAgent', () => {
+    it('returns null when no DM exists for the (owner, agent) pair', () => {
+      expect(store.findActiveDmByOwnerAndAgent('user-a', 'sess-x')).toBeNull();
+    });
+
+    it('returns the active DM matching both owner and agentSession', () => {
+      const dm = store.create({
+        agentSession: 'sess-a',
+        ownerUserId: 'user-a',
+        name: 'A',
+      });
+      const got = store.findActiveDmByOwnerAndAgent('user-a', 'sess-a');
+      expect(got?.id).toBe(dm.id);
+    });
+
+    it('ignores rows owned by a different user', () => {
+      store.create({ agentSession: 'sess-a', ownerUserId: 'user-a', name: 'A' });
+      expect(store.findActiveDmByOwnerAndAgent('user-b', 'sess-a')).toBeNull();
+    });
+
+    it('ignores archived rows', () => {
+      const dm = store.create({
+        agentSession: 'sess-a',
+        ownerUserId: 'user-a',
+        name: 'A',
+      });
+      store.archive(dm.id);
+      expect(store.findActiveDmByOwnerAndAgent('user-a', 'sess-a')).toBeNull();
+    });
+
+    it('ignores type=channel rows', () => {
+      store.create({
+        agentSession: 'sess-shared',
+        ownerUserId: 'user-a',
+        name: '#shared',
+        type: 'channel',
+        teamId: 'team-1',
+      });
+      expect(store.findActiveDmByOwnerAndAgent('user-a', 'sess-shared')).toBeNull();
+    });
+
+    it('prefers the most-recently-active DM when multiple rows exist', () => {
+      // Multiple DMs for the same (owner, agent) are possible after the
+      // unique-index drop; the helper must return the freshest one so the
+      // /agents page lands on the channel the user was last using.
+      const older = store.create({
+        agentSession: 'sess-a',
+        ownerUserId: 'user-a',
+        name: 'older',
+        nowMs: 1000,
+      });
+      const newer = store.create({
+        agentSession: 'sess-a',
+        ownerUserId: 'user-a',
+        name: 'newer',
+        nowMs: 2000,
+      });
+      const got = store.findActiveDmByOwnerAndAgent('user-a', 'sess-a');
+      // Newer row should win — both rows are unarchived, COALESCE(last_message_at,created_at)
+      // picks created_at since neither has had a message; created_at=2000 > 1000.
+      expect(got?.id).toBe(newer.id);
+      // older row is still present (we don't touch it).
+      expect(store.getById(older.id)).not.toBeNull();
+    });
+  });
+
   describe('listByOwner', () => {
     it('returns only this user\'s channels', () => {
       store.create({ agentSession: 'sess-a', ownerUserId: 'user-a', name: 'A', nowMs: 100 });

--- a/backend/src/services/chat-v2/sqlite/channel.store.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.ts
@@ -184,6 +184,41 @@ export class ChannelStore {
   }
 
   /**
+   * Find the most-recent active DM channel owned by a specific user and
+   * bound to a specific agent session. Used by the `ensureDmChannel`
+   * helper backing the /agents page — the owner-scoped variant is needed
+   * because the `uq_channel_agent_dm_active` unique index was dropped
+   * (see chat-db.ts:380-386), so multiple DM rows for the same agent
+   * can coexist (e.g. created by legacy bridge code with the synthetic
+   * `'system'` owner).
+   *
+   * Ordering matches `listByOwner`: most-recent activity first, so the
+   * caller always lands on the DM the user was last using.
+   *
+   * @param ownerUserId - The user_id that must own the channel
+   * @param agentSession - The agent session id
+   * @returns The most-recent active DM channel row, or null
+   */
+  findActiveDmByOwnerAndAgent(
+    ownerUserId: string,
+    agentSession: string,
+  ): ChatChannelRow | null {
+    const row = this.db
+      .prepare(
+        `SELECT ${CHANNEL_SELECT_COLUMNS}
+         FROM chat_channels
+         WHERE owner_user_id = ?
+           AND agent_session = ?
+           AND archived_at IS NULL
+           AND type = 'dm'
+         ORDER BY COALESCE(last_message_at, created_at) DESC
+         LIMIT 1`,
+      )
+      .get(ownerUserId, agentSession) as ChatChannelRow | undefined;
+    return row ?? null;
+  }
+
+  /**
    * List channels owned by a user.
    *
    * Phase C — extended with `type` + `teamId` filter options so the

--- a/frontend/src/components/Chat/AgentDirectory.test.tsx
+++ b/frontend/src/components/Chat/AgentDirectory.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for AgentDirectory — the left rail for /agents.
+ *
+ * @module components/Chat/AgentDirectory.test
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AgentDirectory, type DirectoryAgent } from './AgentDirectory';
+
+const sampleAgents: DirectoryAgent[] = [
+  {
+    agentSession: 'crewly-orc',
+    name: 'Orc',
+    role: 'orchestrator',
+    teamId: 'orchestrator',
+    teamName: 'Orchestrator Team',
+    agentStatus: 'active',
+    workingStatus: 'idle',
+  },
+  {
+    agentSession: 'crewly-marketing-ella',
+    name: 'Ella',
+    role: 'team-leader',
+    teamId: 't-marketing',
+    teamName: 'Marketing',
+    agentStatus: 'active',
+    workingStatus: 'in_progress',
+  },
+  {
+    agentSession: 'crewly-marketing-luna',
+    name: 'Luna',
+    role: 'worker',
+    teamId: 't-marketing',
+    teamName: 'Marketing',
+    agentStatus: 'inactive',
+    workingStatus: 'idle',
+  },
+];
+
+function makeFetchOk(agents: DirectoryAgent[]): typeof fetch {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ success: true, data: { agents } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  ) as unknown as typeof fetch;
+}
+
+describe('AgentDirectory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading then renders agents grouped by team', async () => {
+    const fetchImpl = makeFetchOk(sampleAgents);
+    render(
+      <AgentDirectory onSelectAgent={() => {}} fetchImpl={fetchImpl} />,
+    );
+    expect(screen.getByText('Loading agents…')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Orc')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Ella')).toBeInTheDocument();
+    expect(screen.getByText('Luna')).toBeInTheDocument();
+    // Team headings appear once each.
+    expect(screen.getByText('Orchestrator Team')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no agents are returned', async () => {
+    const fetchImpl = makeFetchOk([]);
+    render(
+      <AgentDirectory onSelectAgent={() => {}} fetchImpl={fetchImpl} />,
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No agents available/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows an error banner + retry button on fetch failure', async () => {
+    const failingFetch = vi.fn(
+      async () => new Response('boom', { status: 500 }),
+    ) as unknown as typeof fetch;
+    render(
+      <AgentDirectory onSelectAgent={() => {}} fetchImpl={failingFetch} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Retry/i)).toBeInTheDocument();
+  });
+
+  it('fires onSelectAgent when a row is clicked', async () => {
+    const onSelect = vi.fn();
+    const fetchImpl = makeFetchOk(sampleAgents);
+    render(
+      <AgentDirectory onSelectAgent={onSelect} fetchImpl={fetchImpl} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Ella')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Ella'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].agentSession).toBe(
+      'crewly-marketing-ella',
+    );
+  });
+
+  it('disables the row + shows "opening…" while a click is in-flight', async () => {
+    const fetchImpl = makeFetchOk(sampleAgents);
+    render(
+      <AgentDirectory
+        onSelectAgent={() => {}}
+        openingAgentSession="crewly-marketing-luna"
+        fetchImpl={fetchImpl}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Luna')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/opening…/i)).toBeInTheDocument();
+    // The Luna button is the closest button ancestor of the "opening…" label.
+    const lunaBtn = screen
+      .getByText('Luna')
+      .closest('button') as HTMLButtonElement;
+    expect(lunaBtn).toBeDisabled();
+  });
+
+  it('highlights the active agent row', async () => {
+    const fetchImpl = makeFetchOk(sampleAgents);
+    render(
+      <AgentDirectory
+        onSelectAgent={() => {}}
+        activeAgentSession="crewly-orc"
+        fetchImpl={fetchImpl}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Orc')).toBeInTheDocument();
+    });
+    const orcBtn = screen.getByText('Orc').closest('button') as HTMLElement;
+    // Tailwind class adds blue background; assert via class string presence
+    // rather than rendered styles since jsdom doesn't compute CSS.
+    expect(orcBtn.className).toMatch(/bg-blue-50|bg-blue-900\/20/);
+  });
+});

--- a/frontend/src/components/Chat/AgentDirectory.tsx
+++ b/frontend/src/components/Chat/AgentDirectory.tsx
@@ -1,0 +1,236 @@
+/**
+ * AgentDirectory — left rail for the /agents page.
+ *
+ * Fetches `GET /api/chat/agents` and renders one row per (team × agent)
+ * so the user can open a DM with any agent in their teams without first
+ * creating a channel. Channels are created lazily on click via the
+ * `Agents` page's `ensureDmChannel` helper.
+ *
+ * Why a custom rail instead of `ChannelList` from `@crewly/chat-ui`?
+ *   `ChannelList` shows persisted channels. On first page load there
+ *   are no DM channels yet, so the rail would be empty and the user
+ *   would have no entry point. Showing agents directly maps better to
+ *   the user's mental model ("I want to talk to Leo") than to channels
+ *   ("I want to open the channel I once created for Leo").
+ *
+ * @module components/Chat/AgentDirectory
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+/**
+ * One row in the `/api/chat/agents` response. Mirrors
+ * `ChatAgentDirectoryEntry` on the backend.
+ */
+export interface DirectoryAgent {
+  agentSession: string;
+  name: string;
+  role: string;
+  teamId: string;
+  teamName: string;
+  agentStatus: string;
+  workingStatus: string;
+  avatar?: string;
+}
+
+interface DirectoryEnvelope {
+  success: boolean;
+  data?: { agents: DirectoryAgent[] };
+  error?: { code: string; message: string };
+}
+
+export interface AgentDirectoryProps {
+  /** sessionName of the currently-open agent (for active-row highlight). */
+  activeAgentSession?: string | null;
+  /**
+   * sessionName of the agent whose channel is mid-`ensure`. Used to show
+   * an inline spinner so users don't double-click while the network call
+   * is in flight.
+   */
+  openingAgentSession?: string | null;
+  onSelectAgent(agent: DirectoryAgent): void;
+  className?: string;
+  /** Override the fetch impl (tests pass a stub). */
+  fetchImpl?: typeof fetch;
+}
+
+const DIRECTORY_PATH = '/api/chat/agents';
+
+/**
+ * Group flat agent rows by teamName so the rail renders a tidy
+ * "Team Marketing → Ella / Luna" hierarchy instead of one long list.
+ */
+function groupByTeam(
+  agents: DirectoryAgent[],
+): Array<{ teamId: string; teamName: string; members: DirectoryAgent[] }> {
+  const buckets = new Map<
+    string,
+    { teamId: string; teamName: string; members: DirectoryAgent[] }
+  >();
+  for (const a of agents) {
+    let bucket = buckets.get(a.teamId);
+    if (!bucket) {
+      bucket = { teamId: a.teamId, teamName: a.teamName, members: [] };
+      buckets.set(a.teamId, bucket);
+    }
+    bucket.members.push(a);
+  }
+  return Array.from(buckets.values());
+}
+
+/**
+ * Map `(agentStatus, workingStatus)` to a tiny status dot color.
+ * Mirrors `resolvePresenceStatus` on the backend, but operates on the
+ * cached fields the directory ships in one round-trip (avoids one
+ * /presence call per row at list-time).
+ */
+function statusDotClass(agent: DirectoryAgent): string {
+  if (agent.agentStatus !== 'active' && agent.agentStatus !== 'started') {
+    if (agent.agentStatus === 'starting') return 'bg-amber-400';
+    return 'bg-slate-500';
+  }
+  if (agent.workingStatus === 'in_progress') return 'bg-blue-400';
+  return 'bg-emerald-400';
+}
+
+export const AgentDirectory: React.FC<AgentDirectoryProps> = ({
+  activeAgentSession = null,
+  openingAgentSession = null,
+  onSelectAgent,
+  className = '',
+  fetchImpl,
+}) => {
+  const [agents, setAgents] = useState<DirectoryAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const doFetch = useMemo(() => fetchImpl ?? globalThis.fetch, [fetchImpl]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await doFetch(DIRECTORY_PATH);
+      const body = (await res.json()) as DirectoryEnvelope;
+      if (!res.ok || !body.success || !body.data) {
+        throw new Error(
+          body?.error?.message ?? `Failed to load agents (HTTP ${res.status})`,
+        );
+      }
+      setAgents(body.data.agents);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [doFetch]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const grouped = useMemo(() => groupByTeam(agents), [agents]);
+
+  return (
+    <aside
+      className={`flex h-full w-64 flex-col border-r border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900 ${className}`}
+      aria-label="Agent directory"
+    >
+      <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+          Agents
+        </h2>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading && (
+          <div
+            className="p-4 text-sm text-slate-500 dark:text-slate-400"
+            role="status"
+            aria-live="polite"
+          >
+            Loading agents…
+          </div>
+        )}
+
+        {error && (
+          <div className="p-4 text-sm text-red-600 dark:text-red-400" role="alert">
+            <div className="mb-2">Failed to load agents: {error}</div>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="text-xs underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && agents.length === 0 && (
+          <div className="p-4 text-sm text-slate-500 dark:text-slate-400">
+            No agents available. Create a team and add a member to get started.
+          </div>
+        )}
+
+        {!loading && !error && grouped.length > 0 && (
+          <ul role="list" className="divide-y divide-slate-100 dark:divide-slate-800">
+            {grouped.map((team) => (
+              <li key={team.teamId} className="py-1">
+                <div className="px-4 py-1 text-[11px] uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  {team.teamName}
+                </div>
+                <ul role="list" className="space-y-px">
+                  {team.members.map((agent) => {
+                    const isActive = agent.agentSession === activeAgentSession;
+                    const isOpening = agent.agentSession === openingAgentSession;
+                    return (
+                      <li key={agent.agentSession}>
+                        <button
+                          type="button"
+                          disabled={isOpening}
+                          onClick={() => onSelectAgent(agent)}
+                          className={`flex w-full items-center gap-3 px-4 py-2 text-left transition hover:bg-slate-50 disabled:cursor-progress disabled:opacity-60 dark:hover:bg-slate-800 ${
+                            isActive ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+                          }`}
+                        >
+                          <span
+                            aria-hidden
+                            className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${statusDotClass(
+                              agent,
+                            )}`}
+                          />
+                          <div className="flex-1 overflow-hidden">
+                            <div className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">
+                              {agent.name}
+                            </div>
+                            <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                              {agent.role}
+                            </div>
+                          </div>
+                          {isOpening && (
+                            <span className="text-[10px] text-slate-500 dark:text-slate-400">
+                              opening…
+                            </span>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+};
+
+export default AgentDirectory;

--- a/frontend/src/pages/Agents.test.tsx
+++ b/frontend/src/pages/Agents.test.tsx
@@ -1,9 +1,11 @@
 /**
  * Agents page tests.
  *
- * Focus: the page mounts the shared chat-ui components, defaults to mock
- * mode, and renders the header + layout scaffold. Deep behavior lives in
- * `@crewly/chat-ui`'s own test suite — duplicating it here would be noise.
+ * Focus: the page mounts the shared chat-ui components, defaults to real
+ * mode, and renders the header + AgentDirectory rail. Deep directory
+ * behavior lives in `AgentDirectory.test.tsx`; deep chat behavior lives
+ * in `@crewly/chat-ui`'s own test suite — duplicating either here would
+ * be noise.
  *
  * @module pages/Agents.test
  */
@@ -12,10 +14,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// The chat-ui package is imported by `./Agents`. We mock each named export
-// so we can assert wiring (e.g. which mode/backendURL the provider gets)
-// without pulling in the real implementation (which fetches channels via
-// the mock client's timers and would slow every test file).
+// Mock chat-ui exports so we can assert wiring (mode/backendURL) without
+// pulling in the real implementation (which would fire network/timer
+// calls on every render).
 vi.mock('@crewly/chat-ui', () => {
   return {
     ChatAPIProvider: ({
@@ -35,12 +36,16 @@ vi.mock('@crewly/chat-ui', () => {
         {children}
       </div>
     ),
-    ChannelList: () => <div data-testid="channel-list" />,
     MessageThread: () => <div data-testid="message-thread" />,
     MessageInput: () => <div data-testid="message-input" />,
     AgentStatusBadge: () => <div data-testid="agent-status-badge" />,
   };
 });
+
+// Mock AgentDirectory so this suite is just about the page-level wiring.
+vi.mock('../components/Chat/AgentDirectory', () => ({
+  AgentDirectory: () => <div data-testid="agent-directory" />,
+}));
 
 import { Agents } from './Agents';
 
@@ -57,15 +62,24 @@ describe('Agents page', () => {
     ).toBeInTheDocument();
   });
 
-  it('mounts ChannelList, MessageThread, and MessageInput', () => {
+  it('mounts AgentDirectory, MessageThread, and MessageInput', () => {
     render(<Agents />);
-    expect(screen.getByTestId('channel-list')).toBeInTheDocument();
+    expect(screen.getByTestId('agent-directory')).toBeInTheDocument();
     expect(screen.getByTestId('message-thread')).toBeInTheDocument();
     expect(screen.getByTestId('message-input')).toBeInTheDocument();
   });
 
-  it('defaults to mock mode when VITE_CHAT_MODE is unset', () => {
+  it('defaults to real mode when VITE_CHAT_MODE is unset', () => {
     vi.stubEnv('VITE_CHAT_MODE', '');
+    render(<Agents />);
+    expect(screen.getByTestId('chat-provider')).toHaveAttribute(
+      'data-mode',
+      'real',
+    );
+  });
+
+  it('falls back to mock mode when VITE_CHAT_MODE=mock', () => {
+    vi.stubEnv('VITE_CHAT_MODE', 'mock');
     render(<Agents />);
     expect(screen.getByTestId('chat-provider')).toHaveAttribute(
       'data-mode',
@@ -73,27 +87,23 @@ describe('Agents page', () => {
     );
   });
 
-  it('shows the "Mock mode" banner when running against the stub', () => {
-    vi.stubEnv('VITE_CHAT_MODE', '');
-    render(<Agents />);
-    const banner = screen.getByRole('note');
-    expect(banner).toHaveTextContent(/mock mode/i);
-  });
+  it('shows the "Mock mode" banner only in mock mode', () => {
+    vi.stubEnv('VITE_CHAT_MODE', 'mock');
+    const { unmount } = render(<Agents />);
+    expect(screen.getByRole('note')).toHaveTextContent(/mock mode/i);
+    unmount();
 
-  it('switches to real mode when VITE_CHAT_MODE=real', () => {
-    vi.stubEnv('VITE_CHAT_MODE', 'real');
-    render(<Agents />);
-    const provider = screen.getByTestId('chat-provider');
-    expect(provider).toHaveAttribute('data-mode', 'real');
-    // `backendURL` should be populated — jsdom sets location.origin to
-    // http://localhost by default.
-    expect(provider.getAttribute('data-backend-url')).toMatch(/^http/);
-  });
-
-  it('does not render the mock banner in real mode', () => {
     vi.stubEnv('VITE_CHAT_MODE', 'real');
     render(<Agents />);
     expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  it('populates backendURL from window.location.origin in real mode', () => {
+    vi.stubEnv('VITE_CHAT_MODE', 'real');
+    render(<Agents />);
+    expect(
+      screen.getByTestId('chat-provider').getAttribute('data-backend-url'),
+    ).toMatch(/^http/);
   });
 
   it('prefers VITE_CHAT_BACKEND_URL override over window origin', () => {
@@ -106,8 +116,10 @@ describe('Agents page', () => {
     );
   });
 
-  it('renders without a selected channel (null channelId path)', () => {
+  it('renders the empty placeholder when no agent is selected', () => {
     render(<Agents />);
-    expect(screen.getByText(/no channel selected/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/select an agent to start chatting/i),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,46 +1,47 @@
 /**
  * Agents page — first-class user ↔ agent direct chat surface.
  *
- * Mounts the shared `@crewly/chat-ui` package, which hosts the same React
- * components used by the Cloud Portal. Keeping the markup here deliberately
- * thin: every chat behavior lives in the shared package so the two surfaces
- * cannot drift.
+ * Renders a left rail of *agents* (discovered via `GET /api/chat/agents`)
+ * rather than channels. Clicking an agent calls
+ * `POST /api/chat/channels/dm/ensure` to find-or-create that agent's DM
+ * channel, then mounts the shared `@crewly/chat-ui` thread + composer on
+ * the resolved channel.
  *
- * The orchestrator-pipe chat at `/chat` is a different product (see
- * `pages/Chat.tsx`); this page is the new Phase 1 Chat namespace
- * (`/api/chat/channels/*`, Sam's tech spec v1.0, §1).
+ * Why agents not channels?
+ *   Channels are an implementation detail — what the user thinks about is
+ *   "which agent am I talking to right now?". The directory rail reads
+ *   directly from the team file so every agent is reachable on first
+ *   page-load, even before any chat has happened.
  *
- * Mode selection:
- *  - `mock` (default, until Sam's backend ships) — exercises the UI + mock
- *    reply loop so we can iterate without waiting on endpoints.
- *  - `real` — wires `HttpChatApiClient` against the current origin; Vite
- *    dev proxy forwards `/api/*` and `/ws/*` to the OSS backend.
- *
- * Switch via `VITE_CHAT_MODE=real npm run dev` or by editing `.env.local`.
+ * Mode selection (kept from prior implementation):
+ *   - `real` (default) — wires `HttpChatApiClient` against the current
+ *     origin; Vite dev proxy forwards `/api/*` and `/ws/*` to the OSS
+ *     backend. Set `VITE_CHAT_MODE=mock` to fall back to the in-memory
+ *     stub when iterating without a backend.
  *
  * @module pages/Agents
  */
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ChatAPIProvider,
-  ChannelList,
   MessageThread,
   MessageInput,
   AgentStatusBadge,
   type Channel,
 } from '@crewly/chat-ui';
+import { AgentDirectory, type DirectoryAgent } from '../components/Chat/AgentDirectory';
 
 /**
  * Resolve the chat-ui provider mode from Vite env at build/dev time.
  *
- * We default to `"mock"` so the page is usable the moment it ships, before
- * Sam's backend endpoints go live. Flip to `"real"` once the first endpoint
- * is up (Day 2 of Week 2).
+ * Defaults to `"real"` so the page is wired to the live backend out of
+ * the box. Set `VITE_CHAT_MODE=mock` in `.env.local` to fall back to the
+ * in-memory stub while iterating on UI bits in isolation.
  */
 function resolveChatMode(): 'mock' | 'real' {
   const raw = (import.meta.env.VITE_CHAT_MODE ?? '').toString().toLowerCase();
-  return raw === 'real' ? 'real' : 'mock';
+  return raw === 'mock' ? 'mock' : 'real';
 }
 
 /**
@@ -71,21 +72,74 @@ function MockModeBanner(): JSX.Element {
     >
       <span className="font-semibold">Mock mode:</span>{' '}
       messages are served from an in-memory stub. Set{' '}
-      <code className="font-mono">VITE_CHAT_MODE=real</code> to hit the
-      live backend once it&apos;s up.
+      <code className="font-mono">VITE_CHAT_MODE=real</code> (default) to hit
+      the live backend.
     </div>
   );
 }
 
 /**
- * Agents page component — 3-pane layout: channel list, message thread,
- * composer. Mirrors the demo app in `packages/chat-ui/demo/App.tsx` so
- * visual regressions in either surface are caught in the other.
+ * POST `/api/chat/channels/dm/ensure` and return the resolved channel.
+ * Throws on any non-2xx so the caller can surface a user-visible error.
+ */
+async function ensureDmChannel(agent: DirectoryAgent): Promise<Channel> {
+  const res = await fetch('/api/chat/channels/dm/ensure', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      agentSession: agent.agentSession,
+      name: agent.name,
+      purpose: `Direct chat with ${agent.name} (${agent.role})`,
+    }),
+  });
+  type EnsureChannelResponse =
+    | { success: true; data: Channel }
+    | { success: false; error: { code: string; message: string } };
+  const body = (await res.json()) as EnsureChannelResponse;
+  if (body.success === false) {
+    throw new Error(`Failed to open chat: ${body.error.message}`);
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to open chat: HTTP ${res.status}`);
+  }
+  return body.data;
+}
+
+/**
+ * Agents page component — 3-pane layout: agent directory, message thread,
+ * composer. The directory replaces the chat-ui ChannelList so the user
+ * sees agents directly (not channels) — a channel is silently created on
+ * the first click.
  */
 export const Agents: React.FC = () => {
   const mode = resolveChatMode();
   const backendURL = mode === 'real' ? resolveBackendURL() : undefined;
   const [active, setActive] = useState<Channel | null>(null);
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [openingAgentSession, setOpeningAgentSession] = useState<string | null>(
+    null,
+  );
+
+  const handleSelectAgent = useCallback(
+    async (agent: DirectoryAgent) => {
+      setOpenError(null);
+      setOpeningAgentSession(agent.agentSession);
+      try {
+        const channel = await ensureDmChannel(agent);
+        setActive(channel);
+      } catch (err) {
+        setOpenError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setOpeningAgentSession(null);
+      }
+    },
+    [],
+  );
+
+  // Clear the error banner when the user successfully lands on a channel.
+  useEffect(() => {
+    if (active) setOpenError(null);
+  }, [active]);
 
   return (
     <ChatAPIProvider mode={mode} backendURL={backendURL}>
@@ -100,18 +154,27 @@ export const Agents: React.FC = () => {
         </header>
 
         {mode === 'mock' && <MockModeBanner />}
+        {openError && (
+          <div
+            className="mb-3 rounded-md border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs text-red-200"
+            role="alert"
+          >
+            {openError}
+          </div>
+        )}
 
         <div className="flex flex-1 overflow-hidden rounded-lg border border-border-dark bg-surface-dark shadow-lg">
-          <ChannelList
-            activeChannelId={active?.id ?? null}
-            onSelectChannel={setActive}
+          <AgentDirectory
+            activeAgentSession={active?.agentSession ?? null}
+            openingAgentSession={openingAgentSession}
+            onSelectAgent={handleSelectAgent}
           />
 
           <main className="flex flex-1 flex-col">
             <div className="flex items-center justify-between border-b border-border-dark px-4 py-3">
               <div className="min-w-0">
                 <h2 className="truncate text-sm font-semibold text-text-primary-dark">
-                  {active?.name ?? 'No channel selected'}
+                  {active?.name ?? 'Select an agent to start chatting'}
                 </h2>
                 {active?.purpose && (
                   <p className="truncate text-xs text-text-secondary-dark">


### PR DESCRIPTION
## Summary

- Replaces the mock-mode placeholder on `/agents` with a fully-wired direct-chat surface
- Adds 3 new endpoints under `/api/chat` (directory, presence, find-or-create DM)
- Frontend left rail is now an `AgentDirectory` (one row per agent across teams, prepended with the synthetic Orchestrator Team) so the user can DM any agent on first load

## What changed

**Backend** (`backend/src/`)
- `chat-v2.controller.ts`: 3 new handlers (`ensureDmChannel`, `listAgents`, `getAgentPresence`) + new `IAgentDirectoryProvider` / `IAgentPresenceProvider` deps with 503 fallbacks for REST-only tests
- `chat-v2.routes.ts`: 3 new routes (`POST /channels/dm/ensure`, `GET /agents`, `GET /presence/:agentId`)
- `chat-v2.service.ts`: `ensureDmChannel` — idempotent find-or-create scoped by (owner, agentSession)
- `sqlite/channel.store.ts`: `findActiveDmByOwnerAndAgent` — owner-scoped DM lookup (safe in multi-user setups now that the legacy `uq_channel_agent_dm_active` unique index is dropped)
- `chat-v2.providers.ts` (new): OSS wirings — directory flattens `StorageService.getTeams()` + prepends synthetic Orchestrator Team; presence maps `(isAgentActive, agentStatus, workingStatus)` → `online | busy | offline | starting`
- `api.routes.ts`: inject the two providers when mounting chat-v2

**Frontend** (`frontend/src/`)
- `pages/Agents.tsx`: defaults to `real` mode now; left rail is `AgentDirectory`; click ensures DM channel via the new endpoint then activates the channel for the existing chat-ui `MessageThread` + `MessageInput`
- `components/Chat/AgentDirectory.tsx` (new): fetches `/api/chat/agents`, renders grouped by team with a presence dot, handles loading/error/empty/in-flight states

**Tests** (CLAUDE.md 1:1 source-to-test policy)
- providers: 15 new tests (directory flattening, orc-prepend logic, presence mapping, graceful degradation)
- controller: 7 new Phase F tests (ensure 201/200, listAgents wired + 503, presence wired + 503)
- service: 5 new ensureDmChannel tests (idempotency, owner-scoping, validation)
- channel.store: 6 new findActiveDmByOwnerAndAgent tests (owner-scope, archived filter, type=channel filter, recency tiebreak)
- AgentDirectory: 6 new component tests (loading/empty/error/click/active/in-flight)
- Agents.tsx: rewritten 8 tests (defaults to real, mock banner only in mock, real-mode wiring)

## Test plan

- [x] Backend typecheck — clean
- [x] Frontend typecheck — clean
- [x] All new backend tests pass (5 + 6 + 7 + 15 = 33)
- [x] All frontend tests pass (14)
- [x] Manual browser check (Claude in Chrome): `/agents` loads → directory groups visible → click Orchestrator → `POST /channels/dm/ensure` returns 200 → header updates → send message returns 201
- [x] `crewly service restart` healthy + new endpoints respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)