### PR TITLE
feat(reconciler+event-bus): redeliver for active-but-idle + agent:idle taxonomy

### DIFF
--- a/backend/src/services/monitoring/activity-monitor.service.test.ts
+++ b/backend/src/services/monitoring/activity-monitor.service.test.ts
@@ -893,6 +893,20 @@ describe('ActivityMonitorService', () => {
         (c: any[]) => c[0].type === 'agent:idle' && c[0].sessionName === 'test-session-1'
       );
       expect(idleEvents).toHaveLength(1);
+
+      // 2026-05-20 follow-up — the precise post-task variant must fire
+      // alongside the generic event so peer-watch triggers can filter on
+      // `agent:idle_after_task` and avoid registration-idle false wakes.
+      const idleAfterTaskEvents = mockEventBus.publish.mock.calls.filter(
+        (c: any[]) => c[0].type === 'agent:idle_after_task' && c[0].sessionName === 'test-session-1'
+      );
+      expect(idleAfterTaskEvents).toHaveLength(1);
+      // ...and crucially, NOT the registration variant — the agent was
+      // observed in_progress before reaching this idle transition.
+      const idleAfterRegEvents = mockEventBus.publish.mock.calls.filter(
+        (c: any[]) => c[0].type === 'agent:idle_after_registration' && c[0].sessionName === 'test-session-1'
+      );
+      expect(idleAfterRegEvents).toHaveLength(0);
     });
   });
 

--- a/backend/src/services/monitoring/activity-monitor.service.ts
+++ b/backend/src/services/monitoring/activity-monitor.service.ts
@@ -189,7 +189,14 @@ export class ActivityMonitorService {
         }
       } else {
         if (elapsed >= PTY_CONSTANTS.MIN_BUSY_DURATION_MS && this.busyEventEmitted.has(key) && this.eventBusService) {
+          // Generic event (back-compat for fleet dashboards / auto-claim / etc.)
           this.eventBusService.publish(this.buildAgentEvent('agent:idle', now, identity, previousStatus, newStatus));
+          // 2026-05-20 follow-up: the in-process busy guard above (`busyEventEmitted`)
+          // guarantees we only reach this branch when the agent was actually
+          // observed busy first — so this transition is unambiguously
+          // post-task. Emit the precise variant so peer-watch triggers
+          // can filter on it without being woken by registration-idle.
+          this.eventBusService.publish(this.buildAgentEvent('agent:idle_after_task', now, identity, previousStatus, newStatus));
         }
         this.busyTransitionTimestamps.delete(key);
         this.busyEventEmitted.delete(key);

--- a/backend/src/services/monitoring/teams-json-watcher.service.test.ts
+++ b/backend/src/services/monitoring/teams-json-watcher.service.test.ts
@@ -361,6 +361,66 @@ describe('TeamsJsonWatcherService', () => {
     });
   });
 
