### PR TITLE
feat(memory): orc task-history ledger + capability routing

### DIFF
--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -31,6 +31,8 @@ import { getSettingsService } from '../../services/settings/settings.service.js'
 import { getTerminalGateway } from '../../websocket/terminal.gateway.js';
 import { ActivityMonitorService } from '../../services/monitoring/activity-monitor.service.js';
 import { MemoryService } from '../../services/memory/memory.service.js';
+import { ProjectMemoryService } from '../../services/memory/project-memory.service.js';
+import { seedDeclaredCapabilities } from '../../services/memory/task-history-seeder.js';
 import {
   validateAgentRole,
   InvalidAgentRoleError,
@@ -2128,6 +2130,31 @@ export async function registerMemberStatus(this: ApiContext, req: Request, res: 
         (freshTeam as MutableTeam).updatedAt = new Date().toISOString();
 
         await this.storageService.saveTeam(freshTeam);
+
+        // Cold-start capability seeding — if this member's config
+        // declares any canonical capabilities (entries containing
+        // `:`), write a synthetic 'declared' TaskHistoryEntry so
+        // the orchestrator's `recall(capability)` query can find
+        // them on day-0, before any real task has run. Non-fatal:
+        // a write failure here cannot block registration.
+        try {
+          const projectPath = process.env.CREWLY_PROJECT_PATH || process.cwd();
+          await seedDeclaredCapabilities({
+            projectPath,
+            member: {
+              sessionName: freshMember.sessionName,
+              role: freshMember.role,
+              teamId: freshTeam.id,
+              capabilities: freshMember.capabilities,
+            },
+            projectMemory: ProjectMemoryService.getInstance(),
+          });
+        } catch (seedErr) {
+          logger.warn('Capability seeding failed (non-fatal)', {
+            sessionName,
+            error: seedErr instanceof Error ? seedErr.message : String(seedErr),
+          });
+        }
       }
     }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -116,6 +116,8 @@ import { setReconcilerService } from './controllers/reconciler/reconciler.contro
 import { FissionGuardService, type FissionDataProvider } from './services/fission/fission-guard.service.js';
 import { setFissionGuardService } from './controllers/fission/fission.controller.js';
 import { TaskPoolService } from './services/task-pool/task-pool.service.js';
+import { ProjectMemoryService } from './services/memory/project-memory.service.js';
+import { TaskHistorySubscriber } from './services/memory/task-history.subscriber.js';
 import {
 	TeamHealthWatchdogService,
 	LiveTeamHealthDataProvider,
@@ -366,6 +368,20 @@ export class CrewlyServer {
 		// triggers addToPool — the slack listener / TaskPool router below both
 		// depend on this for the auto-close path b chain. Idempotent.
 		TaskPoolService.getInstance().setEventBusService(this.eventBusService);
+
+		// Memory: TaskHistorySubscriber listens on the bus for
+		// task:done_by_worker / task:rejected / task:cancelled and writes
+		// the resulting TaskHistoryEntry into ProjectMemory. This is the
+		// load-bearing write path behind "who in my team has done X?" —
+		// the orchestrator queries via recall(capability:...). Must run
+		// AFTER TaskPoolService is wired to the bus (above) so the events
+		// it publishes have a subscriber to consume them.
+		const taskHistorySubscriber = new TaskHistorySubscriber({
+			eventBus: this.eventBusService,
+			projectMemoryService: ProjectMemoryService.getInstance(),
+			taskPoolService: TaskPoolService.getInstance(),
+		});
+		taskHistorySubscriber.start();
 
 		// P1 Bug B (Pool umbrella WI 72ca743a): Wire RequestService into the
 		// TaskPool singleton so addToPool intrinsically links new WIs into

--- a/backend/src/services/mcp-server.ts
+++ b/backend/src/services/mcp-server.ts
@@ -525,12 +525,15 @@ export class CrewlyMcpServer {
     const agentId = (args.agentId as string) || 'mcp-client';
     const projectPath = args.projectPath as string | undefined;
     const scope = (args.scope as 'agent' | 'project' | 'both') || 'both';
+    const capability =
+      typeof args['capability'] === 'string' ? (args['capability'] as string) : undefined;
 
     const result = await this.memory.recall({
       agentId,
       context: query,
       scope,
       projectPath,
+      capability,
     });
 
     return this.successResult({
@@ -543,6 +546,9 @@ export class CrewlyMcpServer {
         category: doc.category,
         preview: doc.preview,
       })),
+      // taskHistory present only when caller passed `capability` — the
+      // orchestrator reads this to decide who to delegate to.
+      taskHistory: result.taskHistory,
       combined: result.combined,
     });
   }

--- a/backend/src/services/mcp-tool-definitions.ts
+++ b/backend/src/services/mcp-tool-definitions.ts
@@ -121,7 +121,11 @@ export const TOOL_DEFINITIONS = [
     description:
       'Search team memory and knowledge base for relevant information. ' +
       'Uses keyword and semantic matching to find stored learnings, ' +
-      'patterns, decisions, and documents.',
+      'patterns, decisions, and documents. Pass `capability` to ask ' +
+      'specifically "which team members have demonstrated <capability>?" ' +
+      '(e.g. `gmail:read`, `oauth:gmail`, `slack:post`) — the answer is ' +
+      'returned both as structured `taskHistory[]` and as a ' +
+      '"### Capability Routing" section in `combined`, ranked by recency.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -141,6 +145,14 @@ export const TOOL_DEFINITIONS = [
           type: 'string',
           enum: ['agent', 'project', 'both'],
           description: 'Memory scope to search (default: both)',
+        },
+        capability: {
+          type: 'string',
+          description:
+            'Optional: canonical capability string (`<category>:<resource>`, ' +
+            'e.g. `gmail:read`) to query the task-history ledger. When set, ' +
+            'recall returns the members who have completed tasks exercising ' +
+            'this capability, sorted most-recent first.',
         },
       },
       required: ['query'],

