### PR TITLE
feat(chat): pinned chats + collapsible list sections

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -557,8 +557,29 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     // The orchestrator DM is reachable (not the no-teams dead-end).
     expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
     expect(screen.getAllByText('Orchestrator').length).toBeGreaterThan(0);
-    // "Direct Messages" appears once (group label only, not also a panel header).
-    expect(screen.getAllByText('Direct Messages').length).toBe(1);
+    // Orchestrator is pinned by default → surfaces under "Pinned Chats".
+    expect(screen.getByText('Pinned Chats')).toBeInTheDocument();
+  });
+
+  it('pins the orchestrator by default and lets you unpin it', async () => {
+    window.localStorage.clear();
+    const channels: Channel[] = [
+      { id: 'orc-dm', agentSession: 'crewly-orc', name: 'Orchestrator', createdAt: ISO, type: 'dm', presence: 'online' },
+      { id: 'dm-ella', agentSession: 'sess-ella', name: 'Ella', createdAt: ISO, type: 'dm', presence: 'online' },
+    ];
+    const { client } = makeStubClient(channels);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+      />,
+    );
+    // Orchestrator pinned by default → Pinned Chats section present; Ella isn't pinned.
+    await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
+    // Unpin the orchestrator via its pin toggle.
+    fireEvent.click(screen.getByTestId('conv-pin-orc-dm'));
+    await waitFor(() => expect(screen.queryByTestId('conv-group-pinned')).not.toBeInTheDocument());
   });
 });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -57,6 +57,7 @@ import {
 } from './EmptyStates';
 import { ChatErrorToast } from './ChatErrorToast';
 import { CreateGroupModal } from './CreateGroupModal';
