### PR TITLE
feat(chat-v2): huddle channel type + broadcast dispatcher (Phase 2 backend)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1316,6 +1316,12 @@ export class CrewlyServer {
 				const chatDispatcher = new ChatV2DispatcherService({
 					agentSink: this.apiController.agentRegistrationService,
 					mentionResolver: chatMentionResolver,
+					// Phase B-2 — huddle roster lookup. ChatV2Service owns
+					// the chat_channel_members table; the dispatcher just
+					// needs the list of session names for a given channel
+					// to fan-out a user message to every huddle member.
+					huddleMembersFor: (channelId) =>
+						chatService.queryHuddleMembersForDispatch(channelId),
 				});
 				this.chatV2Gateway = chatGateway;
 				this.chatV2Dispatcher = chatDispatcher;

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -494,5 +494,151 @@ describe('ChatV2DispatcherService', () => {
         expect(capturedCtx).toEqual({ teamId: 'team-product' });
       });
     });
+
+    // ----------------------------------------------------------------
+    // Phase B-2 (2026-05-17) — huddle broadcast.
+    // ----------------------------------------------------------------
+
+    describe('huddle broadcast', () => {
+      /** Build a `type='huddle'` channel DTO fixture. */
+      function makeHuddle(overrides: Partial<ChatChannelDTO> = {}): ChatChannelDTO {
+        return {
+          id: 'huddle-1',
+          agentSession: '',
+          name: 'Q4 planning',
+          createdAt: 1,
+          archivedAt: null,
+          lastMessageAt: null,
+          agentPresence: { status: 'online', lastSeenAt: null },
+          type: 'huddle',
+          ...overrides,
+        };
+      }
+
+      it('skips when no huddleMembersFor resolver is wired', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({ agentSink: sink });
+
+        const result = await dispatcher.dispatchMessage(
+          makeHuddle(),
+          makeMessage({ mentions: [] }),
+        );
+
+        expect(result.strategy).toBe('skip');
+        expect(result.dispatched).toBe(false);
+        expect(result.reason).toMatch(/huddleMembersFor/);
+        expect(calls).toHaveLength(0);
+      });
+
+      it('skips when the roster is empty', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          huddleMembersFor: () => [],
+        });
+
+        const result = await dispatcher.dispatchMessage(makeHuddle(), makeMessage());
+        expect(result.strategy).toBe('skip');
+        expect(result.reason).toMatch(/no members/);
+        expect(calls).toHaveLength(0);
+      });
+
+      it('broadcasts to EVERY member regardless of mentions', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const members = ['sess-a', 'sess-b', 'sess-c'];
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          huddleMembersFor: () => members,
+        });
+
+        const result = await dispatcher.dispatchMessage(
+          makeHuddle(),
+          makeMessage({ mentions: [] }), // nobody @-mentioned
+        );
+
+        expect(result.strategy).toBe('huddle-broadcast');
+        expect(result.dispatched).toBe(true);
+        expect(result.huddleOutcomes).toHaveLength(3);
+        expect(calls.map((c) => c.sessionName).sort()).toEqual(['sess-a', 'sess-b', 'sess-c']);
+        // No one was @-mentioned → everyone is responseMode='optional'.
+        for (const o of result.huddleOutcomes!) {
+          expect(o.responseMode).toBe('optional');
+          expect(o.dispatched).toBe(true);
+        }
+      });
+
+      it('marks @-mentioned members as response-required, others as optional', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const members = ['sess-a', 'sess-b', 'sess-c'];
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          huddleMembersFor: () => members,
+        });
+
+        const result = await dispatcher.dispatchMessage(
+          makeHuddle(),
+          makeMessage({ mentions: ['sess-b'] }),
+        );
+
+        expect(result.strategy).toBe('huddle-broadcast');
+        const byMember = new Map(result.huddleOutcomes!.map((o) => [o.sessionName, o]));
+        expect(byMember.get('sess-b')!.responseMode).toBe('required');
+        expect(byMember.get('sess-a')!.responseMode).toBe('optional');
+        expect(byMember.get('sess-c')!.responseMode).toBe('optional');
+
+        // Prompt body for sess-b uses the "required" reply hint;
+        // sess-a/c use the "optional" hint.
+        const calledForB = calls.find((c) => c.sessionName === 'sess-b')!;
+        expect(calledForB.message).toContain('reply-channel');
+        expect(calledForB.message).not.toMatch(/否则不回复也可以/);
+
+        const calledForA = calls.find((c) => c.sessionName === 'sess-a')!;
+        expect(calledForA.message).toMatch(/否则不回复也可以/);
+      });
+
+      it('captures per-member sink failures without short-circuiting the rest', async () => {
+        let n = 0;
+        const sink: AgentMessageSink = {
+          async sendMessageToAgent(sessionName) {
+            n += 1;
+            if (sessionName === 'sess-b') {
+              return { success: false, error: 'PTY closed' };
+            }
+            return { success: true };
+          },
+        };
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          huddleMembersFor: () => ['sess-a', 'sess-b', 'sess-c'],
+        });
+
+        const result = await dispatcher.dispatchMessage(makeHuddle(), makeMessage());
+        expect(result.strategy).toBe('huddle-broadcast');
+        // Even though sess-b failed, sess-a and sess-c were attempted.
+        expect(n).toBe(3);
+        // At least one succeeded → dispatched=true.
+        expect(result.dispatched).toBe(true);
+        const failed = result.huddleOutcomes!.filter((o) => !o.dispatched);
+        expect(failed).toHaveLength(1);
+        expect(failed[0].sessionName).toBe('sess-b');
+        expect(failed[0].error).toContain('PTY closed');
+      });
+
+      it('skips agent-origin messages (no self-loopback)', async () => {
+        const { sink, calls } = makeSink({ success: true });
+        const dispatcher = new ChatV2DispatcherService({
+          agentSink: sink,
+          huddleMembersFor: () => ['sess-a', 'sess-b'],
+        });
+
+        const result = await dispatcher.dispatchMessage(
+          makeHuddle(),
+          makeMessage({ senderType: 'agent', senderId: 'sess-a' }),
+        );
+        expect(result.strategy).toBe('skip');
+        expect(result.reason).toMatch(/not a user-origin/);
+        expect(calls).toHaveLength(0);
+      });
+    });
   });
 });

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
@@ -63,6 +63,29 @@ export interface MentionDispatchOutcome {
 }
 
 /**
+ * Phase B-2 (2026-05-17) — one per-member outcome for huddle dispatch.
+ *
+ * Huddles don't go through `MentionResolver` — their roster is read
+ * directly from `chat_channel_members`. The outcome records whether
+ * the member was @-mentioned (which controls `responseMode` in the
+ * prompt) and whether the underlying sink call succeeded.
+ */
+export interface HuddleDispatchOutcome {
+  /** Member's agent session name. */
+  sessionName: string;
+  /**
+   * `'required'` when the member appeared in `message.mentions[]`
+   * (they MUST reply); `'optional'` otherwise (they MAY reply if it
+   * makes sense). Surfaced in the formatted prompt.
+   */
+  responseMode: 'required' | 'optional';
+  /** Whether the prompt was successfully queued for the member. */
+  dispatched: boolean;
+  /** Error message, if delivery failed. */
+  error?: string;
+}
+
+/**
  * Aggregate result of `dispatchMessage`. Reports the chosen routing
  * strategy and per-recipient outcomes so callers (and tests) can assert
  * exactly what fan-out happened without re-running the resolver.
@@ -75,7 +98,7 @@ export interface DispatchMessageResult {
    * - `'skip'`: nothing was dispatched (non-user message, no recipients,
    *   archived/unbound channel, etc.). `reason` is filled.
    */
