### PR TITLE
fix(task-pool): clean cancel path for stuck queued delegate WIs (#609)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -16,6 +16,7 @@ import {
   deleteItem,
   completeItem,
   addItem,
+  cancelQueuedItem,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
 // Express types used for mock helpers below
@@ -51,6 +52,7 @@ const mockService = {
   setOutput: jest.fn(),
   addToPool: jest.fn(),
   getAllItems: jest.fn().mockResolvedValue([]),
+  cancelQueued: jest.fn(),
 };
 
 (TaskPoolService.getInstance as any) = jest.fn().mockReturnValue(mockService);
@@ -1017,6 +1019,79 @@ describe('TaskPoolController', () => {
       const addedWI = mockService.addToPool.mock.calls[0][0];
       expect(addedWI.status).toBe('blocked');
       expect(addedWI.dependsOn).toEqual(['wi-upstream-1', 'wi-upstream-2']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/task-pool/items/:workItemId/cancel (#609 explicit cancel)
+  // -------------------------------------------------------------------------
+
+  describe('cancelQueuedItem (#609)', () => {
+    beforeEach(() => {
+      mockService.cancelQueued.mockReset();
+      mockService.findWorkItem.mockReset();
+    });
+
+    it('returns 200 + cancelledFrom on a successful queued cancel', async () => {
+      mockService.findWorkItem.mockResolvedValue({ id: 'wi-1', status: 'queued' });
+      mockService.cancelQueued.mockResolvedValue(undefined);
+
+      const req = mockReq({ params: { workItemId: 'wi-1' }, body: { reason: 'stuck fallback' } });
+      const res = mockRes();
+      await cancelQueuedItem(req, res);
+
+      expect(mockService.cancelQueued).toHaveBeenCalledWith('wi-1', 'stuck fallback');
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, workItemId: 'wi-1', cancelledFrom: 'queued', reason: 'stuck fallback' }),
+      );
+    });
+
+    it('returns 400 when reason is missing or empty', async () => {
+      const req = mockReq({ params: { workItemId: 'wi-1' }, body: {} });
+      const res = mockRes();
+      await cancelQueuedItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false, error: expect.stringMatching(/reason is required/) }),
+      );
+      expect(mockService.cancelQueued).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when reason is only whitespace', async () => {
+      const req = mockReq({ params: { workItemId: 'wi-1' }, body: { reason: '   ' } });
+      const res = mockRes();
+      await cancelQueuedItem(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockService.cancelQueued).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when WI does not exist', async () => {
+      mockService.findWorkItem.mockResolvedValue(null);
+      const req = mockReq({ params: { workItemId: 'ghost' }, body: { reason: 'why' } });
+      const res = mockRes();
+      await cancelQueuedItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(mockService.cancelQueued).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 with the service error message when WI is in a non-cancellable state', async () => {
+      mockService.findWorkItem.mockResolvedValue({ id: 'wi-2', status: 'running' });
+      mockService.cancelQueued.mockRejectedValue(
+        new Error(
+          "cancelQueued: WorkItem status must be 'queued', 'blocked', or 'scheduled' (got 'running'). Use a status-appropriate API for other states — e.g. failItem for running, or DELETE for terminal-state cleanup.",
+        ),
+      );
+
+      const req = mockReq({ params: { workItemId: 'wi-2' }, body: { reason: 'oops' } });
+      const res = mockRes();
+      await cancelQueuedItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false, error: expect.stringMatching(/status must be 'queued'/) }),
+      );
     });
   });
 });

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -651,6 +651,70 @@ export async function failItemHandler(req: Request, res: Response): Promise<void
 }
 
 // ---------------------------------------------------------------------------
