### PR TITLE
fix(skills): poll-tasks fallback to target= when owner=agent yields zero (D8)

### DIFF
--- a/config/skills/agent/core/poll-tasks/execute.sh
+++ b/config/skills/agent/core/poll-tasks/execute.sh
@@ -64,6 +64,15 @@ fi
 
 # ---------------------------------------------------------------------------
 # Step 1: Query available WorkItems from Task Pool
+#
+# Primary query: owner=agent (normal task-pool queue).
+# Fallback query: target=$SESSION_NAME — picks up orchestrator/TL-owned
+# WorkItems delegated directly to this agent. Without the fallback,
+# direct delegations would never be seen by poll-tasks because they
+# do not match owner=agent. (D8 defect: previously the target= query
+# only fired on HTTP error from the primary, not on count=0, so direct
+# delegations sat in the pool indefinitely while the agent reported
+# "no work".)
 # ---------------------------------------------------------------------------
 
 QUERY_PARAMS="?types=${TYPES}&owner=agent"
@@ -76,6 +85,22 @@ AVAILABLE_RESPONSE=$(api_call GET "/task-pool${QUERY_PARAMS}" 2>&1) || {
 }
 
 AVAILABLE_COUNT=$(printf '%s' "$AVAILABLE_RESPONSE" | jq -r '.count // 0')
+
+# When the primary owner=agent query yields no items, also probe the
+# target= namespace before declaring no work. If the fallback returns
+# items, they are by definition pinned to this agent — record the first
+# item's id so Step 3 can claim it explicitly (the server-side FIFO
+# picker filters owner=agent and would otherwise ignore these items).
+TARGET_PINNED_ID=""
+if [ "$AVAILABLE_COUNT" -eq 0 ]; then
+  TARGET_RESPONSE=$(api_call GET "/task-pool?types=${TYPES}&target=${SESSION_NAME}" 2>&1) || TARGET_RESPONSE=""
+  TARGET_COUNT=$(printf '%s' "$TARGET_RESPONSE" | jq -r '.count // 0' 2>/dev/null || echo 0)
+  if [ "$TARGET_COUNT" -gt 0 ]; then
+    AVAILABLE_RESPONSE="$TARGET_RESPONSE"
+    AVAILABLE_COUNT="$TARGET_COUNT"
+    TARGET_PINNED_ID=$(printf '%s' "$TARGET_RESPONSE" | jq -r '(.data // [])[0].id // empty')
+  fi
+fi
 
 if [ "$AVAILABLE_COUNT" -eq 0 ]; then
   # No available work — return early
@@ -123,15 +148,25 @@ fi
 # We pass our agentId and filters so the server picks the best match.
 # ---------------------------------------------------------------------------
 
