### PR TITLE
fix(chat-v2): wake bound agent on Portal-sourced sendMessage

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1352,6 +1352,11 @@ export class CrewlyServer {
 							service: chatService,
 							gateway: chatGateway,
 							cloudSync: sync,
+							// Wire the dispatcher so Portal-sent user messages also fire the
+							// agent-side prompt (parity with the HTTP controller path).
+							// Without this, Portal user-messages persist but the bound agent
+							// never receives the `[CHAT:<id>]` prompt — orc/etc. stay silent.
+							dispatcher: chatDispatcher,
 							directory: createOssAgentDirectoryProvider(this.storageService),
 							presence: createOssAgentPresenceProvider(this.storageService),
 						});

--- a/backend/src/services/chat-v2/chat-v2.relay-adapter.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.relay-adapter.service.test.ts
@@ -13,6 +13,7 @@ import { ChatV2RelayAdapter } from './chat-v2.relay-adapter.service.js';
 import type {
   ICloudSyncLike,
   IChatV2GatewayLike,
+  IChatV2DispatcherLike,
 } from './chat-v2.relay-adapter.service.js';
 import type {
   IAgentDirectoryProvider,
@@ -61,6 +62,22 @@ class FakeCloudSync extends EventEmitter implements ICloudSyncLike {
 
   emitInbound(msg: IncomingMessage): void {
     this.emit('message', msg);
+  }
+}
+
+/**
+ * Fake ChatV2Dispatcher — records dispatchMessage calls and (optionally)
+ * rejects them. Lets tests assert that Portal-sourced sendMessage RPCs
+ * actually wake the bound agent in addition to persisting.
+ */
+class FakeDispatcher implements IChatV2DispatcherLike {
+  public calls: Array<{ channel: unknown; message: unknown }> = [];
+  public rejectWith: Error | null = null;
+
+  async dispatchMessage(channel: unknown, message: unknown): Promise<unknown> {
+    this.calls.push({ channel, message });
+    if (this.rejectWith) throw this.rejectWith;
+    return undefined;
   }
 }
 
@@ -228,6 +245,135 @@ describe('ChatV2RelayAdapter', () => {
     const msg = r.result as { senderType: string; content: string };
     expect(msg.senderType).toBe('user');
     expect(msg.content).toBe('hello relay');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2026-05-17 dispatcher-wiring: Portal-sourced user `sendMessage` RPCs must
+  // also fire the ChatV2Dispatcher so the bound agent's PTY receives the
+  // `[CHAT:<id>]` prompt. Without this, Portal-sent messages persisted but
+  // agents never reacted (silent regression).
+  // ---------------------------------------------------------------------------
+
+  it('sendMessage fires the dispatcher on a Portal-sourced user message', async () => {
+    adapter.stop();
+    const dispatcher = new FakeDispatcher();
+    const dispatchAdapter = new ChatV2RelayAdapter({
+      service,
+      gateway,
+      cloudSync,
+      dispatcher,
+      directory,
+      presence,
+      now: () => 10_000,
+      portalIdleTtlMs: 60_000,
+    });
+    dispatchAdapter.start();
+
+    const ensure = service.ensureDmChannel({
+      agentSession: 'crewly-orc',
+      name: 'Orc',
+      principal: { userId: 'dev-user-001', source: 'oss' },
+    });
+
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-dispatch', {
+        id: 'r-dispatch',
+        method: 'sendMessage',
+        params: {
+          channelId: ensure.channel.id,
+          content: 'wake the agent',
+          clientMessageId: 'cmid-dispatch',
+        },
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(dispatcher.calls).toHaveLength(1);
+    const dispatched = dispatcher.calls[0].message as {
+      senderType: string;
+      content: string;
+      channelId: string;
+    };
+    expect(dispatched.senderType).toBe('user');
+    expect(dispatched.content).toBe('wake the agent');
+    expect(dispatched.channelId).toBe(ensure.channel.id);
+
+    dispatchAdapter.stop();
+  });
+
+  it('sendMessage skips dispatcher when none is wired (back-compat)', async () => {
+    // Default adapter from beforeEach has no dispatcher — assert that a
+    // Portal sendMessage still persists + replies without throwing.
+    const ensure = service.ensureDmChannel({
+      agentSession: 'crewly-orc',
+      name: 'Orc',
+      principal: { userId: 'dev-user-001', source: 'oss' },
+    });
+
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-nodisp', {
+        id: 'r-nodisp',
+        method: 'sendMessage',
+        params: {
+          channelId: ensure.channel.id,
+          content: 'no dispatcher path',
+          clientMessageId: 'cmid-nodisp',
+        },
+      }),
+    );
+    await flushMicrotasks();
+
+    const reply = cloudSync.outbound[0].payload as ChatResponsePayload;
+    expect(reply.error).toBeUndefined();
+    expect((reply.result as { content: string }).content).toBe(
+      'no dispatcher path',
+    );
+  });
+
+  it('sendMessage swallows dispatcher rejection so the RPC still replies', async () => {
+    adapter.stop();
+    const dispatcher = new FakeDispatcher();
+    dispatcher.rejectWith = new Error('agent PTY closed');
+    const dispatchAdapter = new ChatV2RelayAdapter({
+      service,
+      gateway,
+      cloudSync,
+      dispatcher,
+      directory,
+      presence,
+      now: () => 10_000,
+      portalIdleTtlMs: 60_000,
+    });
+    dispatchAdapter.start();
+
+    const ensure = service.ensureDmChannel({
+      agentSession: 'crewly-orc',
+      name: 'Orc',
+      principal: { userId: 'dev-user-001', source: 'oss' },
+    });
+
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-rej', {
+        id: 'r-rej',
+        method: 'sendMessage',
+        params: {
+          channelId: ensure.channel.id,
+          content: 'dispatch will fail',
+          clientMessageId: 'cmid-rej',
+        },
+      }),
+    );
+    await flushMicrotasks();
+
+    // RPC reply must still land — dispatch is fire-and-forget.
+    const reply = cloudSync.outbound[0].payload as ChatResponsePayload;
+    expect(reply.error).toBeUndefined();
+    expect((reply.result as { content: string }).content).toBe(
+      'dispatch will fail',
+    );
+    expect(dispatcher.calls).toHaveLength(1);
+
+    dispatchAdapter.stop();
   });
 
   it('listAgents flattens the directory provider result', async () => {

--- a/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
@@ -103,6 +103,21 @@ export interface IChatV2GatewayLike {
   ): () => void;
 }
 
+/**
+ * Minimal ChatV2DispatcherService surface. Required for the
+ * `sendMessage` RPC method — when Portal sends a user message via the
+ * relay, the adapter persists it (via ChatV2Service) AND fires the
+ * dispatcher so the bound agent's PTY actually receives a
+ * `[CHAT:<id>]` prompt. The HTTP controller does the same thing for
+ * local /agents traffic; this brings the relay path to parity.
+ */
+export interface IChatV2DispatcherLike {
+  dispatchMessage(
+    channel: ChatChannelDTO,
+    message: ChatMessageDTO,
+  ): Promise<unknown>;
+}
+
 /** Constructor options for {@link ChatV2RelayAdapter}. */
 export interface ChatV2RelayAdapterOptions {
   /** The chat service to dispatch RPC calls against. */
@@ -111,6 +126,14 @@ export interface ChatV2RelayAdapterOptions {
   gateway: IChatV2GatewayLike;
   /** Cloud sync — used both to listen for chat_request and to send replies. */
   cloudSync: ICloudSyncLike;
+  /**
+   * Optional ChatV2 dispatcher — fired after a Portal-sourced user
+   * `sendMessage` RPC so the bound agent's PTY receives the
+   * `[CHAT:<id>]` prompt (mirrors the HTTP controller's post-ack path).
+   * When omitted (REST-only tests), Portal messages persist but agents
+   * don't react — verify carefully before relying on this fallback.
+   */
+  dispatcher?: IChatV2DispatcherLike;
   /** Directory provider — backs the `listAgents` RPC method. */
   directory?: IAgentDirectoryProvider;
   /** Presence provider — backs the `getAgentPresence` RPC method. */
@@ -148,6 +171,7 @@ export class ChatV2RelayAdapter {
   private readonly service: ChatV2Service;
   private readonly gateway: IChatV2GatewayLike;
   private readonly cloudSync: ICloudSyncLike;
+  private readonly dispatcher?: IChatV2DispatcherLike;
   private readonly directory?: IAgentDirectoryProvider;
   private readonly presence?: IAgentPresenceProvider;
   private readonly portalIdleTtlMs: number;
@@ -165,6 +189,7 @@ export class ChatV2RelayAdapter {
     this.service = options.service;
     this.gateway = options.gateway;
     this.cloudSync = options.cloudSync;
+    this.dispatcher = options.dispatcher;
     this.directory = options.directory;
     this.presence = options.presence;
     this.portalIdleTtlMs = options.portalIdleTtlMs ?? DEFAULT_PORTAL_IDLE_TTL_MS;
@@ -424,6 +449,28 @@ export class ChatV2RelayAdapter {
             : undefined,
           threadId: this.optionalString(p, 'threadId'),
         });
+        // Fire-and-forget dispatch: mirror the HTTP controller's post-ack
+        // path so the bound agent's PTY receives a `[CHAT:<id>]` prompt.
+        // Without this, Portal-sent user messages persist but agents
+        // never react — the user sees nothing back.
+        if (this.dispatcher && message.senderType === 'user') {
+          try {
+            const channel = this.service.getChannel(message.channelId, principal);
+            void this.dispatcher
+              .dispatchMessage(channel, message)
+              .catch((err) => {
+                this.logger.warn('Portal-relay dispatch threw (non-fatal)', {
+                  channelId: message.channelId,
+                  error: formatError(err),
+                });
+              });
+          } catch (err) {
+            this.logger.warn('Portal-relay dispatch — getChannel failed (non-fatal)', {
+              channelId: message.channelId,
+              error: formatError(err),
+            });
+          }
+        }
         return this.serializeMessage(message, fromDevice);
       }
       default: {


### PR DESCRIPTION
## Summary

Portal → Relay → OSS chat-v2 was persisting user messages but never waking the bound agent (Orc, etc.). The HTTP controller's `sendMessage` path already fires `chatDispatcher.dispatchMessage` after the write; the relay adapter's `sendMessage` RPC didn't — so any user message arriving via the relay (which is the only path Cloud Portal can use) reached the DB but never the PTY.

## What changed

- `ChatV2RelayAdapter` now accepts an optional `dispatcher: IChatV2DispatcherLike` in its options.
- After a successful `sendMessage` RPC where `senderType === 'user'`, the adapter fires `dispatchMessage(channel, message)` fire-and-forget. Failures are logged via `LoggerService.warn` and never break the RPC reply.
- `index.ts` wires the existing `chatDispatcher` into the adapter at server-construction time (mirrors how it's wired into the HTTP controller).

## Behavior

Without dispatcher: persisted but silent (regression — fixed here).
With dispatcher: persisted **and** `[CHAT:<id>]` prompt lands in the bound agent's `SubAgentMessageQueue`, identical to the local HTTP path.

## Tests

- `sendMessage fires the dispatcher on a Portal-sourced user message` — happy path
- `sendMessage skips dispatcher when none is wired (back-compat)` — REST-only / unit-test path still works
- `sendMessage swallows dispatcher rejection so the RPC still replies` — fire-and-forget guarantee

Full adapter suite: 20/20 pass.

## Test plan

- [x] Unit tests in `chat-v2.relay-adapter.service.test.ts` (20/20)
- [x] Verified end-to-end against running OSS: Portal `sendMessage` (seq=20) → log emits `SubAgentMessageQueue Message queued for sub-agent | sessionName: crewly-orc, queueSize:1, dataLength:1107`
- [ ] Reviewer: confirm no other RPC method needs the dispatcher fan-out (only `sendMessage` reaches user-content persist, so this should be exhaustive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)