### PR TITLE
fix(cron): retry transient PTY-spawn failures instead of skipping (#611) + release 1.8.11

### DIFF
--- a/backend/src/services/workflow/cron-task.service.test.ts
+++ b/backend/src/services/workflow/cron-task.service.test.ts
@@ -402,7 +402,15 @@ describe('CronTaskService', () => {
 		// window, the task must be skipped with `lastSkippedAt` set and
 		// a `lastSkipReason` distinguishable from "never ran" — not
 		// silently dropped.
-		it('skips with lastSkipReason="agent_offline_not_ready" when readiness wait expires', async () => {
+		//
+		// Updated 2026-05-28 (#611): a single readiness failure is now a
+		// TRANSIENT skip — `nextRunAt` is pushed forward and the slot
+		// retries up to 3x. Only after the budget is exhausted does the
+		// task receive the permanent `agent_offline_retries_exhausted`
+		// skip mark. This test now seeds `transientSkipAttempts: 2` so
+		// the next failure IS the third attempt, exercising the
+		// permanent-skip path.
+		it('skips with lastSkipReason="agent_offline_retries_exhausted" after the 3rd transient failure', async () => {
 			const executedTasks: CronTask[] = [];
 			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
 
@@ -419,6 +427,9 @@ describe('CronTaskService', () => {
 						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
 						enabled: true, lastRunAt: null, nextRunAt: pastTime,
 						createdBy: 'user', createdAt: '2026-01-01',
+						// Seed the retry counter so THIS failure is the
+						// budget-exhausting third attempt.
+						transientSkipAttempts: 2,
 					}] });
 				}
 				throw new Error('ENOENT');
@@ -453,8 +464,139 @@ describe('CronTaskService', () => {
 			expect(writeCall).toBeDefined();
 			const written = JSON.parse(writeCall![1] as string);
 			expect(written.tasks[0].lastSkippedAt).toBeTruthy();
-			expect(written.tasks[0].lastSkipReason).toBe('agent_offline_not_ready');
+			expect(written.tasks[0].lastSkipReason).toBe('agent_offline_retries_exhausted');
 			expect(written.tasks[0].lastRunAt).toBeNull();
+			// Counter resets to 0 so the next slot starts with a fresh budget.
+			expect(written.tasks[0].transientSkipAttempts).toBe(0);
+		});
+
+		// #611 — first attempt at agent_offline_not_ready: TRANSIENT skip.
+		// nextRunAt is pushed forward by the linear backoff and the slot
+		// will retry. `lastSkippedAt` / `lastSkipReason` must NOT be set
+		// because nothing has been permanently skipped yet.
+		it('first agent_offline_not_ready is TRANSIENT — pushes nextRunAt, bumps transientSkipAttempts, no lastSkip mutation (#611)', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+			service.setAgentStatusCallback(async () => false);
+			service.setAgentStartCallback(async () => true);
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			const originalNextRun = pastTime;
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-retry-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: originalNextRun,
+						createdBy: 'user', createdAt: '2026-01-01',
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			const realNow = Date.now;
+			let fakeNow = realNow();
+			jest.spyOn(Date, 'now').mockImplementation(() => fakeNow);
+			const origSetTimeout = global.setTimeout;
+			(global as any).setTimeout = (cb: () => void) => {
+				fakeNow += 500;
+				cb();
+				return 0 as any;
+			};
+
+			try {
+				await service.evaluateTasks();
+			} finally {
+				(global as any).setTimeout = origSetTimeout;
+				(Date.now as jest.Mock).mockRestore();
+			}
+
+			expect(executedTasks).toHaveLength(0);
+			const writeCall = mockWriteFile.mock.calls.find(c => String(c[0]).includes('team-a'));
+			expect(writeCall).toBeDefined();
+			const written = JSON.parse(writeCall![1] as string);
+			expect(written.tasks[0].transientSkipAttempts).toBe(1);
+			// Critical: NO permanent-skip mutation on the first attempt.
+			expect(written.tasks[0].lastSkippedAt).toBeFalsy();
+			expect(written.tasks[0].lastSkipReason).toBeFalsy();
+			expect(written.tasks[0].lastRunAt).toBeNull();
+			// nextRunAt moved forward (transient retry) — NOT back to the
+			// original past time. We don't assert exact ms since clocks
+			// drift, but it must be in the future relative to pastTime.
+			expect(new Date(written.tasks[0].nextRunAt).getTime()).toBeGreaterThan(
+				new Date(originalNextRun).getTime(),
+			);
+		});
+
+		// #611 — counter resets on successful execution so the next slot
+		// starts with a fresh retry budget. Without this reset, a string
+		// of bad-luck runs would chain attempt-counts across firings.
+		it('resets transientSkipAttempts to 0 after a successful execution (#611)', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+			service.setAgentStatusCallback(async () => true); // agent IS online
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-ran-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: pastTime,
+						createdBy: 'user', createdAt: '2026-01-01',
+						// Seed a non-zero counter — must end at 0 after the run.
+						transientSkipAttempts: 2,
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			await service.evaluateTasks();
+
+			expect(executedTasks).toHaveLength(1);
+			const writeCall = mockWriteFile.mock.calls.find(c => String(c[0]).includes('team-a'));
+			expect(writeCall).toBeDefined();
+			const written = JSON.parse(writeCall![1] as string);
+			expect(written.tasks[0].lastRunAt).toBeTruthy();
+			expect(written.tasks[0].transientSkipAttempts).toBe(0);
+		});
+
+		// #611 — non-transient skip reasons (no callback wired) MUST go
+		// straight to permanent skip with no retry-counter bump. We don't
+		// want to delay "you literally cannot start this agent" with a
+		// retry budget that will exhaust to the same outcome.
+		it('agent_offline_no_callback is NOT a transient skip — permanent immediately (#611)', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+			service.setAgentStatusCallback(async () => false);
+			// Deliberately NO setAgentStartCallback → triggers agent_offline_no_callback.
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-nocb-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'a1', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: pastTime,
+						createdBy: 'user', createdAt: '2026-01-01',
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			await service.evaluateTasks();
+
+			expect(executedTasks).toHaveLength(0);
+			const writeCall = mockWriteFile.mock.calls.find(c => String(c[0]).includes('team-a'));
+			expect(writeCall).toBeDefined();
+			const written = JSON.parse(writeCall![1] as string);
+			expect(written.tasks[0].lastSkipReason).toBe('agent_offline_no_callback');
+			expect(written.tasks[0].lastSkippedAt).toBeTruthy();
+			// No transient-retry pathway means no counter bump.
+			expect(written.tasks[0].transientSkipAttempts ?? 0).toBe(0);
 		});
 	});
 