+import { usePinnedChats } from '../../hooks/usePinnedChats';
 
 export interface LiveTeamChatPageProps {
   /** OSS backend base URL. Required when no `client` is injected. */
@@ -168,6 +169,11 @@ interface BodyProps {
 /** Prefix marking a synthetic DM row for a directory agent without a channel. */
 const VIRTUAL_DM_PREFIX = 'agent:';
 
+/** Stable pin key for a row: agent session for DMs, channel id for groups. */
+function pinKeyOf(row: ConversationRow): string {
+  return row.agentSession || row.id;
+}
+
 function LiveTeamChatPageBody({
   teamLabels,
   mentionables,
@@ -179,6 +185,7 @@ function LiveTeamChatPageBody({
 }: BodyProps): JSX.Element {
   const { channels, loading: channelsLoading, error: channelsError, refresh } = useChannels();
   const client = useChatApiClient();
+  const pinnedChats = usePinnedChats();
   const [showCreateGroup, setShowCreateGroup] = useState(false);
 
   // Merge the agent directory into the channel list so EVERY agent appears in
@@ -259,7 +266,7 @@ function LiveTeamChatPageBody({
     return m;
   }, [directoryAgents]);
 
-  const groups = useMemo(() => {
+  const sectioned = useMemo(() => {
     const dms = baseGroups.find((g) => g.id === 'dms');
     if (!dms || sessionToTeam.size === 0) return baseGroups;
 
@@ -290,6 +297,25 @@ function LiveTeamChatPageBody({
       return out;
     });
   }, [baseGroups, sessionToTeam]);
+
+  // Lift pinned conversations into a top "Pinned Chats" section, removing them
+  // from their normal section so they appear once. Orchestrator is pinned by
+  // default (see usePinnedChats); the user can pin/unpin any DM or huddle.
+  const groups = useMemo(() => {
+    const pinnedRows: ConversationRow[] = [];
+    const pruned = sectioned
+      .map((g) => {
+        const keep: ConversationRow[] = [];
+        for (const r of g.rows) {
+          if (pinnedChats.isPinned(pinKeyOf(r))) pinnedRows.push(r);
+          else keep.push(r);
+        }
+        return { ...g, rows: keep };
+      })
+      .filter((g) => g.rows.length > 0);
+    if (pinnedRows.length === 0) return pruned;
+    return [{ id: 'pinned', label: 'Pinned Chats', rows: pinnedRows }, ...pruned];
+  }, [sectioned, pinnedChats]);
 
   const totalRows = useMemo(
     () => groups.reduce((acc, g) => acc + g.rows.length, 0),
@@ -393,6 +419,8 @@ function LiveTeamChatPageBody({
         groups={groups}
         activeConversationId={resolvedConversationId}
         onSelectConversation={handleSelectConversation}
+        isPinned={(row) => pinnedChats.isPinned(pinKeyOf(row))}
+        onTogglePin={(row) => pinnedChats.toggle(pinKeyOf(row))}
         headerAction={
           <button
             type="button"

--- a/frontend/src/hooks/usePinnedChats.test.ts
+++ b/frontend/src/hooks/usePinnedChats.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for usePinnedChats — localStorage-backed pinned-conversation set.
+ *
+ * @module hooks/usePinnedChats.test
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePinnedChats } from './usePinnedChats';
+
+describe('usePinnedChats', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('pins the orchestrator by default', () => {
+    const { result } = renderHook(() => usePinnedChats());
+    expect(result.current.isPinned('crewly-orc')).toBe(true);
+    expect(result.current.isPinned('sess-ella')).toBe(false);
+  });
+
+  it('toggles a key on and off and persists to localStorage', () => {
+    const { result } = renderHook(() => usePinnedChats());
+
+    act(() => result.current.toggle('sess-ella'));
+    expect(result.current.isPinned('sess-ella')).toBe(true);
+    expect(window.localStorage.getItem('crewly-chat-pinned')).toContain('sess-ella');
+
+    act(() => result.current.toggle('sess-ella'));
+    expect(result.current.isPinned('sess-ella')).toBe(false);
+  });
+
+  it('honors a stored preference (e.g. orchestrator unpinned) over the default', () => {
+    window.localStorage.setItem('crewly-chat-pinned', JSON.stringify([]));
+    const { result } = renderHook(() => usePinnedChats());
+    expect(result.current.isPinned('crewly-orc')).toBe(false);
+  });
+});

--- a/frontend/src/hooks/usePinnedChats.ts
+++ b/frontend/src/hooks/usePinnedChats.ts
@@ -1,0 +1,70 @@
+/**
+ * usePinnedChats — persistent set of "pinned" conversation keys for the
+ * consolidated chat. Pinned conversations float into a top "Pinned Chats"
+ * section. The orchestrator is pinned by default; the user can pin/unpin any
+ * agent DM or group.
+ *
+ * Persistence is localStorage (per-browser) — there is no backend pin field
+ * yet, mirroring the wiki tree-collapse persistence pattern. A pin "key" is
+ * the conversation's agent session (stable for DMs) or its channel id (groups).
+ *
+ * @module hooks/usePinnedChats
+ */
+
+import { useCallback, useState } from 'react';
+import { ORCHESTRATOR_SESSION } from '../utils/team-chat.utils';
+
+const PINNED_KEY = 'crewly-chat-pinned';
+
+/** Default pins applied when the user has no stored preference yet. */
+const DEFAULT_PINS = [ORCHESTRATOR_SESSION];
+
+function loadPins(): Set<string> {
+  try {
+    const raw = localStorage.getItem(PINNED_KEY);
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) return new Set(arr.filter((x) => typeof x === 'string'));
+    }
+  } catch {
+    // ignore — fall through to defaults
+  }
+  return new Set(DEFAULT_PINS);
+}
+
+export interface UsePinnedChatsResult {
+  /** The set of pinned conversation keys. */
+  pinned: Set<string>;
+  /** True when `key` is pinned. */
+  isPinned: (key: string) => boolean;
+  /** Pin/unpin `key`, persisting the change. */
+  toggle: (key: string) => void;
+}
+
+/**
+ * Hook exposing the pinned-conversation set + a toggle, persisted to
+ * localStorage. Orchestrator is pinned by default.
+ *
+ * @returns The pinned set, an `isPinned` predicate, and a `toggle` action.
+ */
+export function usePinnedChats(): UsePinnedChatsResult {
+  const [pinned, setPinned] = useState<Set<string>>(loadPins);
+
+  const toggle = useCallback((key: string) => {
+    setPinned((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      try {
+        localStorage.setItem(PINNED_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore — pinning is best-effort
+      }
+      return next;
+    });
+  }, []);
+
+  const isPinned = useCallback((key: string) => pinned.has(key), [pinned]);
+
+  return { pinned, isPinned, toggle };
+}

--- a/packages/chat-ui/src/components/ConversationListPanel.test.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.test.tsx
@@ -147,4 +147,29 @@ describe('ConversationListPanel', () => {
     expect(screen.getByText('Channels')).toBeInTheDocument();
     expect(screen.queryByText('Direct Messages')).not.toBeInTheDocument();
   });
+
+  it('collapses and expands a section when its header is clicked', async () => {
+    window.localStorage.clear();
+    renderPanel();
+    expect(screen.getByTestId('conv-row-c-general')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('conv-group-toggle-channels'));
+    expect(screen.queryByTestId('conv-row-c-general')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('conv-group-toggle-channels'));
+    expect(screen.getByTestId('conv-row-c-general')).toBeInTheDocument();
+  });
+
+  it('renders a pin toggle per row that fires onTogglePin without selecting', async () => {
+    window.localStorage.clear();
+    const onTogglePin = vi.fn();
+    const onSelectConversation = vi.fn();
+    renderPanel({ onTogglePin, isPinned: () => false, onSelectConversation });
+    await userEvent.click(screen.getByTestId('conv-pin-dm-sam'));
+    expect(onTogglePin).toHaveBeenCalledTimes(1);
+    expect(onSelectConversation).not.toHaveBeenCalled();
+  });
+
+  it('omits pin toggles when onTogglePin is not provided', () => {
+    renderPanel();
+    expect(screen.queryByTestId('conv-pin-dm-sam')).not.toBeInTheDocument();
+  });
 });

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -24,9 +24,25 @@
  * @module components/ConversationListPanel
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { ConversationGroup, ConversationRow } from '../types/team-chat.types';
 import { AgentStatusBadge } from './AgentStatusBadge';
+
+/** localStorage key for collapsed conversation-group ids. */
+const COLLAPSED_GROUPS_KEY = 'crewly-chat-collapsed-groups';
+
+function loadCollapsedGroups(): Set<string> {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_GROUPS_KEY);
+    if (raw) {
+      const arr = JSON.parse(raw);
+      if (Array.isArray(arr)) return new Set(arr.filter((x) => typeof x === 'string'));
+    }
+  } catch {
+    // ignore — start expanded
+  }
+  return new Set();
+}
 
 export interface ConversationListPanelProps {
   /** Workspace title rendered as the panel header. */
@@ -49,6 +65,10 @@ export interface ConversationListPanelProps {
    * the header renders even if `workspaceName` is omitted.
    */
   headerAction?: React.ReactNode;
+  /** When provided, renders a pin toggle per row; returns true if pinned. */
+  isPinned?: (row: ConversationRow) => boolean;
+  /** Pin/unpin a conversation. Enables the per-row pin affordance. */
+  onTogglePin?: (row: ConversationRow) => void;
   className?: string;
 }
 
@@ -59,12 +79,30 @@ export function ConversationListPanel({
   onSelectConversation,
   emptyState,
   headerAction,
+  isPinned,
+  onTogglePin,
   className = '',
 }: ConversationListPanelProps): JSX.Element {
   const totalRows = useMemo(
     () => groups.reduce((acc, g) => acc + g.rows.length, 0),
     [groups],
   );
+
+  // Collapsed/expanded state per group id, persisted to localStorage.
+  const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsedGroups);
+  const toggleCollapse = useCallback((id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      try {
+        localStorage.setItem(COLLAPSED_GROUPS_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore — collapse state is best-effort
+      }
+      return next;
+    });
+  }, []);
 
   return (
     <aside
@@ -94,6 +132,10 @@ export function ConversationListPanel({
                 group={group}
                 activeConversationId={activeConversationId}
                 onSelectConversation={onSelectConversation}
+                collapsed={collapsed.has(group.id)}
+                onToggleCollapse={() => toggleCollapse(group.id)}
+                isPinned={isPinned}
+                onTogglePin={onTogglePin}
               />
             ) : null,
           )
@@ -107,10 +149,18 @@ function ConversationGroupSection({
   group,
   activeConversationId,
   onSelectConversation,
+  collapsed,
+  onToggleCollapse,
+  isPinned,
+  onTogglePin,
 }: {
   group: ConversationGroup;
   activeConversationId: string | null;
   onSelectConversation?: (row: ConversationRow) => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  isPinned?: (row: ConversationRow) => boolean;
+  onTogglePin?: (row: ConversationRow) => void;
 }): JSX.Element {
   return (
     <section
@@ -118,24 +168,48 @@ function ConversationGroupSection({
       aria-labelledby={`conv-group-${group.id}`}
       data-testid={`conv-group-${group.id}`}
     >
-      <h3
+      {/* Collapsible header — click to expand/collapse the section. */}
+      <button
+        type="button"
         id={`conv-group-${group.id}`}
-        className="px-4 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+        onClick={onToggleCollapse}
+        aria-expanded={!collapsed}
+        data-testid={`conv-group-toggle-${group.id}`}
+        className="flex w-full items-center gap-1 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
       >
-        {group.label}
-      </h3>
-      <ul role="list" className="flex flex-col">
-        {group.rows.map((row) => (
-          <li key={row.id}>
-            <ConversationRowItem
-              row={row}
-              isActive={activeConversationId === row.id}
-              onSelect={onSelectConversation}
-            />
-          </li>
-        ))}
-      </ul>
+        <Chevron collapsed={collapsed} />
+        <span className="truncate">{group.label}</span>
+        <span className="ml-auto text-slate-400 dark:text-slate-500">{group.rows.length}</span>
+      </button>
+      {!collapsed && (
+        <ul role="list" className="flex flex-col">
+          {group.rows.map((row) => (
+            <li key={row.id}>
+              <ConversationRowItem
+                row={row}
+                isActive={activeConversationId === row.id}
+                onSelect={onSelectConversation}
+                pinned={isPinned?.(row) ?? false}
+                onTogglePin={onTogglePin}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
+  );
+}
+
+/** Right-pointing chevron that rotates down when expanded. */
+function Chevron({ collapsed }: { collapsed: boolean }): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 12 12"
+      className={`h-3 w-3 shrink-0 transition-transform ${collapsed ? '' : 'rotate-90'}`}
+    >
+      <path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
   );
 }
 
@@ -143,32 +217,38 @@ function ConversationRowItem({
   row,
   isActive,
   onSelect,
+  pinned,
+  onTogglePin,
 }: {
   row: ConversationRow;
   isActive: boolean;
   onSelect?: (row: ConversationRow) => void;
+  pinned?: boolean;
+  onTogglePin?: (row: ConversationRow) => void;
 }): JSX.Element {
   const hasUnread = (row.unreadCount ?? 0) > 0;
   const hasMentions = (row.mentionCount ?? 0) > 0;
 
   return (
-    <button
-      type="button"
-      onClick={() => onSelect?.(row)}
-      data-testid={`conv-row-${row.id}`}
-      data-active={isActive ? 'true' : 'false'}
-      data-kind={row.kind}
-      data-unread={hasUnread ? 'true' : 'false'}
+    <div
       className={[
-        // Full-width active state per §6.1 — left border + tinted bg, not just text color.
-        'flex w-full items-center gap-2 border-l-2 px-3 py-2 text-left transition',
+        'group/row relative flex w-full items-center border-l-2 transition',
         isActive
           ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
           : 'border-transparent hover:bg-slate-100 dark:hover:bg-slate-800',
       ].join(' ')}
-      aria-current={isActive ? 'page' : undefined}
     >
-      <ConversationKindIcon row={row} />
+      <button
+        type="button"
+        onClick={() => onSelect?.(row)}
+        data-testid={`conv-row-${row.id}`}
+        data-active={isActive ? 'true' : 'false'}
+        data-kind={row.kind}
+        data-unread={hasUnread ? 'true' : 'false'}
+        className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left"
+        aria-current={isActive ? 'page' : undefined}
+      >
+        <ConversationKindIcon row={row} />
 
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -228,7 +308,44 @@ function ConversationRowItem({
           {row.unreadCount}
         </span>
       ) : null}
-    </button>
+      </button>
+
+      {onTogglePin && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onTogglePin(row);
+          }}
+          data-testid={`conv-pin-${row.id}`}
+          aria-label={pinned ? `Unpin ${row.title}` : `Pin ${row.title}`}
+          aria-pressed={pinned}
+          title={pinned ? 'Unpin' : 'Pin'}
+          className={[
+            'mr-2 shrink-0 rounded p-1 text-slate-400 hover:text-amber-500',
+            // Pinned: always visible. Unpinned: reveal on row hover.
+            pinned ? 'text-amber-500' : 'opacity-0 group-hover/row:opacity-100',
+          ].join(' ')}
+        >
+          <PinIcon filled={pinned ?? false} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Pin glyph — filled when pinned. */
+function PinIcon({ filled }: { filled: boolean }): JSX.Element {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5">
+      <path
+        d="M9.5 1.5l5 5-2 .5-2.5 2.5L9 13 7 11 3.5 14.5 3 14l3.5-3.5L4.5 8.5 7 6l.5-2.5 2-2z"
+        fill={filled ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 

--- a/packages/chat-ui/src/hooks/useGroupedChannels.test.ts
+++ b/packages/chat-ui/src/hooks/useGroupedChannels.test.ts
@@ -67,7 +67,7 @@ describe('buildConversationGroups', () => {
     expect(groups[0].id).toBe('channels');
     expect(groups[0].label).toBe('Channels');
     expect(groups[1].id).toBe('huddles');
-    expect(groups[1].label).toBe('Group Chats');
+    expect(groups[1].label).toBe('Huddles');
     expect(groups[2].id).toBe('dms');
     expect(groups[2].label).toBe('Direct Messages');
   });

--- a/packages/chat-ui/src/hooks/useGroupedChannels.ts
+++ b/packages/chat-ui/src/hooks/useGroupedChannels.ts
@@ -81,7 +81,7 @@ export function buildConversationGroups(
   // the Group Chats group is safe — it only shows once a huddle exists.
   return [
     { id: 'channels', label: 'Channels', rows: channelRows },
-    { id: 'huddles', label: 'Group Chats', rows: huddleRows },
+    { id: 'huddles', label: 'Huddles', rows: huddleRows },
     { id: 'dms', label: 'Direct Messages', rows: dmRows },
   ];
 }


### PR DESCRIPTION
Restructures the conversation list: **Pinned Chats** (orchestrator pinned by default; user can pin/unpin any DM/huddle, persisted), **Huddles** (renamed from Group Chats), **Teams** (per-team sections). Every section is collapsible/expandable (persisted). chat-ui changes additive (collapsible self-contained; isPinned/onTogglePin optional). Tests + build green; Quality Gates passed.