-  strategy: 'dm' | 'channel-mentions' | 'skip';
+  strategy: 'dm' | 'channel-mentions' | 'huddle-broadcast' | 'skip';
   /** True when at least one underlying delivery succeeded. */
   dispatched: boolean;
   /** Filled when `strategy === 'skip'`. */
@@ -87,6 +110,12 @@ export interface DispatchMessageResult {
    * resolved target. Empty when no mentions resolved.
    */
   mentionOutcomes?: MentionDispatchOutcome[];
+  /**
+   * Phase B-2 — populated for `strategy === 'huddle-broadcast'`. One
+   * entry per huddle member. Mentioned members carry
+   * `responseMode: 'required'`; the rest are `'optional'`.
+   */
+  huddleOutcomes?: HuddleDispatchOutcome[];
 }
 
 /** Constructor options for {@link ChatV2DispatcherService}. */
@@ -106,6 +135,17 @@ export interface ChatV2DispatcherOptions {
    * by `StorageService.getTeams()`.
    */
   mentionResolver?: ChatV2MentionResolver;
+  /**
+   * Phase B-2 (2026-05-17) — roster lookup used when dispatching a
+   * `type='huddle'` message to every member. Synchronous because the
+   * production implementation is a direct SQLite read against
+   * `chat_channel_members`. When omitted, huddle messages skip
+   * dispatch (mirrors how `mentionResolver` gates `'channel'` rows).
+   *
+   * Returns the list of `agentSession` ids for the huddle's members.
+   * Order doesn't matter — the dispatcher loops over the whole list.
+   */
+  huddleMembersFor?: (channelId: string) => readonly string[];
 }
 
 /** Inputs to the prompt formatter. */
@@ -116,6 +156,15 @@ export interface FormatPromptArgs {
   senderId: string;
   content: string;
   clientMessageId?: string;
+  /**
+   * Phase B-2 — in a huddle, every member receives the prompt but
+   * only the @-mentioned ones MUST reply. The default formatter
+   * appends a "你必须回复" (mandatory) or "你可以选择是否回复" (optional)
+   * tag so the agent's prompt-following heuristics can branch. Defaults
+   * to `'required'` for DMs and `'channel'` (single-mention) dispatches
+   * where every recipient was explicitly addressed.
+   */
+  responseMode?: 'required' | 'optional';
 }
 
 // ---------------------------------------------------------------------------
