### PR TITLE
feat(okr): company→team→project OKR cascade (runtime Mission/KR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,5 @@ frontend/public/models/cow/cow.glb
 # accidentally edit a stale copy.
 chrome-extension/
 chrome-extension.OBSOLETE-*/
+# Runtime message-queue data (not source)
+queue/

--- a/backend/src/controllers/mission/kr.controller.ts
+++ b/backend/src/controllers/mission/kr.controller.ts
@@ -122,3 +122,18 @@ export async function getOKRSummary(req: Request, res: Response, next: NextFunct
     res.json({ success: true, data: summary });
   } catch (err) { next(err); }
 }
+
+/**
+ * GET /api/missions/:id/okr-summary/cascade — Cross-level cascade roll-up.
+ *
+ * Walks the `parentMissionId` tree so the mission's progress aggregates its
+ * approved children's roll-up (company → team → project). Returns a recursive
+ * {@link CascadeOKRSummary}.
+ */
+export async function getCascadeOKRSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const service = KRTrackingService.getInstance();
+    const summary = await service.computeCascadeOKRProgress(req.params.id);
+    res.json({ success: true, data: summary });
+  } catch (err) { next(err); }
+}

--- a/backend/src/controllers/mission/mission-policy.routes.test.ts
+++ b/backend/src/controllers/mission/mission-policy.routes.test.ts
@@ -1,4 +1,11 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import express from 'express';
+import request from 'supertest';
 import { createMissionPolicyRouter } from './mission-policy.routes.js';
+import { OKRCascadeService } from '../../services/v3/okr-cascade.service.js';
+import { KRTrackingService } from '../../services/v3/kr-tracking.service.js';
 
 describe('createMissionPolicyRouter', () => {
   it('should create a router with expected routes', () => {
@@ -20,5 +27,477 @@ describe('createMissionPolicyRouter', () => {
 
     const putIdRoute = entries.find((e) => e.path === '/:id' && e.methods.put);
     expect(putIdRoute).toBeDefined();
+  });
+
+  it('registers the cascade decompose/approve/reject/proposals routes', () => {
+    const router = createMissionPolicyRouter();
+    const entries: Array<{ path: string; methods: Record<string, boolean> }> =
+      (router as any).stack
+        ?.map((r: any) => r.route)
+        .filter(Boolean)
+        .map((r: any) => ({ path: r.path, methods: r.methods })) ?? [];
+
+    expect(entries.find((e) => e.path === '/:id/decompose-okr' && e.methods.post)).toBeDefined();
+    expect(entries.find((e) => e.path === '/:id/proposals' && e.methods.get)).toBeDefined();
+    expect(entries.find((e) => e.path === '/:id/approve' && e.methods.post)).toBeDefined();
+    expect(entries.find((e) => e.path === '/:id/reject' && e.methods.post)).toBeDefined();
+  });
+});
+
+/**
+ * Integration tests for the cascade-aware create/update wiring. Each test runs
+ * in an isolated temporary working directory so missions persist under a fresh
+ * `.crewly/missions` folder.
+ */
+describe('mission cascade routes (create/update round-trip)', () => {
+  let app: express.Express;
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-cascade-'));
+    process.chdir(tmpDir);
+    app = express();
+    app.use(express.json());
+    app.use('/api/missions', createMissionPolicyRouter());
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates a company-level mission with no parent (level defaults to company)', async () => {
+    const res = await request(app)
+      .post('/api/missions')
+      .send({ id: 'co-1', objective: 'Company OKR', ownerTeamId: 't1' });
+    expect(res.status).toBe(201);
+    expect(res.body.data.level).toBe('company');
+  });
+
+  it('round-trips level + projectId + approval on create', async () => {
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'C', ownerTeamId: 't1' });
+    await request(app)
+      .post('/api/missions')
+      .send({ id: 'team-1', objective: 'T', ownerTeamId: 't1', parentMissionId: 'co-1', level: 'team' });
+    const res = await request(app).post('/api/missions').send({
+      id: 'proj-1',
+      objective: 'P',
+      ownerTeamId: 't1',
+      parentMissionId: 'team-1',
+      level: 'project',
+      projectId: 'project-xyz',
+      approval: { state: 'pending_approval', proposedBy: 'agent-1' },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.data.level).toBe('project');
+    expect(res.body.data.projectId).toBe('project-xyz');
+
+    const fetched = await request(app).get('/api/missions/proj-1');
+    expect(fetched.body.data.projectId).toBe('project-xyz');
+    expect(fetched.body.data.approval.state).toBe('pending_approval');
+  });
+
+  it('rejects a project-level mission whose parent is company (level mismatch)', async () => {
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'C', ownerTeamId: 't1' });
+    const res = await request(app).post('/api/missions').send({
+      id: 'bad-proj',
+      objective: 'P',
+      ownerTeamId: 't1',
+      parentMissionId: 'co-1',
+      level: 'project',
+      projectId: 'p',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a project-level mission missing projectId', async () => {
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'C', ownerTeamId: 't1' });
+    await request(app)
+      .post('/api/missions')
+      .send({ id: 'team-1', objective: 'T', ownerTeamId: 't1', parentMissionId: 'co-1', level: 'team' });
+    const res = await request(app).post('/api/missions').send({
+      id: 'proj-noid',
+      objective: 'P',
+      ownerTeamId: 't1',
+      parentMissionId: 'team-1',
+      level: 'project',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('default-on-read migrates a parentless legacy mission to company/approved', async () => {
+    // Finding 5: the read-migration now uses the canonical resolveMissionLevel
+    // (deriveLevel-based) instead of a hardcoded 'team'. A PARENTLESS legacy
+    // mission therefore resolves to 'company' (matching the cascade service).
+    const dir = path.join(tmpDir, '.crewly', 'missions');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'legacy-1.json'),
+      JSON.stringify({
+        id: 'legacy-1',
+        objective: 'Legacy',
+        ownerTeamId: 't1',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        successCriteria: [],
+        activeProjectTaskIds: [],
+      }),
+    );
+    const res = await request(app).get('/api/missions/legacy-1');
+    expect(res.body.data.level).toBe('company');
+    expect(res.body.data.approval.state).toBe('approved');
+  });
+
+  it('default-on-read migrates a one-parent legacy mission to team/approved', async () => {
+    // A legacy (level-less) mission WITH one parent resolves to 'team' via the
+    // parent-chain walk — preserving the team-level migration for nested docs.
+    const dir = path.join(tmpDir, '.crewly', 'missions');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'legacy-co.json'),
+      JSON.stringify({
+        id: 'legacy-co',
+        objective: 'Legacy company',
+        ownerTeamId: 't1',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        successCriteria: [],
+        activeProjectTaskIds: [],
+      }),
+    );
+    await fs.writeFile(
+      path.join(dir, 'legacy-team.json'),
+      JSON.stringify({
+        id: 'legacy-team',
+        objective: 'Legacy team',
+        ownerTeamId: 't1',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        successCriteria: [],
+        activeProjectTaskIds: [],
+        parentMissionId: 'legacy-co',
+      }),
+    );
+    const res = await request(app).get('/api/missions/legacy-team');
+    expect(res.body.data.level).toBe('team');
+    expect(res.body.data.approval.state).toBe('approved');
+  });
+
+  it('PUT cannot mutate approval.state directly', async () => {
+    await request(app)
+      .post('/api/missions')
+      .send({
+        id: 'co-1',
+        objective: 'C',
+        ownerTeamId: 't1',
+        approval: { state: 'pending_approval' },
+      });
+    const res = await request(app)
+      .put('/api/missions/co-1')
+      .send({ approval: { state: 'approved' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('approval.state');
+  });
+
+  // Regression (finding 2): a PUT carrying an `approval` object WITHOUT a
+  // `state` key previously slipped past the guard and overwrote the existing
+  // approval wholesale (the merge replaces, not deep-merges) — dropping
+  // `approval.state` and quietly flipping an approved mission to
+  // not-cascade-active. The whole `approval` key must be rejected and the
+  // persisted state left intact.
+  it('PUT rejects a stateless approval object and preserves approval.state', async () => {
+    await request(app)
+      .post('/api/missions')
+      .send({
+        id: 'co-1',
+        objective: 'C',
+        ownerTeamId: 't1',
+        approval: { state: 'approved' },
+      });
+
+    const res = await request(app)
+      .put('/api/missions/co-1')
+      .send({ approval: { proposedBy: 'sneaky-agent' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('approval.state');
+
+    // The persisted mission must still be approved (governance metadata intact).
+    const fetched = await request(app).get('/api/missions/co-1');
+    expect(fetched.body.data.approval.state).toBe('approved');
+  });
+
+  it('PUT rejects re-parenting that violates level adjacency', async () => {
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'C', ownerTeamId: 't1' });
+    await request(app)
+      .post('/api/missions')
+      .send({ id: 'team-1', objective: 'T', ownerTeamId: 't1', parentMissionId: 'co-1', level: 'team' });
+    // Try to make the company mission a child of a team (illegal).
+    const res = await request(app)
+      .put('/api/missions/co-1')
+      .send({ level: 'company', parentMissionId: 'team-1' });
+    expect(res.status).toBe(400);
+  });
+});
+
+/**
+ * Integration tests for the OKR cascade decompose/approve/reject/proposals
+ * endpoints. Exercises the full propose → await-approval → decide flow through
+ * the live {@link OKRCascadeService}.
+ */
+describe('OKR cascade decompose/approve/reject routes', () => {
+  let app: express.Express;
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    originalCwd = process.cwd();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-cascade-okr-'));
+    process.chdir(tmpDir);
+    app = express();
+    app.use(express.json());
+    app.use('/api/missions', createMissionPolicyRouter());
+    // Seed an approved company-level parent.
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'Company OKR', ownerTeamId: 't1' });
+  });
+
+  afterEach(async () => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  const childPayload = () => ({
+    children: [
+      {
+        objective: 'Team OKR',
+        currentStrategy: 'ship',
+        successCriteria: ['done'],
+        keyResults: [
+          { title: 'Signups', metricType: 'number', baseline: 0, target: 50, unit: 'users' },
+        ],
+      },
+    ],
+  });
+
+  it('POST /:id/decompose-okr creates pending children', async () => {
+    const res = await request(app)
+      .post('/api/missions/co-1/decompose-okr')
+      .set('X-Agent-Session', 'tl-session')
+      .send(childPayload());
+    expect(res.status).toBe(201);
+    expect(res.body.data.childLevel).toBe('team');
+    expect(res.body.data.childMissionIds).toHaveLength(1);
+
+    const childId = res.body.data.childMissionIds[0];
+    const child = await request(app).get(`/api/missions/${childId}`);
+    expect(child.body.data.approval.state).toBe('pending_approval');
+    expect(child.body.data.approval.proposedBy).toBe('tl-session');
+  });
+
+  it('POST /:id/decompose-okr rejects a non-array children body', async () => {
+    const res = await request(app).post('/api/missions/co-1/decompose-okr').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /:id/proposals lists pending children for the parent', async () => {
+    await request(app).post('/api/missions/co-1/decompose-okr').send(childPayload());
+    const res = await request(app).get('/api/missions/co-1/proposals');
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(1);
+  });
+
+  it('POST /:id/approve activates a pending child', async () => {
+    const proposed = await request(app).post('/api/missions/co-1/decompose-okr').send(childPayload());
+    const childId = proposed.body.data.childMissionIds[0];
+
+    const res = await request(app)
+      .post(`/api/missions/${childId}/approve`)
+      .set('X-Agent-Session', 'steve')
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.data.approval.state).toBe('approved');
+    expect(res.body.data.approval.decidedBy).toBe('steve');
+  });
+
+  it('POST /:id/reject requires a reason and records it', async () => {
+    const proposed = await request(app).post('/api/missions/co-1/decompose-okr').send(childPayload());
+    const childId = proposed.body.data.childMissionIds[0];
+
+    const noReason = await request(app).post(`/api/missions/${childId}/reject`).send({});
+    expect(noReason.status).toBe(400);
+
+    const res = await request(app)
+      .post(`/api/missions/${childId}/reject`)
+      .send({ reason: 'scope unclear' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.approval.state).toBe('rejected');
+    expect(res.body.data.approval.rejectionReason).toBe('scope unclear');
+  });
+});
+
+
+describe('GET /:id/okr-summary/cascade (cross-level roll-up endpoint)', () => {
+  let app: express.Express;
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-cascade-route-'));
+    process.chdir(tmpDir);
+    KRTrackingService.resetInstance();
+    app = express();
+    app.use(express.json());
+    app.use('/api/missions', createMissionPolicyRouter());
+  });
+
+  afterEach(async () => {
+    KRTrackingService.resetInstance();
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Create a KR on a mission and drive it to a percentage value. */
+  async function seedKR(missionId: string, current: number): Promise<void> {
+    const created = await request(app)
+      .post(`/api/missions/${missionId}/key-results`)
+      .send({ title: `KR ${missionId}`, metricType: 'percentage', baseline: 0, target: 100, unit: '%' });
+    const krId = created.body.data.id as string;
+    await request(app)
+      .post(`/api/missions/${missionId}/key-results/${krId}/measure`)
+      .send({ value: current, source: 'test' });
+  }
+
+  it('returns a recursive cascade summary with the expected shape', async () => {
+    // company -> team (approved) -> nothing
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'Company', ownerTeamId: 't1' });
+    await request(app).post('/api/missions').send({
+      id: 'team-1',
+      objective: 'Team',
+      ownerTeamId: 't1',
+      parentMissionId: 'co-1',
+      level: 'team',
+    });
+    await seedKR('co-1', 40);
+    await seedKR('team-1', 80);
+
+    const res = await request(app).get('/api/missions/co-1/okr-summary/cascade');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const data = res.body.data;
+    expect(data.missionId).toBe('co-1');
+    expect(data.level).toBe('company');
+    expect(data.childMissionCount).toBe(1);
+    expect(Array.isArray(data.children)).toBe(true);
+    expect(data.children[0].missionId).toBe('team-1');
+    expect(data.children[0].rolledUpProgress).toBe(80);
+    // company roll-up = avg(40, 80) = 60
+    expect(data.rolledUpProgress).toBe(60);
+  });
+
+  it('excludes pending children from the endpoint roll-up', async () => {
+    await request(app).post('/api/missions').send({ id: 'co-1', objective: 'Company', ownerTeamId: 't1' });
+    await request(app).post('/api/missions').send({
+      id: 'team-approved',
+      objective: 'Approved team',
+      ownerTeamId: 't1',
+      parentMissionId: 'co-1',
+      level: 'team',
+    });
+    await request(app).post('/api/missions').send({
+      id: 'team-pending',
+      objective: 'Pending team',
+      ownerTeamId: 't1',
+      parentMissionId: 'co-1',
+      level: 'team',
+      approval: { state: 'pending_approval' },
+    });
+    await seedKR('co-1', 50);
+    await seedKR('team-approved', 100);
+    await seedKR('team-pending', 0);
+
+    const res = await request(app).get('/api/missions/co-1/okr-summary/cascade');
+    expect(res.status).toBe(200);
+    expect(res.body.data.childMissionCount).toBe(1);
+    // avg(50, 100) = 75 (pending excluded)
+    expect(res.body.data.rolledUpProgress).toBe(75);
+  });
+});
+
+
+/**
+ * Regression (finding 5): the route read-migration and the OKRCascadeService
+ * must resolve a level-less, parentless LEGACY mission to the SAME level via the
+ * shared canonical resolver. A parentless legacy mission resolves to `company`
+ * through BOTH paths (previously the service used 'company' while the route
+ * read-migration hardcoded 'team', so the same doc resolved differently).
+ */
+describe('legacy level resolution is identical across route + service (finding 5)', () => {
+  let app: express.Express;
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    originalCwd = process.cwd();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-cascade-level-'));
+    process.chdir(tmpDir);
+    app = express();
+    app.use(express.json());
+    app.use('/api/missions', createMissionPolicyRouter());
+  });
+
+  afterEach(async () => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolves a parentless level-less legacy mission to company through both paths', async () => {
+    // Write a legacy mission file directly: no `level`, no parent, no approval.
+    const dir = path.join(tmpDir, '.crewly', 'missions');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'legacy-co.json'),
+      JSON.stringify({
+        id: 'legacy-co',
+        objective: 'Legacy company OKR',
+        ownerTeamId: 't1',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        successCriteria: [],
+        activeProjectTaskIds: [],
+      }),
+    );
+
+    // Path A — route read-migration.
+    const fetched = await request(app).get('/api/missions/legacy-co');
+    expect(fetched.body.data.level).toBe('company');
+
+    // Path B — cascade service (legacy parent treated as approved => decomposes;
+    // company + 1 === team proves the service also resolved it to company).
+    const service = OKRCascadeService.getInstance();
+    const result = await service.proposeDecomposition(
+      'legacy-co',
+      {
+        children: [
+          {
+            objective: 'Team child',
+            currentStrategy: 's',
+            successCriteria: [],
+            keyResults: [],
+          },
+        ],
+      },
+      'tl',
+    );
+    expect(result.childLevel).toBe('team');
   });
 });

--- a/backend/src/controllers/mission/mission-policy.routes.ts
+++ b/backend/src/controllers/mission/mission-policy.routes.ts
@@ -23,18 +23,45 @@ import {
   deleteKR,
   measureKR,
   getOKRSummary,
+  getCascadeOKRSummary,
 } from './kr.controller.js';
 import { MissionExecutorService, type DecompositionResult } from '../../services/v3/mission-executor.service.js';
 import { OKRReviewService } from '../../services/v3/okr-review.service.js';
+import { OKRCascadeService, type DecomposeOKRInput } from '../../services/v3/okr-cascade.service.js';
 import type { ReviewDecision, KeyResult } from '../../types/v2/key-result.types.js';
 import {
-  validateParentLink,
+  validateCascadeLink,
+  deriveLevel,
+  resolveMissionLevel,
   type Mission,
   type MissionPriority,
+  type MissionLevel,
+  type ProposalState,
 } from '../../types/v2/mission.types.js';
 
 /** Default priority applied to missions missing the field at read time. */
 const DEFAULT_PRIORITY: MissionPriority = 'medium';