--- a/backend/src/services/workflow/cron-task.service.ts
+++ b/backend/src/services/workflow/cron-task.service.ts
@@ -43,6 +43,29 @@ const CRON_AUTO_START_READY_TIMEOUT_MS = 15_000;
 /** How often to re-check the agent's status during the readiness wait. */
 const CRON_AUTO_START_READY_POLL_MS = 500;
 
+/**
+ * #611 transient-skip retry budget. When an auto-start fails because the
+ * PTY spawn momentarily can't acquire a slot (`posix_spawnp failed.` —
+ * observed 2026-05-28 when the user proc count hit 353 against a
+ * `maxProcPerUid` of 1333 → kernel briefly rejected new spawns), the
+ * cron-eval path used to permanently skip the slot. The error itself is
+ * transient ("Wait ~30 s and the next attempt should succeed") so we
+ * instead push `nextRunAt` forward by a short backoff and let the cron
+ * loop retry the same slot up to {@link CRON_TRANSIENT_SKIP_MAX_ATTEMPTS}
+ * times before permanently skipping.
+ */
+const CRON_TRANSIENT_SKIP_MAX_ATTEMPTS = 3;
+
+/**
+ * Base backoff for transient skip retries (#611). Total time waited
+ * across all attempts ≈ BACKOFF × (1 + 2 + 3) = 60 s with the default
+ * 10s base — enough for the PTY spawn limit to clear without unduly
+ * delaying tasks. Multiplied by `transientSkipAttempts` for a linear
+ * backoff (a multi-process spike clears in a small handful of seconds,
+ * exponential would over-delay).
+ */
+const CRON_TRANSIENT_SKIP_BACKOFF_MS = 10_000;
+
 /** Name of the per-team cron task file */
 const CRON_TASKS_FILENAME = 'cron-tasks.json';
 
