### PR TITLE
fix(orc): supersede stale wiki 'silent containment' — process cleanup WIs (1.8.13)

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -700,6 +700,24 @@ even if the user hasn't asked anything in that turn. The escalation
 
 ## Bridge-auto WorkItems — DO NOT bulk-delete (2026-05-27)
 
+> **⚠️ SUPERSEDES any "silent containment / suppress / hold wiki maintenance" learning (2026-05-30).**
+> The 2026-05-27/28 wiki *volume runaway* is **fixed in crewly@1.8.12**: the bridge now
+> counts NET-NEW pages only (migrate WIs are small — single digits, not 500/scan), the
+> bookkeep/reflect reminder spam is fixed (net-new + persisted state), and triggers no
+> longer re-burst on restart. Therefore any earlier orc memory/gotcha that says to
+> *silently cancel, "contain", or hold* bridge-auto wiki WIs as "false-positives" is
+> **obsolete — do not act on it.** Specifically:
+> - **PROCESS `wiki_quality_cleanup` WIs** via `wiki-cleanup` (archive-before-delete to
+>   `VAULT/.wiki-cleanup-archive.json`, fully reversible). Steve greenlit draining the
+>   existing agent-memory bloat on **all vaults** (2026-05-30). This is how the ~500
+>   low-value pages per vault get removed — cancelling these WIs is the one thing that
+>   keeps the vaults bloated.
+> - **PROCESS `wiki_legacy_migrate` WIs** normally too; they are now small. (Migration
+>   still imports agent `memory.json` entries by design — Steve's call — and cleanup then
+>   drains the misfiled ones, so the migrate→cleanup flow is self-correcting.)
+> - Only `[NOTIFY]` Steve (per rule 4 below) if a WI is genuinely unactionable — never
+>   blanket silent-cancel.
+
 The OSS backend runs a `WikiWorkItemBridge` (and similar future maintenance
 bridges) that automatically materialises routine wiki work as claimable
 WorkItems. These show up in your queue marked with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.8.12",
+      "version": "1.8.13",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.8.12",
+  "version": "1.8.13",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
## Why
Monitoring after the 1.8.12 trigger fix showed the orchestrator still auto-cancelling **every** bridge-auto wiki maintenance WI as a "wiki-bookkeep-trigger false-positive" (~45/day, every ~10 min). Root cause: during the 2026-05-27/28 volume runaway the orc wrote 0.3-confidence gotcha pages (migrated from its `memory.json`) telling itself to *silently contain* wiki WIs — and those retrieved memories now override the (correct) prompt rule that says "process bridge WIs, don't delete."

That runaway is **fixed in 1.8.12** (net-new bridge + bookkeep, persisted triggers — migrate WIs are now single-digit net-new, not 500/scan). So the containment is now stale and counterproductive: it cancels legitimate cleanup WIs, keeping each vault bloated with the ~500 agent-memory pages that cleanup is meant to drain.

## Fix
Adds a dated **supersede** note to the orchestrator prompt's "Bridge-auto WorkItems" section:
- The volume runaway is fixed; any prior "silent containment / suppress / hold" learning is obsolete — don't act on it.
- **Process `wiki_quality_cleanup` WIs** (archive-before-delete, reversible; Steve greenlit all vaults 2026-05-30) — this is how the bloat drains.
- Process `wiki_legacy_migrate` WIs normally (now small). Migration still imports agent memory by design (Steve's call); cleanup drains the misfiled ones, so the flow self-corrects.
- Only `[NOTIFY]` on genuinely-unactionable WIs; never blanket silent-cancel.

The prompt is authoritative and always in-context, so it overrides the stale retrieved gotchas **without** editing live vault pages (which the migrate/cleanup machinery would otherwise interfere with).

Version `1.8.12 → 1.8.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)