### PR TITLE
fix(sla): cancel orphan child WIs when orc replies after Request decompose

### DIFF
--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -171,6 +171,7 @@ function buildFakeRequestService(initial: Request[] = []): {
   const linkCalls: Array<{ requestId: string; workItemId: string }> = [];
   const service = {
     getById: jest.fn(async (id: string) => registry.get(id) ?? null),
+    listAll: jest.fn(async () => Array.from(registry.values())),
     update: jest.fn(async (id: string, updates: Partial<Request>) => {
       const r = registry.get(id);
       if (!r) throw new Error(`Request not found: ${id}`);
@@ -1021,6 +1022,158 @@ describe('RequestSlaSubscriber', () => {
       expect(pool.transitionCalls).toHaveLength(0);
       // …but Request still cascades to done.
       expect(svc.registry.get(r.id)?.status).toBe('done');
+    });
+
+    // -----------------------------------------------------------------------
+    // 2026-05-21 closie incident — orphan-Request fallback
+    //
+    // When `RequestDecomposeSubscriber` decomposes a Request before the orc
+    // replies, it calls `markResolved(req, 'workitem_decompose')` which
+    // CLEARS the SLA `threadIndex`. If the orc then replies directly in the
+    // same Slack thread, the primary lookup AND the 250ms retry both miss.
+    // The fallback path scans `RequestService.listAll()` for an open
+    // Request whose sourceConversationItemId references the threadTs, then
+    // cancels all non-terminal child WIs and cascades the close.
+    // -----------------------------------------------------------------------
+    describe('orphan-Request fallback after workitem_decompose race', () => {
+      it('cancels non-terminal child WIs and cascades the Request to done', async () => {
+        // Simulate the post-decompose state directly: a 'ready' Request,
+        // orphan child WIs in the pool, and empty SLA indexes (since the
+        // decompose subscriber's markResolved cleared them in production).
+        // We bypass the request:created handler so the test doesn't have
+        // to navigate the maybeCloseRequest cascade that would have run
+        // synchronously when no children existed yet.
+        const r = buildRequest({ status: 'ready' });
+        svc.registry.set(r.id, r);
+
+        pool.taskPool.addToPool({
+          id: 'wi-plan',
+          requestId: r.id,
+          type: 'delegate',
+          owner: 'orchestrator',
+          status: 'queued',
+          title: 'Plan',
+          description: 'plan',
+          createdAt: new Date().toISOString(),
+          retryCount: 0,
+          maxRetries: 3,
+          inputTokens: 0,
+          outputTokens: 0,
+          cost: 0,
+        } as unknown as WorkItem);
+        pool.taskPool.addToPool({
+          id: 'wi-execute',
+          requestId: r.id,
+          type: 'delegate',
+          owner: 'orchestrator',
+          status: 'blocked',
+          title: 'Execute',
+          description: 'execute',
+          createdAt: new Date().toISOString(),
+          retryCount: 0,
+          maxRetries: 3,
+          inputTokens: 0,
+          outputTokens: 0,
+          cost: 0,
+        } as unknown as WorkItem);
+
+        // Sanity: threadIndex is empty (mirrors post-decompose state).
+        expect((sub as any).threadIndex.get('1772899923.865659')).toBeUndefined();
+
+        // Orc replies directly in the original Slack thread.
+        await sub.markResolvedByThread('1772899923.865659');
+        // Primary + retry both miss → setTimeout schedules the fallback.
+        jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
+        // Flush microtasks queued by the async fallback handler (listAll,
+        // getAllItems, two transitionStatus, maybeCloseRequest chain).
+        for (let i = 0; i < 20; i += 1) await Promise.resolve();
+
+        // Both child WIs transitioned to cancelled with the new reason tag.
+        const cancelTransitions = pool.transitionCalls.filter(
+          (c) => c.status === 'cancelled' && (c.id === 'wi-plan' || c.id === 'wi-execute'),
+        );
+        expect(cancelTransitions).toHaveLength(2);
+
+        // Request cascade closed to done.
+        expect(svc.registry.get(r.id)?.status).toBe('done');
+      });
+
+      it('skips closure when no Request matches the threadTs', async () => {
+        // Nothing registered for this thread — fallback is a no-op.
+        await sub.markResolvedByThread('5555555555.000000');
+        jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
+        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+        expect(pool.transitionCalls).toHaveLength(0);
+      });
+
+      it('skips closure when the matched Request is already terminal', async () => {
+        const r = buildRequest({ status: 'done' });
+        svc.registry.set(r.id, r);
+
+        // Add an orphan child WI to verify the fallback doesn't touch
+        // children when the Request is already terminal.
+        pool.taskPool.addToPool({
+          id: 'wi-after-close',
+          requestId: r.id,
+          type: 'delegate',
+          owner: 'orchestrator',
+          status: 'queued',
+          title: 'Orphan',
+          description: 'orphan',
+          createdAt: new Date().toISOString(),
+          retryCount: 0,
+          maxRetries: 3,
+          inputTokens: 0,
+          outputTokens: 0,
+          cost: 0,
+        } as unknown as WorkItem);
+
+        await sub.markResolvedByThread('1772899923.865659');
+        jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
+        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+
+        // No transitions: TERMINAL gate stops the cleanup.
+        expect(pool.transitionCalls.filter((c) => c.id === 'wi-after-close')).toHaveLength(0);
+      });
+
+      it('chat-v2 case: cancels orphans and closes Request on direct reply after decompose', async () => {
+        const r = buildRequest({
+          status: 'ready',
+          tags: ['chat-v2'],
+          sourceConversationItemId: 'chatv2-CHAN__123',
+        });
+        svc.registry.set(r.id, r);
+
+        pool.taskPool.addToPool({
+          id: 'wi-chatv2-plan',
+          requestId: r.id,
+          type: 'delegate',
+          owner: 'orchestrator',
+          status: 'queued',
+          title: 'Plan',
+          description: 'plan',
+          createdAt: new Date().toISOString(),
+          retryCount: 0,
+          maxRetries: 3,
+          inputTokens: 0,
+          outputTokens: 0,
+          cost: 0,
+        } as unknown as WorkItem);
+
+        expect((sub as any).chatV2Index.get('CHAN')).toBeUndefined();
+
+        await sub.markResolvedByChatV2('CHAN');
+        jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
+        for (let i = 0; i < 20; i += 1) await Promise.resolve();
+
+        expect(
+          pool.transitionCalls.filter(
+            (c) => c.id === 'wi-chatv2-plan' && c.status === 'cancelled',
+          ),
+        ).toHaveLength(1);
+        expect(svc.registry.get(r.id)?.status).toBe('done');
+      });
     });
 
     // -------------------------------------------------------------------------

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -301,6 +301,14 @@ export const VERIFIED_REPLY_REASONS: ReadonlySet<string> = new Set<string>([
   // reason, so it must be in the verified set to pass the
   // {@link RequestSlaSubscriber.maybeCloseRequest} defense gate.
   'orc_reply_recheck',
+  // 2026-05-21 closie incident: orc replied directly AFTER decomposition
+  // already cleared the SLA indexes. The fallback path in
+  // {@link RequestSlaSubscriber.resolveOrphanedRequestByThread} /
+  // {@link RequestSlaSubscriber.resolveOrphanedRequestByChatV2}
+  // re-enters {@link RequestSlaSubscriber.maybeCloseRequest} with these
+  // tags; both must pass the verified-reply gate.
+  'orc_reply_after_decompose',
+  'chatv2_reply_after_decompose',
 ]);
 
 /**
@@ -658,13 +666,32 @@ export class RequestSlaSubscriber {
     // Index miss — schedule a single retry after the
     // `request:created` handler has had time to populate the index.
     // 250ms covers in-memory getById + microtask scheduling + a margin.
-    const retry = setTimeout(() => {
+    const retry = setTimeout(async () => {
       const retryRequestId = this.threadIndex.get(threadTs);
-      if (!retryRequestId) {
-        this.logger.debug('markResolvedByThread retry still missed', { threadTs });
+      if (retryRequestId) {
+        void this.markResolved(retryRequestId, 'orc_reply');
         return;
       }
-      void this.markResolved(retryRequestId, 'orc_reply');
+      // Retry still missed. The most common reason isn't a race — it's
+      // that the Request was already decomposed (workitem_decompose),
+      // which clears `threadIndex` even though the Request is still
+      // open with non-terminal child WIs. Orc just replied directly
+      // anyway (e.g. the question turned out to be a one-shot answer),
+      // so those child WIs are now orphaned and would otherwise sit
+      // queued/blocked forever.
+      //
+      // 2026-05-21 closie incident: Request 2adc23a3 decomposed into
+      // Plan/Execute/Review, orc replied at 04:01 directly, but the 3
+      // children stayed queued/blocked for 8+ hours until manual
+      // cleanup. The status-check skill kept reporting "0/3 done".
+      try {
+        await this.resolveOrphanedRequestByThread(threadTs);
+      } catch (err) {
+        this.logger.warn('Orphaned-Request fallback failed (non-fatal)', {
+          threadTs,
+          error: formatError(err),
+        });
+      }
     }, MARK_RESOLVED_RETRY_MS);
     retry.unref?.();
   }
@@ -689,15 +716,137 @@ export class RequestSlaSubscriber {
     // Mirror the markResolvedByThread retry. Same race shape applies on
     // chat-v2: an agent reply may land before the `request:created`
     // handler has populated `chatV2Index`.
-    const retry = setTimeout(() => {
+    const retry = setTimeout(async () => {
       const retryRequestId = this.chatV2Index.get(channelId);
-      if (!retryRequestId) {
-        this.logger.debug('markResolvedByChatV2 retry still missed', { channelId });
+      if (retryRequestId) {
+        void this.markResolved(retryRequestId, 'chatv2_reply');
         return;
       }
-      void this.markResolved(retryRequestId, 'chatv2_reply');
+      // Retry still missed — same orphan-after-decompose path as the
+      // Slack case in {@link markResolvedByThread}. Look up the Request
+      // by source convo id directly and clean up.
+      try {
+        await this.resolveOrphanedRequestByChatV2(channelId);
+      } catch (err) {
+        this.logger.warn('Orphaned-Request fallback failed (non-fatal)', {
+          channelId,
+          error: formatError(err),
+        });
+      }
     }, MARK_RESOLVED_RETRY_MS);
     retry.unref?.();
+  }
+
+  /**
+   * Orphan-cleanup path for the Slack case in {@link markResolvedByThread}.
+   *
+   * The threadIndex / chatV2Index are populated when an SLA tracker is
+   * registered for the Request and cleared whenever {@link markResolved}
+   * runs — including the `workitem_decompose` resolve. After decomposition,
+   * the Request stays open with non-terminal child WIs while the SLA
+   * indexes are empty. If the orc then replies directly in the original
+   * thread, neither the primary `threadIndex` lookup nor the 250ms retry
+   * will find anything, and the orphan child WIs sit queued/blocked
+   * indefinitely (closie incident, 2026-05-21).
+   *
+   * This fallback authoritatively scans `RequestService.listAll()` for an
+   * open Request whose `sourceConversationItemId` references `threadTs`,
+   * then force-removes any non-terminal child WIs from the pool and
+   * cascades the close. We bypass the index because the index is the
+   * very thing that's stale.
+   *
+   * @param threadTs - The Slack message timestamp the orc replied to
+   */
+  private async resolveOrphanedRequestByThread(threadTs: string): Promise<void> {
+    const all = await this.requestService.listAll();
+    const match = all.find(
+      (r) =>
+        !TERMINAL_REQUEST_STATUSES.has(r.status) &&
+        extractSlackThreadTs(r.sourceConversationItemId) === threadTs,
+    );
+    if (!match) {
+      this.logger.debug('No open Request matches threadTs — nothing to clean up', { threadTs });
+      return;
+    }
+    await this.cancelOrphansAndCloseRequest(match.id, 'orc_reply_after_decompose');
+  }
+
+  /**
+   * Orphan-cleanup path for the chat-v2 case in
+   * {@link markResolvedByChatV2}. Mirrors {@link resolveOrphanedRequestByThread}
+   * but matches on `chatV2-` source id shape.
+   *
+   * @param channelId - The chat-v2 channel id where the agent replied
+   */
+  private async resolveOrphanedRequestByChatV2(channelId: string): Promise<void> {
+    const all = await this.requestService.listAll();
+    const match = all.find(
+      (r) =>
+        !TERMINAL_REQUEST_STATUSES.has(r.status) &&
+        extractChatV2ChannelId(r.sourceConversationItemId) === channelId,
+    );
+    if (!match) {
+      this.logger.debug('No open Request matches channelId — nothing to clean up', { channelId });
+      return;
+    }
+    await this.cancelOrphansAndCloseRequest(match.id, 'chatv2_reply_after_decompose');
+  }
+
+  /**
+   * Cancel all non-terminal WorkItems belonging to a Request, then cascade
+   * the Request to `done`. Shared tail of
+   * {@link resolveOrphanedRequestByThread} and
+   * {@link resolveOrphanedRequestByChatV2}.
+   *
+   * Each WI is transitioned individually so a single failure (illegal
+   * transition, stale claim) does not block the others — the cascade
+   * close at the end only fires if at least one WI flipped to terminal
+   * (otherwise `countOtherActiveWorkItems` will keep the Request open
+   * via {@link maybeCloseRequest}'s sibling-count gate).
+   *
+   * @param requestId - The Request to clean up
+   * @param reason    - Diagnostic tag recorded on each cancelled WI's
+   *   metadata and on the Request's `result` field
+   */
+  private async cancelOrphansAndCloseRequest(requestId: string, reason: string): Promise<void> {
+    const all = await this.taskPool.getAllItems();
+    let cancelled = 0;
+    for (const wi of all) {
+      if (wi.requestId !== requestId) continue;
+      if (TERMINAL_WI_STATUSES.has(wi.status)) continue;
+      try {
+        await this.taskPool.transitionStatus(
+          wi.id,
+          'cancelled',
+          'system',
+          (item) => {
+            item.metadata = {
+              ...(item.metadata ?? {}),
+              slaResolvedReason: reason,
+              slaResolvedAt: new Date().toISOString(),
+            };
+          },
+          `SLA auto-resolved: ${reason}`,
+        );
+        cancelled += 1;
+      } catch (err) {
+        // Most likely cause: a transition we can't satisfy in the state
+        // machine (e.g. a status we didn't anticipate). Log + skip — the
+        // cascade close's sibling-count gate will keep the Request open
+        // if any WIs remain non-terminal, which is the safer outcome.
+        this.logger.warn('Could not cancel orphan WI; leaving in current state', {
+          workItemId: wi.id,
+          status: wi.status,
+          error: formatError(err),
+        });
+      }
+    }
+    this.logger.info('Orphaned-Request cleanup: cancelled non-terminal child WIs', {
+      requestId,
+      reason,
+      cancelled,
+    });
+    await this.maybeCloseRequest(requestId, reason);
   }
 
   /**


### PR DESCRIPTION
## Repro (2026-05-21 closie incident — Request 2adc23a3)

User reported the bot saying "已完成 0/3, 进行中 0, 排队 1, 卡住 2" for a Request that was actually answered ~8 hours earlier. Forensics from the OSS logs:

| Time | Event |
|---|---|
| 03:59:09 | Slack message arrives, Request 2adc23a3 created (open) |
| 03:59:09 | RequestDecomposeSubscriber fires → calls `markResolved(req, 'workitem_decompose')` which clears `trackedByRequest` + `threadIndex` + `chatV2Index` |
| 03:59:09 | Decompose adds 3 child WIs: Plan (queued), Execute (blocked), Review (blocked) |
| 03:59:16 | Reconciler flips Request status open → ready |
| 04:01:20 | ORC replies directly in the Slack thread (full pricing analysis — didn't need the planned pipeline) |
| 04:01:20 | `markResolvedByThread(threadTs)` → threadIndex miss → 250ms retry → still miss → no-op |
| 12:06+ | Plan/Execute/Review still queued/blocked. Status-check skill reports "0/3 done" |

`autoCloseOpenRequests` in `index.ts:2893` only walks `status === 'open'` Requests — a `ready` Request with orphan children is never reached.

## Fix

After the existing 250ms retry inside `markResolvedByThread` / `markResolvedByChatV2` misses, fall back to an authoritative `RequestService.listAll()` scan for an open Request whose `sourceConversationItemId` references the `threadTs` (or `channelId` for chat-v2). If found:

1. Cancel all non-terminal child WIs (`queued → cancelled`, `blocked → cancelled`, `running → cancelled` — all legal in `WORK_ITEM_TRANSITIONS`)
2. Cascade-close via `maybeCloseRequest`

Two new reason tags (`orc_reply_after_decompose`, `chatv2_reply_after_decompose`) are added to `VERIFIED_REPLY_REASONS` so the cascade-close defense gate accepts them.

## Why this shape

- Symmetric: covers both `markResolvedByThread` (Slack) and `markResolvedByChatV2` (chat-v2)
- Authoritative: bypasses the stale index by querying `RequestService` directly
- Non-fatal: a failed transition (illegal edge, race) logs + skips that WI; the cascade close's sibling-count gate keeps the Request open if any WIs remain non-terminal — strictly safer than the current "do nothing" behaviour
- Bounded: only runs on the 250ms retry miss path, so the hot path is unchanged

## Test plan

- [x] 4 new unit tests on `markResolvedByThread`'s orphan-fallback describe block — happy path (2 WIs cancelled + Request → done), no-match no-op, terminal-Request no-op, chat-v2 parallel case
- [x] All 97 existing `request-sla.subscriber.test.ts` tests still pass
- [x] `tsc -p backend/tsconfig.json --noEmit` clean
- [x] Production cleanup already done manually for the closie Request (`/api/task-pool/:wi?force=1` x3); Request auto-closed via cascade
- [ ] Sanity check after merge: dogfood another simple-Q&A Slack message that would normally decompose; verify the 3 child WIs auto-cancel within ~1s of the ORC reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)