-CLAIM_BODY=$(jq -n \
-  --arg agentId "$SESSION_NAME" \
-  --arg types "$TYPES" \
-  '{
-    agentId: $agentId,
-    filters: {
-      types: ($types | split(","))
-    }
-  }')
+# When a target-pinned item was found via the fallback query, claim it
+# by explicit workItemId — the server-side FIFO picker filters owner=agent
+# and would not return orchestrator-owned items via the unfiltered claim.
+if [ -n "$TARGET_PINNED_ID" ]; then
+  CLAIM_BODY=$(jq -n \
+    --arg agentId "$SESSION_NAME" \
+    --arg workItemId "$TARGET_PINNED_ID" \
+    '{agentId: $agentId, workItemId: $workItemId}')
+else
+  CLAIM_BODY=$(jq -n \
+    --arg agentId "$SESSION_NAME" \
+    --arg types "$TYPES" \
+    '{
+      agentId: $agentId,
+      filters: {
+        types: ($types | split(","))
+      }
+    }')
+fi
 
 CLAIM_RESPONSE=$(api_call POST "/task-pool/claim" "$CLAIM_BODY" 2>&1) || {
   CLAIM_ERROR="$CLAIM_RESPONSE"

--- a/config/skills/agent/core/poll-tasks/execute.test.sh
+++ b/config/skills/agent/core/poll-tasks/execute.test.sh
@@ -200,6 +200,104 @@ fi
 assert_eq "empty types uses role default" "delegate,project_task,review" "$FINAL_TYPES2"
 
 # ---------------------------------------------------------------------------
+# Test 7: D8 fallback — target= query when owner=agent yields zero
+#
+# Mirrors the production logic: when the primary owner=agent response has
+# count=0, we should adopt the target= response if it contains any items,
+# and record the first item's id as TARGET_PINNED_ID so the claim step
+# can claim by workItemId rather than by FIFO filters.
+# ---------------------------------------------------------------------------
+echo "Test 7: D8 fallback for orchestrator-owned target items"
+
+OWNER_AGENT_EMPTY='{"success":true,"data":[],"count":0}'
+TARGET_RESPONSE_HIT='{"success":true,"data":[
+  {"id":"wi-orc-1","type":"delegate","owner":"orchestrator","target":"agent-1","status":"queued"},
+  {"id":"wi-orc-2","type":"delegate","owner":"orchestrator","target":"agent-1","status":"queued"}
+],"count":2}'
+
+# Simulate the merge step
+AVAILABLE_RESPONSE_SIM="$OWNER_AGENT_EMPTY"
+AVAILABLE_COUNT_SIM=$(printf '%s' "$AVAILABLE_RESPONSE_SIM" | jq -r '.count // 0')
+TARGET_PINNED_ID_SIM=""
+if [ "$AVAILABLE_COUNT_SIM" -eq 0 ]; then
+  TARGET_RESPONSE_SIM="$TARGET_RESPONSE_HIT"
+  TARGET_COUNT_SIM=$(printf '%s' "$TARGET_RESPONSE_SIM" | jq -r '.count // 0')
+  if [ "$TARGET_COUNT_SIM" -gt 0 ]; then
+    AVAILABLE_RESPONSE_SIM="$TARGET_RESPONSE_SIM"
+    AVAILABLE_COUNT_SIM="$TARGET_COUNT_SIM"
+    TARGET_PINNED_ID_SIM=$(printf '%s' "$TARGET_RESPONSE_SIM" | jq -r '(.data // [])[0].id // empty')
+  fi
+fi
+
+assert_eq "fallback adopts target response count" "2" "$AVAILABLE_COUNT_SIM"
+assert_eq "fallback pins first target item id" "wi-orc-1" "$TARGET_PINNED_ID_SIM"
+
+# When BOTH queries are empty, AVAILABLE_COUNT stays 0 and no pin is set
+AVAILABLE_RESPONSE_EMPTY="$OWNER_AGENT_EMPTY"
+AVAILABLE_COUNT_EMPTY=$(printf '%s' "$AVAILABLE_RESPONSE_EMPTY" | jq -r '.count // 0')
+TARGET_PINNED_ID_EMPTY=""
+if [ "$AVAILABLE_COUNT_EMPTY" -eq 0 ]; then
+  TARGET_RESPONSE_EMPTY='{"success":true,"data":[],"count":0}'
+  TARGET_COUNT_EMPTY=$(printf '%s' "$TARGET_RESPONSE_EMPTY" | jq -r '.count // 0')
+  if [ "$TARGET_COUNT_EMPTY" -gt 0 ]; then
+    AVAILABLE_RESPONSE_EMPTY="$TARGET_RESPONSE_EMPTY"
+    AVAILABLE_COUNT_EMPTY="$TARGET_COUNT_EMPTY"
+    TARGET_PINNED_ID_EMPTY=$(printf '%s' "$TARGET_RESPONSE_EMPTY" | jq -r '(.data // [])[0].id // empty')
+  fi
+fi
+assert_eq "both-empty leaves count at 0" "0" "$AVAILABLE_COUNT_EMPTY"
+assert_eq "both-empty leaves pin empty" "" "$TARGET_PINNED_ID_EMPTY"
+
+# When owner=agent has items already, fallback must NOT fire
+OWNER_AGENT_HIT='{"success":true,"data":[
+  {"id":"wi-agent-1","type":"project_task","owner":"agent","status":"queued"}
+],"count":1}'
+AVAILABLE_RESPONSE_PRI="$OWNER_AGENT_HIT"
+AVAILABLE_COUNT_PRI=$(printf '%s' "$AVAILABLE_RESPONSE_PRI" | jq -r '.count // 0')
+TARGET_PINNED_ID_PRI=""
+if [ "$AVAILABLE_COUNT_PRI" -eq 0 ]; then
+  TARGET_PINNED_ID_PRI="should-not-be-set"
+fi
+assert_eq "primary-hit keeps count=1" "1" "$AVAILABLE_COUNT_PRI"
+assert_eq "primary-hit leaves pin empty (no fallback)" "" "$TARGET_PINNED_ID_PRI"
+
+# ---------------------------------------------------------------------------
+# Test 8: Claim body shape — workItemId vs filters
+#
+# When TARGET_PINNED_ID is set, the claim body must include workItemId.
+# Otherwise it uses the FIFO filters shape. Both are accepted by the
+# /task-pool/claim endpoint, but only the workItemId form will claim
+# orchestrator-owned items.
+# ---------------------------------------------------------------------------
+echo "Test 8: Claim body shape"
+
+build_claim_body() {
+  local pinned="$1" session="$2" types="$3"
+  if [ -n "$pinned" ]; then
+    jq -nc \
+      --arg agentId "$session" \
+      --arg workItemId "$pinned" \
+      '{agentId: $agentId, workItemId: $workItemId}'
+  else
+    jq -nc \
+      --arg agentId "$session" \
+      --arg types "$types" \
+      '{agentId: $agentId, filters: {types: ($types | split(","))}}'
+  fi
+}
+
+PINNED_BODY=$(build_claim_body "wi-orc-1" "agent-1" "delegate,project_task")
+assert_json_field "pinned body has workItemId" "$PINNED_BODY" ".workItemId" "wi-orc-1"
+assert_json_field "pinned body has agentId" "$PINNED_BODY" ".agentId" "agent-1"
+assert_json_field "pinned body has no filters" "$PINNED_BODY" ".filters" "null"
+
+FIFO_BODY=$(build_claim_body "" "agent-1" "delegate,project_task")
+assert_json_field "fifo body has agentId" "$FIFO_BODY" ".agentId" "agent-1"
+assert_json_field "fifo body has no workItemId" "$FIFO_BODY" ".workItemId" "null"
+assert_json_field "fifo body types[0]" "$FIFO_BODY" ".filters.types[0]" "delegate"
+assert_json_field "fifo body types[1]" "$FIFO_BODY" ".filters.types[1]" "project_task"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Closes the D8 defect surfaced by ESTestNode dispatch 2026-05-20 (and chased across multiple workers earlier in the day):

