### PR TITLE
fix(wiki): bookkeep/reflect triggers fire on net-new + persist across restart

### DIFF
--- a/backend/src/controllers/wiki/wiki.controller.ts
+++ b/backend/src/controllers/wiki/wiki.controller.ts
@@ -1175,10 +1175,11 @@ export async function reflectTriggerNow(
       });
       return;
     }
-    // Clear the debounce ledger so a manual fire is never silently
-    // suppressed by an earlier scheduled tick.
-    trigger._resetDebounceForTesting();
-    const result = await trigger.tick();
+    // Force a fire past the debounce window so a manual trigger is never
+    // silently suppressed by an earlier scheduled tick. Unlike clearing the
+    // ledger, this leaves other vaults' debounce + the persisted state intact,
+    // so the next scheduled tick won't re-burst.
+    const result = await trigger.tick({ ignoreDebounce: true });
     res.status(200).json({ success: true, result });
   } catch (err) {
     logger.error('wiki/reflect/trigger-now threw', { error: (err as Error).message });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -452,14 +452,21 @@ void (async () => {
 				const { WikiBookkeepTriggerService } = await import(
 					'./services/wiki/wiki-bookkeep-trigger.service.js'
 				);
-				const intervalMs = Number(process.env['CREWLY_WIKI_BOOKKEEP_INTERVAL_MS'] ?? 30 * 60 * 1000);
-				const debounceMs = Number(process.env['CREWLY_WIKI_BOOKKEEP_DEBOUNCE_MS'] ?? 6 * 3600 * 1000);
+				// Parse a positive-integer ms env override; fall back to the default
+				// when the value is missing or malformed (a NaN would coerce to a
+				// 0ms setInterval — a hot loop).
+				const posIntMs = (raw: string | undefined, fallback: number): number => {
+					const n = Number(raw);
+					return Number.isFinite(n) && n > 0 ? n : fallback;
+				};
+				const intervalMs = posIntMs(process.env['CREWLY_WIKI_BOOKKEEP_INTERVAL_MS'], 30 * 60 * 1000);
+				const debounceMs = posIntMs(process.env['CREWLY_WIKI_BOOKKEEP_DEBOUNCE_MS'], 6 * 3600 * 1000);
 				const trigger = new WikiBookkeepTriggerService({
 					intervalMs,
 					debounceMs,
 					fireFn: async (vaultPath, report) => {
 						if (!this.messageQueueService) return;
-						const summary = `[BOOKKEEP] vault=${vaultPath} | ${report.recentMdCount} new md(s) in last ${report.windowDays}d (threshold ${report.threshold}) | duplicates=${report.duplicateCandidates.length} | pending-queue=${report.queue.pending}. Run wiki-bookkeep to drain.`;
+						const summary = `[BOOKKEEP] vault=${vaultPath} | ${report.netNewMdCount} net-new md(s) since last pass (threshold ${report.threshold}) | duplicates=${report.duplicateCandidates.length} | pending-queue=${report.queue.pending}. Run wiki-bookkeep to drain.`;
 						this.messageQueueService.enqueue({
 							content: summary,
 							conversationId: 'system:wiki-bookkeep',
@@ -484,15 +491,13 @@ void (async () => {
 				const { WikiReflectTriggerService } = await import(
 					'./services/wiki/wiki-reflect-trigger.service.js'
 				);
-				const reflectInterval = Number(
-					process.env['CREWLY_WIKI_REFLECT_INTERVAL_MS'] ?? 60 * 60 * 1000,
-				);
-				const reflectQuiet = Number(
-					process.env['CREWLY_WIKI_REFLECT_QUIET_WINDOW_MS'] ?? 4 * 60 * 60 * 1000,
-				);
-				const reflectDebounce = Number(
-					process.env['CREWLY_WIKI_REFLECT_DEBOUNCE_MS'] ?? 4 * 60 * 60 * 1000,
-				);
+				const posIntMs = (raw: string | undefined, fallback: number): number => {
+					const n = Number(raw);
+					return Number.isFinite(n) && n > 0 ? n : fallback;
+				};
+				const reflectInterval = posIntMs(process.env['CREWLY_WIKI_REFLECT_INTERVAL_MS'], 60 * 60 * 1000);
+				const reflectQuiet = posIntMs(process.env['CREWLY_WIKI_REFLECT_QUIET_WINDOW_MS'], 4 * 60 * 60 * 1000);
+				const reflectDebounce = posIntMs(process.env['CREWLY_WIKI_REFLECT_DEBOUNCE_MS'], 4 * 60 * 60 * 1000);
 				const reflectTrigger = new WikiReflectTriggerService({
 					intervalMs: reflectInterval,
 					quietWindowMs: reflectQuiet,

--- a/backend/src/services/wiki/wiki-bookkeep-trigger.service.test.ts
+++ b/backend/src/services/wiki/wiki-bookkeep-trigger.service.test.ts
@@ -56,22 +56,29 @@ describe('WikiBookkeepTriggerService', () => {
     WikiBookkeepTriggerService.setInstance(null);
   });
 
-  const makeTrigger = (overrides: { intervalMs?: number; debounceMs?: number; threshold?: number } = {}) =>
+  const makeTrigger = (overrides: { intervalMs?: number; debounceMs?: number; statePath?: string | null } = {}) =>
     new WikiBookkeepTriggerService({
       intervalMs: overrides.intervalMs ?? 60_000,
       debounceMs: overrides.debounceMs ?? 1_000_000,
+      statePath: overrides.statePath ?? null,
       bookkeepService: bookkeep,
       discoverRoots: async () => [vault],
       fireFn: async (vaultPath, report) => {
         fired.push({
           vault: vaultPath,
           threshold: report.threshold,
-          recent: report.recentMdCount,
+          recent: report.netNewMdCount,
         });
       },
     });
 
-  describe('tick (single-pass behavior)', () => {
+  const writeMds = async (n: number, prefix = 'p') => {
+    for (let i = 0; i < n; i++) {
+      await fs.writeFile(path.join(vault, `llm-curated/${prefix}-${i}.md`), `# ${prefix} ${i}`, 'utf8');
+    }
+  };
+
+  describe('tick (net-new baseline behavior)', () => {
     it('does NOT fire for an empty vault', async () => {
       const trigger = makeTrigger();
       const res = await trigger.tick();
@@ -80,54 +87,60 @@ describe('WikiBookkeepTriggerService', () => {
       expect(res.fired).toEqual([]);
     });
 
-    it('FIRES when recentMdCount meets threshold (default 10) and the per-vault override is set lower in service.generate', async () => {
-      // We can't pass threshold via the trigger directly — the trigger
-      // delegates to WikiBookkeepService which defaults threshold=10.
-      // Drop 10 new mds → cross threshold.
-      for (let i = 0; i < 10; i++) {
-        await fs.writeFile(
-          path.join(vault, `llm-curated/p-${i}.md`),
-          `# p ${i}`,
-          'utf8',
-        );
-      }
+    it('first sight establishes a baseline and does NOT fire — even with a large backlog', async () => {
+      // Mirrors a freshly-migrated vault: many files, all mtime-recent. The
+      // old mtime-window logic would fire on the whole backlog; net-new does not.
+      await writeMds(15);
       const trigger = makeTrigger();
       const res = await trigger.tick();
-      expect(fired).toHaveLength(1);
-      expect(fired[0].vault).toBe(vault);
-      expect(fired[0].recent).toBeGreaterThanOrEqual(10);
-      expect(res.fired).toEqual([vault]);
+      expect(fired).toHaveLength(0);
+      expect(res.quietVaults).toEqual([vault]);
     });
 
-    it('FIRES when duplicate clusters exist even if recent count is below threshold', async () => {
+    it('FIRES when >= threshold NET-NEW mds are added after the baseline', async () => {
+      const trigger = makeTrigger();
+      await trigger.tick(); // establish baseline at 0
+      expect(fired).toHaveLength(0);
+      await writeMds(10); // 10 net-new (default threshold 10)
+      const res = await trigger.tick();
+      expect(res.fired).toEqual([vault]);
+      expect(fired).toHaveLength(1);
+      expect(fired[0].vault).toBe(vault);
+      expect(fired[0].recent).toBeGreaterThanOrEqual(10); // netNewMdCount
+    });
+
+    it('does NOT fire on duplicate clusters alone (below net-new threshold)', async () => {
+      const trigger = makeTrigger();
+      await trigger.tick(); // baseline
       await fs.writeFile(path.join(vault, 'llm-curated/anthropic-pricing.md'), '#', 'utf8');
       await fs.writeFile(path.join(vault, 'llm-curated/anthropic-pricing-v2.md'), '#', 'utf8');
-      const trigger = makeTrigger();
-      await trigger.tick();
-      expect(fired).toHaveLength(1);
+      await trigger.tick(); // 2 net-new < 10, duplicates present
+      expect(fired).toHaveLength(0);
     });
   });
 
-  describe('debounce ledger', () => {
-    it('does NOT fire twice for the same vault within debounceMs', async () => {
-      for (let i = 0; i < 10; i++) {
-        await fs.writeFile(path.join(vault, `llm-curated/p-${i}.md`), '#', 'utf8');
-      }
-      const trigger = makeTrigger({ debounceMs: 1_000_000 });
-      await trigger.tick();
-      await trigger.tick();
+  describe('debounce + baseline advance', () => {
+    it('does NOT refire until another threshold of net-new accumulates', async () => {
+      const trigger = makeTrigger();
+      await trigger.tick(); // baseline 0
+      await writeMds(10);
+      await trigger.tick(); // fire 1; baseline advances to 10
+      expect(fired).toHaveLength(1);
+      await trigger.tick(); // no new files → netNew 0
       expect(fired).toHaveLength(1);
     });
 
-    it('refires after _resetDebounceForTesting()', async () => {
-      for (let i = 0; i < 10; i++) {
-        await fs.writeFile(path.join(vault, `llm-curated/p-${i}.md`), '#', 'utf8');
-      }
-      const trigger = makeTrigger();
-      await trigger.tick();
-      trigger._resetDebounceForTesting();
-      await trigger.tick();
-      expect(fired).toHaveLength(2);
+    it('debounces a second fire even when net-new is still >= threshold', async () => {
+      const trigger = makeTrigger({ debounceMs: 1_000_000 });
+      await trigger.tick(); // baseline 0
+      await writeMds(10, 'a');
+      await trigger.tick(); // fire 1; baseline → 10
+      expect(fired).toHaveLength(1);
+      // Add 10 MORE so net-new is again >= threshold, but stay inside debounce.
+      await writeMds(10, 'b');
+      const res = await trigger.tick();
+      expect(res.skippedByDebounce).toEqual([vault]);
+      expect(fired).toHaveLength(1);
     });
 
     it('does not fire on subsequent ticks when the vault stays quiet', async () => {
@@ -136,6 +149,21 @@ describe('WikiBookkeepTriggerService', () => {
       await trigger.tick();
       await trigger.tick();
       expect(fired).toHaveLength(0);
+    });
+  });
+
+  describe('persistence (survives restart)', () => {
+    it('persists the baseline so a new instance does not re-fire the backlog', async () => {
+      const statePath = path.join(queueRoot, 'bookkeep-state.json');
+      await writeMds(15);
+      const t1 = makeTrigger({ statePath });
+      await t1.tick(); // baseline = 15, no fire
+      expect(fired).toHaveLength(0);
+      // Simulate a restart: a brand-new instance reading the same state file.
+      const t2 = makeTrigger({ statePath });
+      const res = await t2.tick();
+      expect(fired).toHaveLength(0); // backlog already baselined — no burst
+      expect(res.quietVaults).toEqual([vault]);
     });
   });
 
@@ -151,19 +179,21 @@ describe('WikiBookkeepTriggerService', () => {
     });
 
     it('swallows fireFn errors so one bad vault does not break the scan', async () => {
-      for (let i = 0; i < 10; i++) {
-        await fs.writeFile(path.join(vault, `llm-curated/p-${i}.md`), '#', 'utf8');
-      }
       const trigger = new WikiBookkeepTriggerService({
         intervalMs: 60_000,
         debounceMs: 1_000_000,
+        statePath: null,
         bookkeepService: bookkeep,
         discoverRoots: async () => [vault],
         fireFn: async () => {
           throw new Error('boom');
         },
       });
-      // Should not throw.
+      await trigger.tick(); // establish baseline at 0
+      for (let i = 0; i < 10; i++) {
+        await fs.writeFile(path.join(vault, `llm-curated/p-${i}.md`), '#', 'utf8');
+      }
+      // Net-new now crosses threshold → fireFn fires and throws; must not throw out.
       await expect(trigger.tick()).resolves.toBeDefined();
     });
   });

--- a/backend/src/services/wiki/wiki-bookkeep-trigger.service.ts
+++ b/backend/src/services/wiki/wiki-bookkeep-trigger.service.ts
@@ -29,6 +29,18 @@ import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
 import { LoggerService, ComponentLogger } from '../core/logger.service.js';
 import { WikiBookkeepService, WikiBookkeepReport } from './wiki-bookkeep.service.js';
+import { atomicWriteJson, safeReadJson, ensureDir } from '../../utils/file-io.utils.js';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
+
+const STATE_FILE_NAME = 'wiki-bookkeep-trigger-state.json';
+
+/** Persisted per-vault state: the consolidation high-water mark + last fire. */
+interface VaultBookkeepState {
+  /** Total md count we last established as the baseline (high-water mark). */
+  baselineMdCount: number;
+  /** Last time we fired a bookkeep notification for this vault (ms epoch). */
+  lastFiredAt: number;
+}
 
 export type WikiBookkeepFireFn = (
   vaultPath: string,
@@ -46,6 +58,12 @@ export interface WikiBookkeepTriggerOptions {
   discoverRoots?: () => Promise<string[]>;
   /** Optional override of the bookkeep service (tests). */
   bookkeepService?: WikiBookkeepService;
+  /**
+   * Where to persist per-vault baseline + debounce state. Defaults to
+   * `~/.crewly/wiki-bookkeep-trigger-state.json`. Pass `null` to disable
+   * persistence (tests) so the trigger keeps state in-memory only.
+   */
+  statePath?: string | null;
 }
 
 const DEFAULT_INTERVAL_MS = 30 * 60 * 1000;
@@ -125,10 +143,12 @@ export class WikiBookkeepTriggerService {
   private readonly discoverRoots: () => Promise<string[]>;
   private readonly bookkeepService: WikiBookkeepService;
   private timer: NodeJS.Timeout | null = null;
-  /** vaultPath → last fired timestamp (ms). */
-  private readonly lastFiredAt = new Map<string, number>();
+  /** vaultPath → persisted baseline + last-fired state. */
+  private readonly state = new Map<string, VaultBookkeepState>();
   /** Per-vault locks so two overlapping ticks don't double-fire. */
   private inflight = new Set<string>();
+  private readonly statePath: string | null;
+  private stateLoaded = false;
 
   constructor(opts: WikiBookkeepTriggerOptions) {
     this.logger = LoggerService.getInstance().createComponentLogger('WikiBookkeepTrigger');
@@ -137,6 +157,56 @@ export class WikiBookkeepTriggerService {
     this.fireFn = opts.fireFn;
     this.discoverRoots = opts.discoverRoots ?? discoverWikiVaults;
     this.bookkeepService = opts.bookkeepService ?? WikiBookkeepService.getInstance();
+    if (opts.statePath === null) {
+      this.statePath = null;
+    } else if (typeof opts.statePath === 'string') {
+      this.statePath = opts.statePath;
+    } else {
+      this.statePath = path.join(getCrewlyHomePath(), STATE_FILE_NAME);
+    }
+  }
+
+  /**
+   * Load per-vault baseline + debounce state from disk (once). Without this,
+   * the in-memory ledger resets on every backend restart, so the next tick
+   * re-fires for every eligible vault — the "noise burst after a restart".
+   */
+  private async loadStateFromDisk(): Promise<void> {
+    if (this.stateLoaded) return;
+    this.stateLoaded = true;
+    if (!this.statePath) return;
+    const data = await safeReadJson<Record<string, VaultBookkeepState> | null>(this.statePath, null);
+    if (data && typeof data === 'object') {
+      for (const [vault, entry] of Object.entries(data)) {
+        if (
+          entry &&
+          typeof entry.baselineMdCount === 'number' &&
+          typeof entry.lastFiredAt === 'number'
+        ) {
+          this.state.set(vault, entry);
+        }
+      }
+      this.logger.info('WikiBookkeepTrigger loaded persisted state', {
+        statePath: this.statePath,
+        vaults: this.state.size,
+      });
+    }
+  }
+
+  /** Persist the per-vault state map (best-effort; failures are logged, not thrown). */
+  private async saveStateToDisk(): Promise<void> {
+    if (!this.statePath) return;
+    try {
+      const payload: Record<string, VaultBookkeepState> = {};
+      for (const [vault, entry] of this.state) payload[vault] = entry;
+      await ensureDir(path.dirname(this.statePath));
+      await atomicWriteJson(this.statePath, payload);
+    } catch (err) {
+      this.logger.warn('WikiBookkeepTrigger: failed to persist state (non-fatal)', {
+        statePath: this.statePath,
+        error: (err as Error).message,
+      });
+    }
   }
 
   static getInstance(): WikiBookkeepTriggerService | null {
@@ -180,6 +250,7 @@ export class WikiBookkeepTriggerService {
     skippedByDebounce: string[];
     quietVaults: string[];
   }> {
+    await this.loadStateFromDisk();
     const vaults = await this.discoverRoots();
     const result = {
       scanned: [...vaults],
@@ -187,11 +258,16 @@ export class WikiBookkeepTriggerService {
       skippedByDebounce: [] as string[],
       quietVaults: [] as string[],
     };
+    let stateDirty = false;
     for (const v of vaults) {
       if (this.inflight.has(v)) continue;
       this.inflight.add(v);
       try {
-        const outcome = await this.bookkeepService.generate({ vaultPath: v });
+        const prior = this.state.get(v);
+        const outcome = await this.bookkeepService.generate({
+          vaultPath: v,
+          baselineMdCount: prior?.baselineMdCount,
+        });
         if (!outcome.ok) {
           this.logger.warn('WikiBookkeepTrigger: bookkeep failed for vault', {
             vault: v,
@@ -199,22 +275,45 @@ export class WikiBookkeepTriggerService {
           });
           continue;
         }
+        const total = outcome.report.totalMdCount;
+
+        // First sight of a vault: establish the baseline at the current count
+        // and DON'T fire. This is what stops a freshly-migrated vault (every
+        // file mtime-recent) from firing on its entire backlog — only pages
+        // added AFTER this point count toward the next threshold.
+        if (!prior) {
+          this.state.set(v, { baselineMdCount: total, lastFiredAt: 0 });
+          stateDirty = true;
+          result.quietVaults.push(v);
+          continue;
+        }
+
+        // A vault that shrank (cleanup deleted pages) lowers the baseline so
+        // future adds are measured from the new floor — keep it persisted.
+        if (total < prior.baselineMdCount) {
+          prior.baselineMdCount = total;
+          stateDirty = true;
+        }
+
         if (!outcome.report.shouldFire) {
           result.quietVaults.push(v);
           continue;
         }
-        const last = this.lastFiredAt.get(v) ?? 0;
-        if (Date.now() - last < this.debounceMs) {
+        if (Date.now() - prior.lastFiredAt < this.debounceMs) {
           result.skippedByDebounce.push(v);
           continue;
         }
-        this.lastFiredAt.set(v, Date.now());
+        // Fire, then advance the baseline to the current count so we don't
+        // re-fire until another `threshold` net-new pages accumulate.
+        prior.lastFiredAt = Date.now();
+        prior.baselineMdCount = total;
+        stateDirty = true;
         try {
           await this.fireFn(v, outcome.report);
           result.fired.push(v);
           this.logger.info('WikiBookkeepTrigger fired', {
             vault: v,
-            recentMd: outcome.report.recentMdCount,
+            netNewMd: outcome.report.netNewMdCount,
             threshold: outcome.report.threshold,
             duplicates: outcome.report.duplicateCandidates.length,
           });
@@ -228,11 +327,13 @@ export class WikiBookkeepTriggerService {
         this.inflight.delete(v);
       }
     }
+    if (stateDirty) await this.saveStateToDisk();
     return result;
   }
 
-  /** Test affordance: clear the debounce ledger. */
+  /** Test affordance: clear the in-memory state ledger. */
   _resetDebounceForTesting(): void {
-    this.lastFiredAt.clear();
+    this.state.clear();
+    this.stateLoaded = false;
   }
 }

--- a/backend/src/services/wiki/wiki-bookkeep-trigger.service.ts
+++ b/backend/src/services/wiki/wiki-bookkeep-trigger.service.ts
@@ -175,20 +175,29 @@ export class WikiBookkeepTriggerService {
     if (this.stateLoaded) return;
     this.stateLoaded = true;
     if (!this.statePath) return;
-    const data = await safeReadJson<Record<string, VaultBookkeepState> | null>(this.statePath, null);
-    if (data && typeof data === 'object') {
-      for (const [vault, entry] of Object.entries(data)) {
-        if (
-          entry &&
-          typeof entry.baselineMdCount === 'number' &&
-          typeof entry.lastFiredAt === 'number'
-        ) {
-          this.state.set(vault, entry);
+    try {
+      const data = await safeReadJson<Record<string, VaultBookkeepState> | null>(this.statePath, null);
+      if (data && typeof data === 'object') {
+        for (const [vault, entry] of Object.entries(data)) {
+          if (
+            entry &&
+            typeof entry.baselineMdCount === 'number' &&
+            typeof entry.lastFiredAt === 'number'
+          ) {
+            this.state.set(vault, entry);
+          }
         }
+        this.logger.info('WikiBookkeepTrigger loaded persisted state', {
+          statePath: this.statePath,
+          vaults: this.state.size,
+        });
       }
-      this.logger.info('WikiBookkeepTrigger loaded persisted state', {
+    } catch (err) {
+      // A transient read error (e.g. EACCES) must not abort the tick — start
+      // with an empty ledger this run; a later tick re-establishes baselines.
+      this.logger.warn('WikiBookkeepTrigger: failed to load state (non-fatal)', {
         statePath: this.statePath,
-        vaults: this.state.size,
+        error: (err as Error).message,
       });
     }
   }
@@ -331,9 +340,12 @@ export class WikiBookkeepTriggerService {
     return result;
   }
 
-  /** Test affordance: clear the in-memory state ledger. */
+  /**
+   * Test affordance: clear the in-memory baseline + debounce ledger. Leaves
+   * `stateLoaded` set so a subsequent `tick()` does NOT reload persisted state
+   * (which would undo the clear).
+   */
   _resetDebounceForTesting(): void {
     this.state.clear();
-    this.stateLoaded = false;
   }
 }

--- a/backend/src/services/wiki/wiki-bookkeep.service.test.ts
+++ b/backend/src/services/wiki/wiki-bookkeep.service.test.ts
@@ -111,6 +111,54 @@ describe('WikiBookkeepService', () => {
     });
   });
 
+  describe('net-new baseline (shouldFire driven by baselineMdCount)', () => {
+    const writeMds = async (n: number) => {
+      for (let i = 0; i < n; i++) {
+        await fs.writeFile(path.join(vault, `llm-curated/n-${i}.md`), `# n ${i}`, 'utf8');
+      }
+    };
+
+    it('does NOT fire when the whole vault is already baselined (migration scenario)', async () => {
+      // 12 mtime-recent files but baseline == total → 0 net-new. The old
+      // mtime-window logic would have fired; net-new must not.
+      await writeMds(12);
+      const r = await svc.generate({ vaultPath: vault, threshold: 10, baselineMdCount: 12 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.report.recentMdCount).toBe(12); // window still counts them
+      expect(r.report.netNewMdCount).toBe(0); // but net-new is 0
+      expect(r.report.shouldFire).toBe(false);
+    });
+
+    it('fires when net-new since the baseline reaches the threshold', async () => {
+      await writeMds(12);
+      const r = await svc.generate({ vaultPath: vault, threshold: 10, baselineMdCount: 2 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.report.netNewMdCount).toBe(10); // 12 - 2
+      expect(r.report.shouldFire).toBe(true);
+    });
+
+    it('clamps net-new to 0 when the vault shrank below the baseline', async () => {
+      await writeMds(3);
+      const r = await svc.generate({ vaultPath: vault, threshold: 1, baselineMdCount: 50 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.report.netNewMdCount).toBe(0);
+      expect(r.report.shouldFire).toBe(false);
+    });
+
+    it('duplicate clusters alone do NOT force a fire under net-new', async () => {
+      await fs.writeFile(path.join(vault, 'llm-curated/anthropic-pricing.md'), '#', 'utf8');
+      await fs.writeFile(path.join(vault, 'llm-curated/anthropic-pricing-v2.md'), '#', 'utf8');
+      const r = await svc.generate({ vaultPath: vault, threshold: 10, baselineMdCount: 2 });
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.report.duplicateCandidates.length).toBeGreaterThan(0);
+      expect(r.report.shouldFire).toBe(false);
+    });
+  });
+
   describe('duplicate detection', () => {
     it('flags near-duplicate filenames as a cluster', async () => {
       await fs.mkdir(path.join(vault, 'llm-curated/customers'), { recursive: true });

--- a/backend/src/services/wiki/wiki-bookkeep.service.ts
+++ b/backend/src/services/wiki/wiki-bookkeep.service.ts
@@ -40,6 +40,17 @@ export interface WikiBookkeepInput {
   windowDays?: number;
   /** Md-count threshold used by `shouldFire` (default 10). */
   threshold?: number;
+  /**
+   * Total md count the caller last acted on for this vault (its persisted
+   * baseline / high-water mark). When provided, `shouldFire` is driven by
+   * NET-NEW pages since the baseline (`totalMdCount - baselineMdCount`)
+   * rather than by mtime-recency. This is the robust signal: an mtime
+   * window counts every file a bulk operation (e.g. a vault migration that
+   * writes 500 pages at once) just touched as "recent", so it fires forever;
+   * net-new only counts genuinely-added pages. Omit for a stateless report
+   * (falls back to the mtime-window `recentMdCount`).
+   */
+  baselineMdCount?: number;
 }
 
 export interface WikiPageRef {
@@ -64,8 +75,14 @@ export interface WikiBookkeepReport {
   shouldFire: boolean;
   /** Total md files under the vault (recursive). */
   totalMdCount: number;
-  /** Newly created/touched mds within `windowDays`. */
+  /** Newly created/touched mds within `windowDays` (mtime-based; informational). */
   recentMdCount: number;
+  /**
+   * Net-new pages since the caller's baseline (`max(0, total - baseline)`).
+   * Equals `recentMdCount` when no baseline was supplied. This is what
+   * `shouldFire` is computed from.
+   */
+  netNewMdCount: number;
   /** Per-folder counts under llm-curated/<x>/. */
   countsByFolder: Record<string, number>;
   /** Likely-duplicate clusters by filename Jaccard. */
@@ -181,11 +198,20 @@ export class WikiBookkeepService {
     const duplicateCandidates = this.findDuplicateClusters(pages);
     const queueStats = await this.queue.getStats(input.vaultPath);
 
-    const shouldFire = recentMdCount >= threshold || duplicateCandidates.length > 0;
+    // Net-new is the robust fire signal. When a baseline is supplied, count
+    // only pages added since it; otherwise fall back to the mtime window.
+    // NOTE: duplicate clusters are surfaced in `recommendations` but no longer
+    // force `shouldFire` — a standing set of filename clusters is not "new
+    // activity", so OR-ing it in made every non-trivial vault fire forever.
+    const netNewMdCount =
+      input.baselineMdCount != null
+        ? Math.max(0, totalMdCount - input.baselineMdCount)
+        : recentMdCount;
+    const shouldFire = netNewMdCount >= threshold;
 
     const recommendations = this.buildRecommendations({
       shouldFire,
-      recentMdCount,
+      netNewMdCount,
       threshold,
       duplicates: duplicateCandidates,
       countsByFolder,
@@ -205,6 +231,7 @@ export class WikiBookkeepService {
       shouldFire,
       totalMdCount,
       recentMdCount,
+      netNewMdCount,
       countsByFolder,
       duplicateCandidates,
       staleCount,
@@ -216,6 +243,8 @@ export class WikiBookkeepService {
       vault: input.vaultPath,
       totalMd: totalMdCount,
       recentMd: recentMdCount,
+      netNewMd: netNewMdCount,
+      baseline: input.baselineMdCount ?? null,
       duplicates: duplicateCandidates.length,
       shouldFire,
     });
@@ -336,7 +365,7 @@ export class WikiBookkeepService {
 
   private buildRecommendations(args: {
     shouldFire: boolean;
-    recentMdCount: number;
+    netNewMdCount: number;
     threshold: number;
     duplicates: WikiDuplicateCluster[];
     countsByFolder: Record<string, number>;
@@ -346,11 +375,11 @@ export class WikiBookkeepService {
     const recs: string[] = [];
     if (!args.shouldFire) {
       recs.push(
-        `Quiet vault — only ${args.recentMdCount} new md(s) in the window (threshold ${args.threshold}). No action required.`,
+        `Quiet vault — only ${args.netNewMdCount} net-new md(s) since the last pass (threshold ${args.threshold}). No action required.`,
       );
     } else {
       recs.push(
-        `Window has ${args.recentMdCount} new md(s) — at or above threshold (${args.threshold}). Consider a consolidation pass.`,
+        `${args.netNewMdCount} net-new md(s) since the last pass — at or above threshold (${args.threshold}). Consider a consolidation pass.`,
       );
     }
     if (args.duplicates.length > 0) {

--- a/backend/src/services/wiki/wiki-reflect-trigger.service.test.ts
+++ b/backend/src/services/wiki/wiki-reflect-trigger.service.test.ts
@@ -110,6 +110,25 @@ describe('WikiReflectTriggerService.tick', () => {
     expect(Math.round(meta.msSinceLastQueueAdd / (60 * 60 * 1000))).toBe(5);
   });
 
+  it('tick({ ignoreDebounce: true }) fires even within the debounce window (manual trigger-now)', async () => {
+    trigger = new WikiReflectTriggerService({
+      statePath: null,
+      fireFn,
+      debounceMs: 4 * 60 * 60 * 1000,
+      discoverRoots: async () => [VAULT_A],
+      queueService: makeFakeQueueService([]),
+      now: () => now,
+    });
+    await trigger.tick(); // fire 1, sets lastFiredAt
+    expect(fireFn).toHaveBeenCalledTimes(1);
+    // Only 1h later — inside debounce — but ignoreDebounce forces it.
+    now += 60 * 60 * 1000;
+    const res = await trigger.tick({ ignoreDebounce: true });
+    expect(res.fired).toEqual([VAULT_A]);
+    expect(res.skippedByDebounce).toEqual([]);
+    expect(fireFn).toHaveBeenCalledTimes(2);
+  });
+
   it('debounces — does not refire within the debounce window', async () => {
     trigger = new WikiReflectTriggerService({
       statePath: null,

--- a/backend/src/services/wiki/wiki-reflect-trigger.service.test.ts
+++ b/backend/src/services/wiki/wiki-reflect-trigger.service.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fsp from 'fs/promises';
 import { WikiReflectTriggerService, WikiReflectFireMeta } from './wiki-reflect-trigger.service.js';
 import type { WikiQueueService, WikiQueueItem } from './wiki-queue.service.js';
 import type { WikiSourceType } from './wiki-ingest.service.js';
@@ -58,6 +61,7 @@ afterEach(() => {
 describe('WikiReflectTriggerService.tick', () => {
   it('fires for a vault with zero queue items', async () => {
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       discoverRoots: async () => [VAULT_A],
       queueService: makeFakeQueueService([]),
@@ -76,6 +80,7 @@ describe('WikiReflectTriggerService.tick', () => {
   it('skips a vault that had a queue-add within the quiet window', async () => {
     const recent = new Date(now - 30 * 60 * 1000).toISOString(); // 30m ago
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       quietWindowMs: 4 * 60 * 60 * 1000,
       discoverRoots: async () => [VAULT_A],
@@ -91,6 +96,7 @@ describe('WikiReflectTriggerService.tick', () => {
   it('fires when the last queue-add is older than the quiet window', async () => {
     const old = new Date(now - 5 * 60 * 60 * 1000).toISOString(); // 5h ago
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       quietWindowMs: 4 * 60 * 60 * 1000,
       discoverRoots: async () => [VAULT_A],
@@ -106,6 +112,7 @@ describe('WikiReflectTriggerService.tick', () => {
 
   it('debounces — does not refire within the debounce window', async () => {
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       debounceMs: 4 * 60 * 60 * 1000,
       discoverRoots: async () => [VAULT_A],
@@ -125,6 +132,7 @@ describe('WikiReflectTriggerService.tick', () => {
 
   it('refires after the debounce window elapses', async () => {
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       debounceMs: 4 * 60 * 60 * 1000,
       discoverRoots: async () => [VAULT_A],
@@ -141,6 +149,7 @@ describe('WikiReflectTriggerService.tick', () => {
   it('scans multiple vaults independently', async () => {
     const recent = new Date(now - 10 * 60 * 1000).toISOString(); // 10m ago in vault B
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       discoverRoots: async () => [VAULT_A, VAULT_B],
       queueService: makeFakeQueueService([makeItem(VAULT_B, recent)]),
@@ -156,6 +165,7 @@ describe('WikiReflectTriggerService.tick', () => {
       throw new Error('fireFn boom');
     });
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       discoverRoots: async () => [VAULT_A, VAULT_B],
       queueService: makeFakeQueueService([]),
@@ -172,6 +182,7 @@ describe('WikiReflectTriggerService.tick', () => {
 describe('WikiReflectTriggerService lifecycle', () => {
   it('start/stop is idempotent', () => {
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       intervalMs: 60_000,
       discoverRoots: async () => [],
@@ -186,6 +197,7 @@ describe('WikiReflectTriggerService lifecycle', () => {
 
   it('setInstance + getInstance singleton wiring', () => {
     trigger = new WikiReflectTriggerService({
+      statePath: null,
       fireFn,
       discoverRoots: async () => [],
       queueService: makeFakeQueueService([]),
@@ -194,5 +206,43 @@ describe('WikiReflectTriggerService lifecycle', () => {
     expect(WikiReflectTriggerService.getInstance()).toBe(trigger);
     WikiReflectTriggerService.setInstance(null);
     expect(WikiReflectTriggerService.getInstance()).toBeNull();
+  });
+});
+
+describe('WikiReflectTriggerService persistence (survives restart)', () => {
+  it('a new instance loads the debounce ledger and does not re-burst within the window', async () => {
+    const t0 = Date.UTC(2026, 4, 24, 12, 0, 0);
+    const statePath = path.join(
+      await fsp.mkdtemp(path.join(os.tmpdir(), 'crewly-reflect-state-')),
+      'reflect-state.json',
+    );
+    const fire1 = vi.fn();
+    const t1 = new WikiReflectTriggerService({
+      statePath,
+      debounceMs: 4 * 60 * 60 * 1000,
+      fireFn: fire1,
+      discoverRoots: async () => [VAULT_A],
+      queueService: makeFakeQueueService([]),
+      now: () => t0,
+    });
+    const r1 = await t1.tick();
+    expect(r1.fired).toEqual([VAULT_A]);
+    t1.stop();
+
+    // Simulate a restart 1h later (still inside the 4h debounce): a brand-new
+    // instance must read the persisted lastFiredAt and NOT re-fire.
+    const fire2 = vi.fn();
+    const t2 = new WikiReflectTriggerService({
+      statePath,
+      debounceMs: 4 * 60 * 60 * 1000,
+      fireFn: fire2,
+      discoverRoots: async () => [VAULT_A],
+      queueService: makeFakeQueueService([]),
+      now: () => t0 + 60 * 60 * 1000,
+    });
+    const r2 = await t2.tick();
+    expect(r2.skippedByDebounce).toEqual([VAULT_A]);
+    expect(fire2).not.toHaveBeenCalled();
+    t2.stop();
   });
 });

--- a/backend/src/services/wiki/wiki-reflect-trigger.service.ts
+++ b/backend/src/services/wiki/wiki-reflect-trigger.service.ts
@@ -19,12 +19,17 @@
  * @module services/wiki/wiki-reflect-trigger.service
  */
 
+import * as path from 'path';
 import { LoggerService, ComponentLogger } from '../core/logger.service.js';
 import {
   WikiQueueService,
   WikiQueueItem,
 } from './wiki-queue.service.js';
 import { discoverWikiVaults } from './wiki-bookkeep-trigger.service.js';
+import { atomicWriteJson, safeReadJson, ensureDir } from '../../utils/file-io.utils.js';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
+
+const STATE_FILE_NAME = 'wiki-reflect-trigger-state.json';
 
 export interface WikiReflectFireMeta {
   /** vault path being nudged. */
@@ -54,6 +59,13 @@ export interface WikiReflectTriggerOptions {
   queueService?: WikiQueueService;
   /** Optional time override (tests). */
   now?: () => number;
+  /**
+   * Where to persist the per-vault debounce ledger. Defaults to
+   * `~/.crewly/wiki-reflect-trigger-state.json`. Pass `null` to disable
+   * persistence (tests). Without persistence the ledger resets on every
+   * restart, so the next tick re-fires for every idle vault at once.
+   */
+  statePath?: string | null;
 }
 
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
@@ -78,6 +90,8 @@ export class WikiReflectTriggerService {
   private readonly lastFiredAt = new Map<string, number>();
   /** Per-vault locks so overlapping ticks don't double-fire. */
   private readonly inflight = new Set<string>();
+  private readonly statePath: string | null;
+  private stateLoaded = false;
 
   constructor(opts: WikiReflectTriggerOptions) {
     this.logger = LoggerService.getInstance().createComponentLogger('WikiReflectTrigger');
@@ -88,6 +102,46 @@ export class WikiReflectTriggerService {
     this.discoverRoots = opts.discoverRoots ?? discoverWikiVaults;
     this.queueService = opts.queueService ?? WikiQueueService.getInstance();
     this.nowFn = opts.now ?? (() => Date.now());
+    if (opts.statePath === null) {
+      this.statePath = null;
+    } else if (typeof opts.statePath === 'string') {
+      this.statePath = opts.statePath;
+    } else {
+      this.statePath = path.join(getCrewlyHomePath(), STATE_FILE_NAME);
+    }
+  }
+
+  /** Load the persisted debounce ledger (once) so restarts don't re-burst. */
+  private async loadStateFromDisk(): Promise<void> {
+    if (this.stateLoaded) return;
+    this.stateLoaded = true;
+    if (!this.statePath) return;
+    const data = await safeReadJson<Record<string, number> | null>(this.statePath, null);
+    if (data && typeof data === 'object') {
+      for (const [vault, ts] of Object.entries(data)) {
+        if (typeof ts === 'number') this.lastFiredAt.set(vault, ts);
+      }
+      this.logger.info('WikiReflectTrigger loaded persisted state', {
+        statePath: this.statePath,
+        vaults: this.lastFiredAt.size,
+      });
+    }
+  }
+
+  /** Persist the debounce ledger (best-effort; failures logged, not thrown). */
+  private async saveStateToDisk(): Promise<void> {
+    if (!this.statePath) return;
+    try {
+      const payload: Record<string, number> = {};
+      for (const [vault, ts] of this.lastFiredAt) payload[vault] = ts;
+      await ensureDir(path.dirname(this.statePath));
+      await atomicWriteJson(this.statePath, payload);
+    } catch (err) {
+      this.logger.warn('WikiReflectTrigger: failed to persist state (non-fatal)', {
+        statePath: this.statePath,
+        error: (err as Error).message,
+      });
+    }
   }
 
   static getInstance(): WikiReflectTriggerService | null {
@@ -127,6 +181,7 @@ export class WikiReflectTriggerService {
     skippedByActivity: string[];
     skippedByDebounce: string[];
   }> {
+    await this.loadStateFromDisk();
     const vaults = await this.discoverRoots();
     const result = {
       scanned: [...vaults],
@@ -137,6 +192,7 @@ export class WikiReflectTriggerService {
 
     const now = this.nowFn();
     const cutoff = now - this.quietWindowMs;
+    let stateDirty = false;
 
     for (const v of vaults) {
       if (this.inflight.has(v)) continue;
@@ -165,6 +221,7 @@ export class WikiReflectTriggerService {
         }
 
         this.lastFiredAt.set(v, now);
+        stateDirty = true;
         const msSinceLastQueueAdd =
           lastAddMs === -Infinity ? Number.POSITIVE_INFINITY : now - lastAddMs;
         try {
@@ -193,11 +250,13 @@ export class WikiReflectTriggerService {
         this.inflight.delete(v);
       }
     }
+    if (stateDirty) await this.saveStateToDisk();
     return result;
   }
 
   /** Test affordance — clear debounce ledger. */
   _resetDebounceForTesting(): void {
     this.lastFiredAt.clear();
+    this.stateLoaded = false;
   }
 }

--- a/backend/src/services/wiki/wiki-reflect-trigger.service.ts
+++ b/backend/src/services/wiki/wiki-reflect-trigger.service.ts
@@ -116,14 +116,23 @@ export class WikiReflectTriggerService {
     if (this.stateLoaded) return;
     this.stateLoaded = true;
     if (!this.statePath) return;
-    const data = await safeReadJson<Record<string, number> | null>(this.statePath, null);
-    if (data && typeof data === 'object') {
-      for (const [vault, ts] of Object.entries(data)) {
-        if (typeof ts === 'number') this.lastFiredAt.set(vault, ts);
+    try {
+      const data = await safeReadJson<Record<string, number> | null>(this.statePath, null);
+      if (data && typeof data === 'object') {
+        for (const [vault, ts] of Object.entries(data)) {
+          if (typeof ts === 'number') this.lastFiredAt.set(vault, ts);
+        }
+        this.logger.info('WikiReflectTrigger loaded persisted state', {
+          statePath: this.statePath,
+          vaults: this.lastFiredAt.size,
+        });
       }
-      this.logger.info('WikiReflectTrigger loaded persisted state', {
+    } catch (err) {
+      // A transient read error must not abort the tick — proceed with an empty
+      // ledger this run (worst case: one extra fire, then it re-persists).
+      this.logger.warn('WikiReflectTrigger: failed to load state (non-fatal)', {
         statePath: this.statePath,
-        vaults: this.lastFiredAt.size,
+        error: (err as Error).message,
       });
     }
   }
@@ -175,13 +184,14 @@ export class WikiReflectTriggerService {
   /**
    * Run one scan. Returns the per-vault outcome for observability + tests.
    */
-  async tick(): Promise<{
+  async tick(opts?: { ignoreDebounce?: boolean }): Promise<{
     scanned: string[];
     fired: string[];
     skippedByActivity: string[];
     skippedByDebounce: string[];
   }> {
     await this.loadStateFromDisk();
+    const ignoreDebounce = opts?.ignoreDebounce === true;
     const vaults = await this.discoverRoots();
     const result = {
       scanned: [...vaults],
@@ -215,7 +225,7 @@ export class WikiReflectTriggerService {
           continue;
         }
         const last = this.lastFiredAt.get(v) ?? 0;
-        if (now - last < this.debounceMs) {
+        if (!ignoreDebounce && now - last < this.debounceMs) {
           result.skippedByDebounce.push(v);
           continue;
         }
@@ -254,9 +264,13 @@ export class WikiReflectTriggerService {
     return result;
   }
 
-  /** Test affordance — clear debounce ledger. */
+  /**
+   * Test affordance — clear the in-memory debounce ledger. Leaves `stateLoaded`
+   * set so a subsequent `tick()` does NOT reload the persisted ledger (which
+   * would undo the clear). To force a real fire past debounce in production,
+   * use `tick({ ignoreDebounce: true })` instead of this.
+   */
   _resetDebounceForTesting(): void {
     this.lastFiredAt.clear();
-    this.stateLoaded = false;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.8.11",
+      "version": "1.8.12",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
## Why
The wiki reminder triggers were spamming ORC — "该整理了" (bookkeep) fired for all 7 project vaults on **every** scan, and "该沉淀知识了" (reflect) fired for ~19 vaults at once after a restart. Two compounding causes:

1. **Bookkeep `shouldFire` used an mtime window.** `recentMdCount >= threshold || duplicateCandidates.length > 0`. The 2026-05-26 vault migration wrote 400-650 pages per vault *at once*, so every file's mtime is "recent" → `recentMdCount == totalMdCount`, permanently over threshold. Live logs showed e.g. crewly `653/653`, evership `501/501`, all `shouldFire:true`. The `|| duplicates>0` clause separately fired for any vault with a filename cluster.
2. **In-memory debounce.** Both triggers kept `lastFiredAt` in memory only, so every backend restart wiped it and the next tick re-fired everything — the post-restart burst.

## Fix
- **Net-new signal:** `shouldFire` is now `(totalMdCount - baselineMdCount) >= threshold` — only genuinely-new pages since a persisted per-vault baseline. First sight of a vault establishes the baseline and does **not** fire on the backlog; on fire, the baseline advances. Immune to bulk operations touching mtimes. Duplicates stay in `recommendations` but no longer force a fire.
- **Persistence:** per-vault baseline + `lastFiredAt` persisted to `~/.crewly/wiki-{bookkeep,reflect}-trigger-state.json` (atomic write, best-effort load), mirroring the work-item bridge's state file — so a restart no longer re-bursts.

Same net-new philosophy as the earlier migrate-churn fix.

## Verification
- `npm run build:backend` ✓
- bookkeep service + trigger (jest): 29 tests ✓ · reflect (vitest): 10 tests ✓
- full wiki suite: 165 jest + 93 vitest, all pass
- Pre-commit Quality Gates ✓

Version `1.8.11 → 1.8.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)