+  // 2026-05-20 follow-up — precise idle taxonomy. The watcher must emit
+  // `agent:idle_after_task` when prev was `in_progress`, and
+  // `agent:idle_after_registration` when prev was unset (fresh row).
+  // The generic `agent:idle` still fires for back-compat.
+  describe('idle taxonomy (agent:idle_after_task vs agent:idle_after_registration)', () => {
+    const mkTeam = (memberOverrides: Record<string, unknown>) => ({
+      id: 't1',
+      name: 'Team One',
+      members: [{
+        id: 'm1',
+        name: 'Member One',
+        sessionName: 'sora',
+        agentStatus: 'active',
+        ...memberOverrides,
+      }],
+    } as any);
+
+    const callPublish = (oldTeams: any[], newTeams: any[]) => {
+      const events: any[] = [];
+      const mockBus = { publish: (e: any) => events.push(e) } as any;
+      service.setEventBusService(mockBus);
+      (service as any).publishAgentEvents(oldTeams, newTeams);
+      return events;
+    };
+
+    it('emits agent:idle_after_task when prev workingStatus was in_progress', () => {
+      const events = callPublish(
+        [mkTeam({ workingStatus: 'in_progress' })],
+        [mkTeam({ workingStatus: 'idle' })],
+      );
+      const types = events.map(e => e.type);
+      expect(types).toContain('agent:idle');
+      expect(types).toContain('agent:idle_after_task');
+      expect(types).not.toContain('agent:idle_after_registration');
+    });
+
+    it('emits agent:idle_after_registration when prev workingStatus was unset', () => {
+      const events = callPublish(
+        [mkTeam({})], // no workingStatus on the old row
+        [mkTeam({ workingStatus: 'idle' })],
+      );
+      const types = events.map(e => e.type);
+      expect(types).toContain('agent:idle');
+      expect(types).toContain('agent:idle_after_registration');
+      expect(types).not.toContain('agent:idle_after_task');
+    });
+
+    it('does not emit any idle taxonomy event when transitioning idle → busy', () => {
+      const events = callPublish(
+        [mkTeam({ workingStatus: 'idle' })],
+        [mkTeam({ workingStatus: 'in_progress' })],
+      );
+      const types = events.map(e => e.type);
+      expect(types).toContain('agent:busy');
+      expect(types).not.toContain('agent:idle');
+      expect(types).not.toContain('agent:idle_after_task');
+      expect(types).not.toContain('agent:idle_after_registration');
+    });
+  });
+
   describe('cleanup', () => {
     it('should clean up on process signals', () => {
       const stopSpy = jest.spyOn(service, 'stop');

--- a/backend/src/services/monitoring/teams-json-watcher.service.ts
+++ b/backend/src/services/monitoring/teams-json-watcher.service.ts
@@ -453,6 +453,31 @@ export class TeamsJsonWatcherService extends EventEmitter {
           };
 
           this.eventBusService.publish(workingEvent);
+
+          // 2026-05-20 follow-up — disambiguate idle transitions for
+          // peer-watch triggers. The file-watcher sees raw `oldValue →
+          // newValue` transitions; we can distinguish:
+          //   - prev was `in_progress` → this is `agent:idle_after_task`
+          //   - prev was unset/null/empty (fresh-registration row) →
+          //     `agent:idle_after_registration`
+          // We do NOT emit the precise variant when we can't tell
+          // (e.g. prev='idle', new='idle' — that case is filtered out
+          // by the outer guard anyway).
+          if (newMember.workingStatus === 'idle') {
+            const wasBusy = oldMember.workingStatus === 'in_progress';
+            const wasUnset = !oldMember.workingStatus;
+            const preciseType: 'agent:idle_after_task' | 'agent:idle_after_registration' | null =
+              wasBusy ? 'agent:idle_after_task'
+              : wasUnset ? 'agent:idle_after_registration'
+              : null;
+            if (preciseType) {
+              this.eventBusService.publish({
+                ...workingEvent,
+                id: crypto.randomUUID(),
+                type: preciseType,
+              });
+            }
+          }
         }
       }
     }

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -1077,4 +1077,146 @@ describe('detectUnclaimedTasks', () => {
     expect(wakeActions[0].scoreBreakdown.urgency).toBeGreaterThanOrEqual(0);
     expect(wakeActions[0].score).toBeGreaterThan(0);
   });
+
+  // -----------------------------------------------------------------------
+  // 2026-05-20 Sora case — redeliver strategy for active-but-idle targets
+  // -----------------------------------------------------------------------
+
+  describe('redeliver strategy (active-but-idle target)', () => {
+    // Active-but-idle agents only act AFTER the 5-min effective threshold
+    // when any active agent is in the map. Make WIs ~7min old.
+    const SEVEN_MIN_AGO = new Date(Date.now() - 7 * 60_000).toISOString();
+
+    it('emits redeliver when WI target is active with no active claims', () => {
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'sora',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+      ]);
+
+      const { wakeActions, unclaimedWorkItemIds } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(1);
+      expect(wakeActions[0].strategy).toBe('redeliver');
+      expect(wakeActions[0].agentSessionName).toBe('sora');
+      expect(wakeActions[0].workItemId).toBe(wi.id);
+      expect(wakeActions[0].score).toBe(0);
+      expect(unclaimedWorkItemIds).toContain(wi.id);
+    });
+
+    it('does NOT redeliver when target is active but has active claims', () => {
+      // active-but-busy: the agent already has work and presumably saw
+      // the WI; not a banner-drop scenario.
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'sora',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 2 }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(0);
+    });
+
+    it('does NOT redeliver when WI has no target', () => {
+      // Untargeted WIs never trigger ANY wake (2026-05-17 strict policy).
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: undefined,
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(0);
+    });
+
+    it('does NOT redeliver before the effective threshold', () => {
+      // 4min old < 5min effective threshold when an active agent exists.
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+        type: 'delegate',
+        target: 'sora',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(0);
+    });
+
+    it('prefers redeliver over start when target is active-but-idle and another inactive agent exists', () => {
+      // The target should ALWAYS get the work — never substitute by score
+      // (2026-05-17 strict-target policy). Verifies redeliver takes
+      // precedence over best-score search.
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'sora',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+        // Another developer is inactive — the OLD behaviour would have
+        // tried to start them. The new behaviour must redeliver to sora.
+        ['other-dev', { status: 'inactive', role: 'developer' }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(1);
+      expect(wakeActions[0].strategy).toBe('redeliver');
+      expect(wakeActions[0].agentSessionName).toBe('sora');
+    });
+
+    it('does NOT redeliver to the same agent twice in a single pass', () => {
+      const wi1 = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'sora',
+      });
+      const wi2 = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'sora',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi1, wi2], agentMap);
+      // One redeliver per pass per agent; the oldest WI wins.
+      expect(wakeActions).toHaveLength(1);
+      expect(wakeActions[0].strategy).toBe('redeliver');
+    });
+
+    it('returns empty when only active-but-idle agents exist but no targeted WIs match', () => {
+      // Defensive — verifies the early-return path doesn't skip the
+      // active-idle bucket. WI targets a different (absent) agent.
+      const wi = makeWorkItem({
+        status: 'queued',
+        createdAt: SEVEN_MIN_AGO,
+        type: 'delegate',
+        target: 'someone-else',
+      });
+      const agentMap = makeAgentMap([
+        ['sora', { status: 'active', role: 'developer', activeWorkItemCount: 0 }],
+      ]);
+
+      const { wakeActions } = detectUnclaimedTasks([wi], agentMap);
+      expect(wakeActions).toHaveLength(0);
+    });
+  });
 });

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -728,15 +728,30 @@ export function detectUnclaimedTasks(
   const unclaimedWorkItemIds: string[] = [];
   const now = Date.now();
 
-  // Find agents that can be woken (suspended or inactive)
+  // Find agents that can be woken.
+  //   - suspended → rehydrate (resume the paused session)
+  //   - inactive  → start     (spin a fresh agent session)
+  //   - active + activeWorkItemCount===0 → redeliver (re-POST WI brief to PTY)
+  //
+  // The `redeliver` bucket targets the 2026-05-20 Sora case: a WorkItem was
+  // queued with explicit `target=crewly-test-sora`, the agent was alive at
+  // the prompt, but the original /api/terminal/:session/write landed inside
+  // claude-code's startup banner and was silently dropped. The WI sat in
+  // queued for ~53 minutes until manual /task-pool/claim. We can't catch
+  // the drop at dispatch time (it looks like a successful 200 OK), so the
+  // reconciler is the safety net: if a targeted, queued WI ages past
+  // threshold AND its target is alive-but-empty, re-push the brief.
   const wakableAgents: AgentHealth[] = [];
+  const activeIdleByTarget = new Map<string, AgentHealth>();
   for (const agent of agentHealthMap.values()) {
     if (agent.status === 'suspended' || agent.status === 'inactive') {
       wakableAgents.push(agent);
+    } else if (agent.status === 'active' && (agent.activeWorkItemCount ?? 0) === 0) {
+      activeIdleByTarget.set(agent.sessionName, agent);
     }
   }
 
-  if (wakableAgents.length === 0) {
+  if (wakableAgents.length === 0 && activeIdleByTarget.size === 0) {
     return { wakeActions, unclaimedWorkItemIds };
   }
 
@@ -788,6 +803,29 @@ export function detectUnclaimedTasks(
     // (the WI is unowned). Strict policy: only wake when the WI
     // explicitly names an offline target via `wi.target`.
     if (!wi.target) continue;
+
+    // First chance: if the explicit target is active-but-idle, the original
+    // dispatch likely vanished into a startup banner — schedule a redeliver
+    // instead of waking some other agent that doesn't own this WI.
+    const idleTarget = activeIdleByTarget.get(wi.target);
+    if (idleTarget && !agentsToWake.has(idleTarget.sessionName)) {
+      wakeActions.push({
+        workItemId: wi.id,
+        agentSessionName: idleTarget.sessionName,
+        strategy: 'redeliver',
+        // Redeliver is target-driven, not score-driven — scoring would be
+        // misleading. We use a sentinel score of 0 and an all-zero breakdown
+        // so audit consumers can filter on `strategy === 'redeliver'`.
+        score: 0,
+        scoreBreakdown: { skillMatch: 0, urgency: 0, contextFamiliarity: 0, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+        teamId: idleTarget.teamId,
+        memberId: idleTarget.memberId,
+      });
+      unclaimedWorkItemIds.push(wi.id);
+      agentsToWake.add(idleTarget.sessionName);
+      continue;
+    }
 
     // Score each wakable agent for this WorkItem
     const bestAgent = selectBestAgent(wi, wakableAgents, waitTime, agentsToWake);

--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -25,11 +25,24 @@ jest.mock('../task-pool/task-pool.service.js', () => {
     markClaimExpiring: jest.fn().mockResolvedValue(undefined),
     releaseBack: jest.fn().mockResolvedValue(undefined),
     revokeAndRelease: jest.fn().mockResolvedValue(undefined),
+    findWorkItem: jest.fn().mockResolvedValue(null),
   };
   return {
     TaskPoolService: {
       getInstance: () => mockInstance,
       _mockInstance: mockInstance,
+    },
+  };
+});
+
+jest.mock('../v3/workitem-dispatch.subscriber.js', () => {
+  const mockSubscriber = {
+    redispatch: jest.fn().mockResolvedValue(true),
+  };
+  return {
+    WorkItemDispatchSubscriber: {
+      getInstance: () => mockSubscriber,
+      _mockSubscriber: mockSubscriber,
     },
   };
 });
@@ -89,6 +102,7 @@ import { LiveReconcilerDataProvider } from './reconciler-data-provider.js';
 import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import { StorageService } from '../core/storage.service.js';
 import { AgentSuspendService } from '../agent/agent-suspend.service.js';
+import { WorkItemDispatchSubscriber } from '../v3/workitem-dispatch.subscriber.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import type { TaskClaim } from '../../types/v2/claim.types.js';
 import type { WakeAction } from '../../types/v2/reconcile.types.js';
@@ -97,6 +111,7 @@ import type { WakeAction } from '../../types/v2/reconcile.types.js';
 const mockPool = (TaskPoolService as any)._mockInstance;
 const mockStorage = (StorageService as any)._mockStorage;
 const mockSuspend = (AgentSuspendService as any)._mockSuspend;
+const mockSubscriber = (WorkItemDispatchSubscriber as any)._mockSubscriber;
 
 describe('LiveReconcilerDataProvider', () => {
   let provider: LiveReconcilerDataProvider;
@@ -781,6 +796,95 @@ describe('LiveReconcilerDataProvider', () => {
       expect(result).toBe(false);
 
       globalThis.fetch = originalFetch;
+    });
+
+    // 2026-05-20 follow-up — redeliver strategy for active-but-idle targets
+    describe('redeliver strategy', () => {
+      const buildAction = (): WakeAction => ({
+        workItemId: 'wi-sora-1',
+        agentSessionName: 'sora',
+        strategy: 'redeliver',
+        score: 0,
+        scoreBreakdown: { skillMatch: 0, urgency: 0, contextFamiliarity: 0, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+      });
+
+      const queuedWi: WorkItem = {
+        id: 'wi-sora-1',
+        type: 'delegate',
+        status: 'queued',
+        target: 'sora',
+        owner: 'orc',
+        priority: 'normal',
+        createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+        title: 'redeliver case',
+        description: 'redeliver case',
+      } as unknown as WorkItem;
+
+      beforeEach(() => {
+        mockSubscriber.redispatch.mockReset();
+        mockSubscriber.redispatch.mockResolvedValue(true);
+      });
+
+      it('redelivers a queued WI via WorkItemDispatchSubscriber', async () => {
+        mockPool.findWorkItem.mockResolvedValueOnce(queuedWi);
+
+        const result = await provider.executeWakeAction(buildAction());
+
+        expect(result).toBe(true);
+        expect(mockPool.findWorkItem).toHaveBeenCalledWith('wi-sora-1');
+        expect(mockSubscriber.redispatch).toHaveBeenCalledWith(queuedWi);
+      });
+
+      it('skips redeliver when the WI has moved past queued', async () => {
+        mockPool.findWorkItem.mockResolvedValueOnce({ ...queuedWi, status: 'running' });
+
+        const result = await provider.executeWakeAction(buildAction());
+
+        expect(result).toBe(false);
+        expect(mockSubscriber.redispatch).not.toHaveBeenCalled();
+      });
+
+      it('returns false when the WI no longer exists', async () => {
+        mockPool.findWorkItem.mockResolvedValueOnce(null);
+
+        const result = await provider.executeWakeAction(buildAction());
+
+        expect(result).toBe(false);
+        expect(mockSubscriber.redispatch).not.toHaveBeenCalled();
+      });
+
+      it('bypasses the memory-pressure gate (cheap repost to live agent)', async () => {
+        // 95% used — would block rehydrate/start at the floor, but redeliver
+        // adds no new agent so it must proceed.
+        mockTotalmem.mockReturnValue(16_000_000_000);
+        mockFreemem.mockReturnValue(800_000_000);
+        mockStorage.getTeams.mockResolvedValue([
+          {
+            id: 't1',
+            members: [
+              { id: 'm1', sessionName: 's1', agentStatus: 'active', role: 'dev', updatedAt: '' },
+              { id: 'm2', sessionName: 's2', agentStatus: 'active', role: 'dev', updatedAt: '' },
+              { id: 'm3', sessionName: 's3', agentStatus: 'active', role: 'dev', updatedAt: '' },
+            ],
+          },
+        ]);
+        mockPool.findWorkItem.mockResolvedValueOnce(queuedWi);
+
+        const result = await provider.executeWakeAction(buildAction());
+
+        expect(result).toBe(true);
+        expect(mockSubscriber.redispatch).toHaveBeenCalledWith(queuedWi);
+      });
+
+      it('returns false when redispatch itself fails', async () => {
+        mockPool.findWorkItem.mockResolvedValueOnce(queuedWi);
+        mockSubscriber.redispatch.mockResolvedValueOnce(false);
+
+        const result = await provider.executeWakeAction(buildAction());
+
+        expect(result).toBe(false);
+      });
     });
 
     // 2026-05-13 dogfood: previously this gate UNCONDITIONALLY blocked

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -26,6 +26,7 @@ import { PoolStorage } from '../task-pool/pool-storage.js';
 import { StorageService } from '../core/storage.service.js';
 import { RequestService } from '../v3/request.service.js';
 import { AgentSuspendService } from '../agent/agent-suspend.service.js';
+import { WorkItemDispatchSubscriber } from '../v3/workitem-dispatch.subscriber.js';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { TokenUsageService } from '../monitoring/token-usage.service.js';
 import { isUnderMemoryPressure, getMemoryStats } from '../core/system-health.util.js';
@@ -952,6 +953,46 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
   async executeWakeAction(action: WakeAction): Promise<boolean> {
     const { agentSessionName, strategy } = action;
 
+    // Redeliver is a cheap repost to an already-alive agent — no new session
+    // is created, no extra RAM is consumed. It must bypass the memory-
+    // pressure gate; otherwise the very stuckness the pressure gate is
+    // designed to prevent would block its own primary remediation path.
+    if (strategy === 'redeliver') {
+      this.logger.info('Executing wake action', {
+        agent: agentSessionName,
+        strategy,
+        workItemId: action.workItemId,
+      });
+      try {
+        const pool = TaskPoolService.getInstance();
+        const wi = await pool.findWorkItem(action.workItemId);
+        if (!wi || wi.status !== 'queued') {
+          this.logger.info('Redeliver skipped — WI no longer queued', {
+            agent: agentSessionName,
+            workItemId: action.workItemId,
+            currentStatus: wi?.status,
+          });
+          return false;
+        }
+        const subscriber = WorkItemDispatchSubscriber.getInstance();
+        const delivered = await subscriber.redispatch(wi);
+        if (delivered) {
+          this.logger.info('Redelivered WorkItem brief to active-but-idle agent', {
+            agent: agentSessionName,
+            workItemId: action.workItemId,
+          });
+        }
+        return delivered;
+      } catch (error) {
+        this.logger.error('Redeliver wake action failed', {
+          agent: agentSessionName,
+          workItemId: action.workItemId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+      }
+    }
+
     // Memory-pressure gate with a concurrency floor.
     //
     // Previous behaviour (unconditional skip on >=90% used) wedged the
@@ -1112,6 +1153,9 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         });
         return true;
       } else {
+        // `redeliver` is handled by the early-return path above, before
+        // the memory-pressure gate. Reaching here means an unrecognised
+        // strategy was supplied.
         this.logger.warn('Unknown wake strategy', { strategy, agent: agentSessionName });
         return false;
       }

--- a/backend/src/services/v3/workitem-dispatch.subscriber.ts
+++ b/backend/src/services/v3/workitem-dispatch.subscriber.ts
@@ -225,6 +225,27 @@ export class WorkItemDispatchSubscriber {
     }
   }
 
+  /**
+   * Force-redeliver a WorkItem brief to its target, bypassing the in-process
+   * dedup cache. Used by Hybrid Wake's `redeliver` strategy (2026-05-20):
+   * when a queued WI lingers past threshold but its target is `active` and
+   * `activeWorkItemCount === 0`, the original `dispatchTo` write likely
+   * landed during claude-code's startup banner and was silently dropped.
+   * Resetting the dedup key and reposting the brief gives the now-idle
+   * agent a second chance to see it.
+   *
+   * Returns true if the redelivered write succeeded.
+   *
+   * @param workItem - WorkItem whose brief should be re-pushed
+   * @returns Whether the redelivery write succeeded
+   */
+  async redispatch(workItem: WorkItem): Promise<boolean> {
+    if (!workItem.target) return false;
+    const key = this.dispatchKey(workItem.id, workItem.target);
+    this.dispatched.delete(key);
+    return this.dispatchTo(workItem);
+  }
+
   // -------------------------------------------------------------------------
   // Internal — workitem:queued event path
   // -------------------------------------------------------------------------

--- a/backend/src/types/event-bus.types.test.ts
+++ b/backend/src/types/event-bus.types.test.ts
@@ -26,6 +26,8 @@ describe('Event Bus Types', () => {
         // Agent lifecycle events
         'agent:status_changed',
         'agent:idle',
+        'agent:idle_after_registration',
+        'agent:idle_after_task',
         'agent:busy',
         'agent:active',
         'agent:inactive',

--- a/backend/src/types/event-bus.types.ts
+++ b/backend/src/types/event-bus.types.ts
@@ -19,6 +19,25 @@ export const EVENT_TYPES = [
   // Agent lifecycle events
   'agent:status_changed',
   'agent:idle',
+  // 2026-05-20 follow-up to the Sora stuck-WI incident — split idle into
+  // two semantically distinct events so subscriptions that mean "tell me
+  // when the agent FINISHED a task" stop getting woken by the unrelated
+  // "agent just registered and has nothing to do yet" transition.
+  //
+  // - agent:idle_after_registration: fires once when an agent first
+  //   transitions to idle after registration, without having been
+  //   workingStatus=in_progress at any point. Useful for fleet-monitoring
+  //   dashboards. NOT useful for delegation-complete signalling — a
+  //   peer-watch trigger keyed on this would consume the wake-up event
+  //   before the delegatee has even claimed the WI.
+  // - agent:idle_after_task: fires when an agent returns to idle after
+  //   having been busy. This is the event delegation-watchers want.
+  //
+  // `agent:idle` continues to fire alongside both (back-compat for
+  // existing subscribers). New subscribers should prefer the precise
+  // variant.
+  'agent:idle_after_registration',
+  'agent:idle_after_task',
   'agent:busy',
   'agent:active',
   'agent:inactive',
@@ -138,6 +157,8 @@ export const CRITICAL_EVENT_TYPES: ReadonlySet<EventType> = new Set([
   'task:cancelled',
   'task:input_required',
   'agent:idle',
+  'agent:idle_after_registration',
+  'agent:idle_after_task',
   'agent:inactive',
   'agent:context_critical',
   'hierarchy:escalation',

--- a/backend/src/types/v2/reconcile.types.ts
+++ b/backend/src/types/v2/reconcile.types.ts
@@ -99,8 +99,13 @@ export interface ReconcileCorrection {
  * Strategy for waking an agent based on its current status.
  * - rehydrate: Agent is suspended → call AgentSuspendService.rehydrateAgent()
  * - start: Agent is inactive → call start-agent API
+ * - redeliver: Agent is active-but-idle and was already targeted with a
+ *   pool message that they silently dropped (2026-05-20 Sora case). Don't
+ *   restart their session; re-POST the WorkItem brief to their PTY so the
+ *   message lands again in case the first one was lost in claude-code
+ *   startup output or otherwise unprocessed.
  */
-export type WakeStrategy = 'rehydrate' | 'start';
+export type WakeStrategy = 'rehydrate' | 'start' | 'redeliver';
 
 /**
  * A wake action to bring a dormant agent online for unclaimed work.

--- a/config/roles/developer/prompt.md
+++ b/config/roles/developer/prompt.md
@@ -98,16 +98,19 @@ Do **not** silently expand scope inside one WorkItem. The pipeline is how recurs
 
 When you create a child WorkItem for a peer Worker, hand off via `send-message` for clarification (e.g. dev→architect, dev→qa), or chain a downstream worker via `delegate-task`, you MUST close the loop with **both** signals:
 
-1. **Subscribe to the peer** via `watch-for-event` so you wake on their `agent:idle` (or `task:completed`):
+1. **Subscribe to the peer** via `watch-for-event` so you wake on their `agent:idle_after_task` (or `task:completed`):
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
-     --event-type agent:idle \
+     --event-type agent:idle_after_task \
      --filter-session <peer-session> \
      --title "Peer idle — child WorkItem check" \
      --description "Per §3.0: <peer> went idle on <child workitem id / message ref>. Check whether their reply landed in your inbox or whether the child WorkItem flipped to done." \
      --max-fires 3 \
      --max-idle-fires 3
    ```
+   > Use `agent:idle_after_task` (not the generic `agent:idle`) so the
+   > subscription is NOT consumed by the peer's registration-idle event
+   > if they were just started for this delegation.
 
 2. **Schedule a fallback** at roughly **2× expected ETA** via `schedule-followup` — `agent:idle` is best-effort, not a guarantee, and stalled peers never transition:
    ```bash

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -80,10 +80,10 @@ Your default mode for **interpretation** of user intent is still clarify, not re
 
 Any time you dispatch work — POST a Request that hands off to a TL, escalate to ORC for cross-team staffing, `delegate-task` to a TL, or `send-message` requesting action — you MUST close the loop with **both** signals:
 
-1. **Subscribe to the resolving TL/ORC** via `watch-for-event` so you wake on their `agent:idle` (or `task:completed`):
+1. **Subscribe to the resolving TL/ORC** via `watch-for-event` so you wake on their `agent:idle_after_task` (or `task:completed`):
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
-     --event-type agent:idle \
+     --event-type agent:idle_after_task \
      --filter-session <tl-or-orc-session> \
      --title "TL/ORC idle — Request resolution check" \
      --description "Per §3.0: <TL/ORC> went idle on Request <id>. Check Request status; if `done`, accept; if `running`, extend window or follow up; if blocked, escalate." \

--- a/config/roles/team-leader/tl-addon.md
+++ b/config/roles/team-leader/tl-addon.md
@@ -219,10 +219,10 @@ When you receive a Request or WorkItem ID from your PM/ORC, **the Request is can
 
 Any time you dispatch work — `delegate-task` to a Worker, push a peer-TL handoff, materialise a WorkItem with a `target`, or `send-message` requesting action — you MUST close the loop with **both** signals:
 
-1. **Subscribe to the delegatee** via `watch-for-event` so you wake on the delegatee's `agent:idle` (or `task:completed`):
+1. **Subscribe to the delegatee** via `watch-for-event` so you wake on the delegatee's `agent:idle_after_task` (or `task:completed`):
    ```bash
    bash {{AGENT_SKILLS_PATH}}/core/watch-for-event/execute.sh \
-     --event-type agent:idle \
+     --event-type agent:idle_after_task \
      --filter-session <worker-session> \
      --title "Worker idle — verify-output gate" \
      --description "Per §3.0: <worker> went idle on <task ref>. Run verify-output (build + tests). If green, accept and report up. If red, handle-failure (retry/reassign/escalate)." \


### PR DESCRIPTION
Two follow-ups to PR #601, packaged together because they share the same
2026-05-20 Sora root-cause and the test signal benefits from being
validated as one slice.

## Follow-up #1 — `redeliver` Hybrid Wake strategy

Adds a third Hybrid Wake strategy for the gap surfaced by the Sora
incident (WI d705bfe0 sat queued ~53 min while its target agent was
alive at the prompt; the initial PTY write was silently swallowed by
claude-code's startup banner).

- When a queued WI's explicit target is `active` with
  `activeWorkItemCount === 0` and the WI has aged past threshold, the
  reconciler now re-POSTs the brief via
  `WorkItemDispatchSubscriber.redispatch()` which bypasses the in-process
  dedup cache.
- Redeliver bypasses the memory-pressure gate (no new session = no RAM
  cost — blocking would defeat the gate's own purpose).
- Target-driven, not score-driven; never substitutes another agent.

## Follow-up #2 — `agent:idle_after_registration` vs `agent:idle_after_task`

Peer-watch triggers used by delegate-task were getting woken by the
wrong event: a just-started delegatee fires `agent:idle` at the prompt
before claiming any WI; the watcher consumed it as "task complete" and
false-resolved.

- New event types `agent:idle_after_registration` and
  `agent:idle_after_task` (both also in `CRITICAL_EVENT_TYPES`).
- `agent:idle` continues to fire alongside both (back-compat for
  auto-claim, thread-status-queue, orc-auto-close).
- ActivityMonitor emits `idle_after_task` whenever the in-process
  `busyEventEmitted` guard fires (that guard proves prior busy).
- TeamsJsonWatcher classifies by prev workingStatus
  (`in_progress` → after_task, unset → after_registration).
- Role prompts for developer, PM, and TL updated to subscribe to
  `agent:idle_after_task` in their delegation peer-watch examples.

## Test plan
- [x] 7 new reconcile-rules unit tests
- [x] 5 new data-provider unit tests (incl. memory-pressure bypass)
- [x] 3 new teams-json-watcher unit tests for idle classification
- [x] activity-monitor sustained-busy test extended to assert the new
      `idle_after_task` event and the absence of `idle_after_registration`
- [x] event-bus.types unit test updated for new EVENT_TYPES
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [ ] Sanity check after merge: confirm an injected stuck-WI on dogfood
      triggers a redeliver line in reconciler logs within 60s
- [ ] Sanity check after merge: confirm a peer-watch trigger on
      `agent:idle_after_task` survives a fresh-start delegatee's
      registration-idle without false-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)