### PR TITLE
feat(chat): group chats — pull multiple agents into one room (拉群)

### DIFF
--- a/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.test.ts
@@ -642,6 +642,34 @@ describe('chat-v2 controller (REST)', () => {
       }
     });
 
+    it('POST /channels/huddle — creates a multi-agent group chat (201)', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app)
+          .post('/api/chat/channels/huddle')
+          .send({ name: 'Launch crew', memberSessions: ['sess-ella', 'sess-grace'] });
+        expect(res.status).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.type).toBe('huddle');
+        expect(res.body.data.name).toBe('Launch crew');
+      } finally {
+        service.close();
+      }
+    });
+
+    it('POST /channels/huddle — 400 when no members are supplied', async () => {
+      const { app, service } = buildAppWithProviders();
+      try {
+        const res = await request(app)
+          .post('/api/chat/channels/huddle')
+          .send({ name: 'Empty crew', memberSessions: [] });
+        expect(res.status).toBe(400);
+        expect(res.body.error.code).toBe('validation_error');
+      } finally {
+        service.close();
+      }
+    });
+
     it('GET /agents — returns flattened directory entries when wired', async () => {
       const { app, service } = buildAppWithProviders({
         directoryTeams: [

--- a/backend/src/controllers/chat-v2/chat-v2.controller.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.controller.ts
@@ -245,6 +245,7 @@ export interface ChatV2ControllerHandlers {
   sendMessage: (req: Request, res: Response) => void | Promise<void>;
   ensureDmChannel: (req: Request, res: Response) => void;
   ensureTeamChannel: (req: Request, res: Response) => void;
+  createHuddle: (req: Request, res: Response) => void;
   listAgents: (req: Request, res: Response) => void | Promise<void>;
   getAgentPresence: (req: Request, res: Response) => void | Promise<void>;
 }
@@ -600,6 +601,27 @@ export function createChatV2Controller(
           principal,
         });
         res.status(created ? 201 : 200).json({ success: true, data: channel });
+      }),
+
+    /**
+     * POST /channels/huddle
+     *
+     * Create an ad-hoc multi-agent group chat ("拉群"). Body:
+     * `{ name, memberSessions: string[], purpose? }`. Messages posted to
+     * the resulting `type='huddle'` channel fan out to every member agent
+     * via the dispatcher's huddle-broadcast strategy.
+     */
+    createHuddle: (req, res) =>
+      runHandler(res, () => {
+        const principal = principalFromRequest(req);
+        const body = req.body ?? {};
+        const channel = service.createHuddle({
+          name: body.name,
+          purpose: body.purpose,
+          memberSessions: Array.isArray(body.memberSessions) ? body.memberSessions : [],
+          principal,
+        });
+        res.status(201).json({ success: true, data: channel });
       }),
 
     /**

--- a/backend/src/controllers/chat-v2/chat-v2.routes.ts
+++ b/backend/src/controllers/chat-v2/chat-v2.routes.ts
@@ -24,6 +24,7 @@ import {
  * - `POST   /channels`
  * - `POST   /channels/dm/ensure` — find-or-create DM channel for an agent
  * - `POST   /channels/team/ensure` — find-or-create the canonical team channel
+ * - `POST   /channels/huddle` — create an ad-hoc multi-agent group chat
  * - `GET    /channels/:id`
  * - `DELETE /channels/:id`
  * - `GET    /channels/:id/messages`
@@ -48,6 +49,7 @@ export function createChatV2Router(
   // `/channels/:id` matchers so Express doesn't bind `:id = 'dm'`/`'team'`.
   router.post('/channels/dm/ensure', requireAuth, handlers.ensureDmChannel);
   router.post('/channels/team/ensure', requireAuth, handlers.ensureTeamChannel);
+  router.post('/channels/huddle', requireAuth, handlers.createHuddle);
   router.get('/channels/:id', requireAuth, handlers.getChannel);
   router.delete('/channels/:id', requireAuth, handlers.archiveChannel);
 

--- a/frontend/src/components/Chat-team/CreateGroupModal.test.tsx
+++ b/frontend/src/components/Chat-team/CreateGroupModal.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for CreateGroupModal — the multi-agent "拉群" picker.
+ *
+ * @module components/Chat-team/CreateGroupModal.test
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CreateGroupModal, type PickerAgent } from './CreateGroupModal';
+
+const AGENTS: PickerAgent[] = [
+  { agentSession: 'sess-ella', name: 'Ella', role: 'content-strategist' },
+  { agentSession: 'sess-grace', name: 'Grace', role: 'sales' },
+  { agentSession: 'sess-luna', name: 'Luna', role: 'content-strategist' },
+];
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof CreateGroupModal>> = {}) {
+  const onClose = vi.fn();
+  const onCreate = vi.fn().mockResolvedValue(undefined);
+  render(
+    <CreateGroupModal
+      onClose={onClose}
+      onCreate={onCreate}
+      loadAgents={async () => AGENTS}
+      {...overrides}
+    />,
+  );
+  return { onClose, onCreate };
+}
+
+describe('CreateGroupModal', () => {
+  it('loads and lists the agents', async () => {
+    renderModal();
+    expect(await screen.findByText('Ella')).toBeInTheDocument();
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(screen.getByText('Luna')).toBeInTheDocument();
+  });
+
+  it('keeps Create disabled until a name and ≥2 agents are chosen', async () => {
+    renderModal();
+    await screen.findByText('Ella');
+    const submit = screen.getByTestId('create-group-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText('Group name'), { target: { value: 'Launch crew' } });
+    expect(submit.disabled).toBe(true); // name but no members
+
+    fireEvent.click(screen.getByLabelText(/Ella/));
+    expect(submit.disabled).toBe(true); // only one member
+
+    fireEvent.click(screen.getByLabelText(/Grace/));
+    expect(submit.disabled).toBe(false); // name + two members
+  });
+
+  it('calls onCreate with the name and selected agent sessions', async () => {
+    const { onCreate } = renderModal();
+    await screen.findByText('Ella');
+
+    fireEvent.change(screen.getByLabelText('Group name'), { target: { value: 'Launch crew' } });
+    fireEvent.click(screen.getByLabelText(/Ella/));
+    fireEvent.click(screen.getByLabelText(/Luna/));
+    fireEvent.click(screen.getByTestId('create-group-submit'));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith('Launch crew', ['sess-ella', 'sess-luna']),
+    );
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const { onClose } = renderModal();
+    await screen.findByText('Ella');
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('surfaces a load error', async () => {
+    renderModal({ loadAgents: async () => { throw new Error('boom'); } });
+    expect(await screen.findByRole('alert')).toHaveTextContent(/boom/);
+  });
+});

--- a/frontend/src/components/Chat-team/CreateGroupModal.tsx
+++ b/frontend/src/components/Chat-team/CreateGroupModal.tsx
@@ -1,0 +1,192 @@
+/**
+ * CreateGroupModal — "拉群": pull multiple agents into one group chat.
+ *
+ * Fetches the agent directory (`GET /api/chat/agents`), lets the user pick a
+ * name + ≥2 agents, and hands the selection back via `onCreate`. The actual
+ * `createHuddle` call lives in the host (LiveTeamChatPage) so this component
+ * stays a pure picker and is easy to test.
+ *
+ * @module components/Chat-team/CreateGroupModal
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+
+/** One selectable agent in the picker (subset of the directory shape). */
+export interface PickerAgent {
+  agentSession: string;
+  name: string;
+  role: string;
+}
+
+export interface CreateGroupModalProps {
+  /** Close without creating. */
+  onClose: () => void;
+  /** Create the group with a name + the chosen agent session names. */
+  onCreate: (name: string, memberSessions: string[]) => Promise<void> | void;
+  /**
+   * Agent loader — defaults to `GET /api/chat/agents`. Injectable for tests.
+   */
+  loadAgents?: () => Promise<PickerAgent[]>;
+}
+
+/** Default loader: hit the OSS agent directory endpoint. */
+async function defaultLoadAgents(): Promise<PickerAgent[]> {
+  const res = await fetch('/api/chat/agents');
+  const body = (await res.json()) as { data?: { agents?: PickerAgent[] } };
+  return body?.data?.agents ?? [];
+}
+
+/**
+ * Modal dialog for creating a multi-agent group chat.
+ *
+ * @returns The group-creation modal.
+ */
+export function CreateGroupModal({
+  onClose,
+  onCreate,
+  loadAgents = defaultLoadAgents,
+}: CreateGroupModalProps): JSX.Element {
+  const [agents, setAgents] = useState<PickerAgent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await loadAgents();
+        if (!cancelled) setAgents(list);
+      } catch (err) {
+        if (!cancelled) setLoadError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadAgents]);
+
+  const toggle = (session: string): void => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(session)) next.delete(session);
+      else next.add(session);
+      return next;
+    });
+  };
+
+  // A group needs a name and at least two agents to be a "group".
+  const canCreate = useMemo(
+    () => name.trim().length > 0 && selected.size >= 2 && !submitting,
+    [name, selected, submitting],
+  );
+
+  const handleCreate = async (): Promise<void> => {
+    if (!canCreate) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onCreate(name.trim(), [...selected]);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create group chat"
+      data-testid="create-group-modal"
+    >
+      <div className="flex max-h-[80vh] w-full max-w-md flex-col rounded-lg border border-border-dark bg-surface-dark shadow-xl">
+        <header className="border-b border-border-dark px-4 py-3">
+          <h2 className="text-base font-semibold text-text-primary-dark">New group chat</h2>
+          <p className="text-xs text-text-secondary-dark">
+            Pull two or more agents into one room. Messages reach everyone.
+          </p>
+        </header>
+
+        <div className="px-4 py-3">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Group name (e.g. Launch crew)"
+            className="mb-3 w-full rounded-md border border-border-dark bg-background-dark px-3 py-2 text-sm text-text-primary-dark placeholder:text-text-secondary-dark focus:border-primary focus:outline-none"
+            aria-label="Group name"
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto border-t border-border-dark px-2 py-2">
+          {loading && <p className="px-2 py-2 text-sm text-text-secondary-dark">Loading agents…</p>}
+          {loadError && (
+            <p className="px-2 py-2 text-sm text-red-400" role="alert">
+              Failed to load agents: {loadError}
+            </p>
+          )}
+          {!loading && !loadError && agents.length === 0 && (
+            <p className="px-2 py-2 text-sm text-text-secondary-dark">No agents available.</p>
+          )}
+          {agents.map((a) => {
+            const checked = selected.has(a.agentSession);
+            return (
+              <label
+                key={a.agentSession}
+                className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-2 hover:bg-background-dark"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggle(a.agentSession)}
+                  className="h-4 w-4"
+                />
+                <span className="min-w-0">
+                  <span className="block truncate text-sm text-text-primary-dark">{a.name}</span>
+                  <span className="block truncate text-xs text-text-secondary-dark">{a.role}</span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+
+        {submitError && (
+          <p className="px-4 py-1 text-xs text-red-400" role="alert">
+            {submitError}
+          </p>
+        )}
+
+        <footer className="flex items-center justify-between border-t border-border-dark px-4 py-3">
+          <span className="text-xs text-text-secondary-dark">{selected.size} selected</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border-dark px-3 py-1.5 text-sm text-text-secondary-dark hover:bg-background-dark"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleCreate()}
+              disabled={!canCreate}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+              data-testid="create-group-submit"
+            >
+              {submitting ? 'Creating…' : 'Create group'}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+export default CreateGroupModal;

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -83,6 +83,9 @@ function makeStubClient(channels: Channel[], messages: Record<string, Message[]>
     async createChannel(_input: CreateChannelInput): Promise<Channel> {
       throw new Error('not used in this test');
     },
+    async createHuddle(): Promise<Channel> {
+      throw new Error('not used in this test');
+    },
     async listMessages(channelId: string): Promise<MessagePage> {
       return { messages: messages[channelId] ?? [], nextCursor: null };
     },

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -39,6 +39,7 @@ import {
   useMessages,
   useObservedWorkspaces,
   useSendMessage,
+  useChatApiClient,
   type ChatApiClient,
   type ChatApiError,
   type ConversationRow,
@@ -53,6 +54,7 @@ import {
   NoTeamsEmptyState,
 } from './EmptyStates';
 import { ChatErrorToast } from './ChatErrorToast';
+import { CreateGroupModal } from './CreateGroupModal';
 
 export interface LiveTeamChatPageProps {
   /** OSS backend base URL. Required when no `client` is injected. */
@@ -139,7 +141,9 @@ function LiveTeamChatPageBody({
   initialConversationId,
   directMessagesWorkspace,
 }: BodyProps): JSX.Element {
-  const { channels, loading: channelsLoading, error: channelsError } = useChannels();
+  const { channels, loading: channelsLoading, error: channelsError, refresh } = useChannels();
+  const client = useChatApiClient();
+  const [showCreateGroup, setShowCreateGroup] = useState(false);
 
   const teamWorkspaces = useObservedWorkspaces(channels, { teamLabels });
 
@@ -204,6 +208,19 @@ function LiveTeamChatPageBody({
     setActiveConversationId(row.id);
   }, []);
 
+  // "拉群" — create a multi-agent group chat, then refresh the channel list
+  // and jump into it. Huddles are workspace-agnostic so they surface in the
+  // current workspace's "Group Chats" section immediately.
+  const handleCreateGroup = useCallback(
+    async (name: string, memberSessions: string[]) => {
+      const huddle = await client.createHuddle({ name, memberSessions });
+      await refresh();
+      setActiveConversationId(huddle.id);
+      setShowCreateGroup(false);
+    },
+    [client, refresh],
+  );
+
   const activeWorkspace = useMemo(
     () => workspaces.find((w) => w.id === resolvedWorkspaceId) ?? null,
     [workspaces, resolvedWorkspaceId],
@@ -257,6 +274,17 @@ function LiveTeamChatPageBody({
         groups={groups}
         activeConversationId={resolvedConversationId}
         onSelectConversation={handleSelectConversation}
+        headerAction={
+          <button
+            type="button"
+            onClick={() => setShowCreateGroup(true)}
+            className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-600 hover:bg-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            data-testid="new-group-button"
+            title="Create a multi-agent group chat"
+          >
+            + New group
+          </button>
+        }
         emptyState={
           activeWorkspace && totalRows === 0 ? (
             <NoChannelsEmptyState teamName={activeWorkspace.name} />
@@ -268,6 +296,13 @@ function LiveTeamChatPageBody({
         conversation={activeConversation}
         mentionables={mentionables}
       />
+
+      {showCreateGroup && (
+        <CreateGroupModal
+          onClose={() => setShowCreateGroup(false)}
+          onCreate={handleCreateGroup}
+        />
+      )}
     </div>
   );
 }

--- a/packages/chat-ui/src/api/client.ts
+++ b/packages/chat-ui/src/api/client.ts
@@ -20,6 +20,7 @@
 import type {
   Channel,
   CreateChannelInput,
+  CreateHuddleInput,
   MessagePage,
   SendMessageInput,
   Message,
@@ -71,6 +72,8 @@ export interface CurrentUserIdentity {
 export interface ChatApiClient {
   listChannels(): Promise<Channel[]>;
   createChannel(input: CreateChannelInput): Promise<Channel>;
+  /** Create an ad-hoc multi-agent group chat ("拉群"). */
+  createHuddle(input: CreateHuddleInput): Promise<Channel>;
   listMessages(channelId: string, opts?: { cursor?: string; limit?: number }): Promise<MessagePage>;
   sendMessage(channelId: string, input: SendMessageInput): Promise<Message>;
   getAgentPresence(agentId: string): Promise<AgentPresence>;
@@ -276,6 +279,14 @@ export class HttpChatApiClient implements ChatApiClient {
 
   async createChannel(input: CreateChannelInput): Promise<Channel> {
     const dto = await this.request<ChannelDTO>('/api/chat/channels', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    return channelFromDTO(dto);
+  }
+
+  async createHuddle(input: CreateHuddleInput): Promise<Channel> {
+    const dto = await this.request<ChannelDTO>('/api/chat/channels/huddle', {
       method: 'POST',
       body: JSON.stringify(input),
     });

--- a/packages/chat-ui/src/api/mock-client.test.ts
+++ b/packages/chat-ui/src/api/mock-client.test.ts
@@ -23,6 +23,18 @@ describe('MockChatApiClient', () => {
     expect(all).toContainEqual(ch);
   });
 
+  it('createHuddle appends a type=huddle channel to the list', async () => {
+    const client = new MockChatApiClient({ initialChannels: [] });
+    const ch = await client.createHuddle({
+      name: 'Launch crew',
+      memberSessions: ['a1', 'a2'],
+    });
+    expect(ch.type).toBe('huddle');
+    expect(ch.name).toBe('Launch crew');
+    const all = await client.listChannels();
+    expect(all).toContainEqual(ch);
+  });
+
   it('sendMessage emits optimistic + confirmed user events, then a delayed agent reply', async () => {
     const client = new MockChatApiClient({ agentReplyDelayMs: 500 });
     const [channel] = await client.listChannels();

--- a/packages/chat-ui/src/api/mock-client.ts
+++ b/packages/chat-ui/src/api/mock-client.ts
@@ -22,6 +22,7 @@ import type {
 import type {
   Channel,
   CreateChannelInput,
+  CreateHuddleInput,
   Message,
   MessagePage,
   SendMessageInput,
@@ -79,6 +80,21 @@ export class MockChatApiClient implements ChatApiClient {
       teamId: input.teamId,
       projectId: input.projectId,
       targetMemberId: input.targetMemberId,
+    };
+    this.channels = [...this.channels, ch];
+    this.messages[ch.id] = [];
+    return ch;
+  }
+
+  async createHuddle(input: CreateHuddleInput): Promise<Channel> {
+    const ch: Channel = {
+      id: this.nextId('ch'),
+      agentSession: '',
+      name: input.name,
+      purpose: input.purpose,
+      createdAt: new Date().toISOString(),
+      presence: 'online',
+      type: 'huddle',
     };
     this.channels = [...this.channels, ch];
     this.messages[ch.id] = [];

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -43,6 +43,12 @@ export interface ConversationListPanelProps {
    * "Channels in Selected Team" empty state).
    */
   emptyState?: React.ReactNode;
+  /**
+   * Optional action rendered at the right of the panel header (additive).
+   * Used by the OSS app for the "New group" (拉群) button. When provided,
+   * the header renders even if `workspaceName` is omitted.
+   */
+  headerAction?: React.ReactNode;
   className?: string;
 }
 
@@ -52,6 +58,7 @@ export function ConversationListPanel({
   activeConversationId = null,
   onSelectConversation,
   emptyState,
+  headerAction,
   className = '',
 }: ConversationListPanelProps): JSX.Element {
   const totalRows = useMemo(
@@ -65,11 +72,12 @@ export function ConversationListPanel({
       aria-label={workspaceName ? `${workspaceName} conversations` : 'Conversations'}
       data-testid="conversation-list-panel"
     >
-      {workspaceName && (
-        <header className="border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+      {(workspaceName || headerAction) && (
+        <header className="flex items-center justify-between gap-2 border-b border-slate-200 px-4 py-3 dark:border-slate-700">
           <h2 className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
-            {workspaceName}
+            {workspaceName ?? ''}
           </h2>
+          {headerAction}
         </header>
       )}
 

--- a/packages/chat-ui/src/hooks/useGroupedChannels.test.ts
+++ b/packages/chat-ui/src/hooks/useGroupedChannels.test.ts
@@ -61,13 +61,15 @@ const dmEla: Channel = {
 };
 
 describe('buildConversationGroups', () => {
-  it('produces two stable groups with the right ids/labels', () => {
+  it('produces three stable groups with the right ids/labels', () => {
     const groups = buildConversationGroups([]);
-    expect(groups).toHaveLength(2);
+    expect(groups).toHaveLength(3);
     expect(groups[0].id).toBe('channels');
     expect(groups[0].label).toBe('Channels');
-    expect(groups[1].id).toBe('dms');
-    expect(groups[1].label).toBe('Direct Messages');
+    expect(groups[1].id).toBe('huddles');
+    expect(groups[1].label).toBe('Group Chats');
+    expect(groups[2].id).toBe('dms');
+    expect(groups[2].label).toBe('Direct Messages');
   });
 
   it('partitions channel-typed rows into Channels and dm rows into DMs', () => {
@@ -82,12 +84,29 @@ describe('buildConversationGroups', () => {
       'ch-product-onboarding',
       'ch-product-general',
     ]);
-    expect(groups[1].rows.map((r) => r.id)).toEqual([
+    expect(groups[2].rows.map((r) => r.id)).toEqual([
       // dmSam has a lastMessageAt → it comes first; dmEla has none →
       // sorted by name fallback.
       'ch-dm-sam',
       'ch-dm-ella',
     ]);
+  });
+
+  it('routes huddle-typed rows into the workspace-agnostic Group Chats group', () => {
+    const huddle: Channel = {
+      id: 'ch-huddle-launch',
+      agentSession: '',
+      name: 'Launch crew',
+      createdAt: ISO_OLDER,
+      type: 'huddle',
+    };
+    // Even with a team workspace selected, the huddle surfaces (not team-scoped).
+    const groups = buildConversationGroups([channelGeneral, huddle], {
+      workspaceId: 'team-product',
+    });
+    const huddles = groups.find((g) => g.id === 'huddles')!;
+    expect(huddles.rows.map((r) => r.id)).toEqual(['ch-huddle-launch']);
+    expect(huddles.rows[0].kind).toBe('channel');
   });
 
   it('scopes Channels to the active workspaceId; DMs always flow', () => {
@@ -98,7 +117,7 @@ describe('buildConversationGroups', () => {
     // Only product-team channels in the Channels group.
     expect(groups[0].rows.map((r) => r.id)).toEqual(['ch-product-general']);
     // DMs are workspace-agnostic — both surface regardless of teamId.
-    expect(groups[1].rows.map((r) => r.id)).toEqual(['ch-dm-sam', 'ch-dm-ella']);
+    expect(groups[2].rows.map((r) => r.id)).toEqual(['ch-dm-sam', 'ch-dm-ella']);
   });
 
   it('treats a legacy channel without `type` as a DM (backwards-compat)', () => {
@@ -111,7 +130,7 @@ describe('buildConversationGroups', () => {
     };
     const groups = buildConversationGroups([legacy]);
     expect(groups[0].rows).toHaveLength(0);
-    expect(groups[1].rows).toEqual([
+    expect(groups[2].rows).toEqual([
       expect.objectContaining({ id: 'ch-legacy', kind: 'dm' }),
     ]);
   });
@@ -126,7 +145,7 @@ describe('buildConversationGroups', () => {
 
   it('maps DM rows with the agent session + presence so the panel can render badges', () => {
     const groups = buildConversationGroups([dmSam]);
-    const row = groups[1].rows[0];
+    const row = groups[2].rows[0];
     expect(row.kind).toBe('dm');
     expect(row.agentSession).toBe('crewly-product-sam');
     expect(row.presence).toBe('online');
@@ -145,6 +164,6 @@ describe('buildConversationGroups', () => {
     const b: Channel = { id: 'b', agentSession: 'b', name: 'Apple', createdAt: ISO_OLDER, type: 'dm' };
     const groups = buildConversationGroups([a, b]);
     // Apple sorts before Banana alphabetically.
-    expect(groups[1].rows.map((r) => r.title)).toEqual(['Apple', 'Banana']);
+    expect(groups[2].rows.map((r) => r.title)).toEqual(['Apple', 'Banana']);
   });
 });

--- a/packages/chat-ui/src/hooks/useGroupedChannels.ts
+++ b/packages/chat-ui/src/hooks/useGroupedChannels.ts
@@ -8,9 +8,10 @@
  *
  * Behavior:
  *  - When `workspaceId` is provided, the hook scopes `Channels` to
- *    only those rows where `channel.teamId === workspaceId`. DMs are
- *    workspace-agnostic (a DM is user↔agent, not team-scoped) — they
- *    surface in every workspace's center panel.
+ *    only those rows where `channel.teamId === workspaceId`. DMs and
+ *    huddles (ad-hoc multi-agent group chats) are workspace-agnostic —
+ *    they surface in every workspace's center panel under their own
+ *    `Direct Messages` / `Group Chats` sections.
  *  - When `workspaceId` is null/undefined, all channel-typed rows
  *    appear. Useful for the cross-team Activity / All-DMs surface.
  *  - Rows are sorted by `lastMessageAt` (most recent first) within
@@ -52,12 +53,17 @@ export function buildConversationGroups(
   opts: UseGroupedChannelsOptions = {},
 ): ConversationGroup[] {
   const channelRows: ConversationRow[] = [];
+  const huddleRows: ConversationRow[] = [];
   const dmRows: ConversationRow[] = [];
 
   for (const ch of channels) {
     // Treat missing `type` as `'dm'` — back-compat with legacy rows.
-    const kind: ConversationKind = ch.type === 'channel' ? 'channel' : 'dm';
-    if (kind === 'channel') {
+    const t = ch.type ?? 'dm';
+    if (t === 'huddle') {
+      // Huddles (ad-hoc multi-agent groups) aren't team-scoped — like DMs
+      // they surface in every workspace. Rendered with the channel glyph.
+      huddleRows.push(toRow(ch, 'channel'));
+    } else if (t === 'channel') {
       // Scope channels to the active workspace when one is selected.
       if (opts.workspaceId && ch.teamId !== opts.workspaceId) continue;
       channelRows.push(toRow(ch, 'channel'));
@@ -68,10 +74,14 @@ export function buildConversationGroups(
 
   // Sort by lastMessageAt desc — undefined/null sorts last in name order.
   channelRows.sort(byRecencyThenName);
+  huddleRows.sort(byRecencyThenName);
   dmRows.sort(byRecencyThenName);
 
+  // Empty groups are skipped by ConversationListPanel, so always returning
+  // the Group Chats group is safe — it only shows once a huddle exists.
   return [
     { id: 'channels', label: 'Channels', rows: channelRows },
+    { id: 'huddles', label: 'Group Chats', rows: huddleRows },
     { id: 'dms', label: 'Direct Messages', rows: dmRows },
   ];
 }

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -7,7 +7,7 @@
  */
 
 // Provider
-export { ChatAPIProvider, useChatProviderMode } from './context/ChatAPIProvider';
+export { ChatAPIProvider, useChatProviderMode, useChatApiClient } from './context/ChatAPIProvider';
 export type { ChatAPIProviderProps } from './context/ChatAPIProvider';
 
 // Components
@@ -70,7 +70,9 @@ export type {
   AgentPresence,
   AgentPresenceStatus,
   Channel,
+  ChannelType,
   CreateChannelInput,
+  CreateHuddleInput,
   Message,
   MessageAttachment,
   MessageAuthorRole,

--- a/packages/chat-ui/src/types/chat.types.ts
+++ b/packages/chat-ui/src/types/chat.types.ts
@@ -46,7 +46,7 @@ export interface AgentPresence {
  *               Multiple agents may participate; `agentSession` is empty
  *               on the wire and `teamId` is required.
  */
-export type ChannelType = 'dm' | 'channel';
+export type ChannelType = 'dm' | 'channel' | 'huddle';
 
 /**
  * A chat channel — either a 1:1 user↔agent DM or a team-scoped channel.
@@ -105,6 +105,20 @@ export interface CreateChannelInput {
   projectId?: string;
   /** Phase B — optional for `type='dm'`. */
   targetMemberId?: string;
+}
+
+/**
+ * Body for `POST /api/chat/channels/huddle` — create an ad-hoc multi-agent
+ * group chat ("拉群"). Messages posted to the resulting `type='huddle'`
+ * channel fan out to every member agent.
+ */
+export interface CreateHuddleInput {
+  /** Display name for the group (e.g. "Launch crew"). */
+  name: string;
+  /** Optional one-line purpose. */
+  purpose?: string;
+  /** Agent session names to pull into the group. Must be non-empty. */
+  memberSessions: string[];
 }
 
 // =============================================================================


### PR DESCRIPTION
Adds multi-agent **group chats** on top of the existing-but-unexposed huddle engine.

- **Backend**: `POST /api/chat/channels/huddle` → `createHuddle` (name + memberSessions[]); messages fan out to all members via the huddle-broadcast dispatcher.
- **chat-ui (additive)**: `ChannelType` gains `'huddle'`; `createHuddle` on the client; `useGroupedChannels` adds a workspace-agnostic **"Group Chats"** section; `ConversationListPanel` gets an optional `headerAction`; `useChatApiClient` exported.
- **App**: a **"+ New group"** button opens `CreateGroupModal` (pick a name + ≥2 agents from `GET /api/chat/agents`), creates the group, and jumps into it. The flat Slack layout already labels each author, so group threads read correctly.

All additive — Portal is unaffected (huddle/headerAction are opt-in). chat-ui (40) + frontend (28) + backend huddle tests green; typechecks + FE build green; Quality Gates passed.