- `config/skills/agent/core/poll-tasks/execute.sh` only queried `?types=...&owner=agent`. Orchestrator- or TL-owned WorkItems delegated directly to an agent (`owner=orchestrator|team-leader`, `target=$SESSION_NAME`) do not match `owner=agent` and were invisible to `poll-tasks`.
- The pre-existing `target=$SESSION_NAME` fallback only fired on HTTP error from the primary query — never on `count=0` — so the script exited early reporting "no work" while the WorkItem sat queued in the pool.

## Repro

WI `d705bfe0-8fb0-483a-bbd2-1c46cea260d8` (owner=orchestrator, target=crewly-support-sora-86babdd7, type=delegate, status=queued) was unreachable via `poll-tasks` for ~2.5h despite `GET /api/task-pool?target=crewly-support-sora-86babdd7` clearly returning it. The interim workaround was a direct `POST /api/task-pool/claim` with `{workItemId, agentId}`, which this patch makes the standard path when the fallback fires.

## Fix

1. After `count=0` from the `owner=agent` query, run a secondary `target=$SESSION_NAME` query. If it returns items, adopt that response and record the first item's id as `TARGET_PINNED_ID`.
2. When `TARGET_PINNED_ID` is set, claim by explicit `workItemId` rather than the FIFO `filters` shape — the server-side FIFO matcher filters `owner=agent` and would otherwise ignore orchestrator-owned items even if we passed them through the claim filters.
3. Primary path unchanged when the owner=agent query has results: no behaviour change for the normal task-pool queue.

Net diff: +53 / −9 in `execute.sh`, +98 in `execute.test.sh`.

## Test plan

- [x] Unit tests added (11 new assertions): fallback merge, both-empty no-op, primary-hit no-fallback guard, claim-body shape branching for `workItemId` vs `filters`
- [x] `bash config/skills/agent/core/poll-tasks/execute.test.sh` — 38 passed, 0 failed
- [x] `bash -n` syntax check on execute.sh + execute.test.sh — clean
- [x] Quality gates passed at commit time
- [ ] Reviewer: confirm fallback behavior matches the wider Task Pool/Reconciler invariants Sam is tracking under memory entry `03cf7a1f` (Sam D-stack incident timeline)

## Refs

- Memory entry `03cf7a1f` — Sam D-stack incident timeline; this is the client-side half of one D-class signaling defect chased across workers today
- ESTestNode deploy report (Sora → ORC, 2026-05-20 ~05:00Z) — original surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)