### PR TITLE
fix(reconciler): stop auto-cancelling stale-queued WorkItems

### DIFF
--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -626,52 +626,51 @@ describe('detectStaleQueuedWorkItems', () => {
     expect(staleIds).toHaveLength(0);
   });
 
-  // F-CYCLE7-3 (2026-05-07) — regression: emitted correction MUST be a
-  // canonical valid transition. Prior behavior emitted queued→queued
-  // which StorageService rejected with "Invalid status transition:
-  // queued → queued", generating reconciler-error noise that hid real
-  // signal. Per WORK_ITEM_TRANSITIONS in work-item.types.ts, queued can
-  // legally transition to: running, proposed, scheduled, cancelled.
-  // 'expired' is not a valid WorkItemStatus.
-  describe('F-CYCLE7-3: queued→queued correction fix', () => {
-    it('emits queued→cancelled (NOT queued→queued) for stale-queued WorkItems', () => {
+  // 2026-05-16 policy change — stale-queued WIs MUST NOT be auto-cancelled.
+  // The pre-2026-05-16 behavior emitted `queued→cancelled` corrections
+  // when a WI sat queued past staleThresholdMs. That destroyed real
+  // user work on 2026-05-16 (Steve's X-article task dispatched to
+  // inactive Atlas → cancelled at 60min). PR #585 (eviction-under-
+  // memory-pressure) is the right mechanism to actually make progress
+  // on stale queued WIs. The function now returns staleIds for
+  // observability only; corrections is always empty.
+  describe('2026-05-16 no-auto-cancel policy', () => {
+    it('emits NO corrections — staleIds is observability-only', () => {
       const stale = makeWorkItem({
         status: 'queued',
-        createdAt: new Date(Date.now() - 16 * 3600 * 1000).toISOString(), // 16h ago, like the 945min real-world case
+        createdAt: new Date(Date.now() - 16 * 3600 * 1000).toISOString(), // 16h ago
       });
 
-      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+      const { corrections, staleIds } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
 
-      expect(corrections).toHaveLength(1);
-      expect(corrections[0].previousState).toBe('queued');
-      expect(corrections[0].newState).toBe('cancelled');
-      expect(corrections[0].newState).not.toBe('queued');
+      expect(corrections).toEqual([]);
+      // Still surfaced for callers that want to log/escalate.
+      expect(staleIds).toEqual([stale.id]);
     });
 
-    it('emitted newState is a valid transition target per canonical WORK_ITEM_TRANSITIONS', () => {
+    it('emits no corrections even for very-long-queued WIs (945min real-world case)', () => {
+      const stale = makeWorkItem({
+        status: 'queued',
+        createdAt: new Date(Date.now() - 945 * 60 * 1000).toISOString(), // 945min — earlier real-world case
+      });
+
+      const { corrections, staleIds } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+
+      // Old behaviour cancelled this; new behaviour keeps it queued
+      // so the target agent can eventually pick it up via the wake /
+      // eviction-under-pressure path.
+      expect(corrections).toHaveLength(0);
+      expect(staleIds).toContain(stale.id);
+    });
+
+    it('does not mutate caller-supplied WorkItem objects', () => {
       const stale = makeWorkItem({
         status: 'queued',
         createdAt: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
       });
-
-      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
-
-      expect(corrections).toHaveLength(1);
-      const validNextStates = WORK_ITEM_TRANSITIONS['queued'];
-      expect(validNextStates.has(corrections[0].newState as any)).toBe(true);
-      // Specifically NOT a same-state self-loop.
-      expect(corrections[0].newState).not.toBe(corrections[0].previousState);
-    });
-
-    it('reason field still preserves the queue-wait audit info', () => {
-      const stale = makeWorkItem({
-        status: 'queued',
-        createdAt: new Date(Date.now() - 945 * 60 * 1000).toISOString(), // 945min — exact prod scenario
-      });
-
-      const { corrections } = detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
-
-      expect(corrections[0].reason).toMatch(/queued for \d+ minutes without pickup/);
+      const before = { ...stale };
+      detectStaleQueuedWorkItems([stale], 60 * 60 * 1000);
+      expect(stale).toEqual(before);
     });
   });
 });

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -537,34 +537,44 @@ export function cascadeCancelChildren(
  * Detects WorkItems that have been in 'queued' status for too long
  * without being picked up. These may indicate assignment problems.
  *
- * **F-CYCLE7-3 fix (2026-05-07):** Previously emitted `queued → queued`
- * which is *not* a valid transition per the canonical
- * {@link WORK_ITEM_TRANSITIONS} table — every emitted correction was
- * rejected by `StorageService` with `Invalid status transition: queued →
- * queued`, generating reconciler-error noise that hid real signal. The
- * comment "Don't change status, just flag for audit" assumed an
- * audit-only path that doesn't exist: `applyCorrection()` always calls
- * `pool.updateItemStatus()` which validates against the transition
- * table.
+ * **2026-05-16 policy change — DO NOT auto-cancel stale queued WIs.**
+ * The earlier behavior emitted `queued → cancelled` corrections whenever
+ * a WI sat queued for more than `staleThresholdMs` (default 1h). On
+ * 2026-05-16 a real user request (Steve's X-article analysis dispatched
+ * to inactive Atlas) was destroyed by this rule: the WI sat queued
+ * because the target agent was dead, the 60-min timer expired before
+ * orc could re-wake Atlas, and the WI was silently cancelled. Cancelling
+ * was *masking* the underlying bugs (wake-gate ordering race, idle
+ * agents holding the floor under memory pressure) instead of surfacing
+ * them. PR #585's eviction-under-pressure is the right mechanism to
+ * actually make progress on stale queued WIs — wake their target rather
+ * than kill the work.
  *
- * **Canonical state machine** (`backend/src/types/v2/work-item.types.ts`):
- *   `queued` → one of `{ running, proposed, scheduled, cancelled }`.
+ * This function now returns ONLY `staleIds` for observability (so
+ * callers can log/escalate the stuck condition); no corrections are
+ * emitted, so applying the returned (empty) corrections is a no-op. The
+ * `corrections` field is preserved for API compatibility with
+ * `runPruningPass` which spreads it into the aggregate list.
  *
- * `'expired'` is *not* a valid `WorkItemStatus` (see `WORK_ITEM_STATUSES`),
- * despite earlier reconciler briefs occasionally suggesting it. Of the
- * canonical options, `cancelled` is the only terminal status reachable
- * from `queued`, and is the correct semantic for "queued > threshold,
- * never picked up — work was abandoned."
+ * Historical context preserved:
+ *   - F-CYCLE7-3 (2026-05-07) was an earlier fix that switched the
+ *     emitted correction from `queued→queued` (invalid transition) to
+ *     `queued→cancelled` (valid but destructive). The destructive flip
+ *     is what we're now reverting; the transition-table-validity lesson
+ *     still applies to other rules that DO emit corrections.
+ *   - Canonical state machine (`work-item.types.ts`): `queued` → one of
+ *     `{ running, proposed, scheduled, cancelled }`.
  *
  * @param workItems - All WorkItems to check
  * @param staleThresholdMs - How long in queued before considered stale (default: 1h)
- * @returns Corrections for stale queued WorkItems (transition: queued → cancelled)
+ * @returns `{ corrections: [], staleIds }` — observability-only. The
+ *   `corrections` array is always empty; iterate `staleIds` for the
+ *   list of WIs that have been queued past `staleThresholdMs`.
  */
 export function detectStaleQueuedWorkItems(
   workItems: WorkItem[],
   staleThresholdMs: number = 60 * 60 * 1000,
 ): { corrections: ReconcileCorrection[]; staleIds: string[] } {
-  const corrections: ReconcileCorrection[] = [];
   const staleIds: string[] = [];
   const now = Date.now();
 
@@ -575,21 +585,13 @@ export function detectStaleQueuedWorkItems(
     const waitTime = now - createdAt;
 
     if (waitTime > staleThresholdMs) {
-      corrections.push(createCorrection({
-        entityType: 'work_item',
-        entityId: wi.id,
-        previousState: 'queued',
-        // queued → cancelled is the canonical valid transition for an
-        // abandoned-in-queue WorkItem. See WORK_ITEM_TRANSITIONS.
-        newState: 'cancelled',
-        reason: `WorkItem has been queued for ${Math.round(waitTime / 60000)} minutes without pickup`,
-        evidence: `Created at ${wi.createdAt}, waiting for ${Math.round(waitTime / 60000)}m (threshold: ${Math.round(staleThresholdMs / 60000)}m)`,
-      }));
       staleIds.push(wi.id);
     }
   }
 
-  return { corrections, staleIds };
+  // No corrections — staleIds is observability-only. See the JSDoc
+  // banner above for why we no longer auto-cancel.
+  return { corrections: [], staleIds };
 }
 
 // ---------------------------------------------------------------------------
@@ -606,8 +608,18 @@ export interface PruningResult {
   orphanCancelledCount: number;
   /** WorkItems cancelled due to deep cascade */
   cascadeCancelledCount: number;
-  /** WorkItems flagged as stale in queue */
+  /**
+   * WorkItems still queued past `staleThresholdMs`. Surfaced for
+   * observability ONLY — no longer auto-cancelled (policy change
+   * 2026-05-16; see {@link detectStaleQueuedWorkItems} banner).
+   */
   staleQueuedCount: number;
+  /**
+   * IDs of the still-queued WIs that exceeded the staleness threshold.
+   * Callers (the reconciler service) log these so the stuck condition
+   * is visible without destroying the work. Empty when none are stale.
+   */
+  staleQueuedIds: string[];
   /** Total corrections from pruning */
   totalCorrections: ReconcileCorrection[];
 }
@@ -658,10 +670,14 @@ export function runPruningPass(
     orphanCancelledCount: orphans.orphanIds.length,
     cascadeCancelledCount: cascade.cascadedIds.length,
     staleQueuedCount: stale.staleIds.length,
+    staleQueuedIds: stale.staleIds,
     totalCorrections: [
       ...ttl.corrections,
       ...orphans.corrections,
       ...cascade.corrections,
+      // stale.corrections is intentionally always empty per the
+      // 2026-05-16 policy change — the spread is kept for the
+      // unlikely case that the policy is ever reverted.
       ...stale.corrections,
     ],
   };

--- a/backend/src/services/reconciler/reconciler.service.ts
+++ b/backend/src/services/reconciler/reconciler.service.ts
@@ -41,6 +41,7 @@ import {
 } from './reconcile-rules.js';
 import type { AgentHealth } from './reconcile-rules.js';
 import { getSettingsService } from '../settings/index.js';
+import { LoggerService } from '../core/logger.service.js';
 
 // ---------------------------------------------------------------------------
 // Data Provider Interface (dependency injection)
@@ -194,6 +195,28 @@ export class ReconcilerService {
       const pruning = runPruningPass(workItems);
       result.corrections.push(...pruning.totalCorrections);
       result.staleItemsCleaned += pruning.ttlExpiredCount + pruning.orphanCancelledCount + pruning.cascadeCancelledCount;
+
+      // 4a. Stale-queued visibility (2026-05-16): the pruning rule no
+      // longer auto-cancels these WIs (was destroying user work — Atlas
+      // X-article task on 2026-05-16). Log them so the stuck condition
+      // is observable without destroying the work; the wake / eviction-
+      // under-pressure path (PR #585) is responsible for actually
+      // making progress on them.
+      if (pruning.staleQueuedCount > 0) {
+        // ReconcilerService has no injected logger field (the rest of
+        // the service surfaces failures via result.errors); use the
+        // shared LoggerService directly. Stale-queued isn't a failure
+        // — it's an observability signal, so it lives in the log
+        // stream rather than the result envelope.
+        LoggerService.getInstance()
+          .createComponentLogger('ReconcilerService')
+          .warn('WorkItems queued past staleness threshold (NOT cancelling — eviction path will retry wake)', {
+            staleQueuedCount: pruning.staleQueuedCount,
+            // Cap the id list to avoid huge log lines if dozens accumulate.
+            staleIds: pruning.staleQueuedIds.slice(0, 20),
+            truncated: pruning.staleQueuedIds.length > 20,
+          });
+      }
 
       // 5. Reconcile Request statuses
       for (const request of requests) {


### PR DESCRIPTION
## Summary

Fixes the 2026-05-16 data-loss incident: Steve's X-article analysis request (WI b4ca56cb dispatched to inactive Atlas) was silently destroyed by the \`detectStaleQueuedWorkItems\` rule after 60 minutes in queue. The rule was masking three underlying bugs (wake-gate ordering race, idle-agents-hold-the-floor under pressure, no auto-retry after WI creation) instead of surfacing them.

PR #585 (eviction-under-pressure) is the right mechanism to make progress on stale queued WIs — wake their target rather than kill the work.

## Changes

- \`detectStaleQueuedWorkItems\` no longer emits cancellation corrections; returns \`{ corrections: [], staleIds }\` for observability only
- \`runPruningPass\` surfaces \`staleQueuedIds\` so callers can log
- \`ReconcilerService\` warn-logs the stuck IDs once per pass (capped at 20 to keep log lines bounded) so the condition stays visible without destroying user work
- Updated tests: replaced the destructive-cancellation assertions with the new no-auto-cancel policy assertions

## Test plan

- [x] 76/76 reconcile-rules.test.ts pass
- [x] 35/35 reconciler.service.test.ts pass
- [x] Backend typecheck clean
- [ ] Manual dogfood: after deploy, stale queued WIs stay queued; \`[ReconcilerService] WorkItems queued past staleness threshold\` log line surfaces them; eviction-under-pressure (PR #585) wakes the target instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)