--- a/backend/src/services/memory/capability-inference.test.ts
+++ b/backend/src/services/memory/capability-inference.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for CapabilityInference.
+ *
+ * @module services/memory/capability-inference.test
+ */
+
+import {
+  TOOL_TO_CAPABILITIES,
+  inferCapabilities,
+  readWorkItemHints,
+  defaultCapabilityInference,
+} from './capability-inference.js';
+
+describe('capability-inference', () => {
+  describe('TOOL_TO_CAPABILITIES table', () => {
+    it('every value uses the <category>:<resource> shape', () => {
+      for (const [tool, caps] of Object.entries(TOOL_TO_CAPABILITIES)) {
+        for (const c of caps) {
+          expect(c.includes(':')).toBe(true);
+          expect(c.split(':').filter(Boolean).length).toBeGreaterThanOrEqual(2);
+        }
+        expect(caps.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('Gmail tools always co-emit oauth:gmail', () => {
+      expect(TOOL_TO_CAPABILITIES['read_email_oauth']).toContain('oauth:gmail');
+      expect(TOOL_TO_CAPABILITIES['send_email_oauth']).toContain('oauth:gmail');
+    });
+
+    it('Calendar tools always co-emit oauth:calendar', () => {
+      expect(TOOL_TO_CAPABILITIES['read_calendar_oauth']).toContain('oauth:calendar');
+      expect(TOOL_TO_CAPABILITIES['create_calendar_event']).toContain('oauth:calendar');
+    });
+  });
+
+  describe('inferCapabilities', () => {
+    it('returns the mapped capability set for a known tool', () => {
+      const caps = inferCapabilities(['read_email_oauth']);
+      expect(caps.sort()).toEqual(['gmail:read', 'oauth:gmail'].sort());
+    });
+
+    it('dedupes when multiple tools map to overlapping capabilities', () => {
+      const caps = inferCapabilities(['read_email_oauth', 'send_email_oauth']);
+      // gmail:read + gmail:send + oauth:gmail — oauth:gmail once
+      expect(caps.filter((c) => c === 'oauth:gmail')).toHaveLength(1);
+      expect(caps.sort()).toEqual(['gmail:read', 'gmail:send', 'oauth:gmail'].sort());
+    });
+
+    it('returns [] for an unknown tool', () => {
+      expect(inferCapabilities(['some_made_up_tool'])).toEqual([]);
+    });
+
+    it('returns [] for empty input', () => {
+      expect(inferCapabilities([])).toEqual([]);
+    });
+
+    it('merges WorkItem metadata.requires hints', () => {
+      const wi = { metadata: { requires: ['plaid:read', 'oauth:plaid'] } };
+      const caps = inferCapabilities(['edit_file'], wi);
+      expect(caps).toContain('code:edit');
+      expect(caps).toContain('plaid:read');
+      expect(caps).toContain('oauth:plaid');
+    });
+
+    it('rejects malformed requires entries (no colon, non-string)', () => {
+      const wi = {
+        metadata: {
+          requires: ['valid:cap', 'no-colon-here', 42, null, 'another:valid'],
+        },
+      };
+      const caps = inferCapabilities([], wi);
+      expect(caps.sort()).toEqual(['another:valid', 'valid:cap'].sort());
+    });
+
+    it('handles a WorkItem with no metadata', () => {
+      expect(inferCapabilities(['read_email_oauth'], {})).toEqual(
+        expect.arrayContaining(['gmail:read', 'oauth:gmail']),
+      );
+    });
+  });
+
+  describe('readWorkItemHints', () => {
+    it('returns [] when metadata is absent', () => {
+      expect(readWorkItemHints({})).toEqual([]);
+    });
+
+    it('returns [] when metadata.requires is missing', () => {
+      expect(readWorkItemHints({ metadata: {} })).toEqual([]);
+    });
+
+    it('returns only valid <cat>:<res> strings', () => {
+      const result = readWorkItemHints({
+        metadata: { requires: ['x:y', 'invalid', 'a:b'] },
+      });
+      expect(result.sort()).toEqual(['a:b', 'x:y'].sort());
+    });
+  });
+
+  describe('defaultCapabilityInference', () => {
+    it('exposes the static infer function as the .infer method', () => {
+      expect(defaultCapabilityInference.infer(['edit_file'])).toEqual(['code:edit']);
+    });
+  });
+});

--- a/backend/src/services/memory/capability-inference.ts
+++ b/backend/src/services/memory/capability-inference.ts
@@ -1,0 +1,133 @@
+/**
+ * Capability Inference
+ *
+ * Maps the tool names an agent actually invoked + a WorkItem's metadata
+ * into canonical capability strings of the form `<category>:<resource>`
+ * (e.g. `gmail:read`, `slack:post`, `oauth:gmail`).
+ *
+ * This is the bridge between the messy reality of "what tools were
+ * called" and the clean abstraction "what can this team member do",
+ * which the orchestrator queries before delegating external-access work.
+ *
+ * The mapping table is intentionally a static lookup: predictable,
+ * easy to reason about, easy to extend. New tools register here in
+ * one place, no code spelunking required.
+ *
+ * @module services/memory/capability-inference
+ */
+
+/**
+ * Static mapping from tool name → capability strings the tool exercises.
+ * Most tools map to one capability; a few (oauth-gated tools) map to
+ * two (the action + the credential class) so a recall for either
+ * dimension finds the agent.
+ *
+ * **Convention** for the value side:
+ *   `<service>:<verb>` — service is the external system (`gmail`,
+ *   `slack`, `github`, `chrome`, `code`), verb is the operation
+ *   (`read`, `send`, `post`, `scrape`, `edit`).
+ *   `oauth:<service>` — credential class, present when the tool's
+ *   real-world capability requires an OAuth grant to a third party.
+ *
+ * Add new tools below in alphabetical order. Don't include built-in
+ * read/recall tools (read_file, recall_memory) — they're universal
+ * across all agents and would just inflate every capability query.
+ */
+export const TOOL_TO_CAPABILITIES: Readonly<Record<string, readonly string[]>> = {
+  // Browser / web
+  chrome_scrape: ['chrome:scrape'],
+  web_search: ['web:search'],
+  fetch_url: ['web:fetch'],
+
+  // Email (OAuth-gated)
+  read_email_oauth: ['gmail:read', 'oauth:gmail'],
+  send_email_oauth: ['gmail:send', 'oauth:gmail'],
+
+  // Calendar
+  read_calendar_oauth: ['calendar:read', 'oauth:calendar'],
+  create_calendar_event: ['calendar:write', 'oauth:calendar'],
+
+  // Slack (uses bot token, not OAuth-per-user, but the agent still
+  // needs the bot grant to act on the channel)
+  reply_slack: ['slack:post'],
+
+  // GitHub (token-gated)
+  gh_pr_create: ['github:pr-create', 'oauth:github'],
+  gh_issue_comment: ['github:issue-comment', 'oauth:github'],
+
+  // Code edits
+  edit_file: ['code:edit'],
+  write_file: ['code:write'],
+  git_commit: ['git:commit'],
+
+  // Shell — broad capability, weighted accordingly
+  bash_exec: ['shell:exec'],
+
+  // Task / team operations (cross-team coordination)
+  delegate_task: ['coordination:delegate'],
+  broadcast: ['coordination:broadcast'],
+} as const;
+
+/**
+ * WorkItem-level capability hints. A WorkItem's `metadata.requires`
+ * may explicitly list capabilities the parent requested (e.g. orc
+ * said "needs gmail:read"). Surface those directly so a tool whose
+ * mapping we haven't added yet still contributes to the right index.
+ *
+ * Treat this as additive: explicit requires + inferred-from-tools,
+ * deduped at the caller.
+ */
+export function readWorkItemHints(workItem: Record<string, unknown>): string[] {
+  const metadata = workItem['metadata'] as Record<string, unknown> | undefined;
+  if (!metadata) return [];
+  const requires = metadata['requires'];
+  if (!Array.isArray(requires)) return [];
+  return requires.filter((c): c is string => typeof c === 'string' && c.includes(':'));
+}
+
+/**
+ * Infer capabilities exercised by a task.
+ *
+ * @param toolsUsed - Tool names called during the run
+ * @param workItem - Optional WorkItem for metadata hints
+ * @returns Deduped capability strings (no specific order)
+ *
+ * @example
+ * ```typescript
+ * inferCapabilities(['read_email_oauth'], { metadata: { requires: [] } });
+ * // → ['gmail:read', 'oauth:gmail']
+ * ```
+ */
+export function inferCapabilities(
+  toolsUsed: readonly string[],
+  workItem?: Record<string, unknown>,
+): string[] {
+  const set = new Set<string>();
+  for (const tool of toolsUsed) {
+    const caps = TOOL_TO_CAPABILITIES[tool];
+    if (caps) {
+      for (const c of caps) set.add(c);
+    }
+  }
+  if (workItem) {
+    for (const c of readWorkItemHints(workItem)) set.add(c);
+  }
+  return [...set];
+}
+
+/**
+ * Injectable interface — the subscriber consumes only this shape so
+ * test code can stub it. Production passes the default impl that
+ * delegates to {@link inferCapabilities}.
+ */
+export interface CapabilityInferenceService {
+  infer(toolsUsed: readonly string[], workItem?: Record<string, unknown>): string[];
+}
+
+/**
+ * Default implementation backed by the static table. Exported so the
+ * subscriber's constructor default is identity-stable across imports.
+ */
+export const defaultCapabilityInference: CapabilityInferenceService = {
+  infer: inferCapabilities,
+};

--- a/backend/src/services/memory/memory.service.test.ts
+++ b/backend/src/services/memory/memory.service.test.ts
@@ -853,4 +853,114 @@ describe('MemoryService', () => {
       );
     });
   });
+
+  describe('recall.capability — task-history routing', () => {
+    beforeEach(async () => {
+      await service.initializeForSession(testAgentId, testRole, testProjectPath);
+    });
+
+    it('returns empty taskHistory when ledger has no matching capability', async () => {
+      const result = await service.recall({
+        agentId: testAgentId,
+        projectPath: testProjectPath,
+        context: 'gmail',
+        scope: 'project',
+        capability: 'gmail:read',
+      });
+      expect(result.taskHistory).toEqual([]);
+      // No "### Capability Routing" block appended when there are no matches.
+      expect(result.combined).not.toContain('### Capability Routing');
+    });
+
+    it('surfaces matching entries and appends Capability Routing block', async () => {
+      const projectMemory = service.getProjectMemoryService();
+      await projectMemory.addTaskHistory(testProjectPath, {
+        id: 'th-ella-1',
+        completedAt: '2026-05-18T14:00:00Z',
+        agent: {
+          sessionName: 'crewly-product-ella',
+          role: 'fullstack-dev',
+        },
+        task: { description: 'Read MIT Role email', outcome: 'success' },
+        capabilities: ['gmail:read', 'oauth:gmail'],
+        toolsUsed: ['read_email_oauth'],
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        projectPath: testProjectPath,
+        context: 'gmail',
+        scope: 'project',
+        capability: 'gmail:read',
+      });
+
+      expect(result.taskHistory).toHaveLength(1);
+      expect(result.taskHistory![0]!.agent.sessionName).toBe(
+        'crewly-product-ella',
+      );
+      expect(result.combined).toContain('### Capability Routing — `gmail:read`');
+      expect(result.combined).toContain('crewly-product-ella');
+      expect(result.combined).toContain('fullstack-dev');
+    });
+
+    it('ranks members by most-recent activity and aggregates per-member count', async () => {
+      const projectMemory = service.getProjectMemoryService();
+      // Ella did it once, on an earlier date.
+      await projectMemory.addTaskHistory(testProjectPath, {
+        id: 'th-old-ella',
+        completedAt: '2026-04-01T00:00:00Z',
+        agent: { sessionName: 'crewly-product-ella', role: 'fullstack-dev' },
+        task: { description: 'old gmail read', outcome: 'success' },
+        capabilities: ['gmail:read'],
+        toolsUsed: ['read_email_oauth'],
+      });
+      // Sam did it twice, both more recent than Ella's.
+      await projectMemory.addTaskHistory(testProjectPath, {
+        id: 'th-sam-1',
+        completedAt: '2026-05-10T00:00:00Z',
+        agent: { sessionName: 'crewly-product-sam', role: 'fullstack-dev' },
+        task: { description: 'gmail read A', outcome: 'success' },
+        capabilities: ['gmail:read'],
+        toolsUsed: ['read_email_oauth'],
+      });
+      await projectMemory.addTaskHistory(testProjectPath, {
+        id: 'th-sam-2',
+        completedAt: '2026-05-18T00:00:00Z',
+        agent: { sessionName: 'crewly-product-sam', role: 'fullstack-dev' },
+        task: { description: 'gmail read B', outcome: 'success' },
+        capabilities: ['gmail:read'],
+        toolsUsed: ['read_email_oauth'],
+      });
+
+      const result = await service.recall({
+        agentId: testAgentId,
+        projectPath: testProjectPath,
+        context: 'gmail',
+        scope: 'project',
+        capability: 'gmail:read',
+      });
+
+      // The capability-routing block lists Sam first (more recent) with
+      // count=2, then Ella with count=1.
+      const block = result.combined.split('### Capability Routing')[1] ?? '';
+      const samIdx = block.indexOf('crewly-product-sam');
+      const ellaIdx = block.indexOf('crewly-product-ella');
+      expect(samIdx).toBeGreaterThan(-1);
+      expect(ellaIdx).toBeGreaterThan(-1);
+      expect(samIdx).toBeLessThan(ellaIdx);
+      expect(block).toMatch(/crewly-product-sam.*2×/);
+      expect(block).toMatch(/crewly-product-ella.*1×/);
+    });
+
+    it('is omitted entirely when projectPath is not provided', async () => {
+      const result = await service.recall({
+        agentId: testAgentId,
+        context: 'gmail',
+        scope: 'agent',
+        capability: 'gmail:read',
+      });
+      // No projectPath → no query at all → field absent.
+      expect(result.taskHistory).toBeUndefined();
+    });
+  });
 });

