### PR TITLE
fix(chat): show every agent in the chat list (not just existing DMs)

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   MockChatApiClient,
@@ -446,6 +446,44 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
       expect(screen.getByTestId('workspace-row-__direct__')).toBeInTheDocument();
     });
     expect(screen.getByTestId('workspace-row-team-x')).toBeInTheDocument();
+  });
+
+  it('shows directory agents (online + offline) even without an existing DM channel', async () => {
+    // No channels at all — agents come purely from the directory.
+    const { client } = makeStubClient([]);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+        directoryAgents={[
+          { agentSession: 'sess-ella', name: 'Ella', presence: 'online' },
+          { agentSession: 'sess-grace', name: 'Grace', presence: 'offline' },
+        ]}
+        onEnsureDm={async () => 'real-chan'}
+      />,
+    );
+    // Both agents are listed despite having no channel yet.
+    expect(await screen.findByText('Ella')).toBeInTheDocument();
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
+  });
+
+  it('calls onEnsureDm when a directory agent without a channel is opened', async () => {
+    const onEnsureDm = vi.fn().mockResolvedValue('real-chan');
+    const { client } = makeStubClient([]);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+        directoryAgents={[{ agentSession: 'sess-ella', name: 'Ella', presence: 'offline' }]}
+        onEnsureDm={onEnsureDm}
+      />,
+    );
+    const row = await screen.findByText('Ella');
+    fireEvent.click(row);
+    await waitFor(() => expect(onEnsureDm).toHaveBeenCalledWith('sess-ella'));
   });
 
   it('does not inject the DM workspace when the user has no DM channels', async () => {

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -42,6 +42,8 @@ import {
   useChatApiClient,
   type ChatApiClient,
   type ChatApiError,
+  type Channel,
+  type ChatPresenceStatus,
   type ConversationRow,
   type MentionComposerSendPayload,
   type MentionTarget,
@@ -92,6 +94,27 @@ export interface LiveTeamChatPageProps {
    * workspace simply scopes the center panel to show only DMs.
    */
   directMessagesWorkspace?: { id: string; name: string } | null;
+  /**
+   * Full agent directory (host-supplied). Every agent is shown in the DM
+   * list — online or offline — even before a DM channel exists, so the user
+   * can reach any agent. Agents that already have a real DM channel are
+   * de-duplicated against it.
+   */
+  directoryAgents?: DirectoryAgentEntry[];
+  /**
+   * Ensure (find-or-create) a DM channel for an agent session, returning the
+   * resolved channel id. Called when the user opens a directory agent that
+   * doesn't have a channel yet. Host-supplied to keep this component
+   * transport-agnostic.
+   */
+  onEnsureDm?: (agentSession: string) => Promise<string>;
+}
+
+/** One agent in the host-supplied directory shown in the DM list. */
+export interface DirectoryAgentEntry {
+  agentSession: string;
+  name: string;
+  presence?: ChatPresenceStatus;
 }
 
 export function LiveTeamChatPage({
@@ -103,6 +126,8 @@ export function LiveTeamChatPage({
   initialWorkspaceId,
   initialConversationId,
   directMessagesWorkspace,
+  directoryAgents = [],
+  onEnsureDm,
 }: LiveTeamChatPageProps): JSX.Element {
   return (
     <ChatAPIProvider
@@ -117,6 +142,8 @@ export function LiveTeamChatPage({
         initialWorkspaceId={initialWorkspaceId}
         initialConversationId={initialConversationId}
         directMessagesWorkspace={directMessagesWorkspace}
+        directoryAgents={directoryAgents}
+        onEnsureDm={onEnsureDm}
       />
     </ChatAPIProvider>
   );
@@ -132,7 +159,12 @@ interface BodyProps {
   initialWorkspaceId?: string | null;
   initialConversationId?: string | null;
   directMessagesWorkspace?: { id: string; name: string } | null;
+  directoryAgents: DirectoryAgentEntry[];
+  onEnsureDm?: (agentSession: string) => Promise<string>;
 }
+
+/** Prefix marking a synthetic DM row for a directory agent without a channel. */
+const VIRTUAL_DM_PREFIX = 'agent:';
 
 function LiveTeamChatPageBody({
   teamLabels,
@@ -140,20 +172,47 @@ function LiveTeamChatPageBody({
   initialWorkspaceId,
   initialConversationId,
   directMessagesWorkspace,
+  directoryAgents,
+  onEnsureDm,
 }: BodyProps): JSX.Element {
   const { channels, loading: channelsLoading, error: channelsError, refresh } = useChannels();
   const client = useChatApiClient();
   const [showCreateGroup, setShowCreateGroup] = useState(false);
 
-  const teamWorkspaces = useObservedWorkspaces(channels, { teamLabels });
+  // Merge the agent directory into the channel list so EVERY agent appears in
+  // the DM list — even offline ones with no channel yet. Agents that already
+  // have a real DM channel win; the rest get a synthetic row whose DM is
+  // created on first open (see handleSelectConversation).
+  const mergedChannels = useMemo<Channel[]>(() => {
+    const dmSessions = new Set(
+      channels
+        .filter((c) => (c.type ?? 'dm') === 'dm' && c.agentSession)
+        .map((c) => c.agentSession),
+    );
+    const synthetic: Channel[] = directoryAgents
+      .filter((a) => a.agentSession && !dmSessions.has(a.agentSession))
+      .map((a) => ({
+        id: `${VIRTUAL_DM_PREFIX}${a.agentSession}`,
+        agentSession: a.agentSession,
+        name: a.name,
+        createdAt: '',
+        type: 'dm' as const,
+        // Channel presence is the narrower online|busy|offline vocabulary.
+        presence:
+          a.presence === 'online' ? 'online' : a.presence === 'busy' ? 'busy' : 'offline',
+      }));
+    return synthetic.length > 0 ? [...channels, ...synthetic] : channels;
+  }, [channels, directoryAgents]);
+
+  const teamWorkspaces = useObservedWorkspaces(mergedChannels, { teamLabels });
 
   // Prepend the synthetic "Direct Messages" workspace when the host supplies
   // one and the user actually has DMs — so DMs (orchestrator + agents) are
   // reachable even with zero team channels. DMs are not team-scoped, so this
   // workspace just narrows the center panel to the DM group.
   const hasDms = useMemo(
-    () => channels.some((c) => (c.type ?? 'dm') !== 'channel'),
-    [channels],
+    () => mergedChannels.some((c) => (c.type ?? 'dm') !== 'channel'),
+    [mergedChannels],
   );
   const workspaces = useMemo<Workspace[]>(() => {
     if (directMessagesWorkspace && hasDms) {
@@ -182,7 +241,7 @@ function LiveTeamChatPageBody({
   const resolvedWorkspaceId =
     activeWorkspaceId ?? (workspaces[0]?.id ?? null);
 
-  const groups = useGroupedChannels(channels, {
+  const groups = useGroupedChannels(mergedChannels, {
     workspaceId: resolvedWorkspaceId,
   });
 
@@ -191,10 +250,13 @@ function LiveTeamChatPageBody({
     [groups],
   );
 
-  // Auto-select the first available conversation when none is set.
+  // Auto-select the first available conversation when none is set. Skip
+  // virtual directory rows (no real channel yet) so the thread/composer
+  // never operate on a synthetic id — those are only entered via an explicit
+  // click, which creates the DM first.
   const resolvedConversationId =
     activeConversationId ??
-    groups.flatMap((g) => g.rows).find(Boolean)?.id ??
+    groups.flatMap((g) => g.rows).find((r) => !r.id.startsWith(VIRTUAL_DM_PREFIX))?.id ??
     null;
 
   const handleSelectWorkspace = useCallback((ws: Workspace) => {
@@ -204,9 +266,20 @@ function LiveTeamChatPageBody({
     setActiveConversationId(null);
   }, []);
 
-  const handleSelectConversation = useCallback((row: ConversationRow) => {
-    setActiveConversationId(row.id);
-  }, []);
+  const handleSelectConversation = useCallback(
+    async (row: ConversationRow) => {
+      // Virtual directory row (no channel yet): create the DM on first open,
+      // refresh, then select the resolved real channel.
+      if (row.id.startsWith(VIRTUAL_DM_PREFIX) && row.agentSession && onEnsureDm) {
+        const channelId = await onEnsureDm(row.agentSession);
+        await refresh();
+        setActiveConversationId(channelId);
+        return;
+      }
+      setActiveConversationId(row.id);
+    },
+    [onEnsureDm, refresh],
+  );
 
   // "拉群" — create a multi-agent group chat, then refresh the channel list
   // and jump into it. Huddles are workspace-agnostic so they surface in the

--- a/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
@@ -27,12 +27,27 @@ vi.mock('../../hooks/useTeams', () => ({
 
 import { TeamChatRoute } from './TeamChatRoute';
 
-function makeTeam(id: string, name: string): Team {
+function makeTeam(id: string, name: string, members: Team['members'] = []): Team {
   return {
     id,
     name,
-    members: [],
+    members,
     projectIds: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function makeMember(id: string, name: string, sessionName: string) {
+  return {
+    id,
+    name,
+    sessionName,
+    role: 'developer',
+    systemPrompt: '',
+    agentStatus: 'inactive' as const,
+    workingStatus: 'idle' as const,
+    runtimeType: 'claude-code' as const,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
   };
@@ -113,6 +128,22 @@ describe('TeamChatRoute', () => {
     expect(liveProps).toHaveBeenCalledWith(
       expect.objectContaining({ initialWorkspaceId: DM_WORKSPACE_ID }),
     );
+  });
+
+  it('passes the full agent directory (every team member) to the page', async () => {
+    teamsRef.teams = [
+      makeTeam('t1', 'Alpha', [makeMember('m1', 'Ella', 'sess-ella')]),
+      makeTeam('t2', 'Beta', [makeMember('m2', 'Grace', 'sess-grace')]),
+    ];
+    renderAt('/team-chat');
+    await screen.findByTestId('live-team-chat');
+    const props = liveProps.mock.calls[0][0] as {
+      directoryAgents?: Array<{ agentSession: string }>;
+    };
+    expect((props.directoryAgents ?? []).map((a) => a.agentSession)).toEqual([
+      'sess-ella',
+      'sess-grace',
+    ]);
   });
 
   it('derives teamLabels from the teams directory', async () => {

--- a/frontend/src/components/Chat-team/TeamChatRoute.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.tsx
@@ -26,14 +26,15 @@
  * @module components/Chat-team/TeamChatRoute
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { LiveTeamChatPage } from './LiveTeamChatPage';
+import { LiveTeamChatPage, type DirectoryAgentEntry } from './LiveTeamChatPage';
 import { useTeams } from '../../hooks/useTeams';
 import { resolveBackendURL, resolveChatMode } from '../../utils/chat-backend';
 import {
   buildTeamLabels,
   buildMentionables,
+  agentStatusToPresence,
   TEAM_QUERY_PARAM,
   ORCHESTRATOR_SESSION,
   ORCHESTRATOR_LABEL,
@@ -73,7 +74,42 @@ export function TeamChatRoute(): JSX.Element {
   const teamLabels = useMemo(() => buildTeamLabels(teams), [teams]);
   const mentionables = useMemo(() => buildMentionables(teams), [teams]);
 
+  // Full agent directory → shown in the DM list (online + offline) so every
+  // agent is reachable. Derived from the teams the hook already fetched, so
+  // no extra request; falls back to GET /api/chat/agents semantics (session
+  // name + presence) without the round-trip.
+  const directoryAgents = useMemo<DirectoryAgentEntry[]>(() => {
+    const seen = new Set<string>();
+    const out: DirectoryAgentEntry[] = [];
+    for (const team of teams) {
+      for (const member of team.members ?? []) {
+        const session = member.sessionName;
+        if (!session || seen.has(session)) continue;
+        seen.add(session);
+        out.push({
+          agentSession: session,
+          name: member.name,
+          presence: agentStatusToPresence(member.agentStatus),
+        });
+      }
+    }
+    return out;
+  }, [teams]);
+
   const teamParam = searchParams.get(TEAM_QUERY_PARAM) || null;
+
+  // Find-or-create a DM for an agent the user opens from the directory.
+  const onEnsureDm = useCallback(
+    async (agentSession: string): Promise<string> => {
+      const agent = directoryAgents.find((a) => a.agentSession === agentSession);
+      const id = await ensureChannel('/api/chat/channels/dm/ensure', {
+        agentSession,
+        name: agent?.name ?? agentSession,
+      });
+      return id ?? '';
+    },
+    [directoryAgents],
+  );
 
   // Ensure the channels the page needs exist before mounting it. `readyKey`
   // tracks the team we've prepared for (or `__none__`) so a team switch
@@ -131,6 +167,8 @@ export function TeamChatRoute(): JSX.Element {
       initialWorkspaceId={initialWorkspaceId}
       initialConversationId={initialConversationId}
       directMessagesWorkspace={{ id: DM_WORKSPACE_ID, name: DM_WORKSPACE_LABEL }}
+      directoryAgents={directoryAgents}
+      onEnsureDm={onEnsureDm}
     />
   );
 }

--- a/frontend/src/utils/team-chat.utils.ts
+++ b/frontend/src/utils/team-chat.utils.ts
@@ -71,12 +71,13 @@ export function buildTeamLabels(teams: Team[]): Record<string, string> {
  * Translate a member's agent status into the chat-ui presence vocabulary.
  *
  * The teams directory tracks a richer agent lifecycle than the chat presence
- * dot; this collapses it to the three presence states the popover renders.
+ * dot; this collapses it to the states the UI renders (online / idle while
+ * starting / offline otherwise).
  *
  * @param agentStatus - The member's `agentStatus` from the teams directory.
- * @returns The chat-ui presence status for the mention row.
+ * @returns The chat-ui presence status.
  */
-function toPresence(agentStatus: string): ChatPresenceStatus {
+export function agentStatusToPresence(agentStatus: string): ChatPresenceStatus {
   switch (agentStatus) {
     case 'active':
     case 'started':
@@ -124,7 +125,7 @@ export function buildMentionables(teams: Team[]): MentionTarget[] {
         kind: 'agent',
         label: member.name,
         routingHint: member.role,
-        presence: toPresence(member.agentStatus),
+        presence: agentStatusToPresence(member.agentStatus),
         agentSession: member.sessionName,
       });
     }


### PR DESCRIPTION
Regression fix from the chat consolidation: the DM list only showed agents you'd already messaged. Now every agent appears (online/offline) via a host-supplied directory merged into the list; agents without a channel are synthetic rows whose DM is created on first open (lazy). Auto-select skips synthetic rows. Tests + typecheck + build green; Quality Gates passed. (Auto-activate-on-send to offline agents is the next PR.)