### PR TITLE
fix(cloud-portal): filter Connected Devices to orchestrators only

### DIFF
--- a/frontend/src/pages/CloudPortal.test.tsx
+++ b/frontend/src/pages/CloudPortal.test.tsx
@@ -271,4 +271,50 @@ describe('CloudPortal', () => {
       );
     });
   });
+
+});
+
+// ---------------------------------------------------------------------------
+// 2026-05-17 Connected-Devices role filter
+//
+// Exercising the filter via a full page render proved fragile (the
+// CloudPortal has additional cloud-connection gates around the device
+// list section). The filter itself is a pure function; testing it
+// directly is sharper and far more durable.
+// ---------------------------------------------------------------------------
+
+import { filterToOrchestrators } from './CloudPortal';
+import type { CloudDevice } from '../types/cloud.types';
+
+describe('filterToOrchestrators', () => {
+  it('keeps orchestrator-role entries and drops agent-role entries', () => {
+    const devices: CloudDevice[] = [
+      { sessionId: 'oss-mac', deviceName: 'macbookpro.lan', role: 'orchestrator', state: 'paired' },
+      { sessionId: 'oss-iris', deviceName: 'iriss-air.lan', role: 'orchestrator', state: 'paired' },
+      { sessionId: '85b41885', role: 'agent', state: 'waiting' },
+      { sessionId: 'aad4cb2c', role: 'agent', state: 'paired' },
+    ] as CloudDevice[];
+
+    const result = filterToOrchestrators(devices);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((d) => d.sessionId).sort()).toEqual(['oss-iris', 'oss-mac']);
+  });
+
+  it('returns an empty list when no orchestrators are present', () => {
+    const devices: CloudDevice[] = [
+      { sessionId: '85b41885', role: 'agent', state: 'waiting' },
+      { sessionId: 'aad4cb2c', role: 'agent', state: 'paired' },
+    ] as CloudDevice[];
+
+    expect(filterToOrchestrators(devices)).toEqual([]);
+  });
+
+  it('is a no-op for an already-pure orchestrator list', () => {
+    const devices: CloudDevice[] = [
+      { sessionId: 'oss-1', deviceName: 'host-a.local', role: 'orchestrator', state: 'paired' },
+    ] as CloudDevice[];
+
+    expect(filterToOrchestrators(devices)).toEqual(devices);
+  });
 });

--- a/frontend/src/pages/CloudPortal.tsx
+++ b/frontend/src/pages/CloudPortal.tsx
@@ -158,6 +158,25 @@ const DEVICE_STATE_COLORS: Record<string, string> = {
  * @param devices - Raw device list from the API
  * @returns Deduplicated device list
  */
+/**
+ * Filter a relay device list down to OSS-class entries.
+ *
+ * The relay's `/devices` endpoint returns every session registered for
+ * the user — including `role: 'agent'` Portal browser/mobile sessions.
+ * Those are UI clients, not connected machines, and should not appear
+ * in the "Connected Devices" list (a user shouldn't see their own phone
+ * tab listed as if it were a separate Crewly OSS).
+ *
+ * Exported so the role filter can be unit-tested directly without
+ * spinning up the full CloudPortal page render.
+ *
+ * @param devices - Raw device list (possibly mixed roles)
+ * @returns Only entries whose `role` is `'orchestrator'`
+ */
+export function filterToOrchestrators(devices: CloudDevice[]): CloudDevice[] {
+  return devices.filter((d) => d.role === 'orchestrator');
+}
+
 function deduplicateDevices(devices: CloudDevice[]): CloudDevice[] {
   const seen = new Map<string, CloudDevice>();
   for (const device of devices) {
@@ -322,7 +341,17 @@ const DeviceListSection: React.FC = () => {
     fetchDevices();
   }, [fetchDevices]);
 
-  const uniqueDevices = useMemo(() => deduplicateDevices(devices), [devices]);
+  // Only show OSS-class devices in the "Connected Devices" list. The
+  // relay's `/devices` endpoint returns every session for the user —
+  // including `role: 'agent'` Portal browser/mobile sessions — which
+  // would otherwise appear here as opaque "Device <sessionId-prefix>"
+  // entries and confuse the user (they'd see their own phone's Portal
+  // tab listed as if it were a separate Crewly OSS). Portal sessions
+  // are a UI client, not a connected machine.
+  const uniqueDevices = useMemo(
+    () => filterToOrchestrators(deduplicateDevices(devices)),
+    [devices],
+  );
 
   return (
     <div className="bg-surface-dark border border-border-dark rounded-xl p-6 space-y-3" data-testid="cloud-device-list-section">


### PR DESCRIPTION
## Summary

User report: the OSS \`/cloud\` page lists 19 "Connected Devices" — but most of them are their own Portal browser/mobile sessions plus my curl-test sessions, not real machines. Specifically, the user pointed at \`Device 85b41885\` and asked "what is this extra device? — should only be OSS."

The Connected Devices list was rendering every entry from the relay's \`/devices\` endpoint — including \`role: 'agent'\` entries (Portal sessions). Those are UI clients, not connected machines, and confuse the user.

## Fix

Extract \`filterToOrchestrators(devices)\` and apply it after the dedup pass in \`uniqueDevices\`. The helper is exported so it can be unit-tested without spinning up the full CloudPortal render (which has additional cloud-connection gates around the device list section).

## Test plan

- [x] 3 new unit tests on \`filterToOrchestrators\`: mixed roles, no orchestrators, orchestrator-only no-op
- [x] Frontend builds (\`npm run build\` clean)
- [x] All 14 existing CloudPortal tests still pass
- [ ] Manual: restart OSS locally (or rebuild dist + hot-reload). \`/cloud\` should show only 2 devices (\`iriss-air.lan\`, \`macbookpro.lan\`); the user's mobile Portal session should no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)