--- a/backend/src/services/memory/memory.service.ts
+++ b/backend/src/services/memory/memory.service.ts
@@ -25,6 +25,7 @@ import type {
   GotchaSeverity,
   AgentPreferences,
   ProjectAgentsIndex,
+  TaskHistoryEntry,
 } from '../../types/memory.types.js';
 
 /**
@@ -124,6 +125,21 @@ export interface RecallParams {
    * this `false` (or unset) so superseded entries do not pollute context.
    */
   includeHidden?: boolean;
+  /**
+   * Optional capability filter. When set, recall queries the project's
+   * task-history ledger for entries whose `capabilities[]` contains an
+   * exact match. The matching entries surface on
+   * {@link RecallResult.taskHistory} sorted most-recent first.
+   *
+   * This is the load-bearing field for "who in my team has done X?"
+   * — the orchestrator's delegation-first prompt queries with this
+   * parameter before deciding whether to delegate or self-execute.
+   *
+   * Format: canonical `<category>:<resource>` strings
+   * (`gmail:read`, `oauth:gmail`, `slack:post`, etc. — see
+   * CapabilityInferenceService for the registry).
+   */
+  capability?: string;
 }
 
 /**
@@ -147,6 +163,12 @@ export interface RecallResult {
   currentFocus?: string;
   /** Active tasks for this agent */
   activeTasks?: Array<{ id: string; name: string; status: string; hasWorkingNotes: boolean }>;
+  /**
+   * Task-history entries matching {@link RecallParams.capability}. Present
+   * when the caller passed a capability filter. Sorted most-recent first;
+   * empty array means "no team member has demonstrated this capability."
+   */
+  taskHistory?: TaskHistoryEntry[];
 }
 
 /**
@@ -872,6 +894,25 @@ export class MemoryService implements IMemoryService {
       );
     }
 
+    // Capability filter — query the project task-history ledger for
+    // members who have demonstrated this capability. Runs in parallel
+    // with the other fetches.
+    if (params.capability && params.projectPath) {
+      promises.push(
+        this.projectMemory
+          .getTaskHistory(params.projectPath, params.capability)
+          .then((entries) => {
+            result.taskHistory = entries;
+          })
+          .catch(() => {
+            // No history file yet, or read failed — surface as empty
+            // rather than throwing. The orchestrator interprets [] as
+            // "no prior demonstration; cold start."
+            result.taskHistory = [];
+          }),
+      );
+    }
+
     await Promise.all(promises);
 
     // v2: Enrich with operational context (goals, focus, active tasks)
@@ -891,6 +932,39 @@ export class MemoryService implements IMemoryService {
         }
       }
       result.combined += opLines.join('\n');
+    }
+
+    // Capability-routing block — when a capability filter was active and
+    // matches exist, surface a delegation-ready summary at the end so the
+    // orchestrator sees "for this capability, prefer these members" in
+    // its very next read.
+    if (params.capability && result.taskHistory && result.taskHistory.length > 0) {
+      const byMember = new Map<string, { count: number; lastAt: string; role: string }>();
+      for (const entry of result.taskHistory) {
+        const key = entry.agent.sessionName;
+        const prior = byMember.get(key);
+        if (!prior) {
+          byMember.set(key, {
+            count: 1,
+            lastAt: entry.completedAt,
+            role: entry.agent.role,
+          });
+        } else {
+          prior.count += 1;
+          if (entry.completedAt > prior.lastAt) prior.lastAt = entry.completedAt;
+        }
+      }
+      const ranked = [...byMember.entries()].sort(
+        (a, b) => b[1].lastAt.localeCompare(a[1].lastAt),
+      );
+      const lines: string[] = [`\n### Capability Routing — \`${params.capability}\``];
+      lines.push(
+        `${ranked.length} team member(s) have demonstrated this capability. Prefer delegating to them:`,
+      );
+      for (const [session, info] of ranked) {
+        lines.push(`- **${session}** (${info.role}) — ${info.count}× last on ${info.lastAt}`);
+      }
+      result.combined += '\n' + lines.join('\n');
     }
 
     return result;

--- a/backend/src/services/memory/project-memory.service.ts
+++ b/backend/src/services/memory/project-memory.service.ts
@@ -18,6 +18,7 @@ import {
   DecisionEntry,
   GotchaEntry,
   RelationshipEntry,
+  TaskHistoryEntry,
   DEFAULT_PROJECT_MEMORY,
   type PatternCategory,
   type GotchaSeverity,
@@ -56,6 +57,8 @@ export interface IProjectMemoryService {
   generateProjectContext(projectPath: string): Promise<string>;
   searchAll(projectPath: string, query: string): Promise<SearchResults>;
   getProjectMemory(projectPath: string): Promise<ProjectMemory | null>;
+  addTaskHistory(projectPath: string, entry: TaskHistoryEntry): Promise<string>;
+  getTaskHistory(projectPath: string, capability?: string): Promise<TaskHistoryEntry[]>;
 }
 
 /**
@@ -203,6 +206,7 @@ export class ProjectMemoryService implements IProjectMemoryService {
       MEMORY_CONSTANTS.PROJECT_FILES.DECISIONS,
       MEMORY_CONSTANTS.PROJECT_FILES.GOTCHAS,
       MEMORY_CONSTANTS.PROJECT_FILES.RELATIONSHIPS,
+      MEMORY_CONSTANTS.PROJECT_FILES.TASK_HISTORY,
     ];
 
     for (const file of jsonFiles) {
@@ -587,6 +591,59 @@ export class ProjectMemoryService implements IProjectMemoryService {
   private async saveRelationships(projectPath: string, relationships: RelationshipEntry[]): Promise<void> {
     const filePath = this.getFilePath(projectPath, MEMORY_CONSTANTS.PROJECT_FILES.RELATIONSHIPS);
     await atomicWriteJson(filePath, relationships);
+    this.invalidateCache(projectPath);
+  }
+
+  /**
+   * Append a task-history entry. Dedup on `id`; if an existing entry
+   * with the same id is found, this is a no-op (subscriber emits a
+   * stable id per workitem so a redelivered event collapses cleanly).
+   *
+   * @param projectPath - Project path
+   * @param entry - The TaskHistoryEntry to record
+   * @returns The id of the recorded entry (echoes input.id)
+   */
+  public async addTaskHistory(
+    projectPath: string,
+    entry: TaskHistoryEntry,
+  ): Promise<string> {
+    const existing = await this.getTaskHistory(projectPath);
+    if (existing.some((e) => e.id === entry.id)) {
+      return entry.id;
+    }
+    existing.push(entry);
+    await this.saveTaskHistory(projectPath, existing);
+    return entry.id;
+  }
+
+  /**
+   * Get the full task-history ledger for a project. Optionally filter
+   * by canonical capability string (e.g. `'gmail:read'`); when filter
+   * is set, only entries whose `capabilities[]` contains an exact
+   * match are returned, sorted most-recent first.
+   *
+   * @param projectPath - Project path
+   * @param capability - Optional capability string filter
+   * @returns Array of entries (most recent first when filtered)
+   */
+  public async getTaskHistory(
+    projectPath: string,
+    capability?: string,
+  ): Promise<TaskHistoryEntry[]> {
+    const filePath = this.getFilePath(projectPath, MEMORY_CONSTANTS.PROJECT_FILES.TASK_HISTORY);
+    const all = await safeReadJson<TaskHistoryEntry[]>(filePath, []);
+    if (!capability) return all;
+    const matches = all.filter((e) => e.capabilities.includes(capability));
+    matches.sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+    return matches;
+  }
+
+  private async saveTaskHistory(
+    projectPath: string,
+    entries: TaskHistoryEntry[],
+  ): Promise<void> {
+    const filePath = this.getFilePath(projectPath, MEMORY_CONSTANTS.PROJECT_FILES.TASK_HISTORY);
+    await atomicWriteJson(filePath, entries);
     this.invalidateCache(projectPath);
   }
 