@@ -132,16 +181,23 @@ export interface FormatPromptArgs {
  * instruction on how to reply.
  */
 export function defaultFormatPrompt(args: FormatPromptArgs): string {
-  const { channelId, channelName, senderId, content, clientMessageId } = args;
+  const { channelId, channelName, senderId, content, clientMessageId, responseMode } = args;
   const trimmed = content.trim();
   const idHint = clientMessageId ? ` [cmid:${clientMessageId}]` : '';
+  // Default to "required" so DM and single-mention channel dispatches
+  // preserve the legacy "must reply" semantic. Only huddles flip this
+  // to "optional" for non-@'d members.
+  const mode = responseMode ?? 'required';
+  const replyHint = mode === 'optional'
+    ? `回复本频道: 你在此 huddle 中收到此消息但未被 @ — 如有必要可用 \`reply-channel\` skill (channelId="${channelId}") 回复，否则不回复也可以。`
+    : `回复本频道: 用 \`reply-channel\` skill, 参数 channelId="${channelId}"、content="<your reply>"。`;
   return [
     `[CHAT:${channelId}]${idHint} <${senderId}@${channelName}>`,
     ``,
     trimmed,
     ``,
     `---`,
-    `回复本频道: 用 \`reply-channel\` skill, 参数 channelId="${channelId}"、content="<your reply>"。`,
+    replyHint,
   ].join('\n');
 }
 
@@ -158,12 +214,14 @@ export class ChatV2DispatcherService {
   private readonly agentSink: AgentMessageSink;
   private readonly formatPrompt: (args: FormatPromptArgs) => string;
   private readonly mentionResolver?: ChatV2MentionResolver;
+  private readonly huddleMembersFor?: (channelId: string) => readonly string[];
   private readonly logger: ComponentLogger;
 
   constructor(options: ChatV2DispatcherOptions) {
     this.agentSink = options.agentSink;
     this.formatPrompt = options.formatPrompt ?? defaultFormatPrompt;
     this.mentionResolver = options.mentionResolver;
+    this.huddleMembersFor = options.huddleMembersFor;
     this.logger = LoggerService.getInstance().createComponentLogger('ChatV2Dispatcher');
   }
 
@@ -204,6 +262,10 @@ export class ChatV2DispatcherService {
       return this.dispatchChannelMentions(channel, message);
     }
 
+    if (channel.type === 'huddle') {
+      return this.dispatchHuddleBroadcast(channel, message);
+    }
+
     // Default to the DM path for any other type (including legacy /
     // missing — `type` is non-null after Phase A migration but defensive
     // here keeps the dispatcher robust).
@@ -212,6 +274,110 @@ export class ChatV2DispatcherService {
       strategy: 'dm',
       dispatched: dmResult.dispatched,
       dmResult,
+    };
+  }
+
+  /**
+   * Phase B-2 — fan a user message out to every member of a huddle.
+   *
+   * Resolution path:
+   *   1. Look up the roster via the injected `huddleMembersFor`. No
+   *      resolver wired → return `strategy: 'skip'` (the message still
+   *      persists; nobody is paged).
+   *   2. Empty roster → same skip path. Should not happen since
+   *      `createHuddle` rejects empty membership, but defensive.
+   *   3. For each member, derive `responseMode` from whether their
+   *      session appears in `message.mentions[]`. Format the prompt
+   *      accordingly and call `sendMessageToAgent`.
+   *
+   * Always resolves; per-member errors are captured in
+   * {@link DispatchMessageResult.huddleOutcomes} and never thrown.
+   *
+   * @param channel - The huddle channel.
+   * @param message - The persisted user message.
+   * @returns Aggregate result with one outcome per member.
+   */
+  private async dispatchHuddleBroadcast(
+    channel: ChatChannelDTO,
+    message: ChatMessageDTO,
+  ): Promise<DispatchMessageResult> {
+    if (!this.huddleMembersFor) {
+      this.logger.debug('chat-v2 huddle dispatch skipped — no roster lookup wired', {
+        channelId: channel.id,
+        messageId: message.id,
+      });
+      return {
+        strategy: 'skip',
+        dispatched: false,
+        reason: 'no huddleMembersFor resolver wired',
+      };
+    }
+
+    const members = this.huddleMembersFor(channel.id);
+    if (members.length === 0) {
+      return {
+        strategy: 'skip',
+        dispatched: false,
+        reason: 'huddle has no members',
+      };
+    }
+
+    // Pre-build the mention set so each member lookup is O(1). The
+    // wire mention is the agent session id (same shape as the roster
+    // entries) so a simple Set membership check is enough.
+    const mentioned = new Set(Array.isArray(message.mentions) ? message.mentions : []);
+
+    const outcomes: HuddleDispatchOutcome[] = [];
+    let anyDispatched = false;
+
+    for (const sessionName of members) {
+      const responseMode: 'required' | 'optional' = mentioned.has(sessionName) ? 'required' : 'optional';
+      const prompt = this.formatPrompt({
+        channelId: channel.id,
+        channelName: channel.name,
+        agentSession: sessionName,
+        senderId: message.senderId,
+        content: message.content,
+        clientMessageId:
+          typeof message.metadata?.clientMessageId === 'string'
+            ? (message.metadata.clientMessageId as string)
+            : undefined,
+        responseMode,
+      });
+
+      try {
+        const result = await this.agentSink.sendMessageToAgent(sessionName, prompt);
+        if (result.success) {
+          outcomes.push({ sessionName, responseMode, dispatched: true });
+          anyDispatched = true;
+        } else {
+          this.logger.warn('chat-v2 huddle dispatch reported failure', {
+            channelId: channel.id,
+            sessionName,
+            err: result.error,
+          });
+          outcomes.push({
+            sessionName,
+            responseMode,
+            dispatched: false,
+            error: result.error ?? 'unknown sink failure',
+          });
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        this.logger.error('chat-v2 huddle dispatch threw', {
+          channelId: channel.id,
+          sessionName,
+          err: errMsg,
+        });
+        outcomes.push({ sessionName, responseMode, dispatched: false, error: errMsg });
+      }
+    }
+
+    return {
+      strategy: 'huddle-broadcast',
+      dispatched: anyDispatched,
+      huddleOutcomes: outcomes,
     };
   }
 

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -1664,4 +1664,110 @@ describe('ChatV2Service', () => {
       expect(service.countChannelMessages(ch.id, owner)).toBe(2);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Phase B-2 (2026-05-17): createHuddle + listHuddleMembers + queryHuddleMembersForDispatch
+  // ---------------------------------------------------------------------------
+
+  describe('createHuddle', () => {
+    it('creates a type=huddle channel with the given roster', () => {
+      const dto = service.createHuddle({
+        name: 'Q4 planning',
+        memberSessions: ['sess-a', 'sess-b', 'sess-c'],
+        principal: owner,
+      });
+
+      expect(dto.type).toBe('huddle');
+      expect(dto.name).toBe('Q4 planning');
+      expect(dto.agentSession).toBe(''); // huddle is not 1:1-bound
+      expect(dto.teamId).toBeUndefined();
+      expect(dto.members?.map((m) => m.sessionName).sort()).toEqual(['sess-a', 'sess-b', 'sess-c']);
+      for (const m of dto.members!) {
+        expect(m.joinedAt).toBe(1000); // matches the test clock
+      }
+    });
+
+    it('dedupes and trims member sessions', () => {
+      const dto = service.createHuddle({
+        name: 'Dupes',
+        memberSessions: [' sess-a ', 'sess-a', 'sess-b', '', '   '],
+        principal: owner,
+      });
+      expect(dto.members?.map((m) => m.sessionName).sort()).toEqual(['sess-a', 'sess-b']);
+    });
+
+    it('rejects empty membership', () => {
+      expect(() =>
+        service.createHuddle({ name: 'Empty', memberSessions: [], principal: owner }),
+      ).toThrow(/at least one agent session/);
+      expect(() =>
+        service.createHuddle({ name: 'Whitespace', memberSessions: ['  ', ''], principal: owner }),
+      ).toThrow(/at least one agent session/);
+    });
+
+    it('rejects blank name', () => {
+      expect(() =>
+        service.createHuddle({ name: '   ', memberSessions: ['sess-a'], principal: owner }),
+      ).toThrow(/name is required/);
+    });
+
+    it('caps the roster size to 50', () => {
+      const fifty = Array.from({ length: 50 }, (_, i) => `sess-${i}`);
+      // 50 is fine
+      expect(() =>
+        service.createHuddle({ name: 'Big', memberSessions: fifty, principal: owner }),
+      ).not.toThrow();
+      // 51 throws
+      expect(() =>
+        service.createHuddle({
+          name: 'Bigger',
+          memberSessions: [...fifty, 'sess-51'],
+          principal: owner,
+        }),
+      ).toThrow(/50-member cap/);
+    });
+  });
+
+  describe('listHuddleMembers', () => {
+    it('returns the roster ordered by joined_at ASC', () => {
+      const huddle = service.createHuddle({
+        name: 'h',
+        memberSessions: ['sess-a', 'sess-b', 'sess-c'],
+        principal: owner,
+      });
+      const members = service.listHuddleMembers(huddle.id, owner);
+      expect(members.map((m) => m.sessionName).sort()).toEqual(['sess-a', 'sess-b', 'sess-c']);
+    });
+
+    it('returns an empty array for a non-huddle channel (instead of throwing)', () => {
+      const dm = createSam();
+      expect(service.listHuddleMembers(dm.id, owner)).toEqual([]);
+    });
+
+    it('refuses to expose a huddle owned by a different user', () => {
+      const huddle = service.createHuddle({
+        name: 'h',
+        memberSessions: ['sess-a'],
+        principal: owner,
+      });
+      expect(() => service.listHuddleMembers(huddle.id, otherUser)).toThrow();
+    });
+  });
+
+  describe('queryHuddleMembersForDispatch', () => {
+    it('returns just the session names (dispatcher-shaped)', () => {
+      const huddle = service.createHuddle({
+        name: 'h',
+        memberSessions: ['sess-a', 'sess-b'],
+        principal: owner,
+      });
+      const sessions = service.queryHuddleMembersForDispatch(huddle.id);
+      expect(sessions.sort()).toEqual(['sess-a', 'sess-b']);
+    });
+
+    it('returns empty for non-huddle channels', () => {
+      const dm = createSam();
+      expect(service.queryHuddleMembersForDispatch(dm.id)).toEqual([]);
+    });
+  });
 });

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -26,6 +26,7 @@ import {
   type ChatChannelRow,
   type ChatChannelType,
   type ChatContentType,
+  type ChatHuddleMember,
   type ChatMessageDTO,
   type ChatMessageListResult,
   type ChatMessageRow,
@@ -106,6 +107,23 @@ export interface CreateChannelArgs {
   projectId?: string;
   /** Phase A — optional when `type='dm'`. */
   targetMemberId?: string;
+}
+
+/** Arguments for `createHuddle` (Phase B-2). */
+export interface CreateHuddleArgs {
+  /** Display name shown in the channel list (e.g. "Q4 planning"). */
+  name: string;
+  /** Optional one-liner — purpose of the huddle. */
+  purpose?: string;
+  /**
+   * Agent session names (matches `DirectoryAgent.agentSession`) for
+   * every member of the huddle. Must contain at least one entry; the
+   * service rejects empty arrays so the dispatcher never has zero
+   * recipients to fan out to. Order is not significant — the store
+   * dedupes on insert.
+   */
+  memberSessions: string[];
+  principal: ChatPrincipal;
 }
 
 /** Arguments for `listChannels`. */
@@ -483,6 +501,150 @@ export class ChatV2Service extends EventEmitter {
       nowMs: this.now(),
     });
     return this.toChannelDTO(row);
+  }
+
+  /**
+   * Phase B-2 (2026-05-17) — create a huddle (ad-hoc multi-agent group
+   * channel). Creates a `type='huddle'` channel row with no team
+   * binding, then inserts one row per member into
+   * `chat_channel_members`. The dispatcher uses that roster to fan out
+   * subsequent user messages to every member; agents whose session is
+   * in the outgoing message's `mentions[]` get a "must respond"
+   * prompt, others get an "optional" one.
+   *
+   * @param args - name, optional purpose, member roster, owning principal
+   * @returns The created huddle channel as a DTO, with `members` populated
+   * @throws {ChatError} `validation_error` (400) when name is empty/too long,
+   *   purpose too long, or memberSessions is empty / has too many entries.
+   */
+  createHuddle(args: CreateHuddleArgs): ChatChannelDTO {
+    const name = (args.name ?? '').trim();
+    if (name.length === 0) {
+      throw new ChatError(CHAT_ERROR_CODES.VALIDATION, 400, 'name is required');
+    }
+    if (name.length > this.config.maxChannelNameChars) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `name exceeds ${this.config.maxChannelNameChars} characters`,
+      );
+    }
+    const purpose = args.purpose?.trim();
+    if (purpose && purpose.length > this.config.maxPurposeChars) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `purpose exceeds ${this.config.maxPurposeChars} characters`,
+      );
+    }
+
+    // Dedupe + trim member sessions. We accept any non-empty trimmed
+    // string here — actual agent existence is validated by the
+    // dispatcher when it tries to resolve the session at fan-out time.
+    const seen = new Set<string>();
+    const members: string[] = [];
+    for (const raw of args.memberSessions ?? []) {
+      const s = (raw ?? '').trim();
+      if (!s) continue;
+      if (seen.has(s)) continue;
+      seen.add(s);
+      members.push(s);
+    }
+    if (members.length === 0) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        'memberSessions must include at least one agent session',
+      );
+    }
+    // Defensive upper bound — a 200-member huddle would tax both the
+    // dispatcher fan-out and downstream rate limits. The cap can be
+    // raised when we have a real use case.
+    const MAX_HUDDLE_MEMBERS = 50;
+    if (members.length > MAX_HUDDLE_MEMBERS) {
+      throw new ChatError(
+        CHAT_ERROR_CODES.VALIDATION,
+        400,
+        `huddle exceeds the ${MAX_HUDDLE_MEMBERS}-member cap`,
+      );
+    }
+
+    const nowMs = this.now();
+    const row = this.channels.create({
+      // Huddle isn't 1:1-bound — keep agent_session empty (same convention
+      // as type='channel'). No team_id either: huddles are ad-hoc groups,
+      // not team-scoped surfaces.
+      agentSession: '',
+      ownerUserId: args.principal.userId,
+      name,
+      purpose: purpose || null,
+      type: 'huddle',
+      teamId: null,
+      projectId: null,
+      targetMemberId: null,
+      nowMs,
+    });
+
+    // Insert membership rows. INSERT OR IGNORE is defensive against the
+    // dedupe above getting bypassed (e.g., when callers reuse this
+    // method via the relay adapter with raw input).
+    const memberStmt = this.db.prepare(
+      `INSERT OR IGNORE INTO chat_channel_members
+         (channel_id, member_session, joined_at)
+       VALUES (?, ?, ?)`,
+    );
+    const insertMany = this.db.transaction((rows: string[]) => {
+      for (const s of rows) memberStmt.run(row.id, s, nowMs);
+    });
+    insertMany(members);
+
+    return this.toChannelDTO(row);
+  }
+
+  /**
+   * Phase B-2 — list the members of a huddle channel. Returns an empty
+   * array (not an error) for non-huddle channels so consumers can call
+   * this unconditionally during channel rendering.
+   *
+   * @param channelId - The channel to enumerate
+   * @param principal - The caller; used to verify ownership
+   * @returns Array of `{ sessionName, joinedAt }` rows
+   * @throws {ChatError} `not_found` (404) when the channel doesn't exist or
+   *   isn't owned by `principal`.
+   */
+  listHuddleMembers(channelId: string, principal: ChatPrincipal): ChatHuddleMember[] {
+    const row = this.requireOwnedChannel(channelId, principal);
+    if (row.type !== 'huddle') return [];
+    return this.queryHuddleMembers(channelId);
+  }
+
+  /**
+   * Phase B-2 — dispatcher-facing roster lookup. Returns the session
+   * names of every member in a huddle, in `joined_at ASC` order.
+   * Unlike {@link listHuddleMembers} this is NOT principal-scoped:
+   * the dispatcher runs server-side and already holds the channel
+   * (it just persisted a message into it). Returns an empty array for
+   * non-huddle channels or unknown ids so the dispatcher's
+   * `members.length === 0` skip path stays clean.
+   *
+   * @param channelId - The huddle channel id
+   * @returns Array of agent session names
+   */
+  queryHuddleMembersForDispatch(channelId: string): string[] {
+    return this.queryHuddleMembers(channelId).map((m) => m.sessionName);
+  }
+
+  /** Internal: read members straight from the DB (no ownership check). */
+  private queryHuddleMembers(channelId: string): ChatHuddleMember[] {
+    const rows = this.db
+      .prepare(
+        `SELECT member_session AS sessionName, joined_at AS joinedAt
+           FROM chat_channel_members
+          WHERE channel_id = ?
+          ORDER BY joined_at ASC`,
+      )
+      .all(channelId) as Array<{ sessionName: string; joinedAt: number }>;
+    return rows.map((r) => ({ sessionName: r.sessionName, joinedAt: r.joinedAt }));
   }
 
   /**
@@ -1319,6 +1481,12 @@ export class ChatV2Service extends EventEmitter {
       teamId: row.team_id ?? undefined,
       projectId: row.project_id ?? undefined,
       targetMemberId: row.target_member_id ?? undefined,
+      // Phase B-2: huddle channels surface their roster inline so the
+      // Portal can render member avatars without a second round-trip.
+      // Non-huddle rows leave this undefined.
+      ...(channelType === 'huddle'
+        ? { members: this.queryHuddleMembers(row.id) }
+        : {}),
     };
   }
 

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -157,9 +157,27 @@ export interface SendMessageArgs {
   /** Attachment hooks — the store is added in a later step, so pre-resolved DTOs are accepted. */
   attachments?: ChatAttachmentDTO[];
   /**
-   * Phase A (SEALED §3.2) — array of mention IDs (member or team)
-   * referenced inline in `content`. Persisted as JSON; emitted on the
-   * outbound message DTO. Empty / omitted → no mentions.
+   * Phase A (SEALED §3.2) — array of mention IDs referenced inline in
+   * `content`. Persisted as JSON; emitted on the outbound message DTO.
+   * Empty / omitted → no mentions.
+   *
+   * **Wire-shape varies by channel type — callers must pass the right
+   * one for the channel they're posting to:**
+   *
+   * - `type='channel'`: each entry is a **member id** or **team id**.
+   *   The dispatcher routes these through `ChatV2MentionResolver` to
+   *   look up the matching session name(s).
+   *
+   * - `type='huddle'`: each entry is an **agent session name** (the
+   *   same shape that goes into `chat_channel_members.member_session`).
+   *   The dispatcher does NOT run them through the resolver — they're
+   *   matched directly against the huddle roster to set per-recipient
+   *   `responseMode` (`'required'` for mentioned members, `'optional'`
+   *   otherwise).
+   *
+   * - `type='dm'`: mentions are advisory only — DMs have a single
+   *   recipient already, and the dispatcher doesn't re-route based on
+   *   mentions.
    */
   mentions?: string[];
   /**

--- a/backend/src/services/chat-v2/sqlite/chat-db.test.ts
+++ b/backend/src/services/chat-v2/sqlite/chat-db.test.ts
@@ -332,6 +332,122 @@ describe('openChatDatabase', () => {
       }
     });
 
+    // -------------------------------------------------------------------------
+    // Phase B-2 (2026-05-17) — chat_channels CHECK rebuild safety.
+    //
+    // The chat_channels.type CHECK constraint originally listed only
+    // ('dm','channel'). Adding 'huddle' requires a full table rebuild
+    // (SQLite has no ALTER ... DROP CHECK). The rebuild touches DROP
+    // TABLE + RENAME on a table that's the target of a CASCADE foreign
+    // key from chat_messages — if foreign_keys is left ON during the
+    // rebuild, the DROP cascades and wipes every message. These tests
+    // pin the safe path: messages survive across the migration.
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fresh-Phase-A DDL — what a database built between the Phase A merge
+     * and the huddle PR looks like. Crucially, the CHECK constraint lists
+     * only ('dm','channel') — `rebuildChatChannelsForHuddleIfNeeded` is
+     * supposed to detect that and rebuild.
+     */
+    const PHASE_A_BUT_PRE_HUDDLE_DDL = `
+      CREATE TABLE chat_channels (
+        id                TEXT PRIMARY KEY,
+        agent_session     TEXT NOT NULL,
+        owner_user_id     TEXT NOT NULL,
+        name              TEXT NOT NULL,
+        purpose           TEXT,
+        created_at        INTEGER NOT NULL,
+        archived_at       INTEGER,
+        last_message_at   INTEGER,
+        type              TEXT NOT NULL DEFAULT 'dm'
+                          CHECK(type IN ('dm','channel')),
+        team_id           TEXT,
+        project_id        TEXT,
+        target_member_id  TEXT
+      );
+      CREATE TABLE chat_messages (
+        id           TEXT PRIMARY KEY,
+        channel_id   TEXT NOT NULL REFERENCES chat_channels(id) ON DELETE CASCADE,
+        seq          INTEGER NOT NULL,
+        sender_type  TEXT NOT NULL CHECK(sender_type IN ('user','agent','system')),
+        sender_id    TEXT NOT NULL,
+        content      TEXT NOT NULL,
+        content_type TEXT NOT NULL DEFAULT 'markdown',
+        created_at   INTEGER NOT NULL,
+        metadata     TEXT,
+        mentions     TEXT,
+        thread_id    TEXT
+      );
+    `;
+
+    function openPhaseAButPreHuddleDb() {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const Database = require('better-sqlite3');
+      const db = new Database(':memory:');
+      db.pragma('foreign_keys = ON');
+      db.exec(PHASE_A_BUT_PRE_HUDDLE_DDL);
+      return db;
+    }
+
+    it('rebuilds chat_channels for huddle support WITHOUT wiping cascaded messages', () => {
+      const db = openPhaseAButPreHuddleDb();
+      try {
+        // Seed: one DM channel + three messages. With foreign_keys=ON the
+        // CASCADE FK from chat_messages.channel_id means a naive DROP TABLE
+        // chat_channels would erase all three rows. The migration must
+        // disable foreign_keys around the rebuild to keep them.
+        db.prepare(
+          `INSERT INTO chat_channels (id, agent_session, owner_user_id, name, created_at, type)
+           VALUES (?, ?, ?, ?, ?, 'dm')`,
+        ).run('ch-1', 'sess-a', 'user-1', 'Sam', 1);
+        for (let i = 0; i < 3; i++) {
+          db.prepare(
+            `INSERT INTO chat_messages (id, channel_id, seq, sender_type, sender_id, content, created_at)
+             VALUES (?, 'ch-1', ?, 'user', 'user-1', ?, ?)`,
+          ).run(`msg-${i}`, i + 1, `hello ${i}`, 100 + i);
+        }
+
+        const report = applyPhaseAColumnUpgrades(db);
+        expect(report.channelsCheckRebuilt).toBe(true);
+
+        // All messages survive.
+        const surviving = db
+          .prepare('SELECT id, channel_id, content FROM chat_messages ORDER BY seq ASC')
+          .all() as Array<{ id: string; channel_id: string; content: string }>;
+        expect(surviving).toHaveLength(3);
+        expect(surviving.map((r) => r.id)).toEqual(['msg-0', 'msg-1', 'msg-2']);
+
+        // Channel survives + can now accept type='huddle'.
+        db.prepare(
+          `INSERT INTO chat_channels (id, agent_session, owner_user_id, name, created_at, type)
+           VALUES (?, '', ?, ?, ?, 'huddle')`,
+        ).run('hd-1', 'user-1', 'My huddle', 2);
+        const huddle = db
+          .prepare("SELECT type FROM chat_channels WHERE id = 'hd-1'")
+          .get() as { type: string };
+        expect(huddle.type).toBe('huddle');
+
+        // foreign_keys pragma was restored after the rebuild.
+        const fk = db.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
+        expect(fk.foreign_keys).toBe(1);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('skips the rebuild on a database whose chat_channels already accepts huddle (idempotent)', () => {
+      // Fresh openChatDatabase already bakes the new CHECK; running the
+      // upgrade twice must report channelsCheckRebuilt=false.
+      const db = openChatDatabase({ dbPath: ':memory:', inMemory: true, skipIntegrityCheck: true });
+      try {
+        const report = applyPhaseAColumnUpgrades(db);
+        expect(report.channelsCheckRebuilt).toBe(false);
+      } finally {
+        db.close();
+      }
+    });
+
     it('is no-op idempotent: running the upgrade twice produces no changes the second time', () => {
       const db = openLegacyDb();
       try {

--- a/backend/src/services/chat-v2/sqlite/chat-db.ts
+++ b/backend/src/services/chat-v2/sqlite/chat-db.ts
@@ -138,8 +138,10 @@ CREATE TABLE IF NOT EXISTS chat_channels (
   last_message_at   INTEGER,
   -- Phase A (SEALED §3.1): channel-type discriminator. 'dm' preserves the
   -- Phase 1 1:1 user↔agent contract; 'channel' is the Slack-like team
-  -- surface. Existing rows backfill to 'dm' via applyPhaseAColumnUpgrades.
-  type              TEXT NOT NULL DEFAULT 'dm' CHECK(type IN ('dm','channel')),
+  -- surface. 'huddle' (Phase B-2, 2026-05-17) is ad-hoc multi-agent
+  -- groups with explicit membership in chat_channel_members.
+  -- Existing rows backfill to 'dm' via applyPhaseAColumnUpgrades.
+  type              TEXT NOT NULL DEFAULT 'dm' CHECK(type IN ('dm','channel','huddle')),
   -- Phase A (SEALED §3.1): team workspace link. Required at the service
   -- layer when type='channel'; null for type='dm'.
   team_id           TEXT,
@@ -215,6 +217,23 @@ CREATE TABLE IF NOT EXISTS chat_offline_queue (
 CREATE INDEX IF NOT EXISTS ix_queue_pending
   ON chat_offline_queue(agent_session, delivered_at)
   WHERE delivered_at IS NULL;
+
+-- Phase B-2 (2026-05-17): huddle membership roster. One row per
+-- (huddle_channel, agent_session_name). For type='huddle' channels
+-- only; 'dm' and 'channel' rows have no entries here.
+--
+-- Dispatcher uses this list to fan a user message out to every
+-- huddle member; the @-mention subset gets a "must respond" prompt
+-- variant while the rest get an "optional" one.
+CREATE TABLE IF NOT EXISTS chat_channel_members (
+  channel_id      TEXT NOT NULL REFERENCES chat_channels(id) ON DELETE CASCADE,
+  member_session  TEXT NOT NULL,
+  joined_at       INTEGER NOT NULL,
+  PRIMARY KEY (channel_id, member_session)
+);
+
+CREATE INDEX IF NOT EXISTS ix_channel_members_session
+  ON chat_channel_members(member_session);
 `;
 
 /**
@@ -332,6 +351,13 @@ export function applyPhaseAColumnUpgrades(db: ChatDatabase): {
   messagesAdded: string[];
   legacyIndexDropped: boolean;
   phaseADmIndexDropped: boolean;
+  /**
+   * Phase B-2: whether `chat_channels` was rebuilt to drop the legacy
+   * `CHECK(type IN ('dm','channel'))` constraint and allow `'huddle'`.
+   * `false` on fresh installs (the new CHECK is already in the
+   * baseline DDL) and on subsequent boots after the first rebuild.
+   */
+  channelsCheckRebuilt: boolean;
 } {
   const channelsAdded: string[] = [];
   for (const spec of CHAT_CHANNELS_PHASE_A_COLUMNS) {
@@ -392,7 +418,120 @@ export function applyPhaseAColumnUpgrades(db: ChatDatabase): {
   // EXISTS` makes this a no-op on subsequent boots.
   db.exec(CHAT_V2_PHASE_A_INDEX_SQL);
 
-  return { channelsAdded, messagesAdded, legacyIndexDropped, phaseADmIndexDropped };
+  // Phase B-2 (2026-05-17): relax the chat_channels.type CHECK so
+  // `'huddle'` is accepted. Older DBs were built with
+  // `CHECK(type IN ('dm','channel'))`; SQLite can't ALTER a CHECK in
+  // place, so we rebuild the table when the legacy constraint is
+  // detected. Skipped on fresh installs (the new CHECK is already in
+  // CHAT_V2_MIGRATION_SQL).
+  const channelsCheckRebuilt = rebuildChatChannelsForHuddleIfNeeded(db);
+
+  // Phase B-2: chat_channel_members may be missing on databases
+  // created before this migration. `CREATE TABLE IF NOT EXISTS` is
+  // idempotent — no-op on fresh installs since the table is also in
+  // CHAT_V2_MIGRATION_SQL.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chat_channel_members (
+      channel_id      TEXT NOT NULL REFERENCES chat_channels(id) ON DELETE CASCADE,
+      member_session  TEXT NOT NULL,
+      joined_at       INTEGER NOT NULL,
+      PRIMARY KEY (channel_id, member_session)
+    );
+    CREATE INDEX IF NOT EXISTS ix_channel_members_session
+      ON chat_channel_members(member_session);
+  `);
+
+  return {
+    channelsAdded,
+    messagesAdded,
+    legacyIndexDropped,
+    phaseADmIndexDropped,
+    channelsCheckRebuilt,
+  };
+}
+
+/**
+ * Phase B-2: rebuild `chat_channels` if its `type` CHECK constraint
+ * doesn't list `'huddle'`. SQLite has no `ALTER ... DROP CHECK`, so the
+ * only path is the standard "create new table, INSERT...SELECT, drop
+ * old, rename new" dance.
+ *
+ * Idempotent: returns `false` (and does nothing) when the table
+ * already accepts `'huddle'`, which is the case on fresh installs and
+ * on subsequent boots after the first rebuild.
+ *
+ * @param db - The chat database handle
+ * @returns true when a rebuild happened, false when no-op
+ */
+function rebuildChatChannelsForHuddleIfNeeded(db: ChatDatabase): boolean {
+  const row = db
+    .prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'chat_channels'`,
+    )
+    .get() as { sql: string } | undefined;
+  if (!row || !row.sql) return false;
+  if (row.sql.includes("'huddle'")) {
+    // Constraint already permits 'huddle' — fresh install or
+    // already-migrated. No rebuild needed.
+    return false;
+  }
+
+  // Snapshot what indexes existed on the old table so we can re-create
+  // them after the rename. SQLite drops indexes attached to a renamed
+  // table when the original table is dropped.
+  const indexRows = db
+    .prepare(
+      `SELECT name, sql FROM sqlite_master
+       WHERE type = 'index'
+         AND tbl_name = 'chat_channels'
+         AND sql IS NOT NULL`,
+    )
+    .all() as Array<{ name: string; sql: string }>;
+
+  // Wrap in a transaction so a crash mid-rebuild rolls back cleanly.
+  db.exec('BEGIN');
+  try {
+    db.exec(`
+      CREATE TABLE chat_channels_new (
+        id                TEXT PRIMARY KEY,
+        agent_session     TEXT NOT NULL,
+        owner_user_id     TEXT NOT NULL,
+        name              TEXT NOT NULL,
+        purpose           TEXT,
+        created_at        INTEGER NOT NULL,
+        archived_at       INTEGER,
+        last_message_at   INTEGER,
+        type              TEXT NOT NULL DEFAULT 'dm'
+                          CHECK(type IN ('dm','channel','huddle')),
+        team_id           TEXT,
+        project_id        TEXT,
+        target_member_id  TEXT
+      );
+    `);
+    db.exec(`
+      INSERT INTO chat_channels_new (
+        id, agent_session, owner_user_id, name, purpose,
+        created_at, archived_at, last_message_at,
+        type, team_id, project_id, target_member_id
+      )
+      SELECT
+        id, agent_session, owner_user_id, name, purpose,
+        created_at, archived_at, last_message_at,
+        type, team_id, project_id, target_member_id
+      FROM chat_channels;
+    `);
+    db.exec(`DROP TABLE chat_channels;`);
+    db.exec(`ALTER TABLE chat_channels_new RENAME TO chat_channels;`);
+    // Re-create the pre-existing indexes against the new table.
+    for (const idx of indexRows) {
+      db.exec(idx.sql);
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    db.exec('ROLLBACK');
+    throw err;
+  }
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/sqlite/chat-db.ts
+++ b/backend/src/services/chat-v2/sqlite/chat-db.ts
@@ -488,6 +488,21 @@ function rebuildChatChannelsForHuddleIfNeeded(db: ChatDatabase): boolean {
     )
     .all() as Array<{ name: string; sql: string }>;
 
+  // CRITICAL: `chat_messages.channel_id` is `REFERENCES chat_channels(id)
+  // ON DELETE CASCADE`. With `PRAGMA foreign_keys = ON` (set in
+  // openChatDatabase), `DROP TABLE chat_channels` would cascade-delete
+  // EVERY message in the database — wiping chat history on a real
+  // user's OSS install. SQLite's recommended 12-step ALTER TABLE
+  // procedure (https://www.sqlite.org/lang_altertable.html#otheralter)
+  // requires `foreign_keys = OFF` for the duration of the rebuild and a
+  // `foreign_key_check` afterward to assert no orphans remain.
+  //
+  // We capture the prior pragma state and restore it on exit so this
+  // function is safe to call against either a FK-enforcing or
+  // FK-disabled database.
+  const prevForeignKeys = (db.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number }).foreign_keys;
+  db.exec('PRAGMA foreign_keys = OFF');
+
   // Wrap in a transaction so a crash mid-rebuild rolls back cleanly.
   db.exec('BEGIN');
   try {
@@ -529,7 +544,20 @@ function rebuildChatChannelsForHuddleIfNeeded(db: ChatDatabase): boolean {
     db.exec('COMMIT');
   } catch (err) {
     db.exec('ROLLBACK');
+    db.exec(`PRAGMA foreign_keys = ${prevForeignKeys ? 'ON' : 'OFF'}`);
     throw err;
+  }
+  // Sanity check: no orphaned FK references after the rebuild. If any
+  // chat_messages.channel_id no longer points at a valid row we surface
+  // it as an error so the caller knows the DB needs operator attention
+  // — better than silently re-enabling FK enforcement and getting
+  // surprised at the next write.
+  const orphans = db.prepare(`PRAGMA foreign_key_check`).all() as unknown[];
+  db.exec(`PRAGMA foreign_keys = ${prevForeignKeys ? 'ON' : 'OFF'}`);
+  if (orphans.length > 0) {
+    throw new Error(
+      `chat-v2 migration: foreign_key_check found ${orphans.length} orphaned rows after chat_channels rebuild`,
+    );
   }
   return true;
 }

--- a/backend/src/services/chat-v2/types.ts
+++ b/backend/src/services/chat-v2/types.ts
@@ -36,7 +36,21 @@ export type ChatAgentPresenceStatus = 'online' | 'busy' | 'offline' | 'starting'
  * `idle` / `inactive` UI states via `@crewly/chat-ui`'s `ChatPresenceStatus`
  * union (the translation lives at the boundary, not here).
  */
-export type ChatChannelType = 'dm' | 'channel';
+/**
+ * Channel kind discriminator.
+ *
+ * - `'dm'`: legacy 1:1 user↔agent surface. `agent_session` is the wire
+ *   binding; `team_id` is null.
+ * - `'channel'`: Slack-like team-scoped surface. `team_id` is required;
+ *   membership is implicitly "everyone in the team".
+ * - `'huddle'` (Phase B-2 / 2026-05-17): ad-hoc multi-agent group.
+ *   Members are NOT derived from a team — they're stored explicitly in
+ *   `chat_channel_members`. Dispatcher fans the user's message out to
+ *   every member; agents decide whether to respond, but a member named
+ *   in `mentions[]` is told it MUST respond. See
+ *   `chat-v2.dispatcher.service.ts` for the prompt construction.
+ */
+export type ChatChannelType = 'dm' | 'channel' | 'huddle';
 
 /** Mention target kind — Phase B addition (SEALED design §7.1 chip pattern). */
 export type ChatMentionKind = 'team' | 'agent';
@@ -51,7 +65,7 @@ export const CHAT_CONTENT_TYPES: readonly ChatContentType[] = [
 ];
 
 /** Phase B — channel-type tuple for runtime validation in CreateChannelInput. */
-export const CHAT_CHANNEL_TYPES: readonly ChatChannelType[] = ['dm', 'channel'];
+export const CHAT_CHANNEL_TYPES: readonly ChatChannelType[] = ['dm', 'channel', 'huddle'];
 
 /** Phase B — mention-kind tuple for runtime validation in mention parsing. */
 export const CHAT_MENTION_KINDS: readonly ChatMentionKind[] = ['team', 'agent'];
@@ -189,6 +203,25 @@ export interface ChatChannelDTO {
    * (`@Sam`) rather than the session ID.
    */
   targetMemberId?: string;
+  /**
+   * Phase B-2 (2026-05-17) — for `type='huddle'` channels, the explicit
+   * member roster (agent session names). Populated by
+   * `ChatV2Service.listChannel` from `chat_channel_members`. Undefined
+   * for `'dm'` and `'channel'` rows.
+   */
+  members?: ChatHuddleMember[];
+}
+
+/**
+ * A single member of a huddle channel. Wire shape kept minimal — the
+ * frontend cross-references `sessionName` against the agent directory
+ * for human-readable name, role, presence, etc.
+ */
+export interface ChatHuddleMember {
+  /** Agent session name (matches `DirectoryAgent.agentSession`). */
+  sessionName: string;
+  /** ISO ms timestamp when this member was added to the huddle. */
+  joinedAt: number;
 }
 
 /** Outbound message shape for `GET /messages` / `POST /messages` / WS `message` frame. */


### PR DESCRIPTION
## Summary

Backend foundation for Slack-style **huddles** — ad-hoc multi-agent group chats. Phase 1 (#12) shipped thread + @mention UI; this PR introduces the channel type and dispatcher behavior that lets one user message fan out to every huddle member at once.

## Semantics

- A huddle is a \`type='huddle'\` channel with an explicit member roster in the new \`chat_channel_members\` table (NOT team-derived — huddles are ad-hoc cross-team groups).
- When the user sends in a huddle, the dispatcher fans out to EVERY member.
- Each member's prompt carries a \`responseMode\`:
  - \`'required'\` when the member is named in the message's \`mentions[]\` (they MUST reply).
  - \`'optional'\` otherwise (the agent decides whether to reply).

## Changes

| File | What |
|---|---|
| \`types.ts\` | Adds \`'huddle'\` to \`ChatChannelType\`; \`ChatHuddleMember\` type; \`ChatChannelDTO.members?\` |
| \`sqlite/chat-db.ts\` | CHECK constraint relaxed; \`chat_channel_members\` table; legacy-DB rebuild migration |
| \`chat-v2.service.ts\` | \`createHuddle\`, \`listHuddleMembers\`, \`queryHuddleMembersForDispatch\` |
| \`chat-v2.dispatcher.service.ts\` | \`'huddle-broadcast'\` strategy, \`HuddleDispatchOutcome\`, \`huddleMembersFor\` option, \`responseMode\` in prompt |
| \`index.ts\` | Wires \`huddleMembersFor\` to the service |

## Test plan

- [x] 16 new unit tests (10 service + 6 dispatcher), all pass.
- [x] \`tsc -p backend/tsconfig.json\` clean.
- [x] 2 pre-existing service-test failures on \`main\` are unrelated to this PR — confirmed via \`git stash\` baseline run.
- [ ] Reviewer: confirm the SQLite legacy-DB rebuild (\`rebuildChatChannelsForHuddleIfNeeded\`) is safe — transactionally wrapped, preserves all rows + indexes.
- [ ] Manual: restart OSS on a legacy DB, verify boot succeeds + \`chat_channel_members\` table exists + a fresh huddle round-trips via service test.

## Follow-up

Separate PR: \`ChatV2RelayAdapter\` RPCs (createHuddle / listChannels with type filter) + Portal UI for the huddle creator + multi-agent view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)