+// POST /api/task-pool/items/:workItemId/cancel — Cancel a queued/blocked WI
+// ---------------------------------------------------------------------------
+
+/**
+ * Cleanly cancel a WorkItem that is `queued`, `blocked`, or `scheduled`
+ * (i.e. has not been claimed yet). Closes the #609 gap where no
+ * non-destructive API existed for retiring a stuck queued WI — the only
+ * options were `complete` (requires running) or `DELETE ?force=1` (hard
+ * delete with no audit trail).
+ *
+ * Request body: `{ "reason": "short human-readable why" }`
+ *   `reason` is required. It's persisted on `cancelReason` and surfaces
+ *   in the activity timeline so the cancellation isn't an opaque event.
+ *
+ * Responses:
+ *   - 200 `{ success: true, workItemId, cancelledFrom }`
+ *   - 400 `{ success: false, error: 'reason is required' }`
+ *   - 400 `{ success: false, error: 'WorkItem status must be queued|blocked|scheduled', currentStatus }`
+ *   - 404 `{ success: false, error: 'WorkItem not found' }`
+ */
+export async function cancelQueuedItem(req: Request, res: Response): Promise<void> {
+  try {
+    const { workItemId } = req.params;
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason.trim() : '';
+    if (!workItemId) {
+      res.status(400).json({ success: false, error: 'workItemId param is required' });
+      return;
+    }
+    if (!reason) {
+      res
+        .status(400)
+        .json({ success: false, error: 'reason is required (string, non-empty)' });
+      return;
+    }
+    const before = await getService().findWorkItem(workItemId);
+    if (!before) {
+      res.status(404).json({ success: false, error: 'WorkItem not found' });
+      return;
+    }
+    // Snapshot the pre-cancel status BEFORE calling the service —
+    // transitionStatus mutates the pool's cached object in place, so
+    // `before.status` will read as `'cancelled'` after the await
+    // otherwise (caught live 2026-05-28).
+    const cancelledFrom = before.status;
+    await getService().cancelQueued(workItemId, reason);
+    res.json({
+      success: true,
+      workItemId,
+      cancelledFrom,
+      reason,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // The service throws a friendly message for wrong-state cases;
+    // surface it as 400 so callers can branch.
+    if (/status must be 'queued', 'blocked', or 'scheduled'/.test(msg)) {
+      res.status(400).json({ success: false, error: msg });
+      return;
+    }
+    handleServiceError(res, error);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // GET /api/task-pool/stats — Pool statistics
 // ---------------------------------------------------------------------------
 

--- a/backend/src/controllers/task-pool/task-pool.routes.ts
+++ b/backend/src/controllers/task-pool/task-pool.routes.ts
@@ -16,6 +16,7 @@ import {
   completeItem,
   blockItem,
   failItemHandler,
+  cancelQueuedItem,
   getStats,
   heartbeat,
   extendLease,
@@ -91,6 +92,10 @@ export function createTaskPoolRouter(): Router {
   router.post('/items/:workItemId/output', setItemOutput);
   router.post('/items/:workItemId/handoff', handoffItem);
   router.post('/items/:workItemId/notes', appendItemNote);
+  // #609: clean queued→cancelled transition for stuck WIs. Uses
+  // `cancelQueued` (queued/blocked/scheduled → cancelled). Distinct
+  // from DELETE which is a hard purge.
+  router.post('/items/:workItemId/cancel', cancelQueuedItem);
 
   return router;
 }

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -1459,6 +1459,67 @@ describe('TaskPoolService', () => {
   });
 
   // -----------------------------------------------------------------------
+  // cancelQueued (#609 — clean queued/blocked → cancelled transition)
+  // -----------------------------------------------------------------------
+
+  describe('cancelQueued', () => {
+    it('transitions queued → cancelled with the supplied reason on cancelReason', async () => {
+      const wi = makeWorkItem({ target: 'crewly-orc' });
+      await service.addToPool(wi);
+
+      await service.cancelQueued(wi.id, 'stuck delegate fallback');
+
+      const items = await service.getAllItems();
+      const after = items.find((w) => w.id === wi.id)!;
+      expect(after.status).toBe('cancelled');
+      expect(after.cancelReason).toBe('stuck delegate fallback');
+    });
+
+    it('also accepts a blocked WI (queued/blocked/scheduled all valid)', async () => {
+      // Blocked is the dep-resolver landing state; we want it cleanable
+      // too, otherwise dep-cycles spam dispatches forever.
+      const wi = makeWorkItem({ dependsOn: ['dep-1'] });
+      await service.addToPool(wi);
+      // makeWorkItem with dependsOn lands in 'blocked' per createWorkItem.
+
+      await service.cancelQueued(wi.id, 'parent abandoned');
+
+      const after = (await service.getAllItems()).find((w) => w.id === wi.id)!;
+      expect(after.status).toBe('cancelled');
+      expect(after.cancelReason).toBe('parent abandoned');
+    });
+
+    it('refuses to cancel a running WI (caller should use failItem)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-leo');
+
+      await expect(service.cancelQueued(wi.id, 'oops')).rejects.toThrow(
+        /status must be 'queued', 'blocked', or 'scheduled'/,
+      );
+      // And the WI is NOT mutated — still running.
+      const after = (await service.getAllItems()).find((w) => w.id === wi.id)!;
+      expect(after.status).toBe('running');
+    });
+
+    it('refuses to cancel a terminal WI (cancelled/done/failed/verified)', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi);
+      await service.cancelQueued(wi.id, 'first cancel'); // queued → cancelled
+
+      await expect(service.cancelQueued(wi.id, 'second cancel')).rejects.toThrow(
+        /status must be 'queued', 'blocked', or 'scheduled'/,
+      );
+    });
+
+    it('throws when the WI does not exist', async () => {
+      await expect(service.cancelQueued('ghost-id', 'reason')).rejects.toThrow(
+        'WorkItem not found',
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // requeueAfterFailure (auto-retry path — 2026-05-22)
   // -----------------------------------------------------------------------
 

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1304,6 +1304,54 @@ export class TaskPoolService {
   }
 
   /**
+   * Cancel a WorkItem that is currently `queued` or `blocked` (i.e. has
+   * NOT been claimed yet).
+   *
+   * Closes the 2026-05-25 #609 incident: a fallback delegate WI targeted
+   * at `crewly-orc` got stuck `queued` and kept re-dispatching every
+   * minute. The available APIs were either inappropriate (`fail` requires
+   * `running`, `complete` requires `running`) or destructive (`DELETE
+   * /api/task-pool/:id?force=1` is a hard delete with no audit trail).
+   * This method provides the clean `queued → cancelled` transition with
+   * a reason captured in `cancelReason` for the activity timeline.
+   *
+   * @param workItemId - Target WI id
+   * @param reason     - Human-readable explanation; persisted on
+   *                     `cancelReason` and surfaces in the UI badge.
+   * @throws if the WI doesn't exist, has an active claim, or is in a
+   *         non-cancellable terminal state.
+   */
+  async cancelQueued(workItemId: string, reason: string): Promise<void> {
+    const workItem = await this.storage.findWorkItem(workItemId);
+    if (!workItem) {
+      throw new Error(`WorkItem not found: ${workItemId}`);
+    }
+    if (workItem.status !== 'queued' && workItem.status !== 'blocked' && workItem.status !== 'scheduled') {
+      throw new Error(
+        `cancelQueued: WorkItem status must be 'queued', 'blocked', or 'scheduled' (got '${workItem.status}'). Use a status-appropriate API for other states — e.g. failItem for running, or DELETE for terminal-state cleanup.`,
+      );
+    }
+    const activeClaim = await this.storage.findActiveClaimByWorkItem(workItemId);
+    if (activeClaim) {
+      // Defensive: queued items shouldn't have active claims, but if
+      // some race produced one (e.g. claim got revoked but not cleaned
+      // up), release it cleanly before flipping to cancelled.
+      await this.storage.updateClaim(activeClaim.id, (c) => {
+        c.status = 'released';
+        c.endedAt = new Date().toISOString();
+        c.endReason = `cancelQueued: ${reason}`;
+      });
+    }
+    await this.transitionStatus(workItemId, 'cancelled', 'system', undefined, reason);
+    await this.storage.flush();
+    this.logger.info('WorkItem cancelled (queued → cancelled)', {
+      workItemId,
+      reason,
+      previousStatus: workItem.status,
+    });
+  }
+
+  /**
    * Requeue a failed WorkItem back to `queued` for another attempt.
    *
    * Path: `failed → queued` (legal in WORK_ITEM_TRANSITIONS but previously

--- a/backend/src/services/v3/agent-auto-claim.service.test.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.test.ts
@@ -7,6 +7,30 @@
 // AgentAutoClaimService tests — auto-claim, recovery, wake via team API, Slack escalation
 import { AgentAutoClaimService } from './agent-auto-claim.service.js';
 
+// Axios is dynamically imported inside `recoverPendingTasks` (for the
+// `/api/teams` lookup + member-start POST). The recovery test below
+// asserts on calls to those endpoints, so we stub the default import.
+const mockAxiosGet = jest.fn();
+const mockAxiosPost = jest.fn();
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockAxiosGet(...args),
+    post: (...args: unknown[]) => mockAxiosPost(...args),
+  },
+}));
+
+// Escalation router is dynamically imported; stub it so the recovery
+// test can assert routing decisions without hitting filesystem state.
+const mockRoutePolicyEscalation = jest.fn().mockResolvedValue(null);
+jest.mock('./escalation-router.service.js', () => ({
+  EscalationRouterService: {
+    getInstance: () => ({
+      routePolicyEscalation: mockRoutePolicyEscalation,
+    }),
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -189,6 +213,100 @@ describe('AgentAutoClaimService', () => {
       const result = await service.tryAutoClaimForAgent('agent-1');
       expect(result).toBeNull();
       expect(mockClaimSpecificItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recoverPendingTasks — orchestrator self-loop guard (PR-1.3)', () => {
+    // Reproduces the 2026-05-27 22:29:06 / 23:22:28 incident: a WI
+    // targeted at `crewly-orc` could not be woken via the team-member
+    // start endpoint (returns 400 because the orc is not a regular
+    // team member); the wake-failure path then escalated "to
+    // Orchestrator", but the orc IS the orchestrator → self-loop.
+    function orcTargetedWi(id: string, target = 'crewly-orc') {
+      return {
+        id,
+        title: `Wiki migrate ${id}`,
+        type: 'delegate',
+        owner: 'orchestrator',
+        target,
+        status: 'queued' as const,
+        retryCount: 0,
+        maxRetries: 1,
+        createdAt: new Date().toISOString(),
+        inputTokens: 0,
+        outputTokens: 0,
+        cost: 0,
+      };
+    }
+
+    function teamsResponseWithoutOrc() {
+      return { data: { data: [{ id: 't1', members: [{ id: 'm1', sessionName: 'alice' }] }] } };
+    }
+
+    beforeEach(() => {
+      mockAxiosGet.mockReset();
+      mockAxiosPost.mockReset();
+      mockRoutePolicyEscalation.mockReset().mockResolvedValue(null);
+      // Default teams response excludes orc — that's how the original
+      // bug manifests (orc isn't a "member" of any team in the v3
+      // teams.json shape, so the member-id lookup fails).
+      mockAxiosGet.mockResolvedValue(teamsResponseWithoutOrc());
+    });
+
+    it('does NOT attempt the team-member start endpoint for the orchestrator session', async () => {
+      const service = AgentAutoClaimService.getInstance();
+      // Wire a health provider that flags ORC as inactive (the
+      // condition that pushed the WI into the wake path).
+      service.initialize({ on: jest.fn() } as never, async () => {
+        const map = new Map();
+        map.set('crewly-orc', { sessionName: 'crewly-orc', status: 'inactive' });
+        return map;
+      });
+
+      const orcWi = orcTargetedWi('wi-orc-1');
+      mockGetAvailableItems.mockResolvedValueOnce([orcWi]);
+
+      await (service as unknown as { recoverPendingTasks: () => Promise<void> }).recoverPendingTasks();
+
+      // No member-start POST for the orc — the orc has its own
+      // supervisor-respawn lifecycle.
+      const startCalls = mockAxiosPost.mock.calls.filter((c) =>
+        String(c[0] ?? '').includes('/members/') && String(c[0] ?? '').endsWith('/start'),
+      );
+      expect(startCalls).toHaveLength(0);
+    });
+
+    it('does NOT escalate orc-targeted items even if they fall through to the orphan list', async () => {
+      // Defense-in-depth: even if a future code path adds an
+      // orc-targeted WI directly to `orphanedItems`, the final
+      // escalation filter must drop it.
+      const service = AgentAutoClaimService.getInstance();
+      // Health map does NOT contain `crewly-orc` → falls into "agent
+      // doesn't exist in any team" orphan path (line 430 pre-fix).
+      service.initialize({ on: jest.fn() } as never, async () => new Map());
+
+      const orcWi = orcTargetedWi('wi-orc-2');
+      mockGetAvailableItems.mockResolvedValueOnce([orcWi]);
+
+      await (service as unknown as { recoverPendingTasks: () => Promise<void> }).recoverPendingTasks();
+
+      expect(mockRoutePolicyEscalation).not.toHaveBeenCalled();
+    });
+
+    it('still escalates orphaned NON-orc items normally', async () => {
+      // Regression guard — the new filter must only drop orc items,
+      // not silence the entire escalation flow.
+      const service = AgentAutoClaimService.getInstance();
+      service.initialize({ on: jest.fn() } as never, async () => new Map());
+
+      const wi = orcTargetedWi('wi-alice-1', 'alice-the-dev');
+      mockGetAvailableItems.mockResolvedValueOnce([wi]);
+      // teams API doesn't list alice either → orphan path.
+      mockAxiosGet.mockResolvedValue({ data: { data: [] } });
+
+      await (service as unknown as { recoverPendingTasks: () => Promise<void> }).recoverPendingTasks();
+
+      expect(mockRoutePolicyEscalation).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/services/v3/agent-auto-claim.service.ts
+++ b/backend/src/services/v3/agent-auto-claim.service.ts
@@ -22,6 +22,15 @@ import { TaskPoolService } from '../task-pool/task-pool.service.js';
 import { computeAgentScore, type AgentHealth } from '../reconciler/reconcile-rules.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import { SLA_TRACKER_ID_PATTERN } from './workitem-dispatch.subscriber.js';
+import { CREWLY_CONSTANTS } from '../../constants.js';
+
+/**
+ * The orchestrator's own session name. Used to short-circuit the wake +
+ * escalation paths — those paths are agent-to-agent recovery; firing
+ * them with the orc as both source and target creates a self-referential
+ * loop ("ORC escalates to ORC", observed 2026-05-27).
+ */
+const ORCHESTRATOR_SESSION_NAME = CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -403,7 +412,7 @@ export class AgentAutoClaimService {
     }
 
     const agentsToWake = new Set<string>();
-    const orphanedItems: typeof targetedItems = [];
+    let orphanedItems: typeof targetedItems = [];
     const activeTargetedItems: typeof targetedItems = [];
 
     for (const wi of targetedItems) {
@@ -456,6 +465,24 @@ export class AgentAutoClaimService {
 
     // Wake known offline agents via correct team member start endpoint
     for (const session of agentsToWake) {
+      // The orchestrator manages its own lifecycle (heartbeat-respawn
+      // from the service wrapper / supervisor) — it is NOT a regular
+      // team-member and the `POST /api/teams/:teamId/members/:memberId/start`
+      // endpoint returns 400 for it. Pre-fix, that 400 routed the WI into
+      // `orphanedItems` and then the escalation path "Escalated to
+      // Orchestrator" — but the orchestrator IS the orchestrator, so the
+      // escalation closed the loop into itself ("ORC escalates to ORC",
+      // observed 2026-05-27 22:29:06 / 23:22:28). Skip both the wake
+      // attempt and the escalation; the orc's supervisor will respawn it
+      // and the dispatch subscriber will re-deliver targeted WIs once
+      // the session is back.
+      if (session === ORCHESTRATOR_SESSION_NAME) {
+        this.logger.debug(
+          'Skipping wake for orchestrator session — supervisor handles its respawn',
+          { sessionName: session, pendingWiCount: targetedItems.filter((wi) => wi.target === session).length },
+        );
+        continue;
+      }
       try {
         // Find team and member ID for this session
         const axios = (await import('axios')).default;
@@ -489,6 +516,20 @@ export class AgentAutoClaimService {
         orphanedItems.push(...targetedItems.filter((wi) => wi.target === session));
       }
     }
+
+    // Belt-and-suspenders: a WI whose target IS the orchestrator must
+    // never enter the escalation path — the path delivers via
+    // [RECOVERY] alerts that route back to the orc, which is the same
+    // session that "owns" the WI. Filter them out and log so ops sees
+    // why no alert fired for orc-targeted tasks.
+    const orcOrphans = orphanedItems.filter((wi) => wi.target === ORCHESTRATOR_SESSION_NAME);
+    if (orcOrphans.length > 0) {
+      this.logger.debug(
+        'Dropping orchestrator-targeted items from escalation list (would create self-loop)',
+        { count: orcOrphans.length, workItemIds: orcOrphans.map((wi) => wi.id) },
+      );
+    }
+    orphanedItems = orphanedItems.filter((wi) => wi.target !== ORCHESTRATOR_SESSION_NAME);
 
     // Escalate orphaned tasks — notify Orchestrator via Slack (reliable delivery)
     if (orphanedItems.length > 0) {


### PR DESCRIPTION
Fixes #609.

A delegate-type fallback WorkItem (`type=delegate, target=crewly-orc`) that the orchestrator couldn't claim (`poll-tasks` → `claimed:false, available:0`) was stuck `queued` and re-dispatched ~every minute. The only terminal escapes were invalid or destructive: `complete` requires `running` (`queued → done_by_worker` is rejected), and `DELETE ?force=1` is a hard purge.

Adds `POST /api/task-pool/items/:workItemId/cancel` — a clean `queued|blocked|scheduled → cancelled` transition with a required `reason` (persisted on `cancelReason`, surfaced in the activity timeline). The orchestrator can now resolve a stuck fallback WI without a hard delete, and auto-claim stops re-offering items it structurally cannot complete.

Tests added (controller +75, service +61, agent-auto-claim +118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)