### PR TITLE
fix(cloud-portal): identify OSS devices by deviceName, not self-declared role

### DIFF
--- a/frontend/src/pages/CloudPortal.test.tsx
+++ b/frontend/src/pages/CloudPortal.test.tsx
@@ -275,7 +275,7 @@ describe('CloudPortal', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2026-05-17 Connected-Devices role filter
+// 2026-05-17 Connected-Devices deviceName filter
 //
 // Exercising the filter via a full page render proved fragile (the
 // CloudPortal has additional cloud-connection gates around the device
@@ -283,11 +283,11 @@ describe('CloudPortal', () => {
 // directly is sharper and far more durable.
 // ---------------------------------------------------------------------------
 
-import { filterToOrchestrators } from './CloudPortal';
+import { filterToOssDevices } from './CloudPortal';
 import type { CloudDevice } from '../types/cloud.types';
 
-describe('filterToOrchestrators', () => {
-  it('keeps orchestrator-role entries and drops agent-role entries', () => {
+describe('filterToOssDevices', () => {
+  it('keeps entries that have a hostname (real OSS installations)', () => {
     const devices: CloudDevice[] = [
       { sessionId: 'oss-mac', deviceName: 'macbookpro.lan', role: 'orchestrator', state: 'paired' },
       { sessionId: 'oss-iris', deviceName: 'iriss-air.lan', role: 'orchestrator', state: 'paired' },
@@ -295,26 +295,40 @@ describe('filterToOrchestrators', () => {
       { sessionId: 'aad4cb2c', role: 'agent', state: 'paired' },
     ] as CloudDevice[];
 
-    const result = filterToOrchestrators(devices);
+    const result = filterToOssDevices(devices);
 
     expect(result).toHaveLength(2);
-    expect(result.map((d) => d.sessionId).sort()).toEqual(['oss-iris', 'oss-mac']);
+    expect(result.map((d) => d.deviceName).sort()).toEqual(['iriss-air.lan', 'macbookpro.lan']);
   });
 
-  it('returns an empty list when no orchestrators are present', () => {
+  it('drops entries that claim role=orchestrator but have no deviceName', () => {
+    // role is self-declared and unvalidated. A misbehaving client could
+    // register as `orchestrator` without a hostname — we still must not
+    // show it as if it were a real machine.
+    const devices: CloudDevice[] = [
+      { sessionId: 'fake-oss', role: 'orchestrator', state: 'paired' },
+      { sessionId: 'real-oss', deviceName: 'host.local', role: 'orchestrator', state: 'paired' },
+    ] as CloudDevice[];
+
+    const result = filterToOssDevices(devices);
+    expect(result.map((d) => d.sessionId)).toEqual(['real-oss']);
+  });
+
+  it('drops entries with an empty-string deviceName', () => {
+    const devices: CloudDevice[] = [
+      { sessionId: 'oss-empty', deviceName: '', role: 'orchestrator', state: 'paired' },
+      { sessionId: 'oss-named', deviceName: 'host.local', role: 'orchestrator', state: 'paired' },
+    ] as CloudDevice[];
+
+    expect(filterToOssDevices(devices).map((d) => d.sessionId)).toEqual(['oss-named']);
+  });
+
+  it('returns an empty list when no entry has a deviceName', () => {
     const devices: CloudDevice[] = [
       { sessionId: '85b41885', role: 'agent', state: 'waiting' },
       { sessionId: 'aad4cb2c', role: 'agent', state: 'paired' },
     ] as CloudDevice[];
 
-    expect(filterToOrchestrators(devices)).toEqual([]);
-  });
-
-  it('is a no-op for an already-pure orchestrator list', () => {
-    const devices: CloudDevice[] = [
-      { sessionId: 'oss-1', deviceName: 'host-a.local', role: 'orchestrator', state: 'paired' },
-    ] as CloudDevice[];
-
-    expect(filterToOrchestrators(devices)).toEqual(devices);
+    expect(filterToOssDevices(devices)).toEqual([]);
   });
 });

--- a/frontend/src/pages/CloudPortal.tsx
+++ b/frontend/src/pages/CloudPortal.tsx
@@ -159,22 +159,29 @@ const DEVICE_STATE_COLORS: Record<string, string> = {
  * @returns Deduplicated device list
  */
 /**
- * Filter a relay device list down to OSS-class entries.
+ * Filter a relay device list down to "real machine" entries.
  *
  * The relay's `/devices` endpoint returns every session registered for
- * the user — including `role: 'agent'` Portal browser/mobile sessions.
- * Those are UI clients, not connected machines, and should not appear
- * in the "Connected Devices" list (a user shouldn't see their own phone
- * tab listed as if it were a separate Crewly OSS).
+ * the user — including Portal browser/mobile sessions, which are UI
+ * clients rather than connected machines. We want only the latter.
  *
- * Exported so the role filter can be unit-tested directly without
- * spinning up the full CloudPortal page render.
+ * We key off `deviceName` (the OS hostname) rather than `role`:
+ * `role` is self-declared at register time by the client and isn't
+ * validated by the relay, so it's a soft signal at best. `deviceName`
+ * is only set by clients that actually run on a host with a hostname
+ * — i.e., the Crewly OSS daemon. Portal browsers never set it because
+ * browsers don't know the machine's hostname. That makes
+ * "deviceName is present" the most truthful signal that a row
+ * represents a real OSS installation worth showing in this list.
  *
- * @param devices - Raw device list (possibly mixed roles)
- * @returns Only entries whose `role` is `'orchestrator'`
+ * Exported so the filter can be unit-tested directly without spinning
+ * up the full CloudPortal page render.
+ *
+ * @param devices - Raw device list from `/api/cloud/devices`
+ * @returns Only entries with a non-empty `deviceName`
  */
-export function filterToOrchestrators(devices: CloudDevice[]): CloudDevice[] {
-  return devices.filter((d) => d.role === 'orchestrator');
+export function filterToOssDevices(devices: CloudDevice[]): CloudDevice[] {
+  return devices.filter((d) => typeof d.deviceName === 'string' && d.deviceName.length > 0);
 }
 
 function deduplicateDevices(devices: CloudDevice[]): CloudDevice[] {
@@ -341,15 +348,11 @@ const DeviceListSection: React.FC = () => {
     fetchDevices();
   }, [fetchDevices]);
 
-  // Only show OSS-class devices in the "Connected Devices" list. The
-  // relay's `/devices` endpoint returns every session for the user —
-  // including `role: 'agent'` Portal browser/mobile sessions — which
-  // would otherwise appear here as opaque "Device <sessionId-prefix>"
-  // entries and confuse the user (they'd see their own phone's Portal
-  // tab listed as if it were a separate Crewly OSS). Portal sessions
-  // are a UI client, not a connected machine.
+  // Only show entries that represent a real machine (have a hostname).
+  // See `filterToOssDevices` for why we key off `deviceName` rather
+  // than the client-self-declared `role`.
   const uniqueDevices = useMemo(
-    () => filterToOrchestrators(deduplicateDevices(devices)),
+    () => filterToOssDevices(deduplicateDevices(devices)),
     [devices],
   );
 


### PR DESCRIPTION
## Summary

Follow-up to #594. User pointed out that filtering by \`role === 'orchestrator'\` is fragile: \`role\` is a self-declared field set by the client at register time and the relay doesn't validate it. A misbehaving client could register as \`orchestrator\` and pass the check without actually being a real machine.

\`deviceName\` (OS hostname) is a stronger signal — only clients that actually run on a host with a hostname populate it. The OSS daemon reads the hostname at startup; Portal browsers never set it (browsers don't have hostname access). So "deviceName is present" maps directly to "this row is a Crewly OSS installation worth showing".

## Changes

- Rename \`filterToOrchestrators\` → \`filterToOssDevices\`
- Filter logic: \`typeof d.deviceName === 'string' && d.deviceName.length > 0\`
- Tests extended: now covers the "orchestrator-without-deviceName must NOT show up" case (which the role-only filter would have let through), the empty-string case, and the no-deviceName all-empty case.

## Test plan

- [x] 4 new \`filterToOssDevices\` unit tests pass
- [x] All 14 existing CloudPortal tests still pass
- [x] Frontend builds clean
- [ ] Manual: restart OSS locally, refresh \`/cloud\` — should show only \`macbookpro.lan\` + \`iriss-air.lan\`, no opaque \`Device xxxx\` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)