### PR TITLE
fix: stop reviving idle agents on restart — wake only by explicit WI target

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2402,7 +2402,7 @@ export class CrewlyServer {
 			// and auditor sessions when auditor is disabled
 			const isAuditorEnabled = process.env[AUDITOR_CONSTANTS.ENV_VAR]?.toLowerCase() === 'true'
 				|| (process.env[AUDITOR_CONSTANTS.ENV_VAR] === undefined && AUDITOR_CONSTANTS.ENABLED_BY_DEFAULT);
-			const agentSessions = state.sessions.filter(
+			const baselineSessions = state.sessions.filter(
 				(s) => {
 					if (s.role === ORCHESTRATOR_ROLE) return false;
 					if (!isAuditorEnabled && s.name === AUDITOR_SCHEDULER_CONSTANTS.AUDITOR_SESSION_NAME) return false;
@@ -2410,8 +2410,53 @@ export class CrewlyServer {
 				}
 			);
 
+			// 2026-05-17 — gate by task-pool work. Pre-fix the boot path
+			// blindly resurrected every persisted session even when none had
+			// pending work, defeating the wake-gate philosophy (PR #574/#585)
+			// and bloating RAM until IdleDetection eventually drained them
+			// back. Now: only restore a session if the pool has at least one
+			// non-terminal WorkItem with `target === sessionName`. Idle
+			// agents stay dead until orc dispatches new work, at which point
+			// the dispatcher / wake path raises them on demand.
+			//
+			// Safety valve: if the pool lookup throws (e.g. SQLite not yet
+			// open during early boot), preserve the legacy behaviour rather
+			// than block all restores — better to over-restore than to
+			// silently strand work.
+			let agentSessions = baselineSessions;
+			try {
+				const pool = TaskPoolService.getInstance();
+				const allItems = await pool.getAllItems();
+				const targetedSessions = new Set<string>();
+				for (const wi of allItems) {
+					if (wi.status === 'done' || wi.status === 'cancelled') continue;
+					const t = (wi as { target?: string }).target;
+					if (typeof t === 'string' && t.length > 0) targetedSessions.add(t);
+				}
+				const filtered = baselineSessions.filter((s) => targetedSessions.has(s.name));
+				const skipped = baselineSessions
+					.filter((s) => !targetedSessions.has(s.name))
+					.map((s) => s.name);
+				if (skipped.length > 0) {
+					this.logger.info(
+						'Skipping auto-restore for sessions with no pending WorkItem (idle agents stay dead until dispatched work arrives)',
+						{
+							skippedCount: skipped.length,
+							skipped: skipped.slice(0, 20),
+							truncated: skipped.length > 20,
+						},
+					);
+				}
+				agentSessions = filtered;
+			} catch (poolErr) {
+				this.logger.warn(
+					'Auto-restore could not query task pool; falling back to restoring every persisted session',
+					{ error: poolErr instanceof Error ? poolErr.message : String(poolErr) },
+				);
+			}
+
 			if (agentSessions.length === 0) {
-				this.logger.debug('No non-orchestrator sessions to restore');
+				this.logger.info('No persisted agent sessions to restore (all idle, no pending WorkItems)');
 				return;
 			}
 

--- a/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
@@ -80,6 +80,17 @@ export interface ICloudSyncLike extends EventEmitter {
     type: 'chat_response' | 'chat_event',
     payload: unknown,
   ): Promise<void>;
+  /**
+   * Optional queueId-direct send. When present, the adapter prefers it
+   * for chat_response routing — Portal's queueId may not yet be in the
+   * 30s device-poll cache, and the production relay routes by queueId
+   * anyway. Methods without this fall back to sendMessage (stub-friendly).
+   */
+  sendToPeerQueueId?(
+    peerQueueId: string,
+    type: 'chat_response' | 'chat_event',
+    payload: unknown,
+  ): Promise<void>;
 }
 
 /**
@@ -227,7 +238,18 @@ export class ChatV2RelayAdapter {
    * @param msg - Raw IncomingMessage from CloudSyncService
    */
   private async handleRequest(msg: IncomingMessage): Promise<void> {
-    const fromDevice = msg.from;
+    // The production relay's `/queue/poll` response only returns
+    // `{id, payload, createdAt}` — sender info is dropped. To route the
+    // `chat_response` back to Portal, we fall back to `msg.fromDeviceName`
+    // (preserved verbatim from the sender's wrapper), where Portal stamps
+    // its own queueId. See `relay-chat-client.ts:sendOverRelay`.
+    const fromDevice = msg.from || msg.fromDeviceName || '';
+    if (!fromDevice) {
+      this.logger.warn('chat_request missing sender id (from + fromDeviceName both empty) — dropping', {
+        msgId: msg.id,
+      });
+      return;
+    }
     if (!isChatRequestPayload(msg.payload)) {
       this.logger.warn('chat_request payload failed validation — dropping', {
         fromDevice,
@@ -250,7 +272,15 @@ export class ChatV2RelayAdapter {
     }
 
     try {
-      await this.cloudSync.sendMessage(fromDevice, 'chat_response', response);
+      // Prefer the queueId-direct path when available — Portal's deviceId
+      // == its relay queueId, and that bypasses CloudSyncService's stale
+      // 30s device cache (Portal may have registered moments ago, faster
+      // than the poll cadence).
+      if (typeof this.cloudSync.sendToPeerQueueId === 'function') {
+        await this.cloudSync.sendToPeerQueueId(fromDevice, 'chat_response', response);
+      } else {
+        await this.cloudSync.sendMessage(fromDevice, 'chat_response', response);
+      }
     } catch (err) {
       // If we can't reply, log it — Portal will retry the request on
       // timeout. We can't surface the failure any other way (the
@@ -424,9 +454,15 @@ export class ChatV2RelayAdapter {
     this.pruneExpiredPortals();
     if (this.knownPortals.size === 0) return;
     const payload: ChatEventPayload = { channelId, event };
+    // Prefer queueId-direct path for the same reason as `handleRequest`
+    // — Portal queueIds may not be in the 30s device-poll cache.
+    const send =
+      typeof this.cloudSync.sendToPeerQueueId === 'function'
+        ? this.cloudSync.sendToPeerQueueId.bind(this.cloudSync)
+        : this.cloudSync.sendMessage.bind(this.cloudSync);
     for (const deviceId of this.knownPortals.keys()) {
       // Fire-and-forget — log on failure but keep going.
-      this.cloudSync.sendMessage(deviceId, 'chat_event', payload).catch((err) => {
+      send(deviceId, 'chat_event', payload).catch((err) => {
         this.logger.warn('Failed to forward chat_event to Portal', {
           deviceId,
           channelId,

--- a/backend/src/services/cloud/cloud-sync.service.ts
+++ b/backend/src/services/cloud/cloud-sync.service.ts
@@ -380,6 +380,56 @@ export class CloudSyncService extends EventEmitter {
     this.logger.info('Message sent via Cloud Sync', { to: toDeviceId, type, peerSessionId: targetDevice.sessionId });
   }
 
+  /**
+   * Send a message directly to a peer queueId, bypassing the device cache.
+   *
+   * Used by `ChatV2RelayAdapter` for routing `chat_response` back to a
+   * Portal browser whose deviceId may not yet have propagated to the
+   * 30s-interval device poll. The production relay's `/queue/send`
+   * endpoint accepts a raw `peerQueueId`, so when the target identifier
+   * IS already a queueId (which Portal's wrapper.fromDeviceName field
+   * carries — see `chat-v2.relay-adapter.service.ts:handleRequest`),
+   * we can skip the cache lookup entirely and avoid the race.
+   *
+   * Falls back to `sendMessage(...)` semantics on the wire (same JSON
+   * wrapper) so the receiver's CloudSyncService normalizes it identically.
+   *
+   * @param peerQueueId - The relay queueId to route to (no cache lookup)
+   * @param type - MessageType for the wrapper
+   * @param payload - JSON-serializable inner data
+   * @throws Error when not started or the HTTP send fails
+   */
+  async sendToPeerQueueId(
+    peerQueueId: string,
+    type: MessageType,
+    payload: unknown,
+  ): Promise<void> {
+    if (!this.config) {
+      throw new Error('CloudSyncService not started. Call start() first.');
+    }
+    if (!peerQueueId) {
+      throw new Error('sendToPeerQueueId requires a non-empty peerQueueId');
+    }
+    const url = `${this.config.cloudUrl}${CLOUD_SYNC_CONSTANTS.ENDPOINTS.MESSAGES}`;
+    const wrappedPayload = JSON.stringify({
+      type,
+      data: payload,
+      encrypted: false,
+      fromDeviceName: this.config.deviceName,
+    });
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ peerQueueId, payload: wrappedPayload }),
+      signal: AbortSignal.timeout(CLOUD_SYNC_CONSTANTS.REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(`Failed to send message (queueId path): ${response.status} ${errorText}`);
+    }
+    this.logger.info('Message sent via Cloud Sync (queueId path)', { peerQueueId, type });
+  }
+
   // -------------------------------------------------------------------------
   // Internal: Queue Registration
   // -------------------------------------------------------------------------

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -836,8 +836,11 @@ describe('selectBestAgent', () => {
     expect(result!.agent.sessionName).toBe('agent-1'); // target match = highest score
   });
 
-  it('should exclude agents in excludeAgents set', () => {
-    const wi = makeWorkItem({ target: 'agent-1', type: 'delegate' });
+  it('should exclude agents in excludeAgents set (no-target WI falls back to others)', () => {
+    // No `target` on the WI → fall back to skill-based scoring across all agents.
+    // `makeWorkItem` defaults `target: 'agent-1'`, so we explicitly clear it
+    // to exercise the no-target branch.
+    const wi = { ...makeWorkItem({ type: 'delegate' }), target: undefined } as WorkItem;
     const agents: AgentHealth[] = [
       { sessionName: 'agent-1', status: 'suspended', role: 'developer' },
       { sessionName: 'agent-2', status: 'inactive', role: 'developer' },
@@ -862,6 +865,43 @@ describe('selectBestAgent', () => {
     const result = selectBestAgent(wi, agents, 5 * 60_000, new Set(['agent-1']));
     expect(result).toBeNull();
   });
+
+  // 2026-05-17 — when a WorkItem has an explicit `target`, the reconciler
+  // must ONLY wake that exact agent. The previous "best-score across all
+  // agents" fallback was substituting unrelated agents (Quinn / Reed /
+  // Victor) for SLA-tracker `respond_to_user` WIs targeted at crewly-orc,
+  // causing the team to spin up on every restart with no actual work.
+  describe('2026-05-17 target-strict policy', () => {
+    it('only considers the explicit target when wi.target is set', () => {
+      const wi = makeWorkItem({ target: 'agent-1', type: 'delegate' });
+      const agents: AgentHealth[] = [
+        { sessionName: 'agent-1', status: 'suspended', role: 'developer' },
+        { sessionName: 'agent-2', status: 'inactive', role: 'developer' },
+      ];
+      const result = selectBestAgent(wi, agents, 5 * 60_000);
+      expect(result?.agent.sessionName).toBe('agent-1');
+    });
+
+    it('returns null when the explicit target is excluded — does NOT substitute another agent', () => {
+      const wi = makeWorkItem({ target: 'agent-1', type: 'delegate' });
+      const agents: AgentHealth[] = [
+        { sessionName: 'agent-1', status: 'suspended', role: 'developer' },
+        { sessionName: 'agent-2', status: 'inactive', role: 'developer' },
+      ];
+      const result = selectBestAgent(wi, agents, 5 * 60_000, new Set(['agent-1']));
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the explicit target is not in the wakable list', () => {
+      const wi = makeWorkItem({ target: 'crewly-orc', type: 'review' });
+      const agents: AgentHealth[] = [
+        { sessionName: 'product-quinn', status: 'inactive', role: 'developer' },
+        { sessionName: 'support-reed', status: 'inactive', role: 'customer-support' },
+      ];
+      const result = selectBestAgent(wi, agents, 5 * 60_000);
+      expect(result).toBeNull();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -876,6 +916,11 @@ describe('detectUnclaimedTasks', () => {
       status: 'queued',
       createdAt: TWO_MIN_AGO,
       type: 'delegate',
+      // 2026-05-17 target-strict policy: explicit target must match a wakable
+      // agent. Earlier this test relied on skill-based fallback when target
+      // was 'agent-1' (the makeWorkItem default) and no such agent existed —
+      // that fallback is gone. Target the actual wakable agent.
+      target: 'agent-suspended',
     });
     const agentMap = makeAgentMap([
       ['agent-suspended', { status: 'suspended', role: 'developer' }],
@@ -893,6 +938,7 @@ describe('detectUnclaimedTasks', () => {
       status: 'queued',
       createdAt: TWO_MIN_AGO,
       type: 'delegate',
+      target: 'agent-off', // target-strict policy
     });
     const agentMap = makeAgentMap([
       ['agent-off', { status: 'inactive', role: 'developer' }],
@@ -997,6 +1043,7 @@ describe('detectUnclaimedTasks', () => {
       status: 'queued',
       createdAt: new Date(Date.now() - 6 * 60_000).toISOString(),
       type: 'delegate',
+      target: 'agent-suspended', // target-strict policy
     });
     const agentMap = makeAgentMap([
       ['agent-active', { status: 'active' }],

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -779,6 +779,16 @@ export function detectUnclaimedTasks(
 
     if (hasActiveAgent && waitTime < effectiveThreshold) continue;
 
+    // 2026-05-17 — never auto-wake for untargeted WIs. If a WorkItem
+    // doesn't name a `target`, the reconciler used to pick the
+    // "highest-score" wakable agent by skill match (developer-role +
+    // tag-keyword overlap). That meant a stale unassigned delegate WI
+    // queued days ago could spin a fresh agent back to life on every
+    // restart, racking up RAM with no actual work the agent could do
+    // (the WI is unowned). Strict policy: only wake when the WI
+    // explicitly names an offline target via `wi.target`.
+    if (!wi.target) continue;
+
     // Score each wakable agent for this WorkItem
     const bestAgent = selectBestAgent(wi, wakableAgents, waitTime, agentsToWake);
     if (!bestAgent) continue;
@@ -830,9 +840,22 @@ export function selectBestAgent(
   waitTimeMs: number,
   excludeAgents: Set<string> = new Set(),
 ): { agent: AgentHealth; score: number; breakdown: AgentScoreBreakdown } | null {
+  // 2026-05-17 — when a WorkItem has an explicit `target`, ONLY consider
+  // waking that exact agent. The previous "best-score across all agents"
+  // behaviour quietly substituted a different agent when the named target
+  // was offline (e.g. a queued `respond_to_user` WI for `crewly-orc` would
+  // wake Quinn / Reed / Victor based on skill score). That defeats the
+  // intent of the WI's target field — Quinn cannot respond to a Slack
+  // message addressed to orc. Honouring `target` strictly means: if the
+  // target isn't currently wakable, the WI stays queued and only its
+  // owning agent will pick it up when it comes back online.
+  const candidates = workItem.target
+    ? agents.filter((a) => a.sessionName === workItem.target)
+    : agents;
+
   let bestResult: { agent: AgentHealth; score: number; breakdown: AgentScoreBreakdown } | null = null;
 
-  for (const agent of agents) {
+  for (const agent of candidates) {
     if (excludeAgents.has(agent.sessionName)) continue;
 
     const breakdown = computeAgentScore(workItem, agent, waitTimeMs);


### PR DESCRIPTION
## Summary

User report 2026-05-17: after every OSS restart, half the team came back to life — agents like Quinn, Max, Dex, Atlas would all report \"Recovery complete. No pending tasks targeted at me. Available for new work\" and chew RAM with nothing actually queued for them. The wake-gate from PR #574/#585 was supposed to stop this; it didn't.

## Root causes (three layers)

**1. `selectBestAgent` cross-target substitution**
The reconciler used \"highest-score across all wakable agents\" even when the WorkItem had an explicit \`target\`. An SLA \`respond_to_user\` WI targeted at \`crewly-orc\` would silently wake Quinn instead, picked by developer skill score.
- Fix: if \`wi.target\` is set, ONLY consider that exact agent — null result if it's not in the wakable list. No more cross-target substitution.

**2. `detectUnclaimedTasks` waking for untargeted WIs**
Reconciler happily woke a \"best skill match\" agent for WIs with no \`target\` at all. A stale unassigned \`delegate\` WI queued days ago would spin up developers on every restart.
- Fix: untargeted WIs never trigger an auto-wake. The dispatcher / orc has to assign a target first; only then will the wake fire.

**3. `autoRestoreAgentSessionsIfEnabled` blindly resurrecting persisted sessions**
Boot-time path restored every previously-running session regardless of work.
- Fix: filter by task-pool work — only restore sessions whose name appears as \`target\` on a non-terminal WorkItem. Safety valve preserves old behaviour if the pool query throws.

## Bonus fix surfaced during diagnosis

\`ChatV2RelayAdapter\` couldn't reply to Portal \`chat_request\` messages because the production relay's \`/queue/poll\` doesn't return sender info, leaving \`msg.from\` empty. Portal now stamps its queueId into \`fromDeviceName\` and the adapter falls back to that. Also added \`CloudSyncService.sendToPeerQueueId\` to bypass the 30s device cache when routing chat_response to a freshly-paired Portal.

## Test plan

- [x] selectBestAgent — 3 new cases for target-strict policy
- [x] detectUnclaimedTasks — existing tests updated to set explicit target
- [x] 79/79 reconcile-rules.test.ts pass
- [x] 17/17 chat-v2.relay-adapter.service.test.ts pass
- [x] Backend typecheck clean
- [x] Manual: post-deploy clean OSS restart produces zero \`Executing wake action\` lines for unrelated agents. Only orc auto-starts (its own path) and self-watch-scribe (legitimately has a targeted WI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)