### PR TITLE
fix(cloud-sync): don't synthesize a fake deviceName, defeats the frontend filter

### DIFF
--- a/backend/src/services/cloud/cloud-sync.service.test.ts
+++ b/backend/src/services/cloud/cloud-sync.service.test.ts
@@ -270,6 +270,42 @@ describe('CloudSyncService', () => {
       expect(devices).toHaveLength(1);
       expect(devices[0].lastHeartbeatAt).toBe(newer);
     });
+
+    // -------------------------------------------------------------------------
+    // 2026-05-17 — Don't synthesize a fake deviceName.
+    //
+    // The frontend Connected-Devices filter relies on `deviceName`
+    // being present to distinguish real OSS installations from Portal
+    // browser sessions. If we fill in `Device ${prefix}` here when the
+    // upstream is empty, every Portal session shows up as a fake
+    // machine row. Leave it undefined and let the device card render
+    // its own display-time fallback.
+    // -------------------------------------------------------------------------
+
+    it('does NOT synthesize a deviceName when the upstream entry has none', async () => {
+      mockFetch.mockResolvedValue(
+        mockResponse({
+          success: true,
+          devices: [
+            // Real OSS row — has hostname
+            { deviceId: 'oss-mac', deviceName: 'macbookpro.lan', status: 'online' },
+            // Portal session row — no deviceName, no name field
+            { deviceId: '85b41885-portal', sessionId: '85b41885-portal', status: 'online' },
+          ],
+        })
+      );
+
+      service.start(testConfig);
+      await flushPromises();
+
+      const devices = service.getDevices();
+      const oss = devices.find((d) => d.deviceId === 'oss-mac');
+      const portal = devices.find((d) => d.deviceId === '85b41885-portal');
+
+      expect(oss?.deviceName).toBe('macbookpro.lan');
+      // Crucial: the portal row stays `undefined`, not `Device 85b41885`.
+      expect(portal?.deviceName).toBeUndefined();
+    });
   });
 
   // ----- sendMessage --------------------------------------------------------

--- a/backend/src/services/cloud/cloud-sync.service.ts
+++ b/backend/src/services/cloud/cloud-sync.service.ts
@@ -660,9 +660,18 @@ export class CloudSyncService extends EventEmitter {
           d.state === 'waiting' ||
           (now - new Date(lastSeen).getTime() <= offlineThreshold);
 
+        // IMPORTANT: don't synthesize a fake `deviceName` like
+        // `Device ${prefix}` when the upstream is missing one. The
+        // frontend's Connected-Devices filter keys off whether
+        // `deviceName` is a real hostname to distinguish Crewly OSS
+        // installations (which always set it) from Portal browser
+        // sessions (which can't — browsers don't have a hostname).
+        // A synthesized placeholder defeats that filter and surfaces
+        // Portal sessions as fake "Device 85b41885" rows. The device
+        // card UI has its own display-time fallback for missing names.
         return {
           deviceId,
-          deviceName: d.deviceName || d.name || `Device ${deviceId.slice(0, 8)}`,
+          deviceName: d.deviceName || d.name || undefined,
           status: isOnline ? 'online' as const : 'offline' as const,
           lastHeartbeatAt: lastSeen,
           isLocal: deviceId === this.config!.deviceId,


### PR DESCRIPTION
## Summary

Follow-up to #594 / #595. Even after the frontend filter shipped, the user's \`/cloud\` page still showed \`Device 85b41885\` — their mobile Portal session — as if it were a connected machine.

Root cause: \`cloud-sync.service.ts:665\` was coalescing missing \`deviceName\` into \`Device \${deviceId.slice(0, 8)}\`. So a Portal browser session that never reports a hostname came out of the polldevices mapper looking like a real machine, and the frontend's "filter rows that have a non-empty deviceName" check let it through.

## Fix

Drop the synthesized fallback. \`deviceName\` stays \`undefined\` when the upstream relay row didn't supply one.

\`DeviceCard\` already has its own display-time fallback (\`role (sessionId-prefix...)\`) for the edge case where a real OSS row arrives without a name — so the UI degrades gracefully and the data-vs-display concerns are properly separated.

## Test plan

- [x] New unit test \`does NOT synthesize a deviceName when the upstream entry has none\` — passes
- [x] All 38 other tests still pass (12 pre-existing failures on \`main\` are unrelated)
- [ ] Manual: restart OSS, refresh \`/cloud\` — \`Device 85b41885\` should disappear, only \`macbookpro.lan\` + \`iriss-air.lan\` remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)