+
+/**
+ * Legacy-level fallback for a mission missing `level` AND any parent link, used
+ * only by the update-time cascade re-validation guard (where the effective
+ * parent may itself be changing). The canonical read-migration uses
+ * {@link resolveMissionLevel} so a parentless legacy mission resolves to
+ * `company`; this matches that for a non-parentless mission.
+ */
+const DEFAULT_LEVEL: MissionLevel = 'team';
+
+/**
+ * Default proposal state applied to legacy missions missing `approval` at read
+ * time. Pre-cascade missions are treated as already-approved/active.
+ */
+const DEFAULT_PROPOSAL_STATE: ProposalState = 'approved';
+
+/**
+ * Fallback session identifier used as `proposedBy` / `decidedBy` when the
+ * caller does not supply one (e.g. an anonymous API client).
+ */
+const UNKNOWN_ACTOR = 'unknown';
 
 /** Summary of a KeyResult included inline on mission list/detail responses. */
 interface KeyResultSummary {
@@ -96,15 +123,30 @@ async function readKeyResultSummaries(missionId: string): Promise<KeyResultSumma
  * applies the default priority and attaches inline KR summaries.
  *
  * @param raw - Mission object parsed from JSON
+ * @param byId - Parent-link chain map for canonical level resolution
  * @returns Mission augmented with `keyResults` and a guaranteed `priority`
  */
-async function normalizeMissionForResponse(raw: Mission): Promise<Mission & { keyResults: KeyResultSummary[] }> {
+async function normalizeMissionForResponse(
+  raw: Mission,
+  byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+): Promise<Mission & { keyResults: KeyResultSummary[] }> {
   const keyResults = await readKeyResultSummaries(raw.id);
   return {
     ...raw,
     priority: raw.priority ?? DEFAULT_PRIORITY,
+    // Migrate legacy missions on read via the SINGLE canonical level resolver
+    // (shared with the cascade service) and treat them as already-approved.
+    level: resolveMissionLevel(raw, byId),
+    approval: raw.approval ?? { state: DEFAULT_PROPOSAL_STATE },
     keyResults,
   };
+}
+
+/** Build the lightweight parent-link chain map used by {@link resolveMissionLevel}. */
+function buildChainMap(
+  missions: ReadonlyArray<Pick<Mission, 'id' | 'parentMissionId'>>,
+): Map<string, Pick<Mission, 'id' | 'parentMissionId'>> {
+  return new Map(missions.map((m) => [m.id, { id: m.id, parentMissionId: m.parentMissionId }] as const));
 }
 
 /** Load every mission from disk, skipping unreadable files. */
@@ -133,7 +175,8 @@ async function loadAllMissionsRaw(): Promise<Mission[]> {
 async function listMissions(_req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const missions = await loadAllMissionsRaw();
-    const enriched = await Promise.all(missions.map(normalizeMissionForResponse));
+    const byId = buildChainMap(missions);
+    const enriched = await Promise.all(missions.map((m) => normalizeMissionForResponse(m, byId)));
     res.json({ success: true, data: enriched, count: enriched.length });
   } catch (err) { next(err); }
 }
@@ -143,7 +186,11 @@ async function getMission(req: Request, res: Response, next: NextFunction): Prom
   try {
     const filePath = path.join(getMissionsDir(), `${req.params.id}.json`);
     const raw = await fs.readFile(filePath, 'utf-8');
-    const mission = await normalizeMissionForResponse(JSON.parse(raw) as Mission);
+    const parsed = JSON.parse(raw) as Mission;
+    // Load the full set so the canonical level resolver can walk the parent chain.
+    const byId = buildChainMap(await loadAllMissionsRaw());
+    if (!byId.has(parsed.id)) byId.set(parsed.id, { id: parsed.id, parentMissionId: parsed.parentMissionId });
+    const mission = await normalizeMissionForResponse(parsed, byId);
     res.json({ success: true, data: mission });
   } catch {
     res.status(404).json({ success: false, error: 'Mission not found' });
@@ -162,18 +209,44 @@ async function createMission(req: Request, res: Response, next: NextFunction): P
     await fs.mkdir(dir, { recursive: true });
     const id = req.body.id || `mission-${Date.now()}`;
 
-    const parentMissionId: string | undefined = req.body.parentMissionId;
-    if (parentMissionId) {
-      const existing = await loadAllMissionsRaw();
-      const byId = new Map(existing.map(m => [m.id, m] as const));
-      const reason = validateParentLink(id, parentMissionId, byId);
-      if (reason) {
-        res.status(400).json({ success: false, error: reason });
-        return;
-      }
+    const parentMissionId: string | undefined = req.body.parentMissionId || undefined;
+    // Resolve the child level: explicit body value, else derived from the
+    // parent chain (no parent ⇒ company).
+    const all = await loadAllMissionsRaw();
+    const byId = new Map(all.map(m => [m.id, m] as const));
+    // Build a chain map (id + parentMissionId only) including the new mission so
+    // deriveLevel can walk upward from it.
+    const chainById = new Map<string, Pick<Mission, 'id' | 'parentMissionId'>>(
+      all.map(m => [m.id, { id: m.id, parentMissionId: m.parentMissionId }] as const),
+    );
+    chainById.set(id, { id, parentMissionId });
+    const level: MissionLevel = req.body.level ?? deriveLevel(id, chainById);
+
+    // Combined cascade guard: cycle/self-ref + level adjacency.
+    const reason = validateCascadeLink(id, level, parentMissionId, byId);
+    if (reason) {
+      res.status(400).json({ success: false, error: reason });
+      return;
     }
 
-    const mission = { id, ...req.body, createdAt: new Date().toISOString(), status: req.body.status || 'active' };
+    // A project-level mission must carry a projectId.
+    if (level === 'project' && !req.body.projectId) {
+      res.status(400).json({ success: false, error: 'A project-level mission requires projectId' });
+      return;
+    }
+
+    const mission = {
+      id,
+      ...req.body,
+      level,
+      createdAt: new Date().toISOString(),
+      status: req.body.status || 'active',
+      // Ensure a well-formed Mission shape on disk so downstream readers that
+      // validate with `isMission` (e.g. OKRCascadeService) accept it. These
+      // arrays default to empty when the caller omits them.
+      successCriteria: req.body.successCriteria ?? [],
+      activeProjectTaskIds: req.body.activeProjectTaskIds ?? [],
+    };
     await fs.writeFile(path.join(dir, `${id}.json`), JSON.stringify(mission, null, 2));
     res.status(201).json({ success: true, data: mission });
   } catch (err) { next(err); }
@@ -202,17 +275,45 @@ async function updateMission(req: Request, res: Response, next: NextFunction): P
       return;
     }
 
-    // Re-validate parent link if the caller is changing it.
-    if (Object.prototype.hasOwnProperty.call(req.body, 'parentMissionId')) {
-      const nextParent: string | undefined = req.body.parentMissionId || undefined;
-      if (nextParent) {
-        const all = await loadAllMissionsRaw();
-        const byId = new Map(all.map(m => [m.id, m] as const));
-        const reason = validateParentLink(id, nextParent, byId);
-        if (reason) {
-          res.status(400).json({ success: false, error: reason });
-          return;
-        }
+    // Any direct write to governance metadata is forbidden — the entire
+    // `approval` object (not just `approval.state`) is owned by the dedicated
+    // approve/reject workflow. Accepting an `approval` payload here would
+    // overwrite `existing.approval` wholesale (the merge below replaces, not
+    // deep-merges), so a body like `{ approval: { proposedBy: 'x' } }` would
+    // silently drop `approval.state` — flipping an approved mission to
+    // not-cascade-active and wiping governance metadata. Rejecting the whole
+    // key preserves the single-source-of-transitions invariant (spec §3.3).
+    if (Object.prototype.hasOwnProperty.call(req.body, 'approval')) {
+      res.status(400).json({
+        success: false,
+        error: 'approval.state cannot be set via update; use approve/reject endpoints',
+      });
+      return;
+    }
+
+    // Determine the effective child level + parent for cascade re-validation.
+    const changingParent = Object.prototype.hasOwnProperty.call(req.body, 'parentMissionId');
+    const changingLevel = Object.prototype.hasOwnProperty.call(req.body, 'level');
+    if (changingParent || changingLevel) {
+      const nextParent: string | undefined =
+        (changingParent ? req.body.parentMissionId : existing.parentMissionId) || undefined;
+      const all = await loadAllMissionsRaw();
+      const byId = new Map(all.map(m => [m.id, m] as const));
+      // Resolve the existing level via the canonical resolver when not changing
+      // it, so legacy missions migrate consistently with the read path.
+      const chainById = buildChainMap(all);
+      if (!chainById.has(id)) chainById.set(id, { id, parentMissionId: existing.parentMissionId });
+      const nextLevel: MissionLevel = changingLevel
+        ? (req.body.level ?? DEFAULT_LEVEL)
+        : resolveMissionLevel(existing, chainById);
+      const reason = validateCascadeLink(id, nextLevel, nextParent, byId);
+      if (reason) {
+        res.status(400).json({ success: false, error: reason });
+        return;
+      }
+      if (nextLevel === 'project' && !(req.body.projectId ?? existing.projectId)) {
+        res.status(400).json({ success: false, error: 'A project-level mission requires projectId' });
+        return;
       }
     }
 
@@ -230,6 +331,83 @@ async function updateMission(req: Request, res: Response, next: NextFunction): P
     await fs.writeFile(filePath, JSON.stringify(merged, null, 2));
     res.json({ success: true, data: merged });
   } catch (err) { next(err); }
+}
+
+/**
+ * Resolve the acting session/owner identity for a request.
+ *
+ * Reads the agent session header (set by skill `api_call`) or an explicit body
+ * field, falling back to {@link UNKNOWN_ACTOR}.
+ *
+ * @param req - Incoming request
+ * @param bodyField - Body property to consult (e.g. `proposedBy`/`decidedBy`)
+ * @returns The resolved actor identifier
+ */
+function resolveActor(req: Request, bodyField: 'proposedBy' | 'decidedBy'): string {
+  const fromBody = typeof req.body?.[bodyField] === 'string' ? (req.body[bodyField] as string) : '';
+  const fromHeader = req.header('X-Agent-Session') ?? '';
+  return fromBody || fromHeader || UNKNOWN_ACTOR;
+}
+
+/**
+ * Propose an OKR decomposition (agent drafts child OKRs as a proposal).
+ *
+ * Distinct from the task-level `/:id/decompose` endpoint: this creates child
+ * Missions + KRs in `pending_approval` state, awaiting owner approval.
+ */
+async function decomposeOKR(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const parentId = req.params.id;
+    const input = req.body as DecomposeOKRInput;
+    if (!input || !Array.isArray(input.children)) {
+      res.status(400).json({ success: false, error: 'children array is required' });
+      return;
+    }
+    const proposedBy = resolveActor(req, 'proposedBy');
+    const service = OKRCascadeService.getInstance();
+    const result = await service.proposeDecomposition(parentId, input, proposedBy);
+    res.status(201).json({ success: true, data: result });
+  } catch (err) {
+    res.status(400).json({ success: false, error: (err as Error).message });
+  }
+}
+
+/** List the pending-approval child proposals for a parent mission. */
+async function listProposals(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const service = OKRCascadeService.getInstance();
+    const pending = await service.listPendingApprovals(req.params.id);
+    res.json({ success: true, data: pending, count: pending.length });
+  } catch (err) { next(err); }
+}
+
+/** Approve a pending decomposition proposal (owner decision). */
+async function approveProposal(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const decidedBy = resolveActor(req, 'decidedBy');
+    const service = OKRCascadeService.getInstance();
+    const mission = await service.approveDecomposition(req.params.id, decidedBy);
+    res.json({ success: true, data: mission });
+  } catch (err) {
+    res.status(400).json({ success: false, error: (err as Error).message });
+  }
+}
+
+/** Reject a pending decomposition proposal with a required reason. */
+async function rejectProposal(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason : '';
+    if (!reason || reason.trim().length === 0) {
+      res.status(400).json({ success: false, error: 'reason is required' });
+      return;
+    }
+    const decidedBy = resolveActor(req, 'decidedBy');
+    const service = OKRCascadeService.getInstance();
+    const mission = await service.rejectDecomposition(req.params.id, decidedBy, reason);
+    res.json({ success: true, data: mission });
+  } catch (err) {
+    res.status(400).json({ success: false, error: (err as Error).message });
+  }
 }
 
 /**
@@ -272,6 +450,9 @@ export function createMissionPolicyRouter(): Router {
   // OKR aggregated summary
   router.get('/:id/okr-summary', getOKRSummary);
 
+  // OKR cross-level cascade roll-up (company -> team -> project)
+  router.get('/:id/okr-summary/cascade', getCascadeOKRSummary);
+
   // Get a single KR
   router.get('/:id/key-results/:krId', getKR);
 
@@ -283,6 +464,20 @@ export function createMissionPolicyRouter(): Router {
 
   // Record a measurement
   router.post('/:id/key-results/:krId/measure', measureKR);
+
+  // --- OKR Cascade (decompose / approve / reject) Endpoints ---
+
+  // Propose an OKR decomposition (agent drafts child OKRs as a proposal)
+  router.post('/:id/decompose-okr', decomposeOKR);
+
+  // List pending child proposals for a parent
+  router.get('/:id/proposals', listProposals);
+
+  // Approve a pending proposal (owner)
+  router.post('/:id/approve', approveProposal);
+
+  // Reject a pending proposal with a reason (owner)
+  router.post('/:id/reject', rejectProposal);
 
   // --- Mission Execution Endpoints ---
 

--- a/backend/src/services/v3/kr-tracking.service.test.ts
+++ b/backend/src/services/v3/kr-tracking.service.test.ts
@@ -262,4 +262,215 @@ describe('KRTrackingService', () => {
       expect(summary.recommendation).toBe('continue');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Cross-Level Roll-Up (cascade)
+  // -------------------------------------------------------------------------
+
+  describe('listChildMissions / computeCascadeOKRProgress', () => {
+    /** Minimal Mission writer for cascade tests. */
+    function writeMission(
+      id: string,
+      opts: {
+        parentMissionId?: string;
+        level?: 'company' | 'team' | 'project';
+        approvalState?: 'draft' | 'pending_approval' | 'approved' | 'rejected';
+        staleCycles?: number;
+      } = {},
+    ): void {
+      const dir = join(tempDir, '.crewly', 'missions');
+      mkdirSync(dir, { recursive: true });
+      const mission: Record<string, unknown> = {
+        id,
+        objective: `Objective ${id}`,
+        ownerTeamId: 'team-x',
+        successCriteria: [],
+        currentStrategy: '',
+        activeProjectTaskIds: [],
+        cadence: '0 9 * * 1',
+        policy: { missionId: id },
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        learnings: [],
+        parentMissionId: opts.parentMissionId,
+        level: opts.level,
+        staleCycles: opts.staleCycles,
+      };
+      if (opts.approvalState) {
+        mission.approval = { state: opts.approvalState };
+      }
+      writeFileSync(join(dir, `${id}.json`), JSON.stringify(mission, null, 2));
+    }
+
+    /** Create one KR on a mission and drive it to a given current value. */
+    async function seedKR(missionId: string, current: number): Promise<void> {
+      const service = KRTrackingService.getInstance();
+      const kr = await service.create({
+        missionId,
+        title: `KR for ${missionId}`,
+        metricType: 'percentage',
+        baseline: 0,
+        target: 100,
+        unit: '%',
+      });
+      await service.update(missionId, kr.id, { current });
+    }
+
+    it('lists only cascade-active (approved/legacy) direct children', async () => {
+      writeMission('co', { level: 'company' });
+      writeMission('t-approved', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+      writeMission('t-pending', { parentMissionId: 'co', level: 'team', approvalState: 'pending_approval' });
+      writeMission('t-legacy', { parentMissionId: 'co', level: 'team' }); // no approval => active
+
+      const service = KRTrackingService.getInstance();
+      const children = await service.listChildMissions('co');
+      const ids = children.map((c) => c.id).sort();
+      expect(ids).toEqual(['t-approved', 't-legacy']);
+    });
+
+    it('rolls up a 3-level tree with equal-weight averaging', async () => {
+      // company -> team -> project
+      writeMission('co', { level: 'company' });
+      writeMission('team', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+      writeMission('proj', { parentMissionId: 'team', level: 'project', approvalState: 'approved' });
+
+      await seedKR('co', 30);    // company own = 30
+      await seedKR('team', 60);  // team own = 60
+      await seedKR('proj', 90);  // project own = 90 (leaf)
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('co');
+
+      // project is a leaf: rolledUp = 90
+      const team = summary.children[0];
+      const proj = team.children[0];
+      expect(proj.rolledUpProgress).toBe(90);
+      expect(proj.level).toBe('project');
+      expect(proj.childMissionCount).toBe(0);
+
+      // team: avg(60, 90) = 75
+      expect(team.rolledUpProgress).toBe(75);
+      expect(team.level).toBe('team');
+      expect(team.childMissionCount).toBe(1);
+
+      // company: avg(30, 75) = round(52.5) = 53
+      expect(summary.rolledUpProgress).toBe(53);
+      expect(summary.level).toBe('company');
+      expect(summary.childMissionCount).toBe(1);
+    });
+
+    it('excludes pending/draft/rejected children from roll-up', async () => {
+      writeMission('co', { level: 'company' });
+      writeMission('approved', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+      writeMission('pending', { parentMissionId: 'co', level: 'team', approvalState: 'pending_approval' });
+
+      await seedKR('co', 40);
+      await seedKR('approved', 100);
+      await seedKR('pending', 0); // would drag the avg down if (wrongly) included
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('co');
+
+      expect(summary.childMissionCount).toBe(1);
+      // avg(40, 100) = 70 (pending child excluded)
+      expect(summary.rolledUpProgress).toBe(70);
+    });
+
+    it('treats an orphan (missing parent) as a root for its own subtree', async () => {
+      // No 'ghost' parent file exists.
+      writeMission('orphan', { parentMissionId: 'ghost', level: 'team', approvalState: 'approved' });
+      await seedKR('orphan', 50);
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('orphan');
+      expect(summary.missionId).toBe('orphan');
+      expect(summary.rolledUpProgress).toBe(50);
+      // level honoured from explicit field even though parent is missing
+      expect(summary.level).toBe('team');
+    });
+
+    it('guards against cycles in the parent chain', async () => {
+      // a -> b -> a (illegal, but defend anyway)
+      writeMission('a', { parentMissionId: 'b', level: 'team', approvalState: 'approved' });
+      writeMission('b', { parentMissionId: 'a', level: 'team', approvalState: 'approved' });
+      await seedKR('a', 20);
+      await seedKR('b', 80);
+
+      const service = KRTrackingService.getInstance();
+      // Should terminate (no infinite recursion) and produce a finite summary.
+      const summary = await service.computeCascadeOKRProgress('a');
+      expect(summary.missionId).toBe('a');
+      // a visits b once; b will not re-visit a (already visited).
+      expect(summary.children.map((c) => c.missionId)).toEqual(['b']);
+      expect(summary.children[0].children).toEqual([]);
+    });
+
+    it('derives a roll-up recommendation from own + synthetic child statuses', async () => {
+      writeMission('co', { level: 'company' });
+      writeMission('c1', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+      writeMission('c2', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+
+      // Company has no own KRs; both children are off_track (low progress).
+      await seedKR('c1', 5);
+      await seedKR('c2', 5);
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('co');
+      // Two synthetic off_track child statuses, no healthy => not 'continue'.
+      expect(summary.recommendation).not.toBe('continue');
+    });
+
+    // Regression (finding 1): children stalled at EXACTLY 0% progress must read
+    // as off_track (not not_started) so an all-stalled parent escalates/replans.
+    // Previously deriveKRStatus(0, 0, 0) short-circuited to not_started, masking
+    // the signal; the dedicated deriveCascadeChildStatus mapper fixes it.
+    it('escalates/replans when every child is stalled at 0% rolled-up progress', async () => {
+      writeMission('co', { level: 'company' });
+      writeMission('c1', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+      writeMission('c2', { parentMissionId: 'co', level: 'team', approvalState: 'approved' });
+
+      // Company has no own KRs; both children sit at exactly 0 progress.
+      await seedKR('c1', 0);
+      await seedKR('c2', 0);
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('co');
+
+      // Both children roll up to 0%.
+      expect(summary.children.map((c) => c.rolledUpProgress)).toEqual([0, 0]);
+      // Two synthetic off_track statuses (off_track ratio = 1.0 > 0.4) => replan,
+      // NOT 'continue' and NOT silently suppressed as not_started.
+      expect(summary.recommendation).toBe('replan');
+    });
+
+    // Regression (finding 3): the root's persisted staleCycles must seed the
+    // rollup. Previously computeCascadeOKRProgress defaulted staleCycles to 0,
+    // ignoring the queried root's persisted value and suppressing escalation.
+    it('seeds the root staleCycles from the persisted mission (staleness escalates)', async () => {
+      // Root with 2 stale cycles (>= escalate threshold) and no children.
+      writeMission('co', { level: 'company', staleCycles: 2 });
+      // One own KR so the recommendation logic runs (empty KR set short-circuits
+      // to 'continue' before the staleCycles check).
+      await seedKR('co', 80);
+
+      const service = KRTrackingService.getInstance();
+      // No explicit staleCycles arg => must read the persisted value (2).
+      const summary = await service.computeCascadeOKRProgress('co');
+      expect(summary.childMissionCount).toBe(0);
+      expect(summary.recommendation).toBe('escalate');
+    });
+
+    // An explicit staleCycles argument still overrides the persisted value.
+    it('lets an explicit staleCycles argument override the persisted value', async () => {
+      writeMission('co', { level: 'company', staleCycles: 2 });
+      await seedKR('co', 80);
+
+      const service = KRTrackingService.getInstance();
+      const summary = await service.computeCascadeOKRProgress('co', 0);
+      // staleCycles 0 + a healthy (on_track) KR => continue, not escalate.
+      expect(summary.recommendation).toBe('continue');
+    });
+  });
+
 });

--- a/backend/src/services/v3/kr-tracking.service.ts
+++ b/backend/src/services/v3/kr-tracking.service.ts
@@ -16,17 +16,25 @@ import { existsSync, mkdirSync } from 'fs';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import {
+  deriveLevel,
+  type Mission,
+  type MissionLevel,
+} from '../../types/v2/mission.types.js';
+import {
   type KeyResult,
   type KRMeasurement,
   type KRStatus,
   type CreateKeyResultInput,
   type UpdateKeyResultInput,
   type MissionOKRSummary,
+  type CascadeOKRSummary,
   type OKRRecommendation,
   createKeyResult,
   computeKRProgress,
   deriveKRStatus,
+  deriveCascadeChildStatus,
   deriveOKRRecommendation,
+  computeRolledUpProgress,
   MAX_MEASUREMENT_HISTORY,
   validateCreateKeyResultInput,
 } from '../../types/v2/key-result.types.js';
@@ -49,6 +57,13 @@ function getKRDir(missionId: string): string {
 function getKRPath(missionId: string, krId: string): string {
   return path.join(getKRDir(missionId), `${krId}.json`);
 }
+
+
+/** Proposal state that marks an approved (cascade-active) mission. */
+const APPROVED_STATE = 'approved' as const;
+
+/** Stale-cycle fallback when a mission has no persisted `staleCycles`. */
+const NO_STALE_CYCLES = 0;
 
 // ---------------------------------------------------------------------------
 // Service
@@ -353,6 +368,201 @@ export class KRTrackingService {
       overallProgress,
       recommendation,
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Cross-Level Roll-Up (cascade)
+  // -------------------------------------------------------------------------
+
+  /**
+   * List the cascade-active direct children of a mission.
+   *
+   * Reads every mission document and keeps those whose `parentMissionId`
+   * equals `parentId` AND that are cascade-active. A mission is cascade-active
+   * iff its `approval` is absent (legacy missions) OR
+   * `approval.state === 'approved'`. Draft / pending_approval / rejected
+   * children are excluded from the roll-up per spec §4.2.
+   *
+   * @param parentId - Parent mission ID
+   * @returns The approved direct-child missions (empty if none / on read error)
+   *
+   * @example
+   * ```ts
+   * const children = await KRTrackingService.getInstance().listChildMissions('team-1');
+   * ```
+   */
+  async listChildMissions(parentId: string): Promise<Mission[]> {
+    const all = await this.loadAllMissions();
+    return all.filter((m) => m.parentMissionId === parentId && this.isCascadeActive(m));
+  }
+
+  /**
+   * Compute cross-level cascade roll-up of OKR progress for a mission and its
+   * approved descendants (company → team → project).
+   *
+   * Recursively walks the `parentMissionId` tree. At each node it reuses
+   * {@link computeMissionOKRProgress} for that node's OWN KRs, then folds in the
+   * `rolledUpProgress` of each approved child:
+   *
+   * - `rolledUpProgress` = equal-weight average of this node's own
+   *   `overallProgress` and each approved child's `rolledUpProgress`
+   *   (see {@link computeRolledUpProgress}); a leaf equals its own progress.
+   * - The roll-up recommendation is derived over this node's own KR statuses
+   *   PLUS one synthetic status per child mapped from the child's
+   *   `rolledUpProgress` via {@link deriveCascadeChildStatus} — so "all children
+   *   off_track ⇒ parent escalates/replans" falls out naturally (including when
+   *   children are stalled at 0% progress).
+   *
+   * Orphans (a mission whose `parentMissionId` points at a missing or
+   * non-approved parent) are treated as roots of their own subtree and never
+   * crash. A `visited` set guards against cycles defensively (create/update
+   * already reject cycles).
+   *
+   * @param missionId - Root mission of the subtree to roll up
+   * @param staleCycles - Consecutive stale review cycles for the root node. When
+   *   omitted, the root's PERSISTED `staleCycles` is used so staleness-driven
+   *   replan/escalate is not silently suppressed at the queried node (spec §4.2).
+   *   Pass an explicit number to override the persisted value.
+   * @returns The recursive {@link CascadeOKRSummary} for the subtree
+   *
+   * @example
+   * ```ts
+   * const summary = await KRTrackingService.getInstance().computeCascadeOKRProgress('co-1');
+   * console.log(summary.rolledUpProgress, summary.children.length);
+   * ```
+   */
+  async computeCascadeOKRProgress(
+    missionId: string,
+    staleCycles?: number,
+  ): Promise<CascadeOKRSummary> {
+    const all = await this.loadAllMissions();
+    const byId = new Map<string, Mission>(all.map((m) => [m.id, m] as const));
+    const linkById = new Map<string, Pick<Mission, 'id' | 'parentMissionId'>>(
+      all.map((m) => [m.id, { id: m.id, parentMissionId: m.parentMissionId }] as const),
+    );
+    // Seed the root's stale cycles from its persisted value unless the caller
+    // explicitly overrides it. Children read their own persisted value below.
+    const rootStaleCycles =
+      staleCycles ?? byId.get(missionId)?.staleCycles ?? NO_STALE_CYCLES;
+    return this.rollUp(missionId, rootStaleCycles, byId, linkById, new Set<string>());
+  }
+
+  /**
+   * Recursive worker for {@link computeCascadeOKRProgress}.
+   *
+   * @param missionId - Current node
+   * @param staleCycles - Stale cycles applied to the current node only
+   * @param byId - All missions indexed by ID
+   * @param linkById - Lightweight parent-link map for level derivation
+   * @param visited - Cycle-guard set of already-walked mission IDs
+   * @returns The {@link CascadeOKRSummary} for this node's subtree
+   */
+  private async rollUp(
+    missionId: string,
+    staleCycles: number,
+    byId: ReadonlyMap<string, Mission>,
+    linkById: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+    visited: Set<string>,
+  ): Promise<CascadeOKRSummary> {
+    visited.add(missionId);
+
+    const own = await this.computeMissionOKRProgress(missionId, staleCycles);
+    const level = this.resolveLevel(missionId, byId, linkById);
+
+    // Approved direct children that have not already been visited (cycle guard).
+    const approvedChildren = [...byId.values()].filter(
+      (m) =>
+        m.parentMissionId === missionId &&
+        this.isCascadeActive(m) &&
+        !visited.has(m.id),
+    );
+
+    const children: CascadeOKRSummary[] = [];
+    for (const child of approvedChildren) {
+      // Child stale cycles read from its own persisted value (independent node).
+      children.push(
+        await this.rollUp(child.id, child.staleCycles ?? NO_STALE_CYCLES, byId, linkById, visited),
+      );
+    }
+
+    const childProgresses = children.map((c) => c.rolledUpProgress);
+    const rolledUpProgress = computeRolledUpProgress(own.overallProgress, childProgresses);
+
+    // Roll-up recommendation: own KR statuses + one synthetic status per child
+    // mapped from its rolled-up progress. Uses deriveCascadeChildStatus (no
+    // baseline-equality short-circuit) so a child stalled at 0% reads as
+    // off_track rather than not_started — otherwise an all-stalled parent would
+    // never escalate/replan (spec §4.2).
+    const ownStatuses = (await this.listByMission(missionId)).map((kr) => kr.status);
+    const childStatuses = children.map((c) => deriveCascadeChildStatus(c.rolledUpProgress));
+    const recommendation = deriveOKRRecommendation([...ownStatuses, ...childStatuses], staleCycles);
+
+    return {
+      ...own,
+      recommendation,
+      level,
+      childMissionCount: children.length,
+      rolledUpProgress,
+      children,
+    };
+  }
+
+  /**
+   * Whether a mission counts as cascade-active: approval absent (legacy) or
+   * explicitly approved.
+   *
+   * @param mission - Mission to test
+   * @returns `true` if the mission participates in the cascade roll-up
+   */
+  private isCascadeActive(mission: Mission): boolean {
+    return mission.approval === undefined || mission.approval.state === APPROVED_STATE;
+  }
+
+  /**
+   * Resolve a mission's cascade level: prefer its explicit `level`, else derive
+   * it from the parent chain via {@link deriveLevel}. Missing/orphan missions
+   * fall back to `company` (treated as a root).
+   *
+   * @param missionId - Mission whose level to resolve
+   * @param byId - All missions indexed by ID
+   * @param linkById - Lightweight parent-link map for derivation
+   * @returns The resolved {@link MissionLevel}
+   */
+  private resolveLevel(
+    missionId: string,
+    byId: ReadonlyMap<string, Mission>,
+    linkById: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+  ): MissionLevel {
+    const mission = byId.get(missionId);
+    if (mission?.level) return mission.level;
+    if (!mission) return 'company';
+    return deriveLevel(missionId, linkById);
+  }
+
+  /**
+   * Load all mission documents from disk, skipping unreadable files.
+   *
+   * @returns Array of missions (empty on a missing directory)
+   */
+  private async loadAllMissions(): Promise<Mission[]> {
+    const dir = getMissionsDir();
+    let files: string[] = [];
+    try {
+      files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+    } catch {
+      return [];
+    }
+    const missions = await Promise.all(
+      files.map(async (f) => {
+        try {
+          const raw = await fs.readFile(path.join(dir, f), 'utf-8');
+          return JSON.parse(raw) as Mission;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return missions.filter((m): m is Mission => m !== null);
   }
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/v3/mission-period.service.test.ts
+++ b/backend/src/services/v3/mission-period.service.test.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import { MissionPeriodService } from './mission-period.service.js';
 import { createMission, createMonthlyPeriod } from '../../types/v2/mission.types.js';
@@ -14,8 +15,12 @@ import type { Mission } from '../../types/v2/mission.types.js';
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Resolve the same store the service uses. beforeEach points CREWLY_MISSIONS_DIR
+// at a temp dir so these tests NEVER read or delete the real
+// <cwd>/.crewly/missions store — otherwise cleanMissionsDir() would wipe
+// production missions.
 function getMissionsDir(): string {
-  return path.join(process.cwd(), '.crewly', 'missions');
+  return process.env['CREWLY_MISSIONS_DIR'] || path.join(process.cwd(), '.crewly', 'missions');
 }
 
 async function writeMission(mission: Mission): Promise<void> {
@@ -44,13 +49,23 @@ async function cleanMissionsDir(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 describe('MissionPeriodService', () => {
+  let testMissionsDir: string;
+
   beforeEach(async () => {
     MissionPeriodService.resetInstance();
-    await cleanMissionsDir();
+    // Isolate to a unique temp store so we never touch <cwd>/.crewly/missions.
+    testMissionsDir = path.join(
+      os.tmpdir(),
+      `crewly-mission-period-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    process.env['CREWLY_MISSIONS_DIR'] = testMissionsDir;
+    await fs.mkdir(testMissionsDir, { recursive: true });
   });
 
   afterEach(async () => {
-    await cleanMissionsDir();
+    await fs.rm(testMissionsDir, { recursive: true, force: true });
+    delete process.env['CREWLY_MISSIONS_DIR'];
+    MissionPeriodService.resetInstance();
   });
 
   describe('reconcile', () => {

--- a/backend/src/services/v3/mission-period.service.ts
+++ b/backend/src/services/v3/mission-period.service.ts
@@ -32,8 +32,14 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve the mission store directory. Defaults to `<cwd>/.crewly/missions`
+ * (the production store). Honors the `CREWLY_MISSIONS_DIR` env override so tests
+ * can isolate to a temp directory and never read/delete the real store — without
+ * this override a test's cleanup would wipe production missions.
+ */
 function getMissionsDir(): string {
-  return path.join(process.cwd(), '.crewly', 'missions');
+  return process.env['CREWLY_MISSIONS_DIR'] || path.join(process.cwd(), '.crewly', 'missions');
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/v3/okr-cascade.service.test.ts
+++ b/backend/src/services/v3/okr-cascade.service.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for the OKR Cascade Service — propose / approve / reject workflow.
+ *
+ * @module services/v3/okr-cascade.service.test
+ */
+
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { OKRCascadeService, type DecomposeOKRInput } from './okr-cascade.service.js';
+import { KRTrackingService } from './kr-tracking.service.js';
+import type { Mission } from '../../types/v2/mission.types.js';
+
+// Mock logger so tests do not touch the real logging stack.
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+describe('OKRCascadeService', () => {
+  let tempDir: string;
+  let originalCwd: () => string;
+
+  /** Write a mission JSON file directly to the temp missions dir. */
+  function seedMission(partial: Partial<Mission> & { id: string }): void {
+    const dir = join(tempDir, '.crewly', 'missions');
+    mkdirSync(dir, { recursive: true });
+    const now = new Date().toISOString();
+    const mission: Mission = {
+      // Defaults first; explicit `partial` fields override them via the spread.
+      objective: 'Objective',
+      ownerTeamId: 'team-a',
+      successCriteria: [],
+      currentStrategy: 'strategy',
+      activeProjectTaskIds: [],
+      cadence: '0 9 * * 1',
+      // Minimal policy stub — not exercised by the cascade service.
+      policy: { missionId: partial.id } as Mission['policy'],
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      learnings: [],
+      ...partial,
+    };
+    writeFileSync(join(dir, `${partial.id}.json`), JSON.stringify(mission, null, 2));
+  }
+
+  /** Read a mission JSON file from the temp missions dir. */
+  function readMission(id: string): Mission {
+    const file = join(tempDir, '.crewly', 'missions', `${id}.json`);
+    return JSON.parse(readFileSync(file, 'utf-8')) as Mission;
+  }
+
+  const minimalInput = (): DecomposeOKRInput => ({
+    children: [
+      {
+        objective: 'Team OKR alpha',
+        currentStrategy: 'do the thing',
+        successCriteria: ['criterion'],
+        keyResults: [
+          {
+            title: 'Increase signups',
+            metricType: 'number',
+            baseline: 0,
+            target: 100,
+            unit: 'signups',
+          },
+        ],
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    tempDir = join(tmpdir(), `crewly-cascade-svc-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    originalCwd = process.cwd;
+    process.cwd = () => tempDir;
+  });
+
+  afterEach(() => {
+    OKRCascadeService.resetInstance();
+    KRTrackingService.resetInstance();
+    process.cwd = originalCwd;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('proposeDecomposition', () => {
+    it('creates pending-approval children one level below an approved parent', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+
+      const result = await service.proposeDecomposition('co-1', minimalInput(), 'tl-session');
+
+      expect(result.parentId).toBe('co-1');
+      expect(result.childLevel).toBe('team');
+      expect(result.childMissionIds).toHaveLength(1);
+
+      const child = readMission(result.childMissionIds[0]);
+      expect(child.level).toBe('team');
+      expect(child.parentMissionId).toBe('co-1');
+      expect(child.approval?.state).toBe('pending_approval');
+      expect(child.approval?.proposedBy).toBe('tl-session');
+    });
+
+    it('treats a parent with no approval field as approved (legacy)', async () => {
+      seedMission({ id: 'co-1', level: 'company' });
+      const service = OKRCascadeService.getInstance();
+      const result = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+      expect(result.childMissionIds).toHaveLength(1);
+    });
+
+    it('persists child KRs via KRTrackingService (single source of KR persistence)', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const result = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+
+      const childId = result.childMissionIds[0];
+      const krs = await KRTrackingService.getInstance().listByMission(childId);
+      expect(krs).toHaveLength(1);
+      expect(krs[0].title).toBe('Increase signups');
+      // KR persisted under the child's key-results folder, not duplicated.
+      const krDir = join(tempDir, '.crewly', 'missions', childId, 'key-results');
+      expect(existsSync(krDir)).toBe(true);
+    });
+
+    it('enforces childLevel = parentLevel + 1 (team parent => project child)', async () => {
+      seedMission({ id: 'team-1', level: 'team', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const input: DecomposeOKRInput = {
+        children: [
+          {
+            objective: 'Project OKR',
+            currentStrategy: 's',
+            successCriteria: [],
+            projectId: 'proj-xyz',
+            keyResults: [],
+          },
+        ],
+      };
+      const result = await service.proposeDecomposition('team-1', input, 'tl');
+      expect(result.childLevel).toBe('project');
+      const child = readMission(result.childMissionIds[0]);
+      expect(child.level).toBe('project');
+      expect(child.projectId).toBe('proj-xyz');
+    });
+
+    it('rejects decomposing a project-level parent (bottom of cascade)', async () => {
+      seedMission({ id: 'proj-1', level: 'project', projectId: 'p', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      await expect(
+        service.proposeDecomposition('proj-1', minimalInput(), 'tl'),
+      ).rejects.toThrow(/bottom of the cascade/i);
+    });
+
+    it('rejects when the parent is not approved (pending)', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'pending_approval' } });
+      const service = OKRCascadeService.getInstance();
+      await expect(
+        service.proposeDecomposition('co-1', minimalInput(), 'tl'),
+      ).rejects.toThrow(/not approved/i);
+    });
+
+    it('rejects when the parent does not exist', async () => {
+      const service = OKRCascadeService.getInstance();
+      await expect(
+        service.proposeDecomposition('missing', minimalInput(), 'tl'),
+      ).rejects.toThrow(/does not exist/i);
+    });
+
+    it('rejects when there are no children', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      await expect(
+        service.proposeDecomposition('co-1', { children: [] }, 'tl'),
+      ).rejects.toThrow(/at least one child/i);
+    });
+
+    it('requires projectId when the child level is project', async () => {
+      seedMission({ id: 'team-1', level: 'team', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const input: DecomposeOKRInput = {
+        children: [
+          { objective: 'P', currentStrategy: 's', successCriteria: [], keyResults: [] },
+        ],
+      };
+      await expect(service.proposeDecomposition('team-1', input, 'tl')).rejects.toThrow(/projectId/i);
+    });
+
+    // Regression (finding 4): validation is a PRE-WRITE pass — a later invalid
+    // child must NOT leave an earlier (valid) child persisted. Previously
+    // validation ran interleaved with persistMission, so child[0] (and its KRs)
+    // could land on disk before child[1] failed.
+    it('does not persist the first child when a later child is invalid (all-or-nothing)', async () => {
+      seedMission({ id: 'team-1', level: 'team', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const input: DecomposeOKRInput = {
+        children: [
+          // Valid project child.
+          { objective: 'Valid', currentStrategy: 's', successCriteria: [], projectId: 'p-1', keyResults: [] },
+          // Invalid: project-level child missing projectId.
+          { objective: 'Invalid', currentStrategy: 's', successCriteria: [], keyResults: [] },
+        ],
+      };
+
+      await expect(service.proposeDecomposition('team-1', input, 'tl')).rejects.toThrow(/projectId/i);
+
+      // Nothing from this proposal was written: no pending children exist.
+      const pending = await service.listPendingApprovals('team-1');
+      expect(pending).toHaveLength(0);
+
+      // And the first (valid) child's objective is nowhere on disk.
+      const missionsDir = join(tempDir, '.crewly', 'missions');
+      const files = existsSync(missionsDir) ? readdirSync(missionsDir) : [];
+      const persistedObjectives = files
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => JSON.parse(readFileSync(join(missionsDir, f), 'utf-8')).objective as string);
+      expect(persistedObjectives).not.toContain('Valid');
+    });
+  });
+
+  describe('approveDecomposition', () => {
+    it('transitions a pending child to approved with decidedBy/At', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const { childMissionIds } = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+      const childId = childMissionIds[0];
+
+      const approved = await service.approveDecomposition(childId, 'steve');
+      expect(approved.approval?.state).toBe('approved');
+      expect(approved.approval?.decidedBy).toBe('steve');
+      expect(approved.approval?.decidedAt).toBeDefined();
+
+      // Persisted.
+      expect(readMission(childId).approval?.state).toBe('approved');
+    });
+
+    it('rejects approving an already-approved (terminal) mission', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      await expect(service.approveDecomposition('co-1', 'steve')).rejects.toThrow(/cannot approve/i);
+    });
+
+    it('rejects approving a missing mission', async () => {
+      const service = OKRCascadeService.getInstance();
+      await expect(service.approveDecomposition('nope', 'steve')).rejects.toThrow(/does not exist/i);
+    });
+  });
+
+  describe('rejectDecomposition', () => {
+    it('transitions a pending child to rejected with a reason', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const { childMissionIds } = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+      const childId = childMissionIds[0];
+
+      const rejected = await service.rejectDecomposition(childId, 'steve', 'too vague');
+      expect(rejected.approval?.state).toBe('rejected');
+      expect(rejected.approval?.rejectionReason).toBe('too vague');
+      expect(rejected.approval?.decidedBy).toBe('steve');
+    });
+
+    it('requires a non-empty reason', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const { childMissionIds } = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+      await expect(
+        service.rejectDecomposition(childMissionIds[0], 'steve', '   '),
+      ).rejects.toThrow(/non-empty reason/i);
+    });
+  });
+
+  describe('listPendingApprovals', () => {
+    it('lists only pending missions, optionally scoped by parent', async () => {
+      seedMission({ id: 'co-1', level: 'company', approval: { state: 'approved' } });
+      seedMission({ id: 'co-2', level: 'company', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const a = await service.proposeDecomposition('co-1', minimalInput(), 'tl');
+      await service.proposeDecomposition('co-2', minimalInput(), 'tl');
+
+      const all = await service.listPendingApprovals();
+      expect(all.length).toBe(2);
+
+      const scoped = await service.listPendingApprovals('co-1');
+      expect(scoped.length).toBe(1);
+      expect(scoped[0].id).toBe(a.childMissionIds[0]);
+    });
+  });
+
+  // Regression (finding 5): the service resolves a level-less, parentless legacy
+  // mission via the SAME canonical resolver as the routes' read-migration. A
+  // parentless legacy mission must resolve to `company` (so its child is
+  // `team`), matching resolveMissionLevel rather than the old hardcoded 'team'.
+  describe('legacy level resolution (finding 5)', () => {
+    it('resolves a parentless level-less legacy mission to company (child => team)', async () => {
+      // No `level` field at all (legacy), and no parent.
+      seedMission({ id: 'legacy-co', approval: { state: 'approved' } });
+      const service = OKRCascadeService.getInstance();
+      const result = await service.proposeDecomposition('legacy-co', minimalInput(), 'tl');
+      // company + 1 === team proves the parent resolved to company.
+      expect(result.childLevel).toBe('team');
+    });
+  });
+
+  // Regression (finding 6): a corrupt/hand-edited approval.state must be treated
+  // as INACTIVE on read — neither cascade-active nor a recognized pending state
+  // — and must never crash the transition guards.
+  describe('corrupt approval.state read-time normalization (finding 6)', () => {
+    it('treats an unrecognized approval.state as inactive (not approvable, not pending)', async () => {
+      // Hand-edited corrupt state.
+      seedMission({
+        id: 'corrupt-1',
+        level: 'company',
+        approval: { state: 'frozen' as unknown as 'approved' },
+      });
+      const service = OKRCascadeService.getInstance();
+
+      // Not cascade-active: cannot be decomposed (treated as not-approved).
+      await expect(
+        service.proposeDecomposition('corrupt-1', minimalInput(), 'tl'),
+      ).rejects.toThrow(/not approved/i);
+
+      // Not a recognized pending state: excluded from pending approvals.
+      const pending = await service.listPendingApprovals();
+      expect(pending.find((m) => m.id === 'corrupt-1')).toBeUndefined();
+
+      // The transition guard does not crash; approving a normalized-rejected
+      // doc is rejected cleanly.
+      await expect(service.approveDecomposition('corrupt-1', 'steve')).rejects.toThrow(/cannot approve/i);
+    });
+  });
+});

--- a/backend/src/services/v3/okr-cascade.service.ts
+++ b/backend/src/services/v3/okr-cascade.service.ts
@@ -1,0 +1,527 @@
+/**
+ * OKR Cascade Service
+ *
+ * Owns the decompose → propose → approve/reject workflow for the OKR cascade
+ * (company → team → project). A team-leader/PM agent drafts child OKRs as a
+ * PROPOSAL; the child Missions are persisted with
+ * `approval.state = 'pending_approval'` and are NOT cascade-active until the
+ * human owner approves. Rejection carries a required reason.
+ *
+ * This service is the SINGLE owner of `approval.state` transitions — the
+ * `updateMission` PUT route blocks direct `approval` writes so that all
+ * transitions flow through {@link OKRCascadeService.approveDecomposition} and
+ * {@link OKRCascadeService.rejectDecomposition} (spec §3.2/§3.3).
+ *
+ * FLAG (spec §2.5): the approval *workflow* (this service + its routes) is a
+ * plausible future move to `crewly-pro` as a gated governance feature. The
+ * approval *types* live in `mission.types.ts` and stay there; only this
+ * workflow layer would relocate. Do NOT split now.
+ *
+ * Persistence reuses the existing on-disk layout:
+ *   - Missions: `.crewly/missions/{id}.json`
+ *   - KRs:      `.crewly/missions/{id}/key-results/` (via {@link KRTrackingService})
+ *
+ * @module services/v3/okr-cascade.service
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { KRTrackingService } from './kr-tracking.service.js';
+import {
+  createMission,
+  validateCascadeLink,
+  resolveMissionLevel,
+  isMission,
+  isValidProposalState,
+  isValidProposalTransition,
+  MISSION_LEVELS,
+  MISSION_LEVEL_DEPTH,
+  type Mission,
+  type MissionLevel,
+} from '../../types/v2/mission.types.js';
+import type { CreateKeyResultInput } from '../../types/v2/key-result.types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Workspace root folder for Crewly runtime state. */
+const CREWLY_HOME = '.crewly';
+
+/** Folder under {@link CREWLY_HOME} that holds one JSON file per Mission. */
+const MISSIONS_DIR = 'missions';
+
+/** Proposal state stamped on a freshly-proposed child mission. */
+const PROPOSED_STATE = 'pending_approval' as const;
+
+/** Proposal state after a successful owner approval. */
+const APPROVED_STATE = 'approved' as const;
+
+/** Proposal state after an owner rejection. */
+const REJECTED_STATE = 'rejected' as const;
+
+/**
+ * State a corrupt/unrecognized persisted `approval.state` is normalized to on
+ * read. `rejected` is a recognized, INACTIVE, non-approvable state: a corrupt
+ * doc must NOT be trusted as cascade-active and must NOT be approvable directly
+ * (the only approve path is `pending_approval → approved`). See
+ * {@link OKRCascadeService.sanitizeMission}.
+ */
+const CORRUPT_APPROVAL_FALLBACK = REJECTED_STATE;
+
+// ---------------------------------------------------------------------------
+// Inputs / Results
+// ---------------------------------------------------------------------------
+
+/**
+ * A single proposed child OKR within a decomposition: one objective plus its
+ * Key Results. `projectId` is required only when the resulting child level is
+ * `project`.
+ */
+export interface DecomposeOKRChild {
+  /** Objective statement for the child OKR. */
+  objective: string;
+  /** Strategic approach the child will pursue. */
+  currentStrategy: string;
+  /** Free-text success criteria (in addition to structured KRs). */
+  successCriteria: string[];
+  /** Required when the child level resolves to `project`. */
+  projectId?: string;
+  /**
+   * Key Results to create under the child mission. `missionId` is filled in by
+   * the service once the child mission id is known, so callers omit it.
+   */
+  keyResults: Array<Omit<CreateKeyResultInput, 'missionId'>>;
+}
+
+/**
+ * Input to {@link OKRCascadeService.proposeDecomposition}: the set of child
+ * OKRs to draft one tier below the parent mission.
+ */
+export interface DecomposeOKRInput {
+  /** One entry per proposed child mission. */
+  children: DecomposeOKRChild[];
+}
+
+/** Result of a successful {@link OKRCascadeService.proposeDecomposition} call. */
+export interface ProposeResult {
+  /** The parent mission that was decomposed. */
+  parentId: string;
+  /** Cascade level of every created child (parent level + 1). */
+  childLevel: MissionLevel;
+  /** IDs of the created (pending-approval) child missions. */
+  childMissionIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Singleton service implementing the OKR decomposition / approval workflow.
+ */
+export class OKRCascadeService {
+  private static instance: OKRCascadeService | null = null;
+  private readonly logger: ComponentLogger;
+
+  private constructor() {
+    this.logger = LoggerService.getInstance().createComponentLogger('OKRCascade');
+  }
+
+  /**
+   * Get the singleton instance.
+   *
+   * @returns The shared {@link OKRCascadeService}
+   */
+  static getInstance(): OKRCascadeService {
+    if (!OKRCascadeService.instance) {
+      OKRCascadeService.instance = new OKRCascadeService();
+    }
+    return OKRCascadeService.instance;
+  }
+
+  /**
+   * Reset the singleton (for testing).
+   */
+  static resetInstance(): void {
+    OKRCascadeService.instance = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Draft a child OKR decomposition for a parent mission as a PROPOSAL.
+   *
+   * The parent must exist and be cascade-active (approval absent or
+   * `approval.state === 'approved'`). The child level is computed as exactly one
+   * tier below the parent; decomposing a `project`-level parent is rejected
+   * (there is no tier below project). Each child mission is created with
+   * `approval.state = 'pending_approval'` and is NOT active until the owner
+   * approves. Each child's Key Results are created via {@link KRTrackingService}
+   * (no duplicate KR persistence here).
+   *
+   * The decomposition is "fail before writing": EVERY child is fully validated
+   * (project-id presence + cascade-link adjacency/cycle) BEFORE any mission or
+   * KR is persisted, so a later invalid child never leaves an earlier child
+   * half-written to disk.
+   *
+   * @param parentId - ID of the parent mission to decompose
+   * @param input - The proposed child OKRs (objectives + KRs)
+   * @param proposedBy - Agent session that drafted the proposal
+   * @returns The parent id, resolved child level, and created child IDs
+   * @throws If the parent is missing, not approved, already at `project` level,
+   *   the input has no children, or a child fails cascade-link validation
+   *
+   * @example
+   * ```ts
+   * const result = await OKRCascadeService.getInstance().proposeDecomposition(
+   *   'co-1',
+   *   { children: [{ objective: 'Ship v2', currentStrategy: '...', successCriteria: [], keyResults: [] }] },
+   *   'team-leader-session',
+   * );
+   * ```
+   */
+  async proposeDecomposition(
+    parentId: string,
+    input: DecomposeOKRInput,
+    proposedBy: string,
+  ): Promise<ProposeResult> {
+    if (!input.children || input.children.length === 0) {
+      throw new Error('Decomposition requires at least one child OKR');
+    }
+
+    const all = await this.loadAllMissions();
+    const byId = new Map(all.map((m) => [m.id, m] as const));
+
+    const parent = byId.get(parentId);
+    if (!parent) {
+      throw new Error(`Parent mission ${parentId} does not exist`);
+    }
+    if (!this.isCascadeActive(parent)) {
+      throw new Error(
+        `Parent mission ${parentId} is not approved; only approved missions can be decomposed`,
+      );
+    }
+
+    const parentLevel = this.resolveLevel(parent, byId);
+    const childLevel = this.nextLevel(parentLevel);
+    if (childLevel === null) {
+      throw new Error(
+        `A ${parentLevel}-level mission is the bottom of the cascade and cannot be decomposed further`,
+      );
+    }
+
+    // ----- Pre-write validation pass (fail BEFORE any persist) -------------
+    // Build every child mission up-front and run the FULL cascade guard
+    // (project-id presence + validateCascadeLink) against the live tree plus
+    // the siblings already built in this same proposal. Only once ALL children
+    // pass do we persist anything — so a later invalid child can never leave an
+    // earlier child (or its KRs) on disk (transactional "all-or-nothing").
+    const now = new Date().toISOString();
+    const linkById = new Map<string, Pick<Mission, 'id' | 'parentMissionId' | 'level'>>(
+      all.map((m) => [m.id, { id: m.id, parentMissionId: m.parentMissionId, level: m.level }] as const),
+    );
+    const prepared: Array<{ mission: Mission; child: DecomposeOKRChild }> = [];
+
+    for (const child of input.children) {
+      if (childLevel === 'project' && !child.projectId) {
+        throw new Error('A project-level child OKR requires projectId');
+      }
+
+      const mission = createMission({
+        objective: child.objective,
+        ownerTeamId: parent.ownerTeamId,
+        successCriteria: child.successCriteria,
+        currentStrategy: child.currentStrategy,
+        parentMissionId: parentId,
+        level: childLevel,
+        projectId: child.projectId,
+        approval: {
+          state: PROPOSED_STATE,
+          proposedBy,
+          proposedAt: now,
+        },
+      });
+
+      const reason = validateCascadeLink(mission.id, childLevel, parentId, linkById);
+      if (reason) {
+        throw new Error(`Invalid cascade link for child OKR "${child.objective}": ${reason}`);
+      }
+      // Register the just-validated child so subsequent siblings see it.
+      linkById.set(mission.id, {
+        id: mission.id,
+        parentMissionId: mission.parentMissionId,
+        level: mission.level,
+      });
+      prepared.push({ mission, child });
+    }
+
+    // ----- Write pass (only reached when ALL children validated) -----------
+    const childMissionIds: string[] = [];
+    const krService = KRTrackingService.getInstance();
+    for (const { mission, child } of prepared) {
+      await this.persistMission(mission);
+      // KRs created via KRTrackingService — single source of KR persistence.
+      for (const kr of child.keyResults) {
+        await krService.create({ ...kr, missionId: mission.id });
+      }
+      childMissionIds.push(mission.id);
+    }
+
+    this.logger.info('Proposed OKR decomposition', {
+      parentId,
+      childLevel,
+      childCount: childMissionIds.length,
+      proposedBy,
+    });
+
+    return { parentId, childLevel, childMissionIds };
+  }
+
+  /**
+   * Approve a pending decomposition proposal, making the child mission
+   * cascade-active. Guarded by {@link isValidProposalTransition} so only a
+   * `pending_approval` mission may transition to `approved`.
+   *
+   * @param missionId - ID of the proposed (pending_approval) mission
+   * @param decidedBy - Human owner who approved (e.g. "steve")
+   * @returns The updated mission
+   * @throws If the mission is missing, has no approval state, or the
+   *   `pending_approval → approved` transition is illegal
+   */
+  async approveDecomposition(missionId: string, decidedBy: string): Promise<Mission> {
+    const mission = await this.loadMission(missionId);
+    if (!mission) {
+      throw new Error(`Mission ${missionId} does not exist`);
+    }
+    const current = mission.approval?.state;
+    if (!current) {
+      throw new Error(`Mission ${missionId} has no proposal to approve`);
+    }
+    if (!isValidProposalTransition(current, APPROVED_STATE)) {
+      throw new Error(`Cannot approve a mission in state "${current}"`);
+    }
+
+    const decided: Mission = {
+      ...mission,
+      approval: {
+        ...mission.approval,
+        state: APPROVED_STATE,
+        decidedBy,
+        decidedAt: new Date().toISOString(),
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    await this.persistMission(decided);
+
+    this.logger.info('Approved OKR decomposition', { missionId, decidedBy });
+    return decided;
+  }
+
+  /**
+   * Reject a pending decomposition proposal with a required reason. The
+   * rejected mission is excluded from roll-up and autonomous execution.
+   *
+   * @param missionId - ID of the proposed (pending_approval) mission
+   * @param decidedBy - Human owner who rejected (e.g. "steve")
+   * @param reason - Non-empty explanation surfaced back to the proposing agent
+   * @returns The updated mission
+   * @throws If the reason is empty, the mission is missing, has no approval
+   *   state, or the `pending_approval → rejected` transition is illegal
+   */
+  async rejectDecomposition(
+    missionId: string,
+    decidedBy: string,
+    reason: string,
+  ): Promise<Mission> {
+    if (!reason || reason.trim().length === 0) {
+      throw new Error('Rejection requires a non-empty reason');
+    }
+    const mission = await this.loadMission(missionId);
+    if (!mission) {
+      throw new Error(`Mission ${missionId} does not exist`);
+    }
+    const current = mission.approval?.state;
+    if (!current) {
+      throw new Error(`Mission ${missionId} has no proposal to reject`);
+    }
+    if (!isValidProposalTransition(current, REJECTED_STATE)) {
+      throw new Error(`Cannot reject a mission in state "${current}"`);
+    }
+
+    const decided: Mission = {
+      ...mission,
+      approval: {
+        ...mission.approval,
+        state: REJECTED_STATE,
+        decidedBy,
+        decidedAt: new Date().toISOString(),
+        rejectionReason: reason.trim(),
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    await this.persistMission(decided);
+
+    this.logger.info('Rejected OKR decomposition', { missionId, decidedBy, reason: reason.trim() });
+    return decided;
+  }
+
+  /**
+   * List missions awaiting an owner decision (`approval.state ===
+   * 'pending_approval'`). Optionally scope to the direct children of one parent.
+   *
+   * @param parentId - When provided, only pending children of this parent
+   * @returns Pending-approval missions
+   */
+  async listPendingApprovals(parentId?: string): Promise<Mission[]> {
+    const all = await this.loadAllMissions();
+    return all.filter((m) => {
+      if (m.approval?.state !== PROPOSED_STATE) return false;
+      if (parentId !== undefined && m.parentMissionId !== parentId) return false;
+      return true;
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Whether a mission counts as cascade-active: approval absent (legacy) or
+   * explicitly approved.
+   *
+   * @param mission - Mission to test
+   * @returns `true` if the mission participates in the cascade
+   */
+  private isCascadeActive(mission: Mission): boolean {
+    return mission.approval === undefined || mission.approval.state === APPROVED_STATE;
+  }
+
+  /**
+   * Resolve a mission's effective level through the SINGLE canonical resolver
+   * shared with the routes' read-migration ({@link resolveMissionLevel}), which
+   * prefers an explicit `level` and otherwise falls back to `deriveLevel` over
+   * the parent chain. A parentless legacy mission therefore resolves to
+   * `company` consistently across every read path.
+   *
+   * @param mission - Mission whose level to resolve
+   * @param byId - All missions indexed by ID for the parent-chain walk
+   * @returns The mission's resolved level
+   */
+  private resolveLevel(
+    mission: Mission,
+    byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+  ): MissionLevel {
+    return resolveMissionLevel(mission, byId);
+  }
+
+  /**
+   * Compute the cascade level exactly one tier below the given level.
+   *
+   * @param level - Parent level
+   * @returns The child level, or `null` if `level` is already the bottom tier
+   */
+  private nextLevel(level: MissionLevel): MissionLevel | null {
+    const childDepth = MISSION_LEVEL_DEPTH[level] + 1;
+    return MISSION_LEVELS[childDepth] ?? null;
+  }
+
+  /** Absolute path to the missions directory under the current cwd. */
+  private getMissionsDir(): string {
+    return path.join(process.cwd(), CREWLY_HOME, MISSIONS_DIR);
+  }
+
+  /** Absolute path to a single mission's JSON file. */
+  private getMissionPath(missionId: string): string {
+    return path.join(this.getMissionsDir(), `${missionId}.json`);
+  }
+
+  /**
+   * Validate + normalize a parsed mission document read from disk.
+   *
+   * - Returns `null` for anything that is not structurally a {@link Mission}
+   *   (corrupt / hand-edited / wrong shape), so callers never trust junk.
+   * - When `approval` is present but `approval.state` is NOT a recognized
+   *   {@link isValidProposalState}, the state is normalized to
+   *   {@link CORRUPT_APPROVAL_FALLBACK} (`rejected`). This deliberately treats a
+   *   corrupt governance state as INACTIVE — neither cascade-active nor a
+   *   recognized pending state — rather than silently trusting an unknown
+   *   string (which would otherwise be neither active nor pending and could
+   *   crash transition guards).
+   *
+   * @param value - Raw JSON-parsed value
+   * @returns A validated, normalized Mission, or `null` if not a valid Mission
+   */
+  private sanitizeMission(value: unknown): Mission | null {
+    if (!isMission(value)) return null;
+    const mission = value;
+    if (mission.approval !== undefined && !isValidProposalState(mission.approval.state)) {
+      this.logger.warn('Normalized corrupt approval.state to inactive', {
+        missionId: mission.id,
+        rawState: mission.approval.state,
+      });
+      return {
+        ...mission,
+        approval: { ...mission.approval, state: CORRUPT_APPROVAL_FALLBACK },
+      };
+    }
+    return mission;
+  }
+
+  /**
+   * Load a single mission from disk, validated + normalized via
+   * {@link sanitizeMission}.
+   *
+   * @param missionId - Mission ID
+   * @returns The mission, or `null` if missing/unreadable/not a valid Mission
+   */
+  private async loadMission(missionId: string): Promise<Mission | null> {
+    try {
+      const raw = await fs.readFile(this.getMissionPath(missionId), 'utf-8');
+      return this.sanitizeMission(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Load all missions from disk, skipping unreadable AND structurally-invalid
+   * files (each validated + normalized via {@link sanitizeMission}).
+   *
+   * @returns Array of valid missions
+   */
+  private async loadAllMissions(): Promise<Mission[]> {
+    const dir = this.getMissionsDir();
+    let files: string[] = [];
+    try {
+      files = (await fs.readdir(dir)).filter((f) => f.endsWith('.json'));
+    } catch {
+      return [];
+    }
+    const missions = await Promise.all(
+      files.map(async (f) => {
+        try {
+          const raw = await fs.readFile(path.join(dir, f), 'utf-8');
+          return this.sanitizeMission(JSON.parse(raw));
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return missions.filter((m): m is Mission => m !== null);
+  }
+
+  /**
+   * Persist a mission to disk (creating the missions directory if needed).
+   *
+   * @param mission - Mission to write
+   */
+  private async persistMission(mission: Mission): Promise<void> {
+    const dir = this.getMissionsDir();
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(this.getMissionPath(mission.id), JSON.stringify(mission, null, 2));
+  }
+}

--- a/backend/src/services/v3/okr-review.service.test.ts
+++ b/backend/src/services/v3/okr-review.service.test.ts
@@ -4,7 +4,7 @@
  * @module services/v3/okr-review.service.test
  */
 
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { OKRReviewService } from './okr-review.service.js';
@@ -22,12 +22,14 @@ jest.mock('../core/logger.service.js', () => ({
 
 // Mock KRTrackingService
 const mockComputeProgress = jest.fn();
+const mockComputeCascade = jest.fn();
 const mockKRUpdate = jest.fn();
 
 jest.mock('./kr-tracking.service.js', () => ({
   KRTrackingService: {
     getInstance: () => ({
       computeMissionOKRProgress: mockComputeProgress,
+      computeCascadeOKRProgress: mockComputeCascade,
       update: mockKRUpdate,
     }),
   },
@@ -162,6 +164,49 @@ describe('OKRReviewService', () => {
       const result = await service.executeReview('m1');
 
       expect(result.action).toBe('escalate');
+    });
+
+    it('refreshes the parent lastReviewSummary via cascade roll-up when a child is reviewed', async () => {
+      // parent (no parent) <- child being reviewed
+      writeMission('parent-1', { level: 'company' });
+      writeMission('child-1', { parentMissionId: 'parent-1', level: 'team', approval: { state: 'approved' } });
+
+      mockComputeProgress.mockResolvedValue({
+        missionId: 'child-1', totalKRs: 1, achieved: 0, onTrack: 1, atRisk: 0, offTrack: 0,
+        notStarted: 0, overallProgress: 80, recommendation: 'continue',
+      });
+      mockCheckProgress.mockResolvedValue({ missionId: 'child-1' });
+      mockComputeCascade.mockResolvedValue({
+        missionId: 'parent-1', totalKRs: 0, achieved: 0, onTrack: 0, atRisk: 0, offTrack: 0,
+        notStarted: 0, overallProgress: 0, recommendation: 'continue',
+        level: 'company', childMissionCount: 1, rolledUpProgress: 40, children: [],
+      });
+
+      const service = OKRReviewService.getInstance();
+      await service.executeReview('child-1');
+
+      // The parent roll-up must have been recomputed for parent-1.
+      expect(mockComputeCascade).toHaveBeenCalledWith('parent-1');
+
+      // The parent mission file must now carry a roll-up summary.
+      const parentPath = join(tempDir, '.crewly', 'missions', 'parent-1.json');
+      expect(existsSync(parentPath)).toBe(true);
+      const parent = JSON.parse(readFileSync(parentPath, 'utf-8')) as { lastReviewSummary?: string };
+      expect(parent.lastReviewSummary).toContain('Roll-up: 40%');
+      expect(parent.lastReviewSummary).toContain('1 child OKR(s)');
+    });
+
+    it('does not attempt a parent roll-up when the reviewed mission has no parent', async () => {
+      writeMission('solo', { level: 'company' });
+      mockComputeProgress.mockResolvedValue({
+        missionId: 'solo', totalKRs: 1, achieved: 1, onTrack: 0, atRisk: 0, offTrack: 0,
+        notStarted: 0, overallProgress: 100, recommendation: 'continue',
+      });
+      mockCheckProgress.mockResolvedValue({ missionId: 'solo' });
+
+      const service = OKRReviewService.getInstance();
+      await service.executeReview('solo');
+      expect(mockComputeCascade).not.toHaveBeenCalled();
     });
 
     it('should throw for non-existent mission', async () => {

--- a/backend/src/services/v3/okr-review.service.ts
+++ b/backend/src/services/v3/okr-review.service.ts
@@ -21,6 +21,7 @@ import type {
   OKRReviewResult,
   ReviewDecision,
   MissionOKRSummary,
+  CascadeOKRSummary,
 } from '../../types/v2/key-result.types.js';
 import type { Mission } from '../../types/v2/mission.types.js';
 import { getEffectiveCadence } from '../../types/v2/mission.types.js';
@@ -31,6 +32,19 @@ import { getEffectiveCadence } from '../../types/v2/mission.types.js';
 
 function getMissionsDir(): string {
   return path.join(process.cwd(), '.crewly', 'missions');
+}
+
+/**
+ * Build the one-line review summary string persisted on a mission. Kept in one
+ * place so the on-demand parent roll-up refresh and the self-review write stay
+ * consistent and machine-parseable (see {@link OKRReviewService}).
+ */
+function formatCascadeSummary(summary: CascadeOKRSummary): string {
+  return (
+    `Roll-up: ${summary.rolledUpProgress}% ` +
+    `(own ${summary.overallProgress}%, ${summary.childMissionCount} child OKR(s)) | ` +
+    `Recommendation: ${summary.recommendation}`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +147,11 @@ export class OKRReviewService {
       staleCycles: newStaleCycles,
       lastReviewAt: result.reviewedAt,
     });
+
+    // Cross-level roll-up: on-demand at review time, refresh this mission's
+    // parent so the parent's lastReviewSummary reflects the (now-updated) child.
+    // Event-driven refresh on every child measurement is a follow-up (spec §4.3).
+    await this.refreshParentRollup(mission.parentMissionId);
 
     this.logger.info('OKR review completed', {
       missionId,
@@ -248,6 +267,40 @@ export class OKRReviewService {
     const merged = { ...mission, ...updates, updatedAt: new Date().toISOString() };
     const filePath = path.join(getMissionsDir(), `${missionId}.json`);
     await fs.writeFile(filePath, JSON.stringify(merged, null, 2));
+  }
+
+  /**
+   * Refresh a parent mission's `lastReviewSummary` using the cascade roll-up.
+   *
+   * Called on-demand after a child review so the parent reflects its children's
+   * latest progress without a separate scheduled review. No-op when the
+   * reviewed mission has no parent or the parent has vanished. Errors are
+   * swallowed and logged — a roll-up refresh must never fail the child review.
+   *
+   * @param parentMissionId - The reviewed mission's parent (may be undefined)
+   */
+  private async refreshParentRollup(parentMissionId?: string): Promise<void> {
+    if (!parentMissionId) return;
+    const parent = await this.loadMission(parentMissionId);
+    if (!parent) return;
+    try {
+      const krService = KRTrackingService.getInstance();
+      const rollup = await krService.computeCascadeOKRProgress(parentMissionId);
+      await this.updateMissionReview(parentMissionId, {
+        lastReviewSummary: formatCascadeSummary(rollup),
+        lastReviewAt: new Date().toISOString(),
+      });
+      this.logger.info('Refreshed parent roll-up summary', {
+        parentMissionId,
+        rolledUpProgress: rollup.rolledUpProgress,
+        childMissionCount: rollup.childMissionCount,
+      });
+    } catch (err) {
+      this.logger.warn('Parent roll-up refresh failed', {
+        parentMissionId,
+        error: (err as Error).message,
+      });
+    }
   }
 
   /**

--- a/backend/src/services/wiki/wiki-migrate.service.test.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.test.ts
@@ -14,6 +14,7 @@ import * as os from 'os';
 import {
   WikiMigrateService,
   WIKI_MIGRATE_MANIFEST_FILENAME,
+  WIKI_OKR_FOLDER,
 } from './wiki-migrate.service.js';
 
 let projectRoot: string;
@@ -360,5 +361,181 @@ describe('WikiMigrateService.apply', () => {
       'utf8',
     );
     expect(legacyStill).toContain('d-keep');
+  });
+});
+describe('WikiMigrateService OKR schema (spec okr-cascade.md §5)', () => {
+  it('seeds okr/ in a freshly bootstrapped PROJECT vault schema + dir', async () => {
+    const out = await svc.apply({ projectRoot, homeDir });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    const schema = await fs.readFile(
+      path.join(projectRoot, '.crewly/wiki/SCHEMA.md'),
+      'utf8',
+    );
+    expect(schema).toContain(`- path: ${WIKI_OKR_FOLDER}/`);
+    expect(schema).toContain('service:okr-cascade.service');
+    expect(schema).toContain('agents read-only');
+    // okr/ block must precede llm_curated: (lives under hardcoded:).
+    expect(schema.indexOf(`- path: ${WIKI_OKR_FOLDER}/`)).toBeLessThan(
+      schema.indexOf('llm_curated:'),
+    );
+    const stat = await fs.stat(path.join(projectRoot, '.crewly/wiki', WIKI_OKR_FOLDER));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('seeds okr/ in a freshly bootstrapped TEAM vault schema + dir', async () => {
+    await fs.mkdir(path.join(homeDir, '.crewly', 'teams', 'team-okr'), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(homeDir, '.crewly', 'teams', 'team-okr', 'config.json'),
+      JSON.stringify({ name: 'OKR Team' }),
+      'utf8',
+    );
+    const out = await svc.apply({ projectRoot, homeDir });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    const teamVault = path.join(homeDir, '.crewly/teams/team-okr/wiki');
+    const schema = await fs.readFile(path.join(teamVault, 'SCHEMA.md'), 'utf8');
+    expect(schema).toContain(`- path: ${WIKI_OKR_FOLDER}/`);
+    expect(schema).toContain('service:okr-cascade.service');
+    const stat = await fs.stat(path.join(teamVault, WIKI_OKR_FOLDER));
+    expect(stat.isDirectory()).toBe(true);
+  });
+});
+
+describe('WikiMigrateService.ensureOkrFolders (backfill existing vaults)', () => {
+  /** Write a legacy PROJECT SCHEMA.md WITHOUT an okr/ block. */
+  async function seedLegacyProjectVault(): Promise<string> {
+    const vault = path.join(projectRoot, '.crewly', 'wiki');
+    await fs.mkdir(path.join(vault, 'memory'), { recursive: true });
+    await fs.mkdir(path.join(vault, 'sop-overrides'), { recursive: true });
+    await fs.mkdir(path.join(vault, 'llm-curated'), { recursive: true });
+    await fs.writeFile(
+      path.join(vault, 'SCHEMA.md'),
+      [
+        'vault_scope: project',
+        'vault_id: project',
+        '',
+        'hardcoded:',
+        '  - path: memory/',
+        '    frozen: true',
+        '    description: "facts"',
+        '',
+        '  - path: sop-overrides/',
+        '    frozen: true',
+        '    description: "deltas"',
+        '',
+        'llm_curated:',
+        '  - path: llm-curated/',
+        '    frozen: false',
+        '',
+        'write_policy:',
+        '  canonical:',
+        '    - team-leader',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    return vault;
+  }
+
+  /** Write a legacy TEAM SCHEMA.md WITHOUT an okr/ block. */
+  async function seedLegacyTeamVault(uuid: string): Promise<string> {
+    const vault = path.join(homeDir, '.crewly', 'teams', uuid, 'wiki');
+    await fs.mkdir(path.join(vault, 'sop'), { recursive: true });
+    await fs.mkdir(path.join(vault, 'team-norm'), { recursive: true });
+    await fs.mkdir(path.join(vault, 'llm-curated'), { recursive: true });
+    await fs.writeFile(
+      path.join(vault, 'SCHEMA.md'),
+      [
+        'vault_scope: team',
+        `vault_id: ${uuid}`,
+        '',
+        'hardcoded:',
+        '  - path: sop/',
+        '    frozen: true',
+        '    description: "sops"',
+        '',
+        '  - path: team-norm/',
+        '    frozen: true',
+        '    description: "norms"',
+        '',
+        'llm_curated:',
+        '  - path: llm-curated/',
+        '    frozen: false',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    return vault;
+  }
+
+  it('dry-run reports the missing okr/ block without writing', async () => {
+    const vault = await seedLegacyProjectVault();
+    const out = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: false });
+    expect(out.ok).toBe(true);
+    expect(out.changedCount).toBe(1);
+    const entry = out.vaults.find((v) => v.scope === 'project');
+    expect(entry?.changed).toBe(true);
+    // Nothing written in dry-run.
+    const schema = await fs.readFile(path.join(vault, 'SCHEMA.md'), 'utf8');
+    expect(schema).not.toContain(`- path: ${WIKI_OKR_FOLDER}/`);
+    await expect(fs.stat(path.join(vault, WIKI_OKR_FOLDER))).rejects.toThrow();
+  });
+
+  it('adds okr/ to an existing PROJECT vault missing it', async () => {
+    const vault = await seedLegacyProjectVault();
+    const out = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: true });
+    expect(out.ok).toBe(true);
+    expect(out.applied).toBe(true);
+    expect(out.changedCount).toBe(1);
+    const schema = await fs.readFile(path.join(vault, 'SCHEMA.md'), 'utf8');
+    expect(schema).toContain(`- path: ${WIKI_OKR_FOLDER}/`);
+    expect(schema).toContain('service:okr-cascade.service');
+    // injected under hardcoded:, before llm_curated:
+    expect(schema.indexOf(`- path: ${WIKI_OKR_FOLDER}/`)).toBeLessThan(
+      schema.indexOf('llm_curated:'),
+    );
+    const stat = await fs.stat(path.join(vault, WIKI_OKR_FOLDER));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('adds okr/ to an existing TEAM vault missing it', async () => {
+    const vault = await seedLegacyTeamVault('legacy-team');
+    const out = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: true });
+    expect(out.ok).toBe(true);
+    const teamEntry = out.vaults.find((v) => v.scope === 'team');
+    expect(teamEntry?.changed).toBe(true);
+    const schema = await fs.readFile(path.join(vault, 'SCHEMA.md'), 'utf8');
+    expect(schema).toContain(`- path: ${WIKI_OKR_FOLDER}/`);
+    const stat = await fs.stat(path.join(vault, WIKI_OKR_FOLDER));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('is idempotent — a vault already declaring okr/ is unchanged', async () => {
+    await seedLegacyProjectVault();
+    const first = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: true });
+    expect(first.changedCount).toBe(1);
+    const vault = path.join(projectRoot, '.crewly', 'wiki');
+    const afterFirst = await fs.readFile(path.join(vault, 'SCHEMA.md'), 'utf8');
+
+    const second = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: true });
+    expect(second.changedCount).toBe(0);
+    const projEntry = second.vaults.find((v) => v.scope === 'project');
+    expect(projEntry?.changed).toBe(false);
+    const afterSecond = await fs.readFile(path.join(vault, 'SCHEMA.md'), 'utf8');
+    expect(afterSecond).toBe(afterFirst);
+    // Exactly one okr/ block (no duplication).
+    const occurrences = afterSecond.split(`- path: ${WIKI_OKR_FOLDER}/`).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('skips vaults that have no SCHEMA.md on disk (bootstrap owns those)', async () => {
+    // No project vault created at all.
+    const out = await svc.ensureOkrFolders({ projectRoot, homeDir, apply: true });
+    expect(out.ok).toBe(true);
+    expect(out.vaults).toEqual([]);
+    expect(out.changedCount).toBe(0);
   });
 });

--- a/backend/src/services/wiki/wiki-migrate.service.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.ts
@@ -40,6 +40,29 @@ export const WIKI_MIGRATE_MANIFEST_VERSION = 1;
 /** Hard cap on loose .md files we walk (defensive). */
 export const WIKI_MIGRATE_MAX_LOOSE_MD = 200;
 
+/**
+ * Name of the frozen `okr/` folder added to TEAM + PROJECT vaults for the
+ * OKR cascade (spec okr-cascade.md §5). Holds AUTHORED OKR narrative only —
+ * runtime Mission/KeyResult entities remain the cascade source-of-truth; this
+ * folder optionally mirrors approved Missions and is read-only to agents.
+ */
+export const WIKI_OKR_FOLDER = 'okr';
+
+/**
+ * Service reference recorded in the `okr/` frozen-folder schema block's
+ * `referenced_by` list. Lets the schema-loader / referenced-by resolver link
+ * the folder back to the cascade service that owns its mirrored content.
+ */
+export const WIKI_OKR_REFERENCED_BY = 'service:okr-cascade.service';
+
+/** Human-readable description for the TEAM-scope `okr/` frozen-folder block. */
+export const WIKI_OKR_TEAM_DESCRIPTION =
+  'Authored OKR narrative for this team. Mirrors approved Missions; agents read-only, Steve authors.';
+
+/** Human-readable description for the PROJECT-scope `okr/` frozen-folder block. */
+export const WIKI_OKR_PROJECT_DESCRIPTION =
+  'Authored OKR narrative for this project. Mirrors approved Missions; agents read-only, Steve authors.';
+
 // ---------------------------------------------------------------------------
 // Input / output types
 // ---------------------------------------------------------------------------
@@ -106,6 +129,38 @@ export interface WikiMigrateBootstrapNeeded {
   global: boolean;
   /** UUIDs of team vaults missing their SCHEMA.md. */
   teams: string[];
+}
+
+/**
+ * Per-vault outcome of an `okr/` frozen-folder backfill (OKR cascade spec §5).
+ * One entry per existing vault we inspected; `changed` is true only when this
+ * run actually created the folder and/or injected the schema block.
+ */
+export interface WikiOkrFolderResult {
+  /** Vault scope this entry describes. */
+  scope: 'team' | 'project';
+  /** Absolute path to the vault root (the dir containing `SCHEMA.md`). */
+  vaultPath: string;
+  /** True when the `okr/` directory was created this run. */
+  folderCreated: boolean;
+  /** True when the `okr/` block was injected into `SCHEMA.md` this run. */
+  schemaUpdated: boolean;
+  /** Convenience: folderCreated || schemaUpdated. */
+  changed: boolean;
+}
+
+/**
+ * Aggregate result of {@link WikiMigrateService.ensureOkrFolders}. Lists every
+ * existing TEAM/PROJECT vault that was inspected and whether it changed.
+ */
+export interface WikiEnsureOkrResult {
+  ok: true;
+  /** When false (default), describes what WOULD change without writing. */
+  applied: boolean;
+  /** One entry per existing vault inspected. */
+  vaults: WikiOkrFolderResult[];
+  /** Count of vaults that changed (or would change) this run. */
+  changedCount: number;
 }
 
 export interface WikiMigrateScanResult {
@@ -734,6 +789,7 @@ export class WikiMigrateService {
   private async writeProjectVaultSkeleton(vaultDir: string): Promise<void> {
     await fs.mkdir(path.join(vaultDir, 'memory'), { recursive: true });
     await fs.mkdir(path.join(vaultDir, 'sop-overrides'), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, WIKI_OKR_FOLDER), { recursive: true });
     await fs.mkdir(path.join(vaultDir, 'llm-curated'), { recursive: true });
     await fs.writeFile(
       path.join(vaultDir, 'SCHEMA.md'),
@@ -760,6 +816,7 @@ export class WikiMigrateService {
   ): Promise<void> {
     await fs.mkdir(path.join(vaultDir, 'sop'), { recursive: true });
     await fs.mkdir(path.join(vaultDir, 'team-norm'), { recursive: true });
+    await fs.mkdir(path.join(vaultDir, WIKI_OKR_FOLDER), { recursive: true });
     await fs.mkdir(path.join(vaultDir, 'llm-curated'), { recursive: true });
     const schema = teamVaultSchemaMd(teamUuid, teamName);
     await fs.writeFile(path.join(vaultDir, 'SCHEMA.md'), schema, 'utf8');
@@ -1447,6 +1504,145 @@ export class WikiMigrateService {
     }
     return s;
   }
+
+  // ---------------------------------------------------------------------------
+  // OKR cascade — `okr/` frozen-folder backfill for EXISTING vaults (spec §5)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Idempotently add the frozen `okr/` folder + SCHEMA.md block to EXISTING
+   * team and project vaults that predate the OKR cascade.
+   *
+   * New vaults already seed `okr/` via the skeleton writers; this method covers
+   * vaults already on disk. It is the analogue of {@link bootstrapMissingVaults}
+   * for a single added frozen folder: only vaults whose `SCHEMA.md` already
+   * exists are touched (a fully-missing vault is bootstrapped elsewhere).
+   *
+   * Detection is idempotent — a vault that already declares `okr/` in its
+   * SCHEMA.md and has the directory on disk is reported as `changed: false`.
+   * The cascade source-of-truth stays the runtime Mission tree; this folder
+   * holds authored narrative only.
+   *
+   * @param input.projectRoot - Absolute path to the project root (dir holding
+   *   `.crewly/wiki/`). Its project vault is backfilled when present.
+   * @param input.homeDir - Override for `~`; team vaults live under
+   *   `<homeDir>/.crewly/teams/<uuid>/wiki/`. Tests pass a scratch dir.
+   * @param input.apply - false (default) for a dry-run preview; true to write.
+   * @returns Per-vault results and a changed-vault count.
+   * @example
+   * ```typescript
+   * const res = await WikiMigrateService.getInstance().ensureOkrFolders({
+   *   projectRoot, homeDir, apply: true,
+   * });
+   * ```
+   */
+  async ensureOkrFolders(input: {
+    projectRoot?: string;
+    homeDir?: string;
+    apply?: boolean;
+  }): Promise<WikiEnsureOkrResult> {
+    const apply = input.apply ?? false;
+    const homeDir = input.homeDir ?? os.homedir();
+    const vaults: WikiOkrFolderResult[] = [];
+
+    // Project vault (only when its SCHEMA.md already exists on disk).
+    if (input.projectRoot) {
+      const projectVault = path.join(input.projectRoot, '.crewly', 'wiki');
+      if (existsSync(path.join(projectVault, 'SCHEMA.md'))) {
+        vaults.push(
+          await this.ensureOkrForVault(
+            projectVault,
+            'project',
+            WIKI_OKR_PROJECT_DESCRIPTION,
+            apply,
+          ),
+        );
+      }
+    }
+
+    // Team vaults under <home>/.crewly/teams/<uuid>/wiki/.
+    const teamsRoot = path.join(homeDir, '.crewly', 'teams');
+    if (existsSync(teamsRoot)) {
+      let entries: import('fs').Dirent[] = [];
+      try {
+        entries = await fs.readdir(teamsRoot, { withFileTypes: true });
+      } catch {
+        entries = [];
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (entry.name === 'orchestrator') continue;
+        const teamVault = path.join(teamsRoot, entry.name, 'wiki');
+        if (!existsSync(path.join(teamVault, 'SCHEMA.md'))) continue;
+        vaults.push(
+          await this.ensureOkrForVault(
+            teamVault,
+            'team',
+            WIKI_OKR_TEAM_DESCRIPTION,
+            apply,
+          ),
+        );
+      }
+    }
+
+    return {
+      ok: true,
+      applied: apply,
+      vaults,
+      changedCount: vaults.filter((v) => v.changed).length,
+    };
+  }
+
+  /**
+   * Backfill a single existing vault with the frozen `okr/` folder + schema
+   * block. Idempotent: a no-op (changed=false) when the folder and the schema
+   * block are both already present.
+   *
+   * @param vaultDir - Absolute path to the vault root (contains `SCHEMA.md`).
+   * @param scope - Vault scope, used to pick the schema description copy.
+   * @param description - Description string for the injected `okr/` block.
+   * @param apply - When false, only reports what would change.
+   * @returns The per-vault outcome.
+   */
+  private async ensureOkrForVault(
+    vaultDir: string,
+    scope: 'team' | 'project',
+    description: string,
+    apply: boolean,
+  ): Promise<WikiOkrFolderResult> {
+    const okrDir = path.join(vaultDir, WIKI_OKR_FOLDER);
+    const schemaPath = path.join(vaultDir, 'SCHEMA.md');
+
+    const folderMissing = !existsSync(okrDir);
+
+    let schema = '';
+    try {
+      schema = await fs.readFile(schemaPath, 'utf8');
+    } catch {
+      schema = '';
+    }
+    const schemaMissingBlock = !schemaDeclaresOkr(schema);
+
+    if (apply) {
+      if (folderMissing) {
+        await fs.mkdir(okrDir, { recursive: true });
+      }
+      if (schemaMissingBlock && schema) {
+        const next = injectOkrBlock(schema, description);
+        if (next !== schema) {
+          await fs.writeFile(schemaPath, next, 'utf8');
+        }
+      }
+    }
+
+    return {
+      scope,
+      vaultPath: vaultDir,
+      folderCreated: folderMissing,
+      schemaUpdated: schemaMissingBlock && schema.length > 0,
+      changed: folderMissing || (schemaMissingBlock && schema.length > 0),
+    };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1672,6 +1868,47 @@ function frontmatter(
   return lines.join('\n') + '\n\n';
 }
 
+/**
+ * True when a SCHEMA.md already declares the frozen `okr/` folder. Cheap
+ * line-scan for a `- path: okr/` hardcoded entry; used to keep the OKR
+ * backfill idempotent without parsing the full YAML.
+ *
+ * @param schema - Raw SCHEMA.md contents.
+ * @returns true when an `okr/` path block is present.
+ */
+function schemaDeclaresOkr(schema: string): boolean {
+  return new RegExp(`(^|\\n)\\s*-\\s*path:\\s*${WIKI_OKR_FOLDER}/\\s*(\\n|$)`).test(schema);
+}
+
+/**
+ * Inject an `okr/` frozen-folder block into an existing SCHEMA.md, immediately
+ * before the `llm_curated:` section (so it sits with the other `hardcoded:`
+ * entries). Falls back to appending the block at end-of-file when no
+ * `llm_curated:` marker exists. Returns the input unchanged when `okr/` is
+ * already declared (defensive double-check).
+ *
+ * @param schema - Raw SCHEMA.md contents to mutate.
+ * @param description - Description copy for the injected block.
+ * @returns The updated SCHEMA.md contents.
+ */
+function injectOkrBlock(schema: string, description: string): string {
+  if (schemaDeclaresOkr(schema)) return schema;
+  const block =
+    `  - path: ${WIKI_OKR_FOLDER}/\n` +
+    `    frozen: true\n` +
+    `    description: "${description.replace(/"/g, '\\"')}"\n` +
+    `    referenced_by:\n` +
+    `      - ${WIKI_OKR_REFERENCED_BY}\n\n`;
+
+  const marker = '\nllm_curated:';
+  const idx = schema.indexOf(marker);
+  if (idx === -1) {
+    const sep = schema.endsWith('\n') ? '' : '\n';
+    return `${schema}${sep}\n${block}`;
+  }
+  return schema.slice(0, idx + 1) + block + schema.slice(idx + 1);
+}
+
 // ---------------------------------------------------------------------------
 // SCHEMA.md skeletons
 // ---------------------------------------------------------------------------
@@ -1695,6 +1932,12 @@ hardcoded:
     description: "Project-specific SOP deltas. get-sops reads team-vault sop/ first, then this override layer."
     referenced_by:
       - skill:get-sops
+
+  - path: ${WIKI_OKR_FOLDER}/
+    frozen: true
+    description: "${WIKI_OKR_PROJECT_DESCRIPTION}"
+    referenced_by:
+      - ${WIKI_OKR_REFERENCED_BY}
 
 llm_curated:
   - path: llm-curated/
@@ -1783,6 +2026,12 @@ hardcoded:
     description: "Team norms (canDelegate, role conventions, ROE). Maps from config/sops/<role>/team-norm/ over Phase 2 migration."
     referenced_by:
       - skill:get-team-norms
+
+  - path: ${WIKI_OKR_FOLDER}/
+    frozen: true
+    description: "${WIKI_OKR_TEAM_DESCRIPTION}"
+    referenced_by:
+      - ${WIKI_OKR_REFERENCED_BY}
 
 llm_curated:
   - path: llm-curated/

--- a/backend/src/types/v2/index.ts
+++ b/backend/src/types/v2/index.ts
@@ -145,10 +145,14 @@ export type {
   PolicyDecision,
   EscalationContext,
   CreateMissionInput,
+  UpdateMissionInput,
   UpdatePolicyInput,
   PhaseGateApproval,
   WorkHoursWindow,
   ExecutionCadence,
+  MissionLevel,
+  ProposalState,
+  ApprovalState,
 } from './mission.types.js';
 
 export {
@@ -179,6 +183,17 @@ export {
   createMission,
   getEffectiveCadence,
   mergeExecutionCadence,
+  MISSION_LEVELS,
+  MISSION_LEVEL_DEPTH,
+  PROJECT_LEVEL_DEPTH,
+  PROPOSAL_STATES,
+  PROPOSAL_TRANSITIONS,
+  isValidMissionLevel,
+  validateLevelLink,
+  deriveLevel,
+  isValidProposalState,
+  isValidProposalTransition,
+  validateCascadeLink,
 } from './mission.types.js';
 
 // Key Result types (OKR)
@@ -192,6 +207,7 @@ export type {
   CreateKeyResultInput,
   UpdateKeyResultInput,
   MissionOKRSummary,
+  CascadeOKRSummary,
   OKRRecommendation,
   OKRReviewResult,
   ReviewDecision,
@@ -211,6 +227,7 @@ export {
   computeKRProgress,
   deriveKRStatus,
   deriveOKRRecommendation,
+  computeRolledUpProgress,
 } from './key-result.types.js';
 
 // Workspace types

--- a/backend/src/types/v2/key-result.types.test.ts
+++ b/backend/src/types/v2/key-result.types.test.ts
@@ -13,8 +13,11 @@ import {
   createKeyResult,
   computeKRProgress,
   deriveKRStatus,
+  deriveCascadeChildStatus,
   deriveOKRRecommendation,
+  computeRolledUpProgress,
 } from './key-result.types.js';
+import type { CascadeOKRSummary, MissionOKRSummary } from './key-result.types.js';
 
 // ---------------------------------------------------------------------------
 // Validators
@@ -233,6 +236,26 @@ describe('deriveKRStatus', () => {
 });
 
 // ---------------------------------------------------------------------------
+// deriveCascadeChildStatus (finding 1: no baseline-equality short-circuit)
+// ---------------------------------------------------------------------------
+
+describe('deriveCascadeChildStatus', () => {
+  it('maps a stalled 0% child to off_track (NOT not_started)', () => {
+    // The crux of finding 1: deriveKRStatus(0, 0, 0) is not_started, but a
+    // cascade child stalled at 0% is a genuine off_track signal.
+    expect(deriveCascadeChildStatus(0)).toBe('off_track');
+    expect(deriveKRStatus(0, 0, 0)).toBe('not_started');
+  });
+
+  it('mirrors the deriveKRStatus banding for non-zero progress', () => {
+    expect(deriveCascadeChildStatus(100)).toBe('achieved');
+    expect(deriveCascadeChildStatus(50)).toBe('on_track');
+    expect(deriveCascadeChildStatus(25)).toBe('at_risk');
+    expect(deriveCascadeChildStatus(24)).toBe('off_track');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // deriveOKRRecommendation
 // ---------------------------------------------------------------------------
 
@@ -256,5 +279,77 @@ describe('deriveOKRRecommendation', () => {
 
   it('should return continue for empty KR list', () => {
     expect(deriveOKRRecommendation([])).toBe('continue');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRolledUpProgress (cascade roll-up math)
+// ---------------------------------------------------------------------------
+
+describe('computeRolledUpProgress', () => {
+  it('returns own progress (rounded) for a leaf with no children', () => {
+    expect(computeRolledUpProgress(40, [])).toBe(40);
+    expect(computeRolledUpProgress(40.4, [])).toBe(40);
+    expect(computeRolledUpProgress(0, [])).toBe(0);
+  });
+
+  it('equal-weights own progress with each child progress', () => {
+    // (40 + 80 + 60) / 3 = 60
+    expect(computeRolledUpProgress(40, [80, 60])).toBe(60);
+  });
+
+  it('rounds the average to an integer', () => {
+    // (50 + 51) / 2 = 50.5 -> 51
+    expect(computeRolledUpProgress(50, [51])).toBe(51);
+  });
+
+  it('treats a single child as equal weight with the parent', () => {
+    // (100 + 0) / 2 = 50
+    expect(computeRolledUpProgress(100, [0])).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CascadeOKRSummary type shape
+// ---------------------------------------------------------------------------
+
+describe('CascadeOKRSummary', () => {
+  it('extends MissionOKRSummary with cascade fields', () => {
+    const leaf: CascadeOKRSummary = {
+      missionId: 'proj-1',
+      totalKRs: 1,
+      achieved: 0,
+      onTrack: 1,
+      atRisk: 0,
+      offTrack: 0,
+      notStarted: 0,
+      overallProgress: 70,
+      recommendation: 'continue',
+      level: 'project',
+      childMissionCount: 0,
+      rolledUpProgress: 70,
+      children: [],
+    };
+    const parent: CascadeOKRSummary = {
+      missionId: 'team-1',
+      totalKRs: 0,
+      achieved: 0,
+      onTrack: 0,
+      atRisk: 0,
+      offTrack: 0,
+      notStarted: 0,
+      overallProgress: 0,
+      recommendation: 'continue',
+      level: 'team',
+      childMissionCount: 1,
+      rolledUpProgress: 35,
+      children: [leaf],
+    };
+    // A CascadeOKRSummary is assignable to a MissionOKRSummary (it extends it).
+    const base: MissionOKRSummary = parent;
+    expect(base.missionId).toBe('team-1');
+    expect(parent.children).toHaveLength(1);
+    expect(parent.children[0].level).toBe('project');
+    expect(parent.childMissionCount).toBe(1);
   });
 });

--- a/backend/src/types/v2/key-result.types.ts
+++ b/backend/src/types/v2/key-result.types.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import type { MissionLevel } from './mission.types.js';
 
 // ---------------------------------------------------------------------------
 // Core Enums & Constants
@@ -161,6 +162,32 @@ export interface MissionOKRSummary {
 }
 
 /**
+ * Cross-level (cascade) roll-up of OKR progress for a Mission and its approved
+ * children, walking the `Mission.parentMissionId` tree (company → team →
+ * project).
+ *
+ * Extends {@link MissionOKRSummary} with the recursive subtree so a parent's
+ * progress reflects its children's progress. Only approved children are
+ * included (draft/pending_approval/rejected children are excluded from the
+ * roll-up per spec §4.2).
+ */
+export interface CascadeOKRSummary extends MissionOKRSummary {
+  /** Cascade tier of this mission within company → team → project. */
+  level: MissionLevel;
+  /** Number of approved children that contributed to the roll-up. */
+  childMissionCount: number;
+  /**
+   * Rolled-up progress (0-100). Equal-weight average of this mission's own
+   * `overallProgress` and each approved child's `rolledUpProgress`. For a leaf
+   * (no approved children) this equals `overallProgress`. See
+   * {@link computeRolledUpProgress}.
+   */
+  rolledUpProgress: number;
+  /** Recursive roll-up summaries for each approved child mission. */
+  children: CascadeOKRSummary[];
+}
+
+/**
  * Result of an OKR review cycle.
  */
 export interface OKRReviewResult {
@@ -276,6 +303,19 @@ export function computeKRProgress(kr: Pick<KeyResult, 'baseline' | 'target' | 'c
 }
 
 /**
+ * Progress thresholds (0-100) that delimit the KR status bands. A progress at or
+ * above a threshold maps to the associated status (checked high → low).
+ */
+export const KR_STATUS_THRESHOLDS = {
+  /** At/above this progress the KR is fully achieved. */
+  ACHIEVED: 100,
+  /** At/above this progress the KR is healthy / on track. */
+  ON_TRACK: 50,
+  /** At/above this progress the KR is at risk (but not off track). */
+  AT_RISK: 25,
+} as const;
+
+/**
  * Derive KR status from progress percentage.
  *
  * - achieved: progress >= 100%
@@ -285,11 +325,68 @@ export function computeKRProgress(kr: Pick<KeyResult, 'baseline' | 'target' | 'c
  * - not_started: progress === 0% and current === baseline
  */
 export function deriveKRStatus(progress: number, current: number, baseline: number): KRStatus {
-  if (progress >= 100) return 'achieved';
+  if (progress >= KR_STATUS_THRESHOLDS.ACHIEVED) return 'achieved';
   if (current === baseline) return 'not_started';
-  if (progress >= 50) return 'on_track';
-  if (progress >= 25) return 'at_risk';
+  if (progress >= KR_STATUS_THRESHOLDS.ON_TRACK) return 'on_track';
+  if (progress >= KR_STATUS_THRESHOLDS.AT_RISK) return 'at_risk';
   return 'off_track';
+}
+
+/**
+ * Map a cascade child's rolled-up progress to a single synthetic KR status used
+ * to fold the child into its parent's roll-up recommendation.
+ *
+ * Unlike {@link deriveKRStatus}, this mapper deliberately has NO
+ * `current === baseline` short-circuit: a child stalled at `0` progress is a
+ * genuine "in trouble" signal (`off_track`), NOT `not_started`. Treating an
+ * all-children-at-zero parent as `not_started` would suppress the
+ * escalate/replan recommendation the cascade is meant to surface (spec §4.2).
+ *
+ * Banding mirrors {@link deriveKRStatus}:
+ * - achieved: progress >= 100%
+ * - on_track: progress >= 50%
+ * - at_risk: progress >= 25%
+ * - off_track: progress < 25% (including exactly 0%)
+ *
+ * @param rolledUpProgress - The child's rolled-up progress (0-100)
+ * @returns The synthetic {@link KRStatus} for the child
+ *
+ * @example
+ * ```ts
+ * deriveCascadeChildStatus(0);  // 'off_track' (a stalled child escalates)
+ * deriveCascadeChildStatus(75); // 'on_track'
+ * ```
+ */
+export function deriveCascadeChildStatus(rolledUpProgress: number): KRStatus {
+  if (rolledUpProgress >= KR_STATUS_THRESHOLDS.ACHIEVED) return 'achieved';
+  if (rolledUpProgress >= KR_STATUS_THRESHOLDS.ON_TRACK) return 'on_track';
+  if (rolledUpProgress >= KR_STATUS_THRESHOLDS.AT_RISK) return 'at_risk';
+  return 'off_track';
+}
+
+/**
+ * Compute an equal-weight rolled-up progress for a cascade node.
+ *
+ * v1 weighting is intentionally equal-weight: the node's own progress counts
+ * the same as each approved child's rolled-up progress. Future ownership /
+ * complexity weighting is a documented hook (spec §4.2) — pass per-input
+ * weights here when that lands; do NOT implement weighting now.
+ *
+ * @param ownProgress - This mission's own `overallProgress` (0-100)
+ * @param childProgresses - Each approved child's `rolledUpProgress` (0-100)
+ * @returns Equal-weight average rounded to an integer 0-100; for a leaf
+ *   (no children) this equals `ownProgress` (rounded)
+ *
+ * @example
+ * ```ts
+ * computeRolledUpProgress(40, [80, 60]); // round((40 + 80 + 60) / 3) = 60
+ * computeRolledUpProgress(40, []);       // 40 (leaf)
+ * ```
+ */
+export function computeRolledUpProgress(ownProgress: number, childProgresses: number[]): number {
+  const values = [ownProgress, ...childProgresses];
+  const total = values.reduce((sum, v) => sum + v, 0);
+  return Math.round(total / values.length);
 }
 
 /**

--- a/backend/src/types/v2/mission.types.test.ts
+++ b/backend/src/types/v2/mission.types.test.ts
@@ -35,8 +35,30 @@ import {
   getEffectiveCadence,
   mergeExecutionCadence,
   validateParentLink,
+  MISSION_LEVELS,
+  MISSION_LEVEL_DEPTH,
+  PROPOSAL_STATES,
+  PROPOSAL_TRANSITIONS,
+  isValidMissionLevel,
+  validateLevelLink,
+  deriveLevel,
+  isValidProposalState,
+  isValidProposalTransition,
+  validateCascadeLink,
+  createMonthlyPeriod,
+  isPeriodActive,
 } from './mission.types.js';
-import type { Mission, MissionPolicy, EscalationRule, CreateMissionInput, ExecutionCadence } from './mission.types.js';
+import type {
+  Mission,
+  MissionPolicy,
+  EscalationRule,
+  CreateMissionInput,
+  ExecutionCadence,
+  MissionLevel,
+  ProposalState,
+  ApprovalState,
+  UpdateMissionInput,
+} from './mission.types.js';
 
 describe('Mission Types', () => {
   // -----------------------------------------------------------------------
@@ -663,6 +685,311 @@ describe('Mission Types', () => {
       m.lastReminderAt = new Date().toISOString();
 
       expect(typeof m.lastReminderAt).toBe('string');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // OKR Cascade: MissionLevel
+  // -----------------------------------------------------------------------
+  describe('MissionLevel', () => {
+    it('MISSION_LEVELS contains exactly company, team, project in order', () => {
+      expect(MISSION_LEVELS).toEqual(['company', 'team', 'project']);
+    });
+
+    it('MISSION_LEVEL_DEPTH assigns ascending depths', () => {
+      expect(MISSION_LEVEL_DEPTH).toEqual({ company: 0, team: 1, project: 2 });
+    });
+
+    it('isValidMissionLevel accepts valid levels', () => {
+      for (const lvl of MISSION_LEVELS) {
+        expect(isValidMissionLevel(lvl)).toBe(true);
+      }
+    });
+
+    it('isValidMissionLevel rejects unknown strings', () => {
+      expect(isValidMissionLevel('individual')).toBe(false);
+      expect(isValidMissionLevel('')).toBe(false);
+    });
+  });
+
+  describe('validateLevelLink (adjacency matrix)', () => {
+    it('company with no parent is valid', () => {
+      expect(validateLevelLink('company', undefined)).toBeNull();
+    });
+
+    it('company with a parent is invalid', () => {
+      expect(validateLevelLink('company', 'team')).not.toBeNull();
+      expect(validateLevelLink('company', 'company')).not.toBeNull();
+    });
+
+    it('team requires a company parent', () => {
+      expect(validateLevelLink('team', 'company')).toBeNull();
+      expect(validateLevelLink('team', undefined)).not.toBeNull();
+      expect(validateLevelLink('team', 'team')).not.toBeNull();
+      expect(validateLevelLink('team', 'project')).not.toBeNull();
+    });
+
+    it('project requires a team parent', () => {
+      expect(validateLevelLink('project', 'team')).toBeNull();
+      expect(validateLevelLink('project', undefined)).not.toBeNull();
+      expect(validateLevelLink('project', 'company')).not.toBeNull();
+      expect(validateLevelLink('project', 'project')).not.toBeNull();
+    });
+
+    it('covers the full child x parent matrix exactly once-legal-per-child', () => {
+      const parents: Array<MissionLevel | undefined> = [undefined, 'company', 'team', 'project'];
+      const legal: Record<MissionLevel, MissionLevel | undefined> = {
+        company: undefined,
+        team: 'company',
+        project: 'team',
+      };
+      for (const child of MISSION_LEVELS) {
+        for (const parent of parents) {
+          const result = validateLevelLink(child, parent);
+          if (parent === legal[child]) {
+            expect(result).toBeNull();
+          } else {
+            expect(result).not.toBeNull();
+          }
+        }
+      }
+    });
+  });
+
+  describe('deriveLevel', () => {
+    const byId = new Map<string, Pick<Mission, 'id' | 'parentMissionId'>>([
+      ['co', { id: 'co' }],
+      ['team', { id: 'team', parentMissionId: 'co' }],
+      ['proj', { id: 'proj', parentMissionId: 'team' }],
+      ['deep', { id: 'deep', parentMissionId: 'proj' }],
+    ]);
+
+    it('depth 0 (no parent) ⇒ company', () => {
+      expect(deriveLevel('co', byId)).toBe('company');
+    });
+
+    it('depth 1 ⇒ team', () => {
+      expect(deriveLevel('team', byId)).toBe('team');
+    });
+
+    it('depth 2 ⇒ project', () => {
+      expect(deriveLevel('proj', byId)).toBe('project');
+    });
+
+    it('depth >= 2 stays project', () => {
+      expect(deriveLevel('deep', byId)).toBe('project');
+    });
+
+    it('handles a cycle without infinite looping', () => {
+      const cyclic = new Map<string, Pick<Mission, 'id' | 'parentMissionId'>>([
+        ['a', { id: 'a', parentMissionId: 'b' }],
+        ['b', { id: 'b', parentMissionId: 'a' }],
+      ]);
+      const level = deriveLevel('a', cyclic);
+      expect(MISSION_LEVELS).toContain(level);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // OKR Cascade: Proposal / Approval governance
+  // -----------------------------------------------------------------------
+  describe('ProposalState', () => {
+    it('PROPOSAL_STATES lists the four states', () => {
+      expect(PROPOSAL_STATES).toEqual(['draft', 'pending_approval', 'approved', 'rejected']);
+    });
+
+    it('isValidProposalState validates membership', () => {
+      for (const s of PROPOSAL_STATES) {
+        expect(isValidProposalState(s)).toBe(true);
+      }
+      expect(isValidProposalState('active')).toBe(false);
+    });
+  });
+
+  describe('isValidProposalTransition', () => {
+    it('draft only advances to pending_approval', () => {
+      expect(isValidProposalTransition('draft', 'pending_approval')).toBe(true);
+      expect(isValidProposalTransition('draft', 'approved')).toBe(false);
+      expect(isValidProposalTransition('draft', 'rejected')).toBe(false);
+    });
+
+    it('pending_approval advances to approved or rejected', () => {
+      expect(isValidProposalTransition('pending_approval', 'approved')).toBe(true);
+      expect(isValidProposalTransition('pending_approval', 'rejected')).toBe(true);
+      expect(isValidProposalTransition('pending_approval', 'draft')).toBe(false);
+    });
+
+    it('approved is terminal', () => {
+      for (const to of PROPOSAL_STATES) {
+        expect(isValidProposalTransition('approved', to)).toBe(false);
+      }
+    });
+
+    it('rejected can return to draft for a redraft', () => {
+      expect(isValidProposalTransition('rejected', 'draft')).toBe(true);
+      expect(isValidProposalTransition('rejected', 'approved')).toBe(false);
+    });
+
+    it('PROPOSAL_TRANSITIONS matches the guard', () => {
+      for (const from of PROPOSAL_STATES) {
+        for (const to of PROPOSAL_STATES) {
+          expect(isValidProposalTransition(from, to)).toBe(PROPOSAL_TRANSITIONS[from].has(to));
+        }
+      }
+    });
+
+    it('ApprovalState shape is assignable', () => {
+      const a: ApprovalState = {
+        state: 'rejected',
+        proposedBy: 'agent-1',
+        proposedAt: new Date().toISOString(),
+        decidedBy: 'steve',
+        decidedAt: new Date().toISOString(),
+        rejectionReason: 'scope too broad',
+      };
+      expect(a.state).toBe('rejected');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // OKR Cascade: validateCascadeLink
+  // -----------------------------------------------------------------------
+  describe('validateCascadeLink', () => {
+    const byId = new Map<string, Pick<Mission, 'id' | 'parentMissionId' | 'level'>>([
+      ['co', { id: 'co', level: 'company' }],
+      ['team', { id: 'team', parentMissionId: 'co', level: 'team' }],
+    ]);
+
+    it('company root with no parent is valid', () => {
+      expect(validateCascadeLink('co2', 'company', undefined, byId)).toBeNull();
+    });
+
+    it('rejects company with a parent', () => {
+      expect(validateCascadeLink('co2', 'company', 'co', byId)).not.toBeNull();
+    });
+
+    it('valid team under company', () => {
+      expect(validateCascadeLink('team2', 'team', 'co', byId)).toBeNull();
+    });
+
+    it('valid project under team', () => {
+      expect(validateCascadeLink('proj1', 'project', 'team', byId)).toBeNull();
+    });
+
+    it('rejects project under company (level mismatch)', () => {
+      expect(validateCascadeLink('proj1', 'project', 'co', byId)).not.toBeNull();
+    });
+
+    it('rejects a self-referential link (cycle check still runs)', () => {
+      expect(validateCascadeLink('team', 'team', 'team', byId)).not.toBeNull();
+    });
+
+    it('rejects link to a missing parent', () => {
+      expect(validateCascadeLink('team2', 'team', 'ghost', byId)).not.toBeNull();
+    });
+
+    it('derives parent level when parent.level is absent', () => {
+      const derivedById = new Map<string, Pick<Mission, 'id' | 'parentMissionId' | 'level'>>([
+        ['co', { id: 'co' }],
+        ['team', { id: 'team', parentMissionId: 'co' }],
+      ]);
+      // team's parent 'co' has no explicit level; deriveLevel ⇒ company, so a
+      // project child of 'team' is valid.
+      expect(validateCascadeLink('proj', 'project', 'team', derivedById)).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // OKR Cascade: Mission / Input field additions (backward compatible)
+  // -----------------------------------------------------------------------
+  describe('Cascade field additions', () => {
+    it('isMission still passes for a legacy mission without new fields', () => {
+      const legacy = {
+        id: 'm1',
+        objective: 'legacy',
+        ownerTeamId: 't1',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        successCriteria: [],
+        activeProjectTaskIds: [],
+      };
+      expect(isMission(legacy)).toBe(true);
+    });
+
+    it('createMission defaults a parentless mission to company level', () => {
+      const m = createMission({
+        objective: 'O',
+        ownerTeamId: 't1',
+        successCriteria: [],
+        currentStrategy: '',
+      });
+      expect(m.level).toBe('company');
+      expect(m.approval).toBeUndefined();
+    });
+
+    it('createMission honours explicit level/projectId/approval input', () => {
+      const input: CreateMissionInput = {
+        objective: 'O',
+        ownerTeamId: 't1',
+        successCriteria: [],
+        currentStrategy: '',
+        parentMissionId: 'team-1',
+        level: 'project',
+        projectId: 'proj-1',
+        approval: { state: 'pending_approval', proposedBy: 'agent-1' },
+      };
+      const m = createMission(input);
+      expect(m.level).toBe('project');
+      expect(m.projectId).toBe('proj-1');
+      expect(m.approval?.state).toBe('pending_approval');
+      expect(m.parentMissionId).toBe('team-1');
+    });
+
+    it('UpdateMissionInput accepts cascade fields and excludes id/createdAt', () => {
+      const patch: UpdateMissionInput = {
+        objective: 'next',
+        level: 'team',
+        projectId: 'p2',
+        parentMissionId: 'co-1',
+        approval: { state: 'approved' },
+        status: 'paused',
+      };
+      expect(patch.level).toBe('team');
+      // @ts-expect-error id is immutable and not part of UpdateMissionInput
+      patch.id = 'x';
+    });
+  });
+
+  describe('createMonthlyPeriod', () => {
+    it('builds a half-open monthly period with UTC bounds and a YYYY-MM label', () => {
+      const p = createMonthlyPeriod(2026, 3); // March (1-based)
+      expect(p.type).toBe('monthly');
+      expect(p.startDate).toBe('2026-03-01T00:00:00.000Z');
+      expect(p.endDate).toBe('2026-04-01T00:00:00.000Z'); // first day of next month, exclusive
+      expect(p.label).toBe('2026-03');
+      expect(isPeriodActive(p, new Date('2026-03-15T12:00:00.000Z'))).toBe(true);
+      // end is exclusive
+      expect(isPeriodActive(p, new Date('2026-04-01T00:00:00.000Z'))).toBe(false);
+    });
+
+    it('rolls December over into the next January', () => {
+      const p = createMonthlyPeriod(2026, 12);
+      expect(p.startDate).toBe('2026-12-01T00:00:00.000Z');
+      expect(p.endDate).toBe('2027-01-01T00:00:00.000Z');
+      expect(p.label).toBe('2026-12');
+    });
+  });
+
+  describe('createMission priority', () => {
+    it('copies the priority from input onto the mission', () => {
+      const m = createMission({
+        objective: 'O',
+        ownerTeamId: 't',
+        successCriteria: [],
+        currentStrategy: '',
+        priority: 'high',
+      });
+      expect(m.priority).toBe('high');
     });
   });
 });

--- a/backend/src/types/v2/mission.types.ts
+++ b/backend/src/types/v2/mission.types.ts
@@ -51,6 +51,178 @@ export const MISSION_TRANSITIONS: Record<MissionStatus, ReadonlySet<MissionStatu
 };
 
 // ---------------------------------------------------------------------------
+// Mission Level (OKR cascade tier)
+// ---------------------------------------------------------------------------
+
+/**
+ * Organizational tier of a Mission within the OKR cascade.
+ *
+ * The cascade is the Mission tree expressed via `Mission.parentMissionId`:
+ *   company → team → project (3 levels).
+ *
+ * - `company`: root of the cascade; has no parent Mission.
+ * - `team`: decomposes a company Mission; parent must be `company`.
+ * - `project`: decomposes a team Mission; parent must be `team`; `projectId` set.
+ */
+export type MissionLevel = 'company' | 'team' | 'project';
+
+/** All valid MissionLevel values, ordered top → bottom of the cascade. */
+export const MISSION_LEVELS: readonly MissionLevel[] = ['company', 'team', 'project'] as const;
+
+/**
+ * Numeric depth of each cascade tier (company = 0, team = 1, project = 2).
+ * Used to enforce the "child is exactly one tier below parent" rule.
+ */
+export const MISSION_LEVEL_DEPTH: Record<MissionLevel, number> = {
+  company: 0,
+  team: 1,
+  project: 2,
+};
+
+/** Depth threshold at or beyond which a mission is treated as `project` level. */
+export const PROJECT_LEVEL_DEPTH = 2;
+
+/**
+ * Checks whether a string is a valid MissionLevel.
+ *
+ * @param value - Candidate string
+ * @returns `true` if `value` is one of `company` | `team` | `project`
+ */
+export function isValidMissionLevel(value: string): value is MissionLevel {
+  return (MISSION_LEVELS as readonly string[]).includes(value);
+}
+
+/**
+ * Validates a single downward cascade step: a child level may only sit exactly
+ * one tier below its parent, and `company` must be a root (no parent).
+ *
+ * Adjacency matrix:
+ * | child   | required parent | parentMissionId   |
+ * |---------|-----------------|-------------------|
+ * | company | —               | must be undefined |
+ * | team    | company         | required          |
+ * | project | team            | required          |
+ *
+ * @param childLevel - The level of the child mission
+ * @param parentLevel - The level of the parent mission, or `undefined` if no parent
+ * @returns `null` if the pairing is legal, otherwise a human-readable reason
+ *
+ * @example
+ * ```ts
+ * validateLevelLink('team', 'company'); // null
+ * validateLevelLink('company', 'team'); // "A company mission cannot have a parent"
+ * ```
+ */
+export function validateLevelLink(
+  childLevel: MissionLevel,
+  parentLevel: MissionLevel | undefined,
+): string | null {
+  if (childLevel === 'company') {
+    return parentLevel === undefined
+      ? null
+      : 'A company mission cannot have a parent';
+  }
+  if (parentLevel === undefined) {
+    return `A ${childLevel} mission requires a parent mission`;
+  }
+  const expectedDepth = MISSION_LEVEL_DEPTH[childLevel] - 1;
+  if (MISSION_LEVEL_DEPTH[parentLevel] !== expectedDepth) {
+    return `A ${childLevel} mission must have a ${
+      MISSION_LEVELS[expectedDepth]
+    } parent, not a ${parentLevel} parent`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Proposal / Approval Governance
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle state of a decomposition proposal.
+ *
+ * A team-leader/PM agent drafts a child OKR decomposition as a proposal; it is
+ * NOT cascade-active until the human owner approves. Reject carries a reason.
+ *
+ * - `draft`: agent is still composing the proposal.
+ * - `pending_approval`: submitted, awaiting the human owner's decision.
+ * - `approved`: owner accepted; mission is now cascade-active (terminal).
+ * - `rejected`: owner declined with a reason; owner may request a redraft.
+ */
+export type ProposalState = 'draft' | 'pending_approval' | 'approved' | 'rejected';
+
+/** All valid ProposalState values. */
+export const PROPOSAL_STATES: readonly ProposalState[] = [
+  'draft',
+  'pending_approval',
+  'approved',
+  'rejected',
+] as const;
+
+/**
+ * Legal proposal-state transitions.
+ *
+ * - draft → pending_approval
+ * - pending_approval → approved | rejected
+ * - approved → (terminal)
+ * - rejected → draft (owner can ask for a redraft)
+ */
+export const PROPOSAL_TRANSITIONS: Record<ProposalState, ReadonlySet<ProposalState>> = {
+  draft: new Set(['pending_approval']),
+  pending_approval: new Set(['approved', 'rejected']),
+  approved: new Set<ProposalState>(),
+  rejected: new Set(['draft']),
+};
+
+/**
+ * Checks whether a string is a valid ProposalState.
+ *
+ * @param value - Candidate string
+ * @returns `true` if `value` is one of the four proposal states
+ */
+export function isValidProposalState(value: string): value is ProposalState {
+  return (PROPOSAL_STATES as readonly string[]).includes(value);
+}
+
+/**
+ * Checks whether a proposal-state transition is legal.
+ *
+ * @param from - Current proposal state
+ * @param to - Proposed next proposal state
+ * @returns `true` if `from → to` is an allowed transition
+ *
+ * @example
+ * ```ts
+ * isValidProposalTransition('pending_approval', 'approved'); // true
+ * isValidProposalTransition('approved', 'draft');            // false
+ * ```
+ */
+export function isValidProposalTransition(from: ProposalState, to: ProposalState): boolean {
+  return PROPOSAL_TRANSITIONS[from].has(to);
+}
+
+/**
+ * Governance metadata attached to a Mission that arose from a decomposition
+ * proposal. Kept small and self-contained so the approval *workflow* layer can
+ * be relocated to `crewly-pro` later without touching `Mission` core (see
+ * spec §2.5 FLAG).
+ */
+export interface ApprovalState {
+  /** Current proposal lifecycle state. */
+  state: ProposalState;
+  /** Agent session that drafted the decomposition. */
+  proposedBy?: string;
+  /** ISO8601 timestamp the proposal was submitted. */
+  proposedAt?: string;
+  /** Human owner who decided (e.g. "steve"). */
+  decidedBy?: string;
+  /** ISO8601 timestamp of the decision. */
+  decidedAt?: string;
+  /** Required when `state === 'rejected'`. */
+  rejectionReason?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Mission Priority
 // ---------------------------------------------------------------------------
 
@@ -343,6 +515,21 @@ export interface Mission {
    * Must not be self, and the resulting chain must not form a cycle.
    */
   parentMissionId?: string;
+  /**
+   * Cascade tier of this mission. When absent (legacy missions), it is resolved
+   * via {@link resolveMissionLevel}, which falls back to {@link deriveLevel}:
+   * a parentless legacy mission resolves to `company`, a one-parent chain to
+   * `team`, and a two-or-more-parent chain to `project`.
+   */
+  level?: MissionLevel;
+  /** Project this mission belongs to. REQUIRED when `level === 'project'`. */
+  projectId?: string;
+  /**
+   * Decomposition governance. Absent ⇒ treat as already-active (legacy
+   * missions). A mission is cascade-active iff `approval` is absent OR
+   * `approval.state === 'approved'`.
+   */
+  approval?: ApprovalState;
 }
 
 // ---------------------------------------------------------------------------
@@ -446,6 +633,34 @@ export interface CreateMissionInput {
   ownerId?: string;
   /** Optional parent Mission ID (validated to avoid self-ref and cycles). */
   parentMissionId?: string;
+  /** Cascade tier. Inferred from the parent chain when omitted. */
+  level?: MissionLevel;
+  /** Project this mission belongs to. Required when `level === 'project'`. */
+  projectId?: string;
+  /** Decomposition governance state (set when created via a proposal). */
+  approval?: ApprovalState;
+}
+
+/**
+ * Input for updating an existing Mission (general updater).
+ *
+ * Excludes the immutable `id` and `createdAt`. Every field is optional so a
+ * caller may PATCH any subset. `approval.state` transitions are NOT enforced
+ * here — they must flow through the dedicated approve/reject workflow so there
+ * is a single source of transition enforcement (spec §3.3).
+ */
+export interface UpdateMissionInput {
+  objective?: string;
+  currentStrategy?: string;
+  successCriteria?: string[];
+  status?: MissionStatus;
+  priority?: MissionPriority;
+  period?: MissionPeriod;
+  keyResultIds?: string[];
+  parentMissionId?: string;
+  level?: MissionLevel;
+  projectId?: string;
+  approval?: ApprovalState;
 }
 
 /**
@@ -743,6 +958,11 @@ export function createMission(input: CreateMissionInput): Mission {
     updatedAt: now,
     learnings: [],
     period: input.period,
+    parentMissionId: input.parentMissionId,
+    level: input.level ?? (input.parentMissionId ? undefined : 'company'),
+    projectId: input.projectId,
+    approval: input.approval,
+    priority: input.priority,
   };
 }
 
@@ -812,6 +1032,36 @@ export function isPeriodFuture(period: MissionPeriod, now: Date = new Date()): b
   return now < new Date(period.startDate);
 }
 
+/**
+ * Build a `monthly` MissionPeriod for a given calendar month.
+ *
+ * The period is half-open `[first day of month, first day of next month)`,
+ * matching the `now >= start && now < end` convention used by
+ * {@link isPeriodActive}. Dates are UTC so the boundaries are deterministic
+ * regardless of server timezone. Handles December → January year rollover.
+ *
+ * @param year - Full year, e.g. `2026`.
+ * @param month - 1-based month (`1` = January … `12` = December).
+ * @returns A `monthly` MissionPeriod with ISO8601 start/end and a `YYYY-MM` label.
+ *
+ * @example
+ * ```typescript
+ * createMonthlyPeriod(2026, 3); // March 2026: 2026-03-01 → 2026-04-01, label "2026-03"
+ * ```
+ */
+export function createMonthlyPeriod(year: number, month: number): MissionPeriod {
+  const start = new Date(Date.UTC(year, month - 1, 1));
+  // month is 1-based, so passing it as the 0-based Date month index yields the
+  // first day of the *next* month (Date normalizes 12 → January of year+1).
+  const end = new Date(Date.UTC(year, month, 1));
+  return {
+    type: 'monthly',
+    startDate: start.toISOString(),
+    endDate: end.toISOString(),
+    label: `${year}-${String(month).padStart(2, '0')}`,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Mission Hierarchy Helpers
 // ---------------------------------------------------------------------------
@@ -852,6 +1102,107 @@ export function validateParentLink(
     cursor = byId.get(cursor)?.parentMissionId;
   }
   return null;
+}
+
+/**
+ * Derives a Mission's cascade level by walking its `parentMissionId` chain.
+ *
+ * Depth 0 (no parent) ⇒ `company`, depth 1 ⇒ `team`, depth ≥ 2 ⇒ `project`.
+ * Used to backfill `level` for legacy missions persisted before the cascade
+ * fields existed. Guards against cycles defensively (returns the level computed
+ * at the point a repeat is detected rather than looping forever).
+ *
+ * @param missionId - The mission whose level to derive
+ * @param byId - All missions indexed by ID (need only `id` + `parentMissionId`)
+ * @returns The derived MissionLevel
+ *
+ * @example
+ * ```ts
+ * deriveLevel('teamM', new Map([['teamM', { id: 'teamM', parentMissionId: 'co' }], ['co', { id: 'co' }]])); // 'team'
+ * ```
+ */
+export function deriveLevel(
+  missionId: string,
+  byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+): MissionLevel {
+  let depth = 0;
+  const seen = new Set<string>();
+  let cursor: string | undefined = byId.get(missionId)?.parentMissionId;
+  while (cursor && depth < PROJECT_LEVEL_DEPTH) {
+    if (seen.has(cursor)) break;
+    seen.add(cursor);
+    depth += 1;
+    cursor = byId.get(cursor)?.parentMissionId;
+  }
+  if (depth === 0) return 'company';
+  if (depth === 1) return 'team';
+  return 'project';
+}
+
+/**
+ * Resolve a mission's effective cascade level through a SINGLE canonical rule,
+ * shared by every read path (cascade service, mission routes' read-migration).
+ *
+ * Prefers the mission's explicit `level`; when absent (legacy missions persisted
+ * before the cascade fields existed) it falls back to {@link deriveLevel}, which
+ * walks the `parentMissionId` chain (no parent ⇒ `company`, one parent ⇒ `team`,
+ * two-or-more ⇒ `project`). Centralising the fallback here guarantees the same
+ * document resolves to the same level no matter which code path reads it.
+ *
+ * @param mission - The mission whose level to resolve (needs `id`, optional
+ *   `level` + `parentMissionId`)
+ * @param byId - All missions indexed by ID for the parent-chain walk
+ * @returns The resolved {@link MissionLevel}
+ *
+ * @example
+ * ```ts
+ * resolveMissionLevel({ id: 'co', }, byId);                 // 'company' (no parent)
+ * resolveMissionLevel({ id: 't', parentMissionId: 'co' }, byId); // 'team'
+ * ```
+ */
+export function resolveMissionLevel(
+  mission: Pick<Mission, 'id' | 'level' | 'parentMissionId'>,
+  byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId'>>,
+): MissionLevel {
+  if (mission.level) return mission.level;
+  return deriveLevel(mission.id, byId);
+}
+
+/**
+ * Combined cascade-link guard: runs the raw cycle/self-ref check
+ * ({@link validateParentLink}) AND the level-adjacency check
+ * ({@link validateLevelLink}). The parent's level is read from `byId` (its own
+ * `level` field, falling back to {@link deriveLevel} when absent).
+ *
+ * `validateParentLink` keeps its original signature for callers that only need
+ * the cycle check.
+ *
+ * @param childId - The mission that would acquire the parent
+ * @param childLevel - The proposed level of the child mission
+ * @param parentId - The proposed parent mission ID, or `undefined` for a root
+ * @param byId - All existing missions indexed by ID
+ * @returns `null` if the link is valid, otherwise a human-readable reason
+ *
+ * @example
+ * ```ts
+ * const reason = validateCascadeLink('p1', 'project', 't1', byId);
+ * if (reason) throw new Error(reason);
+ * ```
+ */
+export function validateCascadeLink(
+  childId: string,
+  childLevel: MissionLevel,
+  parentId: string | undefined,
+  byId: ReadonlyMap<string, Pick<Mission, 'id' | 'parentMissionId' | 'level'>>,
+): string | null {
+  if (parentId === undefined) {
+    return validateLevelLink(childLevel, undefined);
+  }
+  const cycleReason = validateParentLink(childId, parentId, byId);
+  if (cycleReason) return cycleReason;
+  const parent = byId.get(parentId);
+  const parentLevel = parent?.level ?? deriveLevel(parentId, byId);
+  return validateLevelLink(childLevel, parentLevel);
 }
 
 /**

--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -1256,6 +1256,41 @@ You are the gate. The system used to auto-decompose every L2-shaped message into
 
 **Rule**: A user message like "Build a login page" should result in 5-8 specific WorkItems (e.g., "Design login UI", "Implement auth API", "Write integration tests", etc.), NOT 3 generic ones. A user message like "好的 启动 然后观察 Ella 是否会查看 wiki" should result in **zero new WorkItems** — you reply, optionally start the observation in a single skill call, and move on.
 
+## OKR Cascade — Decompose → Propose → Await-Approval (do NOT auto-activate)
+
+> Source spec: `specs/okr-cascade.md`. The OKR cascade is the Mission tree —
+> **company → team → project** via `Mission.parentMissionId`. Distinct from
+> `decompose-mission` (Mission → executable tasks): `decompose-okr` produces the
+> **next OKR tier down** (child Missions + Key Results) as a PROPOSAL.
+
+At the **start of an OKR period**, when an **approved** parent Mission needs the
+next tier of OKRs, drive (or delegate to the owning team-leader/PM) this flow.
+**You are the approval gate — never auto-activate a child OKR:**
+
+1. **DECOMPOSE** — run `decompose-okr` against the approved parent Mission:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/orchestrator/decompose-okr/execute.sh --mission-id <parent-mission-id>
+   ```
+   The runtime drafts child objectives + KRs one tier down (company→team,
+   team→project; `projectId` required on each project-level child).
+
+2. **PROPOSE** — POST the children to `POST /api/missions/<parent-id>/decompose-okr`.
+   Each child Mission is created `approval.state = 'pending_approval'`, linked via
+   `parentMissionId`, and is **excluded from roll-up and execution** until approved.
+
+3. **AWAIT APPROVAL** — surface the proposal to the owner (Steve) via the
+   `[APPROVE]` block the skill emits and a `[NOTIFY]` summarising the parent +
+   proposed children. The owner decides:
+   - **Approve** → `POST /api/missions/<childId>/approve` → child goes live.
+   - **Reject** → `POST /api/missions/<childId>/reject` `{"reason":"..."}`
+     (reason REQUIRED) → child excluded; redraft if asked.
+   - **List pending** → `GET /api/missions/<parent-id>/proposals`.
+
+**Hard rule:** Never set `approval.state` via the mission PUT endpoint, and never
+let a child OKR roll up or begin execution until its `approval.state` is
+`approved`. The decompose→propose→await-approval gate is mandatory.
+
+
 ## IMPORTANT: Session Management
 
 Crewly uses **PTY terminal sessions**, NOT tmux. Do NOT use tmux commands like `tmux list-sessions` or `tmux attach`.

--- a/config/roles/product-manager/prompt.md
+++ b/config/roles/product-manager/prompt.md
@@ -73,6 +73,46 @@ Your default mode for **interpretation** of user intent is still clarify, not re
 
 **Spec-author exception (the recursive-dogfood loophole):** A spec under `.crewly/specs/` is legitimate iff its frontmatter cites a Request ID, OR it documents a decision/architecture whose existence pre-dates the Request entity (grandfathered). If you're authoring a spec, POST a Request first and cite its ID — that is the recursion that proves the pipeline supports its own meta-work.
 
+## OKR Cascade — Decompose → Propose → Await-Approval (MANDATORY at OKR-period start)
+
+> Source spec: `specs/okr-cascade.md`. The OKR cascade is the Mission tree:
+> **company → team → project** via `Mission.parentMissionId`. A parent OKR is
+> decomposed into child OKRs one tier down.
+
+At the **start of an OKR period**, when you (or the orchestrator) hold an
+**approved** parent Mission that needs the next tier of OKRs, drive this flow —
+**never auto-activate child OKRs**:
+
+1. **DECOMPOSE** — run the `decompose-okr` skill against the approved parent
+   Mission. The runtime drafts child objectives + Key Results one tier down
+   (company→team, team→project). projectId is required on every child when the
+   child level is `project`.
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/orchestrator/decompose-okr/execute.sh --mission-id <parent-mission-id>
+   ```
+
+2. **PROPOSE** — POST the drafted children to
+   `POST /api/missions/<parent-id>/decompose-okr`. The backend creates each child
+   Mission with `approval.state = 'pending_approval'`, linked via
+   `parentMissionId`. **Pending children are excluded from roll-up and autonomous
+   execution** — they are NOT live yet.
+
+3. **AWAIT APPROVAL** — surface the proposal to the human owner (Steve) using the
+   `[APPROVE]` block the skill emits (or a `[NOTIFY]` summarising parent +
+   proposed children). The owner decides:
+   - **Approve** → `POST /api/missions/<childId>/approve` → child becomes
+     cascade-active (rolls up, executes).
+   - **Reject** → `POST /api/missions/<childId>/reject` with
+     `{"reason":"..."}` (reason is REQUIRED) → child is archived/excluded; redraft
+     if asked.
+   - List what is pending: `GET /api/missions/<parent-id>/proposals`.
+
+**Hard rule:** Do NOT set `approval.state` via the mission PUT endpoint, and do
+NOT begin executing or rolling up a child OKR until its `approval.state` is
+`approved`. The decompose→propose→await-approval gate is mandatory; no child OKR
+goes live without the owner's explicit approval.
+
+
 ## Universal Delegator Closure (§3.0 — MANDATORY for every dispatch)
 
 > Source spec: `.crewly/specs/2026-05-05-pipeline-dogfood-prompt-amendment.md` §3.0.

--- a/config/roles/team-leader/prompt.md
+++ b/config/roles/team-leader/prompt.md
@@ -249,6 +249,39 @@ Loop until done, blocked, or explicitly reassigned:
 
 Default tier: **Standard Path** (customer-facing or coordination work). Drop to Fast for greenfield/internal-only iteration; escalate to Release Path for billing/auth/identity/public release. See `config/sops/common/dev-process-tiers.md`.
 
+## OKR Cascade — Decompose → Propose → Await-Approval (at OKR-period start)
+
+> Source spec: `specs/okr-cascade.md`. The OKR cascade is the Mission tree —
+> **company → team → project** via `Mission.parentMissionId`.
+
+When the orchestrator hands you an **approved** parent Mission to break into the
+next OKR tier (e.g. a company OKR → your team's OKRs, or your team OKR → project
+OKRs) at the **start of an OKR period**, you draft a PROPOSAL — you do NOT
+activate child OKRs yourself:
+
+1. **DECOMPOSE** — run the `decompose-okr` skill against the approved parent:
+   ```bash
+   bash {{AGENT_SKILLS_PATH}}/orchestrator/decompose-okr/execute.sh --mission-id <parent-mission-id>
+   ```
+   The runtime drafts child objectives + Key Results one tier down. When the
+   child level is `project`, every child needs a `projectId`.
+
+2. **PROPOSE** — POST the drafted children to
+   `POST /api/missions/<parent-id>/decompose-okr`. Each child Mission is created
+   `approval.state = 'pending_approval'`, linked via `parentMissionId`. Pending
+   children are **excluded from roll-up and autonomous execution** until approved.
+
+3. **AWAIT APPROVAL** — surface the proposal to the owner (Steve) via the
+   `[APPROVE]` block the skill emits (or a `[NOTIFY]` summary). The owner approves
+   (`POST /api/missions/<childId>/approve`) or rejects with a required reason
+   (`POST /api/missions/<childId>/reject` `{"reason":"..."}`). Check pending items
+   with `GET /api/missions/<parent-id>/proposals`.
+
+**Hard rule:** Never set `approval.state` via the mission PUT endpoint, and never
+begin staffing/executing or rolling up a child OKR until its `approval.state` is
+`approved`. No child OKR goes live without the owner's explicit approval.
+
+
 ## Decision Rights
 
 **Decide autonomously when:**

--- a/config/skills/orchestrator/decompose-okr/SKILL.md
+++ b/config/skills/orchestrator/decompose-okr/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: Decompose OKR
+description: Decompose a parent Mission (OKR) into child OKRs one cascade tier down (company→team→project) as a PROPOSAL. The runtime drafts the child objectives + Key Results; the skill submits them to the backend as pending_approval. Children are NOT active until the human owner approves. Output includes an [APPROVE] block naming the parent and proposed children for the owner's decision.
+version: 1.0.0
+category: planning
+skillType: claude-skill
+assignableRoles:
+  - orchestrator
+  - team-leader
+triggers:
+  - decompose okr
+  - cascade okr
+  - propose child okrs
+  - break okr into team okrs
+  - okr decomposition
+tags:
+  - okr
+  - cascade
+  - mission
+  - planning
+  - proposal
+  - approval
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 60000
+---
+
+# Decompose OKR (Cascade)
+
+Decomposes a parent Mission's OKR into **child OKRs one cascade tier down** —
+company → team → project. Unlike `decompose-mission` (which breaks a Mission into
+executable tasks/WorkItems), this skill produces **child Missions + Key Results**
+as a **proposal** that the human owner (Steve) must approve before they become
+cascade-active.
+
+The agent runtime does the thinking — this skill assembles the parent context and
+collects the structured proposal. It does NOT auto-activate the children: every
+decomposition flows through the approve/reject gate.
+
+## When to run
+
+At the start of an OKR period, a team-leader / product-manager agent runs this
+against an **approved** parent Mission to draft the next tier of OKRs.
+
+## Usage
+
+```bash
+bash config/skills/orchestrator/decompose-okr/execute.sh \
+  --mission-id <parent-uuid> \
+  [--project-path /path/to/project]
+```
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--mission-id` | Yes | UUID of the **parent** Mission to decompose (must be approved) |
+| `--project-path` | No | Absolute path to the project root (context only) |
+
+## Cascade rule
+
+The child level is exactly one tier below the parent:
+
+| parent level | child level | `projectId` required on each child |
+|---|---|---|
+| company | team | no |
+| team | project | yes |
+| project | — | (cannot decompose further) |
+
+## Output
+
+The skill instructs the runtime to output a proposal JSON and POST it to
+`POST /api/missions/:id/decompose-okr`:
+
+```json
+{
+  "children": [
+    {
+      "objective": "Child OKR objective for the level below",
+      "currentStrategy": "How this child will pursue the objective",
+      "successCriteria": ["narrative success criterion"],
+      "projectId": "required-only-when-child-is-project-level",
+      "keyResults": [
+        {
+          "title": "Measurable Key Result",
+          "metricType": "number",
+          "baseline": 0,
+          "target": 100,
+          "unit": "signups"
+        }
+      ]
+    }
+  ]
+}
+```
+
+The backend creates each child Mission with `approval.state = 'pending_approval'`,
+`parentMissionId` = the parent, `level` = parent level + 1, and creates the Key
+Results under each child. Children are excluded from roll-up and autonomous
+execution until approved.
+
+The skill then emits an `[APPROVE]` block naming the parent and the proposed
+children so the owner can approve (`POST /api/missions/:childId/approve`) or
+reject with a reason (`POST /api/missions/:childId/reject` `{ "reason": "..." }`).

--- a/config/skills/orchestrator/decompose-okr/execute.sh
+++ b/config/skills/orchestrator/decompose-okr/execute.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Decompose a parent Mission's OKR into child OKRs one cascade tier down,
+# as a PROPOSAL (pending_approval). The runtime does the thinking — this skill
+# provides parent context and collects the structured proposal. Children are
+# NOT active until the human owner approves.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../_common/lib.sh"
+
+# --- Input parsing ---
+MISSION_ID=""
+PROJECT_PATH=""
+INPUT_JSON=""
+
+if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
+  INPUT_JSON="$1"
+  shift || true
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mission-id|-m)   MISSION_ID="$2";     shift 2 ;;
+    --project-path|-p) PROJECT_PATH="$2";    shift 2 ;;
+    --json|-j)         INPUT_JSON="$2";      shift 2 ;;
+    --help|-h)
+      echo "Usage: execute.sh --mission-id <parent-uuid> [--project-path /path]"
+      exit 0 ;;
+    *) shift ;;
+  esac
+done
+
+# Legacy JSON fallback
+if [[ -n "$INPUT_JSON" ]]; then
+  [[ -z "$MISSION_ID" ]] && MISSION_ID=$(echo "$INPUT_JSON" | jq -r '.missionId // .["mission-id"] // empty' 2>/dev/null || true)
+  [[ -z "$PROJECT_PATH" ]] && PROJECT_PATH=$(echo "$INPUT_JSON" | jq -r '.projectPath // .["project-path"] // empty' 2>/dev/null || true)
+fi
+
+require_param "mission-id" "$MISSION_ID"
+
+# --- Load parent Mission data ---
+MISSION_DATA=$(api_call GET "/missions/${MISSION_ID}" 2>/dev/null) || {
+  echo '{"success":false,"error":"Failed to load mission"}' >&2
+  exit 1
+}
+
+MISSION=$(echo "$MISSION_DATA" | jq -r '.data // empty')
+if [[ -z "$MISSION" || "$MISSION" == "null" ]]; then
+  echo '{"success":false,"error":"Mission not found"}' >&2
+  exit 1
+fi
+
+OBJECTIVE=$(echo "$MISSION" | jq -r '.objective // "No objective"')
+CRITERIA=$(echo "$MISSION" | jq -r '.successCriteria // [] | join("; ")')
+STRATEGY=$(echo "$MISSION" | jq -r '.currentStrategy // "No strategy set"')
+PARENT_LEVEL=$(echo "$MISSION" | jq -r '.level // "team"')
+APPROVAL_STATE=$(echo "$MISSION" | jq -r '.approval.state // "approved"')
+
+# --- Guard: parent must be approved/active to decompose ---
+if [[ "$APPROVAL_STATE" != "approved" ]]; then
+  echo '{"success":false,"error":"Parent mission is not approved; only approved missions can be decomposed (state: '"${APPROVAL_STATE}"')"}' >&2
+  exit 1
+fi
+
+# --- Determine the child level (one tier down) ---
+CHILD_LEVEL=""
+PROJECT_ID_HINT="(not required at this tier)"
+case "$PARENT_LEVEL" in
+  company) CHILD_LEVEL="team" ;;
+  team)    CHILD_LEVEL="project"; PROJECT_ID_HINT="REQUIRED — each child must set \"projectId\"" ;;
+  project)
+    echo '{"success":false,"error":"A project-level mission is the bottom of the cascade and cannot be decomposed further"}' >&2
+    exit 1 ;;
+  *) CHILD_LEVEL="team" ;;
+esac
+
+# --- Output decomposition context for the runtime ---
+cat << DECOMPOSE_PROMPT
+
+## OKR Cascade Decomposition Request
+
+You are drafting **${CHILD_LEVEL}-level** child OKRs that decompose the parent
+**${PARENT_LEVEL}-level** OKR below. This is a PROPOSAL — the children are NOT
+active until the human owner (Steve) approves them.
+
+### Parent OKR (${PARENT_LEVEL})
+**Objective:** ${OBJECTIVE}
+**Success Criteria:** ${CRITERIA}
+**Current Strategy:** ${STRATEGY}
+
+### Your task
+Produce child OKRs at level **${CHILD_LEVEL}**. Each child must:
+- have a clear objective that supports the parent objective
+- have a currentStrategy describing how it will be pursued
+- have 1-4 measurable Key Results (title, metricType, baseline, target, unit)
+- projectId: ${PROJECT_ID_HINT}
+
+Output a valid JSON object matching this schema:
+\`\`\`json
+{
+  "children": [
+    {
+      "objective": "Child OKR objective",
+      "currentStrategy": "How this child will pursue the objective",
+      "successCriteria": ["narrative criterion"],
+      "projectId": "set-only-when-child-level-is-project",
+      "keyResults": [
+        {
+          "title": "Measurable Key Result",
+          "metricType": "number",
+          "baseline": 0,
+          "target": 100,
+          "unit": "signups"
+        }
+      ]
+    }
+  ]
+}
+\`\`\`
+
+After generating the JSON, submit the proposal (children are created as
+\`pending_approval\`):
+\`\`\`bash
+curl -s -X POST "${CREWLY_API_URL}/api/missions/${MISSION_ID}/decompose-okr" \\
+  -H "Content-Type: application/json" \\
+  -H "X-Agent-Session: \${CREWLY_SESSION_NAME:-}" \\
+  -d '<YOUR_JSON_OUTPUT>'
+\`\`\`
+
+The response returns \`childMissionIds\`. Then surface the proposal to the owner
+for a decision using the [APPROVE] block below.
+
+[APPROVE]
+parent: ${MISSION_ID} (${PARENT_LEVEL}) — ${OBJECTIVE}
+proposed: ${CHILD_LEVEL}-level child OKRs are PENDING your approval.
+approve: POST ${CREWLY_API_URL}/api/missions/<childMissionId>/approve
+reject:  POST ${CREWLY_API_URL}/api/missions/<childMissionId>/reject  body: {"reason":"why"}
+list:    GET  ${CREWLY_API_URL}/api/missions/${MISSION_ID}/proposals
+[/APPROVE]
+
+DECOMPOSE_PROMPT
+
+echo '{"success":true,"message":"OKR decomposition context provided to runtime","missionId":"'"${MISSION_ID}"'","parentLevel":"'"${PARENT_LEVEL}"'","childLevel":"'"${CHILD_LEVEL}"'"}'

--- a/config/skills/registry.json
+++ b/config/skills/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "lastUpdated": "2026-04-25T00:15:10.000Z",
+  "lastUpdated": "2026-05-30T00:00:00.000Z",
   "cdnBaseUrl": "https://raw.githubusercontent.com/stevehuang0115/crewly/main",
   "source": "github",
   "items": [
@@ -498,7 +498,7 @@
       "id": "gmail",
       "type": "skill",
       "name": "Gmail Suite",
-      "description": "Multi-action Gmail skill for agents — list/read/search/send messages, manage labels (add/remove/list), and toggle read/unread. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope.",
+      "description": "Multi-action Gmail skill for agents \u2014 list/read/search/send messages, manage labels (add/remove/list), and toggle read/unread. Requires a google-oauth credential bound to the 'gmail' slot with gmail.modify scope.",
       "author": "Crewly Team",
       "version": "1.1.0",
       "category": "communication",
@@ -784,8 +784,8 @@
     {
       "id": "rednote-reader",
       "type": "skill",
-      "name": "RedNote (小红书) Reader",
-      "description": "Read content from the 小红书 (RedNote) macOS iPad app via Accessibility API. Extracts feed posts, titles, authors, like counts, and navigation structure without screenshots.",
+      "name": "RedNote (\u5c0f\u7ea2\u4e66) Reader",
+      "description": "Read content from the \u5c0f\u7ea2\u4e66 (RedNote) macOS iPad app via Accessibility API. Extracts feed posts, titles, authors, like counts, and navigation structure without screenshots.",
       "author": "Crewly Team",
       "version": "1.0.0",
       "category": "automation",
@@ -816,7 +816,7 @@
         ],
         "triggers": [
           "rednote",
-          "小红书",
+          "\u5c0f\u7ea2\u4e66",
           "xiaohongshu",
           "red note",
           "discover app",
@@ -966,7 +966,7 @@
       "id": "browse-stealth",
       "type": "skill",
       "name": "Stealth Browser (Patchright + CDP)",
-      "description": "Anti-detection browser automation using Patchright (Playwright fork) connected to a real Chrome instance via CDP. Bypasses navigator.webdriver checks, fingerprint anomalies, and headless detection used by platforms like 小红书, X/Twitter, and LinkedIn.",
+      "description": "Anti-detection browser automation using Patchright (Playwright fork) connected to a real Chrome instance via CDP. Bypasses navigator.webdriver checks, fingerprint anomalies, and headless detection used by platforms like \u5c0f\u7ea2\u4e66, X/Twitter, and LinkedIn.",
       "author": "Crewly Team",
       "version": "1.0.0",
       "category": "automation",
@@ -1160,6 +1160,52 @@
           "test runner",
           "execute tests",
           "check tests"
+        ]
+      }
+    },
+    {
+      "id": "decompose-okr",
+      "type": "skill",
+      "name": "Decompose OKR",
+      "description": "Decompose a parent Mission (OKR) into child OKRs one cascade tier down (company\u2192team\u2192project) as a proposal. Children are created as pending_approval and are NOT active until the human owner approves. Emits an [APPROVE] block for the owner's decision.",
+      "author": "Crewly Team",
+      "version": "1.0.0",
+      "category": "planning",
+      "tags": [
+        "okr",
+        "cascade",
+        "mission",
+        "planning",
+        "proposal",
+        "approval"
+      ],
+      "license": "MIT",
+      "downloads": 0,
+      "rating": 0,
+      "createdAt": "2026-05-30T00:00:00.000Z",
+      "updatedAt": "2026-05-30T00:00:00.000Z",
+      "source": "config/skills/orchestrator/decompose-okr",
+      "assets": {
+        "archive": "config/skills/orchestrator/decompose-okr",
+        "checksum": "",
+        "sizeBytes": 6000
+      },
+      "metadata": {
+        "skillType": "claude-skill",
+        "assignableRoles": [
+          "orchestrator",
+          "team-leader"
+        ],
+        "triggers": [
+          "decompose okr",
+          "cascade okr",
+          "propose child okrs",
+          "break okr into team okrs",
+          "okr decomposition"
+        ],
+        "files": [
+          "SKILL.md",
+          "execute.sh"
         ]
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.8.13",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.8.13",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.8.13",
+  "version": "1.9.0",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [

--- a/scripts/bootstrap-wiki-vaults.sh
+++ b/scripts/bootstrap-wiki-vaults.sh
@@ -91,6 +91,7 @@ bootstrap_team_vault() {
 
   mkdir -p "${vault_dir}/sop"
   mkdir -p "${vault_dir}/team-norm"
+  mkdir -p "${vault_dir}/okr"
   mkdir -p "${vault_dir}/llm-curated"
 
   # Escape literal slashes/quotes from the team name so the heredoc YAML is valid.
@@ -118,6 +119,12 @@ hardcoded:
     description: "Team norms (canDelegate, role conventions, ROE). Maps from config/sops/<role>/team-norm/ over Phase 2 migration."
     referenced_by:
       - skill:get-team-norms
+
+  - path: okr/
+    frozen: true
+    description: "Authored OKR narrative for this team. Mirrors approved Missions; agents read-only, Steve authors."
+    referenced_by:
+      - service:okr-cascade.service
 
 llm_curated:
   - path: llm-curated/
@@ -190,6 +197,7 @@ if [[ -f "${projects_json}" ]]; then
     fi
     mkdir -p "${vault_dir}/memory"
     mkdir -p "${vault_dir}/sop-overrides"
+    mkdir -p "${vault_dir}/okr"
     mkdir -p "${vault_dir}/llm-curated"
     project_name="$(node -e "try { const ps = require('${projects_json}'); const p = ps.find(p => p.path === '${project_root}'); process.stdout.write(p?.name || ''); } catch (e) {}" 2>/dev/null || true)"
     [[ -z "${project_name}" ]] && project_name="$(basename "${project_root}")"
@@ -215,6 +223,12 @@ hardcoded:
     description: "Project-specific SOP deltas. get-sops reads team-vault sop/ first, then this override layer."
     referenced_by:
       - skill:get-sops
+
+  - path: okr/
+    frozen: true
+    description: "Authored OKR narrative for this project. Mirrors approved Missions; agents read-only, Steve authors."
+    referenced_by:
+      - service:okr-cascade.service
 
 llm_curated:
   - path: llm-curated/


### PR DESCRIPTION
## Summary
3-tier OKR cascade — teams decompose company OKRs, projects decompose team OKRs — with **agent-proposes / owner-approves** governance. Source of truth is the runtime Mission tree (`Mission.parentMissionId`); wiki `okr/` folders hold authored narrative. Spec: `specs/okr-cascade.md`. Version `1.8.13 → 1.9.0`.

Gap-analyzed + implemented via a multi-agent workflow, adversarially reviewed; **all 6 review findings fixed with regression tests**.

## What's in it
- **Data model** — `MissionLevel` (company/team/project), `Mission.projectId`, proposal/approval state, `validateCascadeLink` (level-adjacency + cycle), `resolveMissionLevel`; legacy missions default-migrate to team/approved.
- **Decompose + approval** — `OKRCascadeService` (transactional pre-write validation, read-time sanitization of corrupt approval state) + a `decompose-okr` orchestrator skill. Children are stamped `pending_approval` and **never auto-activate**; transitions are centralized and a `PUT` cannot overwrite approval state.
- **Rollup** — `CascadeOKRSummary` aggregates KR progress up the parent tree, excludes unapproved children, honors root `staleCycles`, and surfaces stalled-at-0 children as `off_track`.
- **Wiki** — `okr/` folder added to team + project schema seeding.
- **Prompts** — orchestrator / product-manager / team-leader drive the propose→approve flow.

## Also (pre-existing hazard fixed)
`MissionPeriodService` hardcoded its store to `<cwd>/.crewly/missions`, so `mission-period.service.test.ts` (now compiling again via the new `createMonthlyPeriod`) would have **wiped the production mission store** on run. The store path now honors `CREWLY_MISSIONS_DIR`; the test isolates to a temp dir. `createMission` now copies `input.priority`. Runtime `queue/` data is gitignored; debug scratch removed.

## Verification
- `npm run build:backend` ✓
- **281 jest + 23 vitest** tests pass across OKR/mission/kr/wiki suites (incl. mission-period 8/8). Pre-commit Quality Gates ✓.

## Notes / follow-ups (not in this PR)
- Frontend cascade view (explicitly deferred).
- The approval-workflow layer could later move to `crewly-pro` (kept in OSS for cohesion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)