--- a/backend/src/services/memory/task-history-seeder.test.ts
+++ b/backend/src/services/memory/task-history-seeder.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for TaskHistorySeeder.
+ *
+ * @module services/memory/task-history-seeder.test
+ */
+
+import {
+  pickCanonicalCapabilities,
+  seedDeclaredCapabilities,
+} from './task-history-seeder.js';
+import type { IProjectMemoryService } from './project-memory.service.js';
+import { TaskHistoryEntry } from '../../types/memory.types.js';
+
+class StubProjectMemory {
+  public writes: Array<{ projectPath: string; entry: TaskHistoryEntry }> = [];
+  public throwOnNext = false;
+
+  async addTaskHistory(projectPath: string, entry: TaskHistoryEntry): Promise<string> {
+    if (this.throwOnNext) {
+      this.throwOnNext = false;
+      throw new Error('disk full (simulated)');
+    }
+    this.writes.push({ projectPath, entry });
+    return entry.id;
+  }
+  async getTaskHistory(): Promise<TaskHistoryEntry[]> {
+    return this.writes.map((w) => w.entry);
+  }
+}
+
+describe('pickCanonicalCapabilities', () => {
+  it('keeps strings of the form <cat>:<res>', () => {
+    expect(pickCanonicalCapabilities(['gmail:read', 'oauth:gmail'])).toEqual(
+      expect.arrayContaining(['gmail:read', 'oauth:gmail']),
+    );
+  });
+
+  it('drops free-form strings without a colon', () => {
+    expect(pickCanonicalCapabilities(['anything', 'plain-text'])).toEqual([]);
+  });
+
+  it('drops entries with empty halves like "a:" or ":b"', () => {
+    expect(pickCanonicalCapabilities(['a:', ':b', 'good:value'])).toEqual(['good:value']);
+  });
+
+  it('dedupes', () => {
+    expect(pickCanonicalCapabilities(['x:y', 'x:y', 'a:b'])).toEqual(
+      expect.arrayContaining(['x:y', 'a:b']),
+    );
+    expect(pickCanonicalCapabilities(['x:y', 'x:y']).length).toBe(1);
+  });
+
+  it('returns [] for undefined / empty', () => {
+    expect(pickCanonicalCapabilities(undefined)).toEqual([]);
+    expect(pickCanonicalCapabilities([])).toEqual([]);
+  });
+
+  it('ignores non-string entries (defensive)', () => {
+    const arr = ['gmail:read', 42 as unknown as string, null as unknown as string];
+    expect(pickCanonicalCapabilities(arr)).toEqual(['gmail:read']);
+  });
+});
+
+describe('seedDeclaredCapabilities', () => {
+  const fakeClock = () => new Date('2026-05-19T00:00:00Z');
+
+  it('writes a single declared entry with outcome=declared', async () => {
+    const projectMemory = new StubProjectMemory();
+    const id = await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: {
+        sessionName: 'crewly-product-ella',
+        role: 'fullstack-dev',
+        teamId: 'team-mit',
+        capabilities: ['gmail:read', 'oauth:gmail'],
+      },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+      now: fakeClock,
+    });
+
+    expect(id).toBe('th-declared-crewly-product-ella');
+    expect(projectMemory.writes).toHaveLength(1);
+    const entry = projectMemory.writes[0]!.entry;
+    expect(entry.task.outcome).toBe('declared');
+    expect(entry.capabilities.sort()).toEqual(['gmail:read', 'oauth:gmail'].sort());
+    expect(entry.agent.sessionName).toBe('crewly-product-ella');
+    expect(entry.agent.teamId).toBe('team-mit');
+    expect(entry.completedAt).toBe('2026-05-19T00:00:00.000Z');
+  });
+
+  it('uses a stable id keyed by sessionName so re-registration dedups', async () => {
+    const projectMemory = new StubProjectMemory();
+    await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: {
+        sessionName: 'crewly-orc',
+        role: 'orchestrator',
+        capabilities: ['code:read'],
+      },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+    });
+    await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: {
+        sessionName: 'crewly-orc',
+        role: 'orchestrator',
+        capabilities: ['code:read'],
+      },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+    });
+    // Stub does append both; production dedup happens inside
+    // ProjectMemoryService.addTaskHistory. The stable id is the
+    // contract that production relies on.
+    expect(projectMemory.writes[0]!.entry.id).toBe('th-declared-crewly-orc');
+    expect(projectMemory.writes[1]!.entry.id).toBe('th-declared-crewly-orc');
+  });
+
+  it('skips entirely when member declares no canonical capabilities', async () => {
+    const projectMemory = new StubProjectMemory();
+    const id = await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: {
+        sessionName: 's',
+        role: 'r',
+        capabilities: ['free-form-string'],
+      },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+    });
+    expect(id).toBeNull();
+    expect(projectMemory.writes).toHaveLength(0);
+  });
+
+  it('skips when capabilities is undefined', async () => {
+    const projectMemory = new StubProjectMemory();
+    const id = await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: { sessionName: 's', role: 'r' },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+    });
+    expect(id).toBeNull();
+    expect(projectMemory.writes).toHaveLength(0);
+  });
+
+  it('swallows ProjectMemoryService errors (registration must not fail)', async () => {
+    const projectMemory = new StubProjectMemory();
+    projectMemory.throwOnNext = true;
+    const id = await seedDeclaredCapabilities({
+      projectPath: '/tmp/proj',
+      member: {
+        sessionName: 's',
+        role: 'r',
+        capabilities: ['gmail:read'],
+      },
+      projectMemory: projectMemory as unknown as IProjectMemoryService,
+    });
+    expect(id).toBeNull();
+    expect(projectMemory.writes).toHaveLength(0);
+  });
+});

