### PR TITLE
feat(chat): Slack-style team-chat UI (flat messages, no lonely rail, deduped header)

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -409,8 +409,18 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     );
   });
 
-  it('injects a Direct Messages workspace so DMs show without any team channels', async () => {
+  it('injects a Direct Messages workspace when the user has DMs (rail shown alongside a team)', async () => {
+    // A team channel + a DM → two workspaces, so the rail is visible and we
+    // can assert the synthetic DM workspace was prepended.
     const channels: Channel[] = [
+      {
+        id: 'ch-team',
+        agentSession: '',
+        name: 'general',
+        createdAt: ISO,
+        type: 'channel',
+        teamId: 'team-x',
+      },
       {
         id: 'orc-dm',
         agentSession: 'crewly-orc',
@@ -432,22 +442,14 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workspace-row-__direct__')).toBeInTheDocument();
     });
-    // Not the no-teams dead-end, and the orchestrator DM is listed (it also
-    // appears in the right-panel header once auto-selected — hence getAllByText).
-    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Orchestrator').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('workspace-row-team-x')).toBeInTheDocument();
   });
 
   it('does not inject the DM workspace when the user has no DM channels', async () => {
+    // Two team channels, no DMs → two team workspaces, no DM workspace.
     const channels: Channel[] = [
-      {
-        id: 'ch-x',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-x',
-      },
+      { id: 'ch-a', agentSession: '', name: 'general', createdAt: ISO, type: 'channel', teamId: 'team-a' },
+      { id: 'ch-b', agentSession: '', name: 'general', createdAt: ISO, type: 'channel', teamId: 'team-b' },
     ];
     const { client } = makeStubClient(channels);
     render(
@@ -459,9 +461,40 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId('workspace-row-team-x')).toBeInTheDocument(),
+      expect(screen.getByTestId('workspace-row-team-a')).toBeInTheDocument(),
     );
     expect(screen.queryByTestId('workspace-row-__direct__')).not.toBeInTheDocument();
+  });
+
+  it('hides the workspace rail and dedupes the header when only the DM workspace exists', async () => {
+    // DM-only → a single workspace → Slack-style 3-column layout (no rail).
+    const channels: Channel[] = [
+      {
+        id: 'orc-dm',
+        agentSession: 'crewly-orc',
+        name: 'Orchestrator',
+        createdAt: ISO,
+        type: 'dm',
+        presence: 'online',
+      },
+    ];
+    const { client } = makeStubClient(channels);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('team-chat-page')).toBeInTheDocument());
+    // No workspace rail when there's a single workspace.
+    expect(screen.queryAllByTestId(/^workspace-row-/).length).toBe(0);
+    // The orchestrator DM is reachable (not the no-teams dead-end).
+    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Orchestrator').length).toBeGreaterThan(0);
+    // "Direct Messages" appears once (group label only, not also a panel header).
+    expect(screen.getAllByText('Direct Messages').length).toBe(1);
   });
 });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -235,14 +235,25 @@ function LiveTeamChatPageBody({
       data-loading={channelsLoading ? 'true' : 'false'}
       data-error={channelsError ? 'true' : 'false'}
     >
-      <WorkspaceRail
-        workspaces={workspaces}
-        activeWorkspaceId={resolvedWorkspaceId}
-        onSelectWorkspace={handleSelectWorkspace}
-      />
+      {/* Slack hides the workspace switcher when there's only one workspace
+          (e.g. DM-only). Showing a single lonely icon column adds noise. */}
+      {workspaces.length > 1 && (
+        <WorkspaceRail
+          workspaces={workspaces}
+          activeWorkspaceId={resolvedWorkspaceId}
+          onSelectWorkspace={handleSelectWorkspace}
+        />
+      )}
 
       <ConversationListPanel
-        workspaceName={activeWorkspace?.name}
+        // Avoid a duplicate header: the DM workspace's group label ("Direct
+        // Messages") already heads the list, so don't also render it as the
+        // panel title. Real team workspaces still show their name.
+        workspaceName={
+          activeWorkspace && activeWorkspace.id !== directMessagesWorkspace?.id
+            ? activeWorkspace.name
+            : undefined
+        }
         groups={groups}
         activeConversationId={resolvedConversationId}
         onSelectConversation={handleSelectConversation}
@@ -401,6 +412,7 @@ function LiveTeamChatRightPanelInner({
       <MessageThread
         channelId={conversation.id}
         agentName={recipientName}
+        layout="flat"
         emptyState={
           <NoMessagesEmptyState
             kind={conversation.kind === 'dm' ? 'dm' : 'channel'}

--- a/packages/chat-ui/src/components/MessageThread.test.tsx
+++ b/packages/chat-ui/src/components/MessageThread.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { ChatAPIProvider } from '../context/ChatAPIProvider';
 import { MockChatApiClient } from '../api/mock-client';
-import { MessageThread } from './MessageThread';
+import { MessageThread, avatarInitials, avatarColor } from './MessageThread';
 
 describe('MessageThread', () => {
   beforeEach(() => {
@@ -99,5 +99,61 @@ describe('MessageThread', () => {
     await waitFor(() => expect(screen.getByText(/Welcome/i)).toBeInTheDocument());
     const divider = screen.getByTestId('unread-divider');
     expect(divider).toHaveTextContent('Unread');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Slack-like flat layout (additive — default stays `bubble`).
+  // ---------------------------------------------------------------------------
+
+  it('default (bubble) layout renders messages in rounded bubbles', async () => {
+    const client = new MockChatApiClient();
+    const channels = await client.listChannels();
+    const { container } = render(
+      <ChatAPIProvider client={client} mode="mock">
+        <MessageThread channelId={channels[0].id} />
+      </ChatAPIProvider>,
+    );
+    await waitFor(() => expect(screen.getByText(/Welcome/i)).toBeInTheDocument());
+    expect(container.querySelector('.rounded-2xl')).not.toBeNull();
+  });
+
+  it('flat layout renders messages without chat bubbles', async () => {
+    const client = new MockChatApiClient();
+    const channels = await client.listChannels();
+    const { container } = render(
+      <ChatAPIProvider client={client} mode="mock">
+        <MessageThread channelId={channels[0].id} layout="flat" />
+      </ChatAPIProvider>,
+    );
+    await waitFor(() => expect(screen.getByText(/Welcome/i)).toBeInTheDocument());
+    // No iMessage bubble styling in flat mode.
+    expect(container.querySelector('.rounded-2xl')).toBeNull();
+    expect(container.querySelector('.bg-blue-500')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Avatar helpers — pure, exercised independently per the 1:1 test policy.
+// ---------------------------------------------------------------------------
+
+describe('avatarInitials / avatarColor', () => {
+  it('derives initials from a single-word name', () => {
+    expect(avatarInitials('Sam')).toBe('SA');
+  });
+
+  it('derives initials from the first two words / segments', () => {
+    expect(avatarInitials('crewly-orc')).toBe('CO');
+    expect(avatarInitials('Crewly Product Team')).toBe('CP');
+  });
+
+  it('falls back to "?" for an empty name', () => {
+    expect(avatarInitials('')).toBe('?');
+  });
+
+  it('is deterministic and returns a known palette class', () => {
+    const a = avatarColor('Orchestrator');
+    const b = avatarColor('Orchestrator');
+    expect(a).toBe(b);
+    expect(a.startsWith('bg-')).toBe(true);
   });
 });

--- a/packages/chat-ui/src/components/MessageThread.tsx
+++ b/packages/chat-ui/src/components/MessageThread.tsx
@@ -54,6 +54,15 @@ export interface MessageThreadProps {
   unreadAfterSeq?: number | null;
   /** Override label for the unread divider. Defaults to `New`. */
   unreadDividerLabel?: string;
+  /**
+   * Visual layout (additive — existing callers keep the chat-bubble look).
+   *
+   * - `'bubble'` (default): iMessage-style bubbles, user-right / agent-left.
+   * - `'flat'`: Slack-style flat list — left-aligned avatar + bold name +
+   *   inline timestamp, plain text, consecutive same-author messages
+   *   grouped under one header. Used by the consolidated team-chat surface.
+   */
+  layout?: 'bubble' | 'flat';
 }
 
 export function MessageThread({
@@ -63,6 +72,7 @@ export function MessageThread({
   emptyState,
   unreadAfterSeq = null,
   unreadDividerLabel = 'New',
+  layout = 'bubble',
 }: MessageThreadProps): JSX.Element {
   const { messages, loading, error, hasMore, agentThinking, loadMore } = useMessages(channelId);
   const bottomRef = useRef<HTMLDivElement | null>(null);
@@ -101,8 +111,13 @@ export function MessageThread({
         </div>
       )}
 
-      <ul role="list" className="flex flex-1 flex-col gap-3 px-4 py-4">
-        {renderTimeline({ messages, unreadAfterSeq, unreadDividerLabel })}
+      <ul
+        role="list"
+        className={`flex flex-1 flex-col ${
+          layout === 'flat' ? 'gap-0.5 px-2 py-3' : 'gap-3 px-4 py-4'
+        }`}
+      >
+        {renderTimeline({ messages, unreadAfterSeq, unreadDividerLabel, layout })}
         {agentThinking && <AgentThinkingRow agentName={agentName} />}
         {loading && (
           <li className="text-xs text-slate-400" role="status">
@@ -129,29 +144,34 @@ function renderTimeline(args: {
   messages: Message[];
   unreadAfterSeq: number | null;
   unreadDividerLabel: string;
+  layout: 'bubble' | 'flat';
 }): React.ReactNode[] {
-  const { messages, unreadAfterSeq, unreadDividerLabel } = args;
-  if (unreadAfterSeq === null || unreadAfterSeq === undefined) {
-    return messages.map((m) => <MessageRow key={m.id} message={m} />);
-  }
+  const { messages, unreadAfterSeq, unreadDividerLabel, layout } = args;
   const out: React.ReactNode[] = [];
-  let dividerInserted = false;
-  // Find whether the matching seq is in the loaded window.
-  const hasMatchingSeq = messages.some((m) => m.seq === unreadAfterSeq);
-  for (const m of messages) {
-    out.push(<MessageRow key={m.id} message={m} />);
-    if (!dividerInserted && hasMatchingSeq && m.seq === unreadAfterSeq) {
-      out.push(
-        <UnreadDividerRow key="unread-divider" label={unreadDividerLabel} />,
-      );
-      dividerInserted = true;
-    }
+
+  // In flat (Slack) mode, consecutive messages from the same author group
+  // under one avatar/name header. `groupStart` is always true in bubble
+  // mode (each message keeps its own header), preserving prior behavior.
+  let prevAuthor: string | null = null;
+  const hasMatchingSeq =
+    unreadAfterSeq != null && messages.some((m) => m.seq === unreadAfterSeq);
+
+  // Edge case: matching seq paged off-screen — surface the divider at the top.
+  if (unreadAfterSeq != null && !hasMatchingSeq && messages.length > 0) {
+    out.push(<UnreadDividerRow key="unread-divider" label={unreadDividerLabel} />);
   }
-  // Edge case: the matching seq is not in the loaded window. Surface
-  // the divider at the top so the boundary stays legible — this is the
-  // case when older messages have been paged off-screen.
-  if (!dividerInserted && messages.length > 0) {
-    out.unshift(<UnreadDividerRow key="unread-divider" label={unreadDividerLabel} />);
+
+  let dividerInserted = false;
+  for (const m of messages) {
+    const groupStart = layout !== 'flat' || prevAuthor !== m.author.id;
+    out.push(<MessageRow key={m.id} message={m} layout={layout} groupStart={groupStart} />);
+    prevAuthor = m.author.id;
+    if (!dividerInserted && hasMatchingSeq && m.seq === unreadAfterSeq) {
+      out.push(<UnreadDividerRow key="unread-divider" label={unreadDividerLabel} />);
+      dividerInserted = true;
+      // A divider visually breaks the group — next message starts fresh.
+      prevAuthor = null;
+    }
   }
   return out;
 }
@@ -176,7 +196,18 @@ function UnreadDividerRow({ label }: { label: string }): JSX.Element {
   );
 }
 
-function MessageRow({ message }: { message: Message }): JSX.Element {
+function MessageRow({
+  message,
+  layout = 'bubble',
+  groupStart = true,
+}: {
+  message: Message;
+  layout?: 'bubble' | 'flat';
+  groupStart?: boolean;
+}): JSX.Element {
+  if (layout === 'flat') {
+    return <FlatMessageRow message={message} groupStart={groupStart} />;
+  }
   const isUser = message.author.role === 'user';
   const alignment = isUser ? 'items-end' : 'items-start';
   const status = message.deliveryStatus;
@@ -214,6 +245,124 @@ function MessageRow({ message }: { message: Message }): JSX.Element {
       </div>
       <DeliveryFooter message={message} />
     </li>
+  );
+}
+
+/**
+ * Slack-style flat message row. Left-aligned for every author: an avatar
+ * gutter, then a bold name + inline timestamp header (on the first message
+ * of an author group) followed by plain text. Follow-on messages in the
+ * same group omit the avatar/name and reveal their timestamp on hover.
+ */
+function FlatMessageRow({
+  message,
+  groupStart,
+}: {
+  message: Message;
+  groupStart: boolean;
+}): JSX.Element {
+  const status = message.deliveryStatus;
+  const name = message.author.name ?? message.author.id;
+  const faded = status === 'pending' ? 'opacity-60' : '';
+
+  return (
+    <li
+      className={`group flex gap-2 rounded px-2 hover:bg-slate-100 dark:hover:bg-slate-900 ${
+        groupStart ? 'mt-3 pt-0.5' : ''
+      }`}
+      data-author-role={message.author.role}
+      data-delivery-status={status ?? 'sent'}
+    >
+      <div className="w-9 shrink-0 select-none">
+        {groupStart ? (
+          <Avatar name={name} />
+        ) : (
+          <time className="block w-9 pt-0.5 text-right text-[10px] leading-5 text-transparent group-hover:text-slate-400">
+            {formatTimestamp(message.createdAt)}
+          </time>
+        )}
+      </div>
+      <div className="min-w-0 flex-1 pb-0.5">
+        {groupStart && (
+          <div className="flex items-baseline gap-2">
+            <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+              {name}
+            </span>
+            <time className="text-[11px] text-slate-400 dark:text-slate-500">
+              {formatTimestamp(message.createdAt)}
+            </time>
+          </div>
+        )}
+        <div className={`text-sm leading-relaxed text-slate-700 dark:text-slate-200 ${faded}`}>
+          {renderMinimalMarkdown(message.content)}
+          {message.attachments?.map((a) =>
+            a.kind === 'image' ? (
+              <img
+                key={a.id}
+                src={a.url}
+                alt={a.filename ?? 'attachment'}
+                className="mt-2 max-h-64 max-w-full rounded-lg"
+              />
+            ) : null,
+          )}
+        </div>
+        {status === 'pending' && (
+          <span className="text-[10px] italic text-slate-400 dark:text-slate-500">
+            Sending…
+          </span>
+        )}
+        {status === 'failed' && (
+          <span className="text-[10px] font-medium text-red-500" role="alert">
+            Send failed — tap to retry
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+
+/** Tailwind background classes for avatar tiles — picked by hashing the name. */
+const AVATAR_COLORS = [
+  'bg-rose-500',
+  'bg-orange-500',
+  'bg-amber-500',
+  'bg-emerald-500',
+  'bg-teal-500',
+  'bg-sky-500',
+  'bg-indigo-500',
+  'bg-violet-500',
+  'bg-fuchsia-500',
+] as const;
+
+/**
+ * Derive 1–2 uppercase initials from a display name. Splits on spaces and
+ * common separators so `crewly-orc` → `CO` and `Sam` → `SA`.
+ */
+export function avatarInitials(name: string): string {
+  const parts = name.split(/[\s\-_.]+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+/** Deterministically map a name to one of the avatar colors. */
+export function avatarColor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i += 1) {
+    h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  }
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+
+/** Slack-style rounded-square avatar tile with initials. */
+function Avatar({ name }: { name: string }): JSX.Element {
+  return (
+    <span
+      className={`flex h-9 w-9 items-center justify-center rounded-md text-xs font-semibold text-white ${avatarColor(name)}`}
+      aria-hidden="true"
+    >
+      {avatarInitials(name)}
+    </span>
   );
 }
 


### PR DESCRIPTION
Makes the consolidated /team-chat look like Slack instead of iMessage-in-a-4-column-shell.

- **Flat messages**: `MessageThread` gets an additive `layout` prop (`bubble` default | `flat`). Flat = left-aligned avatar + bold name + inline timestamp + plain text, consecutive same-author messages grouped, follow-on rows show a hover-only time. No bubbles, no right-alignment. Bubble markup kept byte-for-byte → Portal (omits the prop) unaffected. Adds `avatarInitials`/`avatarColor` tinted-tile helpers.
- **No lonely rail**: hide the WorkspaceRail when there's a single workspace (the DM-only case showed one orphan "DM" icon column) → clean 3-column Slack layout.
- **Deduped header**: stop passing `workspaceName` for the synthetic DM workspace, so "Direct Messages" renders once (group label), not twice.

Tests: flat-layout (no bubble classes) + avatar-helper units; DM-workspace tests reworked to multi-workspace fixtures + a rail-hidden/deduped-header case. chat-ui package (35) + frontend suites green; FE build green.

Deferred polish (follow-up): conversation-row density/active-state tweaks, composer theming.