### PR TITLE
feat(chat-v2-relay-adapter): expose createHuddle + listHuddleMembers RPCs

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.relay-adapter.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.relay-adapter.service.test.ts
@@ -201,6 +201,73 @@ describe('ChatV2RelayAdapter', () => {
     expect((r.result as { channels: unknown[] }).channels).toEqual([]);
   });
 
+  // -------------------------------------------------------------------------
+  // 2026-05-17 Phase B-2 — huddle RPC plumbing
+  // -------------------------------------------------------------------------
+
+  it('createHuddle RPC creates a type=huddle channel with the given roster', async () => {
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-h1', {
+        id: 'r-h1',
+        method: 'createHuddle',
+        params: {
+          name: 'Q4 planning',
+          memberSessions: ['sess-a', 'sess-b', 'sess-c'],
+        },
+      }),
+    );
+    await flushMicrotasks();
+    const r = cloudSync.outbound[0].payload as ChatResponsePayload;
+    expect(r.error).toBeUndefined();
+    const ch = r.result as { type: string; name: string; members: Array<{ sessionName: string }> };
+    expect(ch.type).toBe('huddle');
+    expect(ch.name).toBe('Q4 planning');
+    expect(ch.members.map((m) => m.sessionName).sort()).toEqual(['sess-a', 'sess-b', 'sess-c']);
+  });
+
+  it('createHuddle RPC ignores non-string members in the input array', async () => {
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-h2', {
+        id: 'r-h2',
+        method: 'createHuddle',
+        params: {
+          name: 'h',
+          // Caller passes a junky array (mistake or hostile input).
+          // The adapter must filter out non-strings before calling
+          // the service so we never crash on `.trim()`.
+          memberSessions: ['sess-a', 42, null, 'sess-b'] as unknown as string[],
+        },
+      }),
+    );
+    await flushMicrotasks();
+    const r = cloudSync.outbound[0].payload as ChatResponsePayload;
+    expect(r.error).toBeUndefined();
+    const ch = r.result as { members: Array<{ sessionName: string }> };
+    expect(ch.members.map((m) => m.sessionName).sort()).toEqual(['sess-a', 'sess-b']);
+  });
+
+  it('listHuddleMembers RPC returns the roster for an existing huddle', async () => {
+    // First create a huddle so we have something to list.
+    const huddle = service.createHuddle({
+      name: 'h',
+      memberSessions: ['sess-x', 'sess-y'],
+      principal: { userId: 'dev-user-001', source: 'oss' },
+    });
+
+    cloudSync.emitInbound(
+      buildRequestMsg('portal-h3', {
+        id: 'r-h3',
+        method: 'listHuddleMembers',
+        params: { channelId: huddle.id },
+      }),
+    );
+    await flushMicrotasks();
+    const r = cloudSync.outbound[0].payload as ChatResponsePayload;
+    expect(r.error).toBeUndefined();
+    const out = r.result as { members: Array<{ sessionName: string }> };
+    expect(out.members.map((m) => m.sessionName).sort()).toEqual(['sess-x', 'sess-y']);
+  });
+
   it('ensureDmChannel creates a channel and replies with the DTO', async () => {
     cloudSync.emitInbound(
       buildRequestMsg('portal-2', {

--- a/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.relay-adapter.service.ts
@@ -419,12 +419,31 @@ export class ChatV2RelayAdapter {
           name: this.requireString(p, 'name'),
           purpose: this.optionalString(p, 'purpose'),
           principal,
-          type: p['type'] as 'dm' | 'channel' | undefined,
+          type: p['type'] as 'dm' | 'channel' | 'huddle' | undefined,
           teamId: this.optionalString(p, 'teamId'),
           projectId: this.optionalString(p, 'projectId'),
           targetMemberId: this.optionalString(p, 'targetMemberId'),
         });
         return this.serializeChannel(channel);
+      }
+      case 'createHuddle': {
+        const rawMembers = Array.isArray(p['memberSessions'])
+          ? (p['memberSessions'] as unknown[]).filter((m): m is string => typeof m === 'string')
+          : [];
+        const channel = this.service.createHuddle({
+          name: this.requireString(p, 'name'),
+          purpose: this.optionalString(p, 'purpose'),
+          memberSessions: rawMembers,
+          principal,
+        });
+        return this.serializeChannel(channel);
+      }
+      case 'listHuddleMembers': {
+        const members = this.service.listHuddleMembers(
+          this.requireString(p, 'channelId'),
+          principal,
+        );
+        return { members };
       }
       case 'listMessages': {
         const result = this.service.listMessages({

--- a/backend/src/services/cloud/cloud-sync.types.test.ts
+++ b/backend/src/services/cloud/cloud-sync.types.test.ts
@@ -239,6 +239,8 @@ describe('cloud-sync.types', () => {
         'listChannels',
         'ensureDmChannel',
         'createChannel',
+        'createHuddle',
+        'listHuddleMembers',
         'listMessages',
         'sendMessage',
       ]);

--- a/backend/src/services/cloud/cloud-sync.types.ts
+++ b/backend/src/services/cloud/cloud-sync.types.ts
@@ -289,6 +289,8 @@ export type ChatRpcMethod =
   | 'listChannels'
   | 'ensureDmChannel'
   | 'createChannel'
+  | 'createHuddle'
+  | 'listHuddleMembers'
   | 'listMessages'
   | 'sendMessage';
 
@@ -299,6 +301,8 @@ export const CHAT_RPC_METHODS: readonly ChatRpcMethod[] = [
   'listChannels',
   'ensureDmChannel',
   'createChannel',
+  'createHuddle',
+  'listHuddleMembers',
   'listMessages',
   'sendMessage',
 ] as const;


### PR DESCRIPTION
## Summary

Wire layer that lets the Portal create huddles end-to-end. Builds on the chat-v2 service plumbing from #597.

## Changes

- \`cloud-sync.types.ts\`: \`ChatRpcMethod\` union + \`CHAT_RPC_METHODS\` tuple gain \`createHuddle\` and \`listHuddleMembers\`. The pinned-set test is updated alongside so adding a new method requires both touches.
- \`chat-v2.relay-adapter.service.ts\`: two new dispatch cases.
  - \`createHuddle\` filters the \`memberSessions\` array to string entries before delegating to the service — defensive against malformed Portal payloads.
  - \`listHuddleMembers\` wraps the service's roster in \`{ members }\` for a stable wire shape.
  - \`case 'createChannel'\` widened to also accept \`'huddle'\` (callers can use either path).

## Test plan

- [x] 3 new adapter tests + 1 updated pinned-set test, all pass (66/66 in changed suites).
- [x] \`tsc -p backend/tsconfig.json\` clean.
- [ ] Reviewer: confirm no other RPC method needs huddle-aware widening — only \`sendMessage\` reaches user content, and its dispatcher path already handles \`channel.type === 'huddle'\` from #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)