### PR TITLE
feat(chat): activate an offline agent on send, then deliver

### DIFF
--- a/backend/src/controllers/team/team.controller.test.ts
+++ b/backend/src/controllers/team/team.controller.test.ts
@@ -123,6 +123,7 @@ describe('Teams Handlers', () => {
       saveProject: jest.fn<any>(),
       getOrchestratorStatus: jest.fn<any>(),
       updateOrchestratorStatus: jest.fn<any>(),
+      findMemberBySessionName: jest.fn<any>(),
     };
 
     mockTmuxService = {
@@ -181,6 +182,15 @@ describe('Teams Handlers', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
+  });
+
+  describe('activateAgentBySession', () => {
+    it('returns an error when no member matches the session', async () => {
+      mockStorageService.findMemberBySessionName.mockResolvedValue(null);
+      const res = await teamsHandlers.activateAgentBySession(mockApiContext, 'ghost-session');
+      expect(res.success).toBe(false);
+      expect(res.error).toMatch(/No team member/);
+    });
   });
 
   describe('createTeam', () => {

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -479,6 +479,41 @@ function resolveAgentStatus(
 }
 
 /**
+ * Activate (start) a single agent by its session name — the user-initiated
+ * path used by chat "activate-on-send" (messaging an offline agent wakes it).
+ *
+ * Unlike the {@link startTeamMember} HTTP handler, this intentionally skips
+ * the orchestrator wake-gate: a human directly messaging the agent IS the
+ * authorization. Resolves the member's team + current project, then runs the
+ * shared start core. Idempotent — returns success if already active.
+ *
+ * @param context - API context (storage / registration / tmux services).
+ * @param sessionName - The agent session to activate.
+ * @returns `{ success, error? }`.
+ */
+export async function activateAgentBySession(
+  context: ApiContext,
+  sessionName: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const found = await context.storageService.findMemberBySessionName(sessionName);
+    if (!found) {
+      return { success: false, error: `No team member found for session '${sessionName}'` };
+    }
+    const { team, member } = found;
+    let projectPath: string | undefined;
+    if (team.projectIds[0]) {
+      const projects = await context.storageService.getProjects();
+      projectPath = projects.find((p) => p.id === team.projectIds[0])?.path;
+    }
+    const result = await _startTeamMemberCore(context, team, member, projectPath);
+    return { success: result.success, error: result.error };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
  * Core logic for starting a single team member
  * @param context - API context with services
  * @param team - The team containing the member

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1499,6 +1499,16 @@ void (async () => {
 					// to fan-out a user message to every huddle member.
 					huddleMembersFor: (channelId) =>
 						chatService.queryHuddleMembersForDispatch(channelId),
+					// Activate-on-send: messaging an offline agent wakes it, then
+					// the dispatcher retries delivery. User-initiated, so it uses
+					// the wake-gate-free activation path.
+					activateAgent: async (agentSession: string) => {
+						const { activateAgentBySession } = await import(
+							'./controllers/team/team.controller.js'
+						);
+						const res = await activateAgentBySession(this.apiController, agentSession);
+						return res.success;
+					},
 				});
 				this.chatV2Gateway = chatGateway;
 				this.chatV2Dispatcher = chatDispatcher;

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -149,6 +149,45 @@ describe('ChatV2DispatcherService', () => {
       expect(result).toEqual({ dispatched: false, error: 'no such session' });
     });
 
+    it('activates an inactive agent on send, then retries delivery', async () => {
+      // First send fails (no session); after activation the retry succeeds.
+      const calls: string[] = [];
+      let attempt = 0;
+      const sink: AgentMessageSink = {
+        async sendMessageToAgent(sessionName) {
+          calls.push(sessionName);
+          attempt += 1;
+          return attempt === 1
+            ? { success: false, error: 'Session does not exist' }
+            : { success: true };
+        },
+      };
+      const activated: string[] = [];
+      const dispatcher = new ChatV2DispatcherService({
+        agentSink: sink,
+        activateAgent: async (s) => {
+          activated.push(s);
+          return true;
+        },
+      });
+
+      const result = await dispatcher.dispatchToAgent(makeChannel(), makeMessage());
+      expect(result).toEqual({ dispatched: true });
+      expect(activated).toEqual(['crewly-product-sam-dd2b46f7']); // bound session
+      expect(calls).toHaveLength(2); // initial + retry after activation
+    });
+
+    it('stays failed when activation does not bring the agent up', async () => {
+      const { sink } = makeSink({ success: false, error: 'Session does not exist' });
+      const dispatcher = new ChatV2DispatcherService({
+        agentSink: sink,
+        activateAgent: async () => false,
+      });
+
+      const result = await dispatcher.dispatchToAgent(makeChannel(), makeMessage());
+      expect(result).toEqual({ dispatched: false, error: 'Session does not exist' });
+    });
+
     it('treats thrown errors as a clean, reportable failure', async () => {
       const sink: AgentMessageSink = {
         async sendMessageToAgent() {

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
@@ -146,6 +146,14 @@ export interface ChatV2DispatcherOptions {
    * Order doesn't matter — the dispatcher loops over the whole list.
    */
   huddleMembersFor?: (channelId: string) => readonly string[];
+  /**
+   * Activate-on-send hook. When a DM dispatch fails because the agent's
+   * session doesn't exist (inactive), the dispatcher calls this to start the
+   * agent, then retries delivery once. Returns true when the agent is now
+   * active. User-initiated, so it bypasses the orchestrator wake-gate by
+   * design. When omitted, inactive sends just queue (legacy behavior).
+   */
+  activateAgent?: (agentSession: string) => Promise<boolean>;
 }
 
 /** Inputs to the prompt formatter. */
@@ -215,6 +223,7 @@ export class ChatV2DispatcherService {
   private readonly formatPrompt: (args: FormatPromptArgs) => string;
   private readonly mentionResolver?: ChatV2MentionResolver;
   private readonly huddleMembersFor?: (channelId: string) => readonly string[];
+  private readonly activateAgent?: (agentSession: string) => Promise<boolean>;
   private readonly logger: ComponentLogger;
 
   constructor(options: ChatV2DispatcherOptions) {
@@ -222,6 +231,7 @@ export class ChatV2DispatcherService {
     this.formatPrompt = options.formatPrompt ?? defaultFormatPrompt;
     this.mentionResolver = options.mentionResolver;
     this.huddleMembersFor = options.huddleMembersFor;
+    this.activateAgent = options.activateAgent;
     this.logger = LoggerService.getInstance().createComponentLogger('ChatV2Dispatcher');
   }
 
@@ -537,12 +547,45 @@ export class ChatV2DispatcherService {
     }
 
     if (!result.success) {
-      this.logger.warn('chat-v2 dispatch reported failure', {
-        channelId: channel.id,
-        agentSession: channel.agentSession,
-        err: result.error,
-      });
-      return { dispatched: false, error: result.error ?? 'unknown sink failure' };
+      // Auto-activate on send: the agent's session doesn't exist (inactive).
+      // When an activation hook is wired, start the agent and retry delivery
+      // once — so messaging an offline agent wakes it and delivers, instead
+      // of silently queueing. This is user-initiated, so it bypasses the
+      // orchestrator wake-gate by design.
+      if (this.activateAgent) {
+        this.logger.info('chat-v2 dispatch: agent inactive — activating on send', {
+          channelId: channel.id,
+          agentSession: channel.agentSession,
+        });
+        let activated = false;
+        try {
+          activated = await this.activateAgent(channel.agentSession);
+        } catch (err) {
+          this.logger.warn('chat-v2 activate-on-send failed', {
+            agentSession: channel.agentSession,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+        if (activated) {
+          try {
+            result = await this.agentSink.sendMessageToAgent(channel.agentSession, prompt);
+          } catch (err) {
+            return {
+              dispatched: false,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }
+      }
+
+      if (!result.success) {
+        this.logger.warn('chat-v2 dispatch reported failure', {
+          channelId: channel.id,
+          agentSession: channel.agentSession,
+          err: result.error,
+        });
+        return { dispatched: false, error: result.error ?? 'unknown sink failure' };
+      }
     }
 
     this.logger.debug('chat-v2 dispatched', {

--- a/frontend/src/components/Chat-team/EmptyStates.test.tsx
+++ b/frontend/src/components/Chat-team/EmptyStates.test.tsx
@@ -43,10 +43,10 @@ describe('Chat-team EmptyStates', () => {
     expect(screen.getByText(/notify this agent/i)).toBeInTheDocument();
   });
 
-  it('AgentOfflineBanner explains queueing without disabling the composer', () => {
+  it('AgentOfflineBanner explains activate-on-send without disabling the composer', () => {
     render(<AgentOfflineBanner agentName="Max" />);
     expect(screen.getByTestId('banner-agent-offline')).toBeInTheDocument();
     expect(screen.getByText(/Max is currently inactive/i)).toBeInTheDocument();
-    expect(screen.getByText(/delivered to the private queue/i)).toBeInTheDocument();
+    expect(screen.getByText(/will activate/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Chat-team/EmptyStates.tsx
+++ b/frontend/src/components/Chat-team/EmptyStates.tsx
@@ -150,8 +150,8 @@ export function NoMessagesEmptyState({
 
 /**
  * §9.4 — Active DM but the agent is currently inactive/offline. NOT a
- * dead end — the composer stays available, the banner explains the
- * queueing behavior so the user knows what happens next.
+ * dead end — the composer stays available. Sending activates the agent and
+ * delivers the message; the banner sets that expectation.
  */
 export function AgentOfflineBanner({ agentName }: { agentName: string }): JSX.Element {
   return (
@@ -160,8 +160,8 @@ export function AgentOfflineBanner({ agentName }: { agentName: string }): JSX.El
       data-testid="banner-agent-offline"
       className="border-b border-amber-300 bg-amber-50 px-4 py-2 text-xs text-amber-800 dark:border-amber-600/40 dark:bg-amber-900/20 dark:text-amber-100"
     >
-      <strong>{agentName} is currently inactive.</strong> Your message will be delivered to the
-      private queue and surfaced when {agentName} resumes the session.
+      <strong>{agentName} is currently inactive.</strong> Sending a message will activate{' '}
+      {agentName} and deliver it once the session is up.
     </div>
   );
 }

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -538,7 +538,7 @@ function LiveTeamChatRightPanelInner({
         onSend={handleSend}
         inactiveHelper={
           isInactiveDm && recipientName
-            ? `${recipientName} is inactive. Message will queue for later delivery.`
+            ? `${recipientName} is inactive — sending will activate them and deliver your message.`
             : threadRoot
               ? `Replying in thread ${threadRoot}`
               : undefined


### PR DESCRIPTION
Messaging an offline agent now wakes it and delivers (was: queue-only). Dispatcher gets an optional activateAgent hook; on a no-session DM failure it activates the agent (via a new wake-gate-free activateAgentBySession — user-directed) and retries delivery once. Banner copy updated. Tests + typechecks green; Quality Gates passed.