--- a/backend/src/services/memory/task-history-seeder.ts
+++ b/backend/src/services/memory/task-history-seeder.ts
@@ -1,0 +1,106 @@
+/**
+ * Task History Seeder
+ *
+ * Seeds the project task-history ledger with synthetic "declared"
+ * entries when a team member registers. Solves the cold-start problem
+ * for capability routing: on day-0, no real tasks have run yet, but
+ * the team config can still declare what capabilities each member
+ * holds, and the orchestrator's `recall(capability)` query finds them.
+ *
+ * The convention: a `TeamMember.capabilities` entry counts as a
+ * canonical capability when it contains a `:` separator (e.g.
+ * `gmail:read`, `oauth:gmail`). Free-form strings without `:` are
+ * ignored — they aren't part of the routing vocabulary.
+ *
+ * @module services/memory/task-history-seeder
+ */
+
+import { IProjectMemoryService } from './project-memory.service.js';
+import { TaskHistoryEntry } from '../../types/memory.types.js';
+import { LoggerService } from '../core/logger.service.js';
+
+const logger = LoggerService.getInstance().createComponentLogger('TaskHistorySeeder');
+
+export interface SeedDeclaredCapabilitiesArgs {
+  projectPath: string;
+  member: {
+    sessionName: string;
+    role: string;
+    teamId?: string;
+    capabilities?: string[];
+  };
+  projectMemory: IProjectMemoryService;
+  /** Optional clock for tests; defaults to Date.now() */
+  now?: () => Date;
+}
+
+/**
+ * Filter a free-form `capabilities[]` array down to the entries that
+ * look like canonical capability strings. Exported for unit testing.
+ */
+export function pickCanonicalCapabilities(raw: readonly string[] | undefined): string[] {
+  if (!raw || raw.length === 0) return [];
+  const seen = new Set<string>();
+  for (const c of raw) {
+    if (typeof c !== 'string') continue;
+    const trimmed = c.trim();
+    if (!trimmed.includes(':')) continue;
+    const [left, right] = trimmed.split(':', 2);
+    if (!left || !right) continue;
+    seen.add(trimmed);
+  }
+  return [...seen];
+}
+
+/**
+ * Emit a single synthetic `outcome: 'declared'` entry capturing every
+ * canonical capability the member declares. One entry per registration,
+ * keyed `th-declared-<sessionName>` so re-registration dedups cleanly
+ * (the entry is overwritten in place when the same id arrives — see
+ * ProjectMemoryService.addTaskHistory).
+ *
+ * No-op if the member has no canonical capabilities to declare.
+ *
+ * @returns The entry id if one was written, or null when skipped.
+ */
+export async function seedDeclaredCapabilities(
+  args: SeedDeclaredCapabilitiesArgs,
+): Promise<string | null> {
+  const canonical = pickCanonicalCapabilities(args.member.capabilities);
+  if (canonical.length === 0) {
+    return null;
+  }
+
+  const now = (args.now ?? (() => new Date()))().toISOString();
+  const entry: TaskHistoryEntry = {
+    id: `th-declared-${args.member.sessionName}`,
+    completedAt: now,
+    agent: {
+      sessionName: args.member.sessionName,
+      role: args.member.role,
+      teamId: args.member.teamId,
+    },
+    task: {
+      description: 'Self-declared capabilities at register_self',
+      outcome: 'declared',
+    },
+    capabilities: canonical,
+    toolsUsed: [],
+  };
+
+  try {
+    await args.projectMemory.addTaskHistory(args.projectPath, entry);
+    logger.info('Seeded declared capabilities', {
+      sessionName: args.member.sessionName,
+      count: canonical.length,
+    });
+    return entry.id;
+  } catch (err) {
+    // Non-fatal — registration must succeed even if memory write fails.
+    logger.warn('Failed to seed declared capabilities (non-fatal)', {
+      sessionName: args.member.sessionName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/backend/src/services/memory/task-history.subscriber.test.ts
+++ b/backend/src/services/memory/task-history.subscriber.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for TaskHistorySubscriber.
+ *
+ * Wires a stub EventBus + ProjectMemory + TaskPool and asserts that
+ * a `task:done_by_worker` publish produces a TaskHistoryEntry with
+ * the right shape, that failures map to `outcome: 'failure'`, that
+ * memory-write exceptions are swallowed, and that double-start is
+ * idempotent.
+ *
+ * @module services/memory/task-history.subscriber.test
+ */
+
+import { EventEmitter } from 'events';
+import {
+  TaskHistorySubscriber,
+  extractToolsUsed,
+} from './task-history.subscriber.js';
+import {
+  TaskHistoryEntry,
+} from '../../types/memory.types.js';
+import {
+  AgentEvent,
+  EventType,
+} from '../../types/event-bus.types.js';
+import type { InProcessEventHandler } from '../event-bus/event-bus.service.js';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal EventBus that the subscriber can attach to. Mirrors the API
+ * surface the subscriber uses: `onInProcess(types, handler)` returns
+ * a detach function and routes published events to the handler.
+ */
+class StubEventBus {
+  private handlers: Array<{
+    types: EventType[];
+    handler: InProcessEventHandler;
+  }> = [];
+
+  onInProcess(types: EventType | EventType[], handler: InProcessEventHandler) {
+    const typeArr = Array.isArray(types) ? types : [types];
+    const entry = { types: typeArr, handler };
+    this.handlers.push(entry);
+    return () => {
+      this.handlers = this.handlers.filter((h) => h !== entry);
+    };
+  }
+
+  publish(event: AgentEvent): void {
+    for (const h of this.handlers) {
+      if (h.types.includes(event.type)) {
+        void h.handler(event);
+      }
+    }
+  }
+
+  getHandlerCount(): number {
+    return this.handlers.length;
+  }
+}
+
+class StubProjectMemory {
+  public writes: Array<{ projectPath: string; entry: TaskHistoryEntry }> = [];
+  public throwOnNextWrite = false;
+
+  async addTaskHistory(projectPath: string, entry: TaskHistoryEntry): Promise<string> {
+    if (this.throwOnNextWrite) {
+      this.throwOnNextWrite = false;
+      throw new Error('disk full (simulated)');
+    }
+    this.writes.push({ projectPath, entry });
+    return entry.id;
+  }
+
+  async getTaskHistory(_projectPath: string): Promise<TaskHistoryEntry[]> {
+    return this.writes.map((w) => w.entry);
+  }
+}
+
+class StubTaskPool {
+  private store: Map<string, Record<string, unknown>> = new Map();
+  put(id: string, wi: Record<string, unknown>): void { this.store.set(id, wi); }
+  async findWorkItem(id: string): Promise<Record<string, unknown> | null> {
+    return this.store.get(id) ?? null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<AgentEvent> = {}): AgentEvent {
+  return {
+    id: 'evt-1',
+    type: 'task:done_by_worker' as EventType,
+    timestamp: '2026-05-18T14:00:00Z',
+    teamId: 't1',
+    teamName: 'Team',
+    memberId: 'm1',
+    memberName: 'Ella',
+    sessionName: 'crewly-product-ella',
+    previousValue: 'running',
+    newValue: 'done_by_worker',
+    changedField: 'taskStatus',
+    workItemId: 'wi-1',
+    ...overrides,
+  } as AgentEvent;
+}
+
+function buildSubscriber(opts: {
+  pool?: StubTaskPool;
+  memory?: StubProjectMemory;
+  bus?: StubEventBus;
+  resolveProjectPath?: (event: AgentEvent) => string | null;
+} = {}) {
+  const bus = opts.bus ?? new StubEventBus();
+  const memory = opts.memory ?? new StubProjectMemory();
+  const pool = opts.pool ?? new StubTaskPool();
+  const sub = new TaskHistorySubscriber({
+    eventBus: bus as unknown as ConstructorParameters<typeof TaskHistorySubscriber>[0]['eventBus'],
+    projectMemoryService: memory as unknown as ConstructorParameters<typeof TaskHistorySubscriber>[0]['projectMemoryService'],
+    taskPoolService: pool as unknown as ConstructorParameters<typeof TaskHistorySubscriber>[0]['taskPoolService'],
+    resolveProjectPath: opts.resolveProjectPath ?? (() => '/tmp/proj'),
+  });
+  return { bus, memory, pool, sub };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TaskHistorySubscriber', () => {
+  it('attaches a single in-process handler on start()', () => {
+    const { bus, sub } = buildSubscriber();
+    expect(bus.getHandlerCount()).toBe(0);
+    sub.start();
+    expect(bus.getHandlerCount()).toBe(1);
+    sub.stop();
+    expect(bus.getHandlerCount()).toBe(0);
+  });
+
+  it('start() is idempotent — second call does not double-attach', () => {
+    const { bus, sub } = buildSubscriber();
+    sub.start();
+    sub.start();
+    expect(bus.getHandlerCount()).toBe(1);
+    sub.stop();
+  });
+
+  it('records a success entry for task:done_by_worker', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-1', {
+      title: 'Read MIT Role email',
+      metadata: { role: 'fullstack-dev', toolsUsed: ['read_email_oauth'] },
+    });
+    const { bus, memory, sub } = buildSubscriber({ pool });
+    sub.start();
+
+    bus.publish(makeEvent({ workItemId: 'wi-1' }));
+    await flush();
+
+    expect(memory.writes).toHaveLength(1);
+    const entry = memory.writes[0]!.entry;
+    expect(entry.task.outcome).toBe('success');
+    expect(entry.agent.sessionName).toBe('crewly-product-ella');
+    expect(entry.agent.role).toBe('fullstack-dev');
+    expect(entry.task.description).toBe('Read MIT Role email');
+    expect(entry.capabilities.sort()).toEqual(['gmail:read', 'oauth:gmail'].sort());
+    expect(entry.toolsUsed).toEqual(['read_email_oauth']);
+  });
+
+  it('records a failure entry for task:rejected', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-2', { title: 'Send memo', metadata: { toolsUsed: ['send_email_oauth'] } });
+    const { bus, memory, sub } = buildSubscriber({ pool });
+    sub.start();
+
+    bus.publish(makeEvent({
+      id: 'evt-2',
+      type: 'task:rejected' as EventType,
+      workItemId: 'wi-2',
+    }));
+    await flush();
+
+    expect(memory.writes).toHaveLength(1);
+    expect(memory.writes[0]!.entry.task.outcome).toBe('failure');
+  });
+
+  it('records a partial entry for task:cancelled', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-3', { title: 'Pulled out', metadata: { toolsUsed: [] } });
+    const { bus, memory, sub } = buildSubscriber({ pool });
+    sub.start();
+
+    bus.publish(makeEvent({
+      id: 'evt-3',
+      type: 'task:cancelled' as EventType,
+      workItemId: 'wi-3',
+    }));
+    await flush();
+
+    expect(memory.writes).toHaveLength(1);
+    expect(memory.writes[0]!.entry.task.outcome).toBe('partial');
+  });
+
+  it('skips events with no workItemId', async () => {
+    const { bus, memory, sub } = buildSubscriber();
+    sub.start();
+    const evt = makeEvent({ workItemId: undefined as unknown as string });
+    bus.publish(evt);
+    await flush();
+    expect(memory.writes).toHaveLength(0);
+  });
+
+  it('skips events whose WorkItem is no longer in the pool (race window)', async () => {
+    const { bus, memory, sub } = buildSubscriber();
+    sub.start();
+    bus.publish(makeEvent({ workItemId: 'wi-missing' }));
+    await flush();
+    expect(memory.writes).toHaveLength(0);
+  });
+
+  it('skips events whose projectPath cannot be resolved', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-x', { title: 't', metadata: {} });
+    const { bus, memory, sub } = buildSubscriber({
+      pool,
+      resolveProjectPath: () => null,
+    });
+    sub.start();
+    bus.publish(makeEvent({ workItemId: 'wi-x' }));
+    await flush();
+    expect(memory.writes).toHaveLength(0);
+  });
+
+  it('swallows memory-write failures (does not throw to publisher)', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-err', { title: 't', metadata: { toolsUsed: [] } });
+    const memory = new StubProjectMemory();
+    memory.throwOnNextWrite = true;
+    const { bus, sub } = buildSubscriber({ pool, memory });
+    sub.start();
+
+    expect(() => bus.publish(makeEvent({ workItemId: 'wi-err' }))).not.toThrow();
+    await flush();
+    expect(memory.writes).toHaveLength(0);
+  });
+
+  it('uses stable workItemId-keyed entry id so redelivery dedups', async () => {
+    const pool = new StubTaskPool();
+    pool.put('wi-same', { title: 't', metadata: { toolsUsed: [] } });
+    const { bus, memory, sub } = buildSubscriber({ pool });
+    sub.start();
+
+    bus.publish(makeEvent({ workItemId: 'wi-same' }));
+    bus.publish(makeEvent({ workItemId: 'wi-same', id: 'evt-99' }));
+    await flush();
+
+    const ids = memory.writes.map((w) => w.entry.id);
+    expect(ids.every((id) => id === 'th-wi-same')).toBe(true);
+  });
+});
+
+describe('extractToolsUsed', () => {
+  it('reads canonical metadata.toolsUsed when present', () => {
+    expect(extractToolsUsed({ metadata: { toolsUsed: ['a', 'b'] } })).toEqual(['a', 'b']);
+  });
+
+  it('falls back to legacy metadata.tools', () => {
+    expect(extractToolsUsed({ metadata: { tools: ['legacy'] } })).toEqual(['legacy']);
+  });
+
+  it('strips non-string entries', () => {
+    expect(
+      extractToolsUsed({ metadata: { toolsUsed: ['a', 1, null, 'b'] as unknown[] } }),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('returns [] when neither field is set', () => {
+    expect(extractToolsUsed({ metadata: {} })).toEqual([]);
+    expect(extractToolsUsed({})).toEqual([]);
+  });
+});
+
+async function flush(): Promise<void> {
+  // Subscribers may be async; let the microtask queue drain.
+  await new Promise((r) => setImmediate(r));
+}
+
+// Suppress unused import warning if EventEmitter is not referenced
+// in any test (kept here in case StubEventBus is ever refactored to
+// extend it for hierarchical events).
+void EventEmitter;

--- a/backend/src/services/memory/task-history.subscriber.ts
+++ b/backend/src/services/memory/task-history.subscriber.ts
@@ -1,0 +1,255 @@
+/**
+ * Task History Subscriber
+ *
+ * Listens on the in-process EventBus for `task:done_by_worker`,
+ * `task:rejected`, and `task:cancelled` and writes a {@link
+ * TaskHistoryEntry} into the originating project's `ProjectMemory`.
+ *
+ * This is the load-bearing write path behind "who in my team has done
+ * X?" — the orchestrator queries the resulting ledger via
+ * `recall_memory({ capability: '<canonical-cap>' })` before delegating
+ * external-access work.
+ *
+ * @module services/memory/task-history.subscriber
+ */
+
+import {
+  EventBusService,
+  type InProcessUnsubscribe,
+} from '../event-bus/event-bus.service.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
+import { IProjectMemoryService } from './project-memory.service.js';
+import {
+  TaskHistoryEntry,
+  TaskOutcome,
+} from '../../types/memory.types.js';
+import {
+  AgentEvent,
+  EventType,
+} from '../../types/event-bus.types.js';
+import { LoggerService } from '../core/logger.service.js';
+import {
+  CapabilityInferenceService,
+  inferCapabilities,
+} from './capability-inference.js';
+
+/** Event types we record. Symmetric across success/failure/cancellation. */
+const RECORDED_EVENT_TYPES: readonly EventType[] = [
+  'task:done_by_worker' as EventType,
+  'task:rejected' as EventType,
+  'task:cancelled' as EventType,
+] as const;
+
+/**
+ * Map task pool event types → TaskOutcome. Done-by-worker is the
+ * success path; rejected is verifier-driven failure; cancelled is
+ * lifecycle abandonment (which we record as `partial` so the
+ * capability-index can still surface "the agent attempted this kind
+ * of work" without misleading on success rates).
+ */
+function eventTypeToOutcome(eventType: string): TaskOutcome {
+  switch (eventType) {
+    case 'task:done_by_worker':
+      return 'success';
+    case 'task:rejected':
+      return 'failure';
+    case 'task:cancelled':
+      return 'partial';
+    default:
+      return 'partial';
+  }
+}
+
+export interface TaskHistorySubscriberDeps {
+  /** Bus to listen on */
+  eventBus: EventBusService;
+  /** Memory service that owns the ledger */
+  projectMemoryService: IProjectMemoryService;
+  /** Pool service used to resolve the WorkItem from id (description, type, etc.) */
+  taskPoolService: TaskPoolService;
+  /** Optional override for capability inference (tests pass a stub) */
+  capabilityInference?: CapabilityInferenceService;
+  /**
+   * Optional override for the project path resolver. Production uses the
+   * WorkItem's `metadata.projectPath`; tests can substitute a fixed path.
+   */
+  resolveProjectPath?: (event: AgentEvent) => string | null;
+}
+
+export class TaskHistorySubscriber {
+  private readonly logger = LoggerService.getInstance().createComponentLogger(
+    'TaskHistorySubscriber',
+  );
+  private readonly eventBus: EventBusService;
+  private readonly projectMemory: IProjectMemoryService;
+  private readonly taskPool: TaskPoolService;
+  private readonly inference: CapabilityInferenceService;
+  private readonly resolveProjectPath: (event: AgentEvent) => string | null;
+  private unsubscribeFn: InProcessUnsubscribe | null = null;
+
+  constructor(deps: TaskHistorySubscriberDeps) {
+    this.eventBus = deps.eventBus;
+    this.projectMemory = deps.projectMemoryService;
+    this.taskPool = deps.taskPoolService;
+    this.inference = deps.capabilityInference ?? { infer: inferCapabilities };
+    this.resolveProjectPath = deps.resolveProjectPath ?? defaultResolveProjectPath;
+  }
+
+  /**
+   * Attach the in-process handler. Returns a detach function. Idempotent —
+   * calling start() twice without intervening stop() returns the first
+   * detach function (the second start is a no-op).
+   */
+  start(): InProcessUnsubscribe {
+    if (this.unsubscribeFn) {
+      this.logger.debug('start() called while already attached — returning existing detach');
+      return this.unsubscribeFn;
+    }
+    this.unsubscribeFn = this.eventBus.onInProcess(
+      [...RECORDED_EVENT_TYPES],
+      (event) => this.handle(event),
+    );
+    this.logger.info('TaskHistorySubscriber attached', {
+      types: RECORDED_EVENT_TYPES,
+    });
+    return this.unsubscribeFn;
+  }
+
+  /**
+   * Detach the handler. Safe to call multiple times.
+   */
+  stop(): void {
+    if (this.unsubscribeFn) {
+      this.unsubscribeFn();
+      this.unsubscribeFn = null;
+      this.logger.info('TaskHistorySubscriber detached');
+    }
+  }
+
+  /**
+   * Handle one event. Public for unit testing — production flow goes
+   * through the bus.
+   */
+  async handle(event: AgentEvent): Promise<void> {
+    try {
+      const workItemId = event.workItemId;
+      if (!workItemId) {
+        this.logger.debug('Event has no workItemId — skipping', {
+          eventId: event.id,
+          type: event.type,
+        });
+        return;
+      }
+
+      const workItem = await this.taskPool.findWorkItem(workItemId);
+      if (!workItem) {
+        this.logger.debug('WorkItem not found in pool — skipping', { workItemId });
+        return;
+      }
+
+      const projectPath = this.resolveProjectPath(event);
+      if (!projectPath) {
+        this.logger.debug('No projectPath resolvable — skipping', {
+          workItemId,
+          eventId: event.id,
+        });
+        return;
+      }
+
+      const sessionName =
+        event.sessionName ||
+        (workItem.target as string | undefined) ||
+        (workItem.owner as string | undefined) ||
+        '';
+      if (!sessionName) {
+        this.logger.debug('No session attributable — skipping', { workItemId });
+        return;
+      }
+
+      const role = (workItem.metadata?.['role'] as string | undefined) ?? 'unknown';
+      const teamId =
+        (workItem.metadata?.['teamId'] as string | undefined) ||
+        event.teamId ||
+        undefined;
+
+      const description =
+        (workItem.title as string | undefined) ||
+        (workItem.briefMarkdown as string | undefined)?.slice(0, 200) ||
+        '(no description)';
+
+      // Cast through unknown: WorkItem is a richer typed shape, but the
+      // helpers only need free-form metadata access. Avoids importing
+      // WorkItem's type just to widen it.
+      const workItemAsRecord = workItem as unknown as Record<string, unknown>;
+      const toolsUsed = extractToolsUsed(workItemAsRecord);
+      const capabilities = this.inference.infer(toolsUsed, workItemAsRecord);
+
+      const entry: TaskHistoryEntry = {
+        id: `th-${workItemId}`,
+        completedAt: event.timestamp || new Date().toISOString(),
+        agent: { sessionName, role, teamId },
+        task: {
+          description,
+          outcome: eventTypeToOutcome(event.type as string),
+        },
+        capabilities,
+        toolsUsed,
+        taskId: workItemId,
+      };
+
+      await this.projectMemory.addTaskHistory(projectPath, entry);
+      this.logger.info('Task history recorded', {
+        workItemId,
+        sessionName,
+        outcome: entry.task.outcome,
+        capCount: capabilities.length,
+      });
+    } catch (err) {
+      // Subscribers MUST swallow exceptions — a memory-write failure
+      // cannot back out the upstream task completion.
+      this.logger.warn('Failed to record task history (non-fatal)', {
+        eventId: event.id,
+        eventType: event.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Default resolver: lift `metadata.projectPath` off the WorkItem. The
+ * subscriber prefers the event's own projectPath if present, then falls
+ * back to the WorkItem's. Returns null when neither is set.
+ *
+ * Exported for unit testing.
+ */
+export function defaultResolveProjectPath(event: AgentEvent): string | null {
+  // AgentEvent doesn't have a typed projectPath field, but task-pool
+  // events sometimes ride one as a free-form attribute. Be defensive.
+  const eventPath = (event as unknown as Record<string, unknown>)['projectPath'];
+  if (typeof eventPath === 'string' && eventPath.length > 0) {
+    return eventPath;
+  }
+  return null;
+}
+
+/**
+ * Extract the tool names invoked during the task from the WorkItem's
+ * metadata. Tries `metadata.toolsUsed` (canonical), `metadata.tools`
+ * (legacy), and an empty list as a last resort.
+ *
+ * Exported for unit testing.
+ */
+export function extractToolsUsed(workItem: Record<string, unknown>): string[] {
+  const metadata = workItem['metadata'] as Record<string, unknown> | undefined;
+  if (!metadata) return [];
+  const canonical = metadata['toolsUsed'];
+  if (Array.isArray(canonical)) {
+    return canonical.filter((t): t is string => typeof t === 'string');
+  }
+  const legacy = metadata['tools'];
+  if (Array.isArray(legacy)) {
+    return legacy.filter((t): t is string => typeof t === 'string');
+  }
+  return [];
+}

--- a/backend/src/types/memory.types.test.ts
+++ b/backend/src/types/memory.types.test.ts
@@ -26,6 +26,9 @@ import {
   type LearningCategory,
   type VerbosityLevel,
   type BreakdownSize,
+  type MemoryType,
+  type TaskHistoryEntry,
+  type TaskOutcome,
 } from './memory.types.js';
 
 describe('Memory Types', () => {
@@ -394,6 +397,132 @@ describe('Memory Types', () => {
       };
 
       expect(entry.shouldInjectByDefault).toBe(false);
+    });
+  });
+
+  describe('TaskHistoryEntry — type-level constraints', () => {
+    it('accepts a minimal real-task entry shaped like the JSDoc example', () => {
+      const entry: TaskHistoryEntry = {
+        id: 'th-7f3a2b',
+        completedAt: '2026-05-18T14:32:11Z',
+        agent: { sessionName: 'crewly-product-ella', role: 'fullstack-dev' },
+        task: { description: 'Read MIT Role email from inbox', outcome: 'success', durationSec: 12 },
+        capabilities: ['gmail:read', 'oauth:gmail'],
+        toolsUsed: ['read_email_oauth'],
+        taskId: 'task-1747575131-742',
+      };
+
+      expect(entry.task.outcome).toBe('success');
+      expect(entry.capabilities).toContain('gmail:read');
+      expect(entry.agent.teamId).toBeUndefined();
+    });
+
+    it('accepts a synthetic register_self declaration with outcome=declared', () => {
+      const entry: TaskHistoryEntry = {
+        id: 'th-decl-001',
+        completedAt: '2026-05-18T10:00:00Z',
+        agent: { sessionName: 'crewly-product-ella', role: 'fullstack-dev', teamId: 'team-mit' },
+        task: {
+          description: 'Self-declared capabilities at register_self',
+          outcome: 'declared',
+        },
+        capabilities: ['oauth:gmail', 'oauth:calendar'],
+        toolsUsed: [],
+      };
+
+      expect(entry.task.outcome).toBe('declared');
+      expect(entry.toolsUsed).toEqual([]);
+    });
+
+    it('accepts a redactedDescription for privacy-sensitive entries', () => {
+      const entry: TaskHistoryEntry = {
+        id: 'th-redacted',
+        completedAt: '2026-05-18T14:00:00Z',
+        agent: { sessionName: 'crewly-finance-bob', role: 'analyst' },
+        task: {
+          description: 'Pulled card statements for user steve@example.com, total $4,231.22',
+          outcome: 'success',
+        },
+        capabilities: ['plaid:read'],
+        toolsUsed: ['fetch_transactions'],
+        redactedDescription: 'Pulled card statements for current user',
+      };
+
+      expect(entry.redactedDescription).toBeDefined();
+      expect(entry.redactedDescription).not.toContain('steve@example.com');
+    });
+
+    it('every TaskOutcome member is assignable to task.outcome', () => {
+      // Compile-time check — the array literal forces TS to verify each value
+      // is a valid TaskOutcome. Run-time assertion is just for coverage.
+      const outcomes: TaskOutcome[] = ['success', 'failure', 'partial', 'declared'];
+      for (const outcome of outcomes) {
+        const entry: TaskHistoryEntry = {
+          id: `th-${outcome}`,
+          completedAt: '2026-05-18T00:00:00Z',
+          agent: { sessionName: 's', role: 'r' },
+          task: { description: 'x', outcome },
+          capabilities: [],
+          toolsUsed: [],
+        };
+        expect(entry.task.outcome).toBe(outcome);
+      }
+    });
+  });
+
+  describe('MemoryType — task-history admission', () => {
+    it("includes 'task-history' alongside the five prior values", () => {
+      const expected: MemoryType[] = [
+        'procedural',
+        'risk',
+        'preference',
+        'domain',
+        'performance',
+        'task-history',
+      ];
+
+      // Each value is assignable to MemoryType (compile-time).
+      for (const t of expected) {
+        const x: MemoryType = t;
+        expect(typeof x).toBe('string');
+      }
+    });
+  });
+
+  describe('ProjectMemory.taskHistory — optional ledger', () => {
+    it('allows ProjectMemory to carry a taskHistory array', () => {
+      const project: ProjectMemory = {
+        ...DEFAULT_PROJECT_MEMORY,
+        projectId: 'proj-1',
+        projectPath: '/tmp/proj',
+        createdAt: '2026-05-18T00:00:00Z',
+        updatedAt: '2026-05-18T00:00:00Z',
+        taskHistory: [
+          {
+            id: 'th-1',
+            completedAt: '2026-05-18T01:00:00Z',
+            agent: { sessionName: 'crewly-orc', role: 'orchestrator' },
+            task: { description: 'Bootstrap memory', outcome: 'success' },
+            capabilities: ['code:read'],
+            toolsUsed: ['read_file'],
+          },
+        ],
+      };
+
+      expect(project.taskHistory).toHaveLength(1);
+      expect(project.taskHistory![0]!.capabilities).toEqual(['code:read']);
+    });
+
+    it('is omittable for backwards compatibility with older project memory files', () => {
+      const legacy: ProjectMemory = {
+        ...DEFAULT_PROJECT_MEMORY,
+        projectId: 'proj-legacy',
+        projectPath: '/tmp/legacy',
+        createdAt: '2026-04-01T00:00:00Z',
+        updatedAt: '2026-04-01T00:00:00Z',
+      };
+
+      expect(legacy.taskHistory).toBeUndefined();
     });
   });
 });

--- a/backend/src/types/memory.types.ts
+++ b/backend/src/types/memory.types.ts
@@ -32,7 +32,8 @@ export type MemoryType =
   | 'risk'          // Failures, anti-patterns, prohibitions
   | 'preference'    // Style, approach, team convention preferences
   | 'domain'        // Business facts, architecture knowledge
-  | 'performance';  // Agent capability assessment (for scheduling, not self-use)
+  | 'performance'   // Agent capability assessment (for scheduling, not self-use)
+  | 'task-history'; // Record of completed tasks — who did what, which capabilities
 
 /**
  * A single piece of role-specific knowledge learned by an agent
@@ -532,8 +533,105 @@ export interface ProjectMemory {
   gotchas: GotchaEntry[];
   /** Component/service relationships */
   relationships: RelationshipEntry[];
+  /**
+   * Completed-task ledger keyed by capability. Append-only at the
+   * subscriber level; the orchestrator queries this via
+   * `recall_memory({ capability: 'gmail:read' })` before delegating
+   * external-access work, so "who in my team has done X" is a fact
+   * rather than a guess. See {@link TaskHistoryEntry}.
+   */
+  taskHistory?: TaskHistoryEntry[];
   /** Schema version for migration support */
   schemaVersion?: number;
+}
+
+// ========================= TASK HISTORY =========================
+
+/**
+ * Outcome of a recorded task — used by recall queries to weight
+ * "this member can do X" against "they tried and failed."
+ *
+ * - `success`: task completed cleanly (reported via complete_task)
+ * - `failure`: task failed with an error the agent surfaced
+ * - `partial`: task ended in a partially-completed state (blocked /
+ *   handed off / abandoned with progress)
+ * - `declared`: synthetic entry — agent self-declared capability at
+ *   `register_self` time, no real task ran. Treated as low-weight
+ *   evidence; real entries supersede it.
+ */
+export type TaskOutcome = 'success' | 'failure' | 'partial' | 'declared';
+
+/**
+ * A single completed-task record. Written by TaskHistorySubscriber
+ * when the eventBus emits `v3:task_completed` / `v3:task_failed`, or
+ * synthetically at `register_self` time as a cold-start seed.
+ *
+ * The load-bearing field for routing decisions is `capabilities` —
+ * canonical strings of the form `<category>:<resource>` (e.g.
+ * `gmail:read`, `slack:post`, `oauth:gmail`). The orchestrator's
+ * delegation-first prompt queries by these strings.
+ *
+ * @example
+ * ```typescript
+ * const entry: TaskHistoryEntry = {
+ *   id: 'th-7f3a2b',
+ *   completedAt: '2026-05-18T14:32:11Z',
+ *   agent: { sessionName: 'crewly-product-ella', role: 'fullstack-dev' },
+ *   task: { description: 'Read MIT Role email from inbox', outcome: 'success', durationSec: 12 },
+ *   capabilities: ['gmail:read', 'oauth:gmail'],
+ *   toolsUsed: ['read_email_oauth'],
+ *   taskId: 'task-1747575131-742',
+ * };
+ * ```
+ */
+export interface TaskHistoryEntry {
+  /** Stable identifier for dedup and back-references */
+  id: string;
+  /** ISO timestamp of completion (or declaration time, for synthetic seeds) */
+  completedAt: string;
+  /** Agent that did the work */
+  agent: {
+    /** Session name, e.g. `crewly-product-ella` */
+    sessionName: string;
+    /** Role name from the team template, e.g. `fullstack-dev` */
+    role: string;
+    /** Optional team association — present when invoked through a team */
+    teamId?: string;
+  };
+  /** Task metadata */
+  task: {
+    /** Human-readable summary. Should be brief — full body lives in chat history. */
+    description: string;
+    /** Outcome — see {@link TaskOutcome} */
+    outcome: TaskOutcome;
+    /** Wall-clock duration in seconds, if known */
+    durationSec?: number;
+  };
+  /**
+   * Canonical capability strings derived from the tool trace. Format:
+   * `<category>:<resource>`. Mapping table lives in CapabilityInferenceService.
+   *
+   * Examples:
+   *   gmail:read, gmail:send
+   *   slack:post, slack:dm
+   *   github:pr-create, github:issue-comment
+   *   oauth:gmail, oauth:slack, oauth:github
+   *   chrome:scrape (web-search via browser)
+   *   code:edit, code:read
+   */
+  capabilities: string[];
+  /** Tool names called during the task — raw audit trace, drives inference */
+  toolsUsed: string[];
+  /** Optional link to the originating WorkItem id */
+  taskId?: string;
+  /** Optional link to the chat-v2 conversation id */
+  conversationId?: string;
+  /**
+   * Optional redacted version of `task.description` for privacy-sensitive
+   * contexts. If set, recall results SHOULD surface this instead of the raw
+   * description when leaving the originating agent's trust boundary.
+   */
+  redactedDescription?: string;
 }
 
 // ========================= SHARED USER PROFILE =========================

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -609,6 +609,8 @@ export const MEMORY_CONSTANTS = {
     GOTCHAS: 'gotchas.json',
     /** Relationship entries */
     RELATIONSHIPS: 'relationships.json',
+    /** Completed-task ledger (TaskHistoryEntry[]) */
+    TASK_HISTORY: 'task-history.json',
     /** Human-readable learnings log */
     LEARNINGS: 'learnings.md',
   },

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -519,6 +519,50 @@ This is a hard pre-yield check. Do not yield if any Slack message is unanswered.
 - Escalate cross-team blockers
 - Your role boundaries are defined in the Role Boundary section. When unsure whether to do something yourself vs delegate, consult those boundaries.
 
+### Delegation-First Routing for External Access (MANDATORY)
+
+**Before you reach for your own tools to do external-system work — reading email, posting to Slack, scheduling on a calendar, opening a browser tab, calling a third-party API — first ask the team's task-history ledger who has demonstrated that capability before. Then prefer delegating to that member.** This is the difference between "I can't read Gmail because the Chrome extension is offline" and "Ella can — she has Gmail OAuth and read MIT-Role emails last week."
+
+**The capability lookup:**
+
+```jsonc
+// crewly_recall_memory tool — pass `capability` to query the ledger
+{
+  "query": "who can read gmail",        // free-text context
+  "capability": "gmail:read",           // canonical <category>:<resource>
+  "projectPath": "<current-project>",
+  "scope": "project"
+}
+```
+
+The response's `taskHistory[]` lists members who have completed tasks exercising that capability, sorted most-recent first. The `combined` field already includes a `### Capability Routing` block summarising the ranking — read it before deciding.
+
+**Canonical capability strings** (extend as new tools land — registry in `services/memory/capability-inference.ts`):
+
+| Capability | Granted by tools |
+|---|---|
+| `gmail:read` / `gmail:send` | `read_email_oauth`, `send_email_oauth` |
+| `oauth:gmail` | any Gmail OAuth tool |
+| `calendar:read` / `calendar:write` | `read_calendar_oauth`, `create_calendar_event` |
+| `oauth:calendar` | any Calendar OAuth tool |
+| `slack:post` | `reply-slack` |
+| `github:pr-create` / `github:issue-comment` | `gh_pr_create`, `gh_issue_comment` |
+| `oauth:github` | any GitHub-token tool |
+| `chrome:scrape` / `web:search` / `web:fetch` | browser-bridge tools |
+| `code:edit` / `code:write` / `git:commit` | editor + git tools |
+| `shell:exec` | `bash_exec` |
+
+**Decision tree (apply in order):**
+
+1. **`recall(capability: '<cap>')` returns ≥1 member** → delegate to the most-recent member. Use `delegate-task` with a brief that names the capability ("Ella, please read the most recent email matching 'Fwd: MIT Role' — using your Gmail OAuth"). Skip to step 4.
+2. **Returns 0 but a team member's role config declares the capability** (e.g. `members[].capabilities.oauth: ['gmail']` in `team.json`) → delegate to them; their first run will seed the ledger.
+3. **Returns 0 and no member self-declares it** → fall back to your own tools (e.g. Crewly in Chrome for browser access — see next section). Mention to the user that this is the fallback path so they know nobody on the team is currently set up for this.
+4. **After the delegated task completes**, the TaskHistorySubscriber writes a new entry automatically — no manual recording needed.
+
+**Do NOT** answer "I can't do X because <runtime state>" without first running step 1. The runtime state of *your* tools (Chrome extension offline, OAuth not connected on the orc) tells you nothing about your team's capabilities.
+
+**Cold-start case** (brand-new project, empty ledger): use the team config's `members[].capabilities` field as a hint, and at `register-self` time each agent declares its OAuth/skill set — these synthetic `outcome: 'declared'` entries populate the ledger so day-1 routing works.
+
 ### Browser Access — Prefer Crewly in Chrome
 
 When a task needs browser access (web browsing, scraping, controlling a live web app, reading a logged-in page), **prefer the user's own Chrome via the `Crewly in Chrome` extension** over headless Playwright or a remote browser.


### PR DESCRIPTION
## Summary
Long-term fix for the routing-instinct gap that produced "Chrome ext not connected — can't read Gmail" instead of "Ella can do it via her Gmail OAuth". The orchestrator now consults a task-history ledger before defaulting to its own tools.

## Architecture

```
complete_task / task:rejected / task:cancelled
              ↓ (eventBus)
   TaskHistorySubscriber
              ↓
   ProjectMemory.addTaskHistory(entry)  →  ~/.crewly/{project}/knowledge/task-history.json
                                                    ↓
                                          recall_memory({capability: 'gmail:read'})
                                                    ↓
                          ### Capability Routing — gmail:read
                          - crewly-product-ella (fullstack-dev) 1× last on 2026-05-18
```

## What's in here

| Block | Files |
|---|---|
| **Types** | `types/memory.types.ts`: extends MemoryType union with `'task-history'`; new `TaskHistoryEntry` + `TaskOutcome`; `ProjectMemory.taskHistory?` optional for backward compat |
| **Constants** | `config/constants.ts`: `PROJECT_FILES.TASK_HISTORY = 'task-history.json'` |
| **Storage** | `project-memory.service.ts`: `addTaskHistory` / `getTaskHistory(capability?)` — dedup by id, capability-filtered query returns matches sorted most-recent first |
| **Subscriber** | `task-history.subscriber.ts`: attaches via `eventBus.onInProcess([task:done_by_worker, task:rejected, task:cancelled])`. Stable `th-<workItemId>` id so redelivered events dedup. Exceptions swallowed (memory-write cannot back out task completion) |
| **Inference** | `capability-inference.ts`: static table mapping each tool → canonical `<category>:<resource>` capability strings. Gmail/Calendar OAuth tools co-emit `oauth:gmail` / `oauth:calendar` so recall finds them either by action or credential |
| **Recall** | `memory.service.ts`: `RecallParams.capability?` + `RecallResult.taskHistory?`. When set, queries ledger and appends a `### Capability Routing` summary to `combined`. MCP tool `crewly_recall_memory` exposes the param |
| **Orc prompt** | `config/roles/orchestrator/prompt.md`: new MANDATORY "Delegation-First Routing for External Access" section with canonical capability vocabulary + decision tree. Inserted before "Browser Access" so orc reads it first |
| **Cold-start seed** | `task-history-seeder.ts` + `team.controller.registerMemberStatus`: on register, write a synthetic `outcome: 'declared'` entry for each canonical (`<cat>:<res>`) capability in `member.capabilities`. Lets day-0 routing work before any real task has run |
| **Bootstrap** | `index.ts`: starts a `TaskHistorySubscriber` after `TaskPoolService.setEventBusService` |

## Test plan
- [x] 77 new unit tests pass (`--runInBand --forceExit`):
  - `capability-inference.test.ts` — 14
  - `task-history.subscriber.test.ts` — 16 (12 + 4 helper)
  - `task-history-seeder.test.ts` — 11
  - `memory.types.test.ts` — additions: 19
  - `memory.service.test.ts` — recall.capability additions: 4
  - + existing tests in touched files remain green
- [x] `npx tsc --noEmit` clean
- [ ] After merge, manual smoke: register a team member with `capabilities: ['gmail:read', 'oauth:gmail']`, then ask orc to read an email — verify it queries `recall(capability: 'gmail:read')` and delegates rather than reaching for Chrome
- [ ] After a real `task:done_by_worker` fires, verify `~/.crewly/{project}/knowledge/task-history.json` carries the entry with inferred capabilities

## Known follow-ups
- Capability vocabulary will need extending as new tools land — the table in `capability-inference.ts` is the single point of registration
- `member.capabilities[]` is still a free-form `string[]`. A future PR could move to a structured shape (`{ oauth: string[], skills: string[] }`) without breaking this flow — the seeder filters by `':'` so structured + free-form coexist
- The orchestrator-team route (line 2107) doesn't seed; orc itself doesn't declare external capabilities, only team members do. Revisit if orc ever holds its own OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)