@@ -814,6 +837,43 @@ export class CronTaskService {
 		}
 
 		if (!agentOnline) {
+			// #611: transient-skip retry budget. The reasons that fire here
+			// (`agent_offline_not_ready` / `agent_offline_start_failed`) can
+			// be caused by short-lived PTY spawn failures that clear in
+			// seconds (observed 2026-05-28: kernel briefly rejected
+			// posix_spawnp at user-proc-count 353/1333). Push `nextRunAt`
+			// forward by a small linear backoff and retry the SAME slot up
+			// to CRON_TRANSIENT_SKIP_MAX_ATTEMPTS before surrendering to the
+			// old "advance + mark skipped" path. Surplus skip reasons
+			// (`agent_offline_no_callback`) are NOT transient — they go
+			// straight to permanent skip.
+			const isTransient =
+				skipReason === 'agent_offline_not_ready' ||
+				skipReason === 'agent_offline_start_failed';
+			if (isTransient) {
+				const attempts = (task.transientSkipAttempts ?? 0) + 1;
+				if (attempts < CRON_TRANSIENT_SKIP_MAX_ATTEMPTS) {
+					const backoffMs = CRON_TRANSIENT_SKIP_BACKOFF_MS * attempts;
+					task.transientSkipAttempts = attempts;
+					task.nextRunAt = new Date(Date.now() + backoffMs).toISOString();
+					this.logger.warn('Cron transient-skip — retrying slot after backoff', {
+						id: task.id,
+						target: task.targetAgent,
+						skipReason,
+						attempt: attempts,
+						maxAttempts: CRON_TRANSIENT_SKIP_MAX_ATTEMPTS,
+						backoffMs,
+						nextRunAt: task.nextRunAt,
+					});
+					return true;
+				}
+				// Budget exhausted — fall through to permanent skip with a
+				// distinct reason so dashboards can tell "we tried" vs "gave
+				// up first round". Reset the counter so the next regular
+				// firing starts fresh.
+				skipReason = 'agent_offline_retries_exhausted';
+				task.transientSkipAttempts = 0;
+			}
 			this.logger.warn('Skipping cron task — agent offline and auto-start unavailable', {
 				id: task.id,
 				target: task.targetAgent,
@@ -848,6 +908,14 @@ export class CronTaskService {
 		// Update run times regardless of execution success
 		task.lastRunAt = now.toISOString();
 		task.nextRunAt = getNextRunTime(task.cronExpression, task.timezone, now);
+		// #611: a successful (or attempted) execution clears the
+		// transient-skip retry counter so the NEXT slot starts with a
+		// fresh budget. Without this reset, a string of bad-luck runs
+		// would carry attempt-counts across firings and exhaust the
+		// budget prematurely.
+		if ((task.transientSkipAttempts ?? 0) > 0) {
+			task.transientSkipAttempts = 0;
+		}
 		return true;
 	}
 

--- a/backend/src/types/cron-task.types.ts
+++ b/backend/src/types/cron-task.types.ts
@@ -47,9 +47,24 @@ export interface CronTask {
 	 *   - `agent_offline_start_failed` — callback threw or returned false
 	 *   - `agent_offline_not_ready` — callback succeeded but agent
 	 *     didn't come online within the wait window
-	 * Issue #305.
+	 *   - `agent_offline_retries_exhausted` — transient retries (#611) ran
+	 *     out; equivalent terminal-skip for the consumer
+	 * Issue #305 / #611.
 	 */
 	lastSkipReason?: string;
+	/**
+	 * Transient-skip retry counter (#611, 2026-05-28). Incremented every
+	 * time `agent_offline_not_ready` / `agent_offline_start_failed` would
+	 * have produced a permanent skip; reset to 0 on any successful run.
+	 * The cron-eval loop reads this to decide whether to push `nextRunAt`
+	 * out by a short backoff (retry) vs. permanently skip the slot.
+	 *
+	 * Why a stored counter and not an in-memory one: cron eval can fire
+	 * on a fresh process (restart) and we still want the retry budget to
+	 * survive — otherwise a transient OS spike that happens to coincide
+	 * with a backend bounce would defeat the retry mechanism entirely.
+	 */
+	transientSkipAttempts?: number;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.8.10",
+      "version": "1.8.11",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
Fixes #611.

When `CronTaskService` auto-started an offline agent and the PTY spawn hit a transient `posix_spawnp failed` (kernel momentarily over `maxProcPerUid`), the cron slot was **permanently skipped** (`skipReason: agent_offline_not_ready`) and the task silently never fired. This dropped Ella's email-processing and morning-brief crons on 2026-05-28 (the user noticed only because email was never processed).

The spawn error is transient ("wait ~30s and retry succeeds"), so instead of skipping we push `nextRunAt` forward by a short backoff and retry the same slot up to `CRON_TRANSIENT_SKIP_MAX_ATTEMPTS` (3 attempts, ≈60s total at the 10s base) before permanently skipping. `transientSkipAttempts` is persisted on the cron task so the retry budget survives a backend restart.

**Release:** bumps `1.8.10 → 1.8.11` (covers the wiki feature + #607 + #609 + #611).

Tests added (cron-task.service.test.ts +146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)