### PR TITLE
feat(chat): nest per-team sections under a collapsible "Teams" parent

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -484,8 +484,9 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
         onEnsureDm={async () => 'real-chan'}
       />,
     );
-    // Team section headers, with their agents underneath.
-    expect(await screen.findByText('Content')).toBeInTheDocument();
+    // Team sections nest under a "Teams" parent, each with its agents.
+    expect(await screen.findByText('Teams')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
     expect(screen.getByText('Sales')).toBeInTheDocument();
     expect(screen.getByText('Ella')).toBeInTheDocument();
     expect(screen.getByText('Luna')).toBeInTheDocument();

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -44,6 +44,7 @@ import {
   type ChatApiError,
   type Channel,
   type ChatPresenceStatus,
+  type ConversationGroup,
   type ConversationRow,
   type MentionComposerSendPayload,
   type MentionTarget,
@@ -174,6 +175,16 @@ function pinKeyOf(row: ConversationRow): string {
   return row.agentSession || row.id;
 }
 
+/** Count rows in a group including nested sub-groups. */
+function countGroupRows(group: ConversationGroup): number {
+  return group.rows.length + (group.subGroups?.reduce((a, g) => a + countGroupRows(g), 0) ?? 0);
+}
+
+/** Flatten all rows across groups + nested sub-groups, in render order. */
+function flattenRows(groups: ConversationGroup[]): ConversationRow[] {
+  return groups.flatMap((g) => [...g.rows, ...flattenRows(g.subGroups ?? [])]);
+}
+
 function LiveTeamChatPageBody({
   teamLabels,
   mentionables,
@@ -283,36 +294,40 @@ function LiveTeamChatPageBody({
       }
     }
 
-    const teamSections = [...byTeam.entries()]
+    const teamSections: ConversationGroup[] = [...byTeam.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([team, rows]) => ({ id: `dm-team:${team}`, label: team, rows }));
 
-    // Preserve original order (channels, huddles) then DMs: orchestrator/
-    // teamless DMs first, then per-team sections.
-    return baseGroups.flatMap((g) => {
+    // Per-team sections nest under a single collapsible "Teams" parent.
+    // Order: channels, huddles, teamless DMs, then Teams.
+    return baseGroups.flatMap<ConversationGroup>((g) => {
       if (g.id !== 'dms') return [g];
-      const out = [];
+      const out: ConversationGroup[] = [];
       if (noTeam.length > 0) out.push({ id: 'dms', label: 'Direct Messages', rows: noTeam });
-      out.push(...teamSections);
+      if (teamSections.length > 0) {
+        out.push({ id: 'teams', label: 'Teams', rows: [], subGroups: teamSections });
+      }
       return out;
     });
   }, [baseGroups, sessionToTeam]);
 
   // Lift pinned conversations into a top "Pinned Chats" section, removing them
-  // from their normal section so they appear once. Orchestrator is pinned by
-  // default (see usePinnedChats); the user can pin/unpin any DM or huddle.
+  // from their normal section (including nested team sub-groups) so they appear
+  // once. Orchestrator is pinned by default; the user can pin/unpin any chat.
   const groups = useMemo(() => {
     const pinnedRows: ConversationRow[] = [];
-    const pruned = sectioned
-      .map((g) => {
-        const keep: ConversationRow[] = [];
-        for (const r of g.rows) {
-          if (pinnedChats.isPinned(pinKeyOf(r))) pinnedRows.push(r);
-          else keep.push(r);
-        }
-        return { ...g, rows: keep };
-      })
-      .filter((g) => g.rows.length > 0);
+    const prune = (g: ConversationGroup): ConversationGroup => {
+      const keep: ConversationRow[] = [];
+      for (const r of g.rows) {
+        if (pinnedChats.isPinned(pinKeyOf(r))) pinnedRows.push(r);
+        else keep.push(r);
+      }
+      const subs = (g.subGroups ?? [])
+        .map(prune)
+        .filter((sg) => countGroupRows(sg) > 0);
+      return { ...g, rows: keep, subGroups: subs.length > 0 ? subs : undefined };
+    };
+    const pruned = sectioned.map(prune).filter((g) => countGroupRows(g) > 0);
     if (pinnedRows.length === 0) return pruned;
     return [{ id: 'pinned', label: 'Pinned Chats', rows: pinnedRows }, ...pruned];
   }, [sectioned, pinnedChats]);
@@ -328,7 +343,7 @@ function LiveTeamChatPageBody({
   // click, which creates the DM first.
   const resolvedConversationId =
     activeConversationId ??
-    groups.flatMap((g) => g.rows).find((r) => !r.id.startsWith(VIRTUAL_DM_PREFIX))?.id ??
+    flattenRows(groups).find((r) => !r.id.startsWith(VIRTUAL_DM_PREFIX))?.id ??
     null;
 
   const handleSelectWorkspace = useCallback((ws: Workspace) => {
@@ -370,13 +385,10 @@ function LiveTeamChatPageBody({
     () => workspaces.find((w) => w.id === resolvedWorkspaceId) ?? null,
     [workspaces, resolvedWorkspaceId],
   );
-  const activeConversation = useMemo(() => {
-    for (const g of groups) {
-      const found = g.rows.find((r) => r.id === resolvedConversationId);
-      if (found) return found;
-    }
-    return undefined;
-  }, [groups, resolvedConversationId]);
+  const activeConversation = useMemo(
+    () => flattenRows(groups).find((r) => r.id === resolvedConversationId),
+    [groups, resolvedConversationId],
+  );
 
   // §9.1 — no workspaces visible at all (e.g. brand-new account).
   if (workspaces.length === 0 && !channelsLoading) {

--- a/packages/chat-ui/src/components/ConversationListPanel.test.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.test.tsx
@@ -172,4 +172,30 @@ describe('ConversationListPanel', () => {
     renderPanel();
     expect(screen.queryByTestId('conv-pin-dm-sam')).not.toBeInTheDocument();
   });
+
+  it('renders nested sub-groups; collapsing the parent hides its children', async () => {
+    window.localStorage.clear();
+    renderPanel({
+      groups: [
+        {
+          id: 'teams',
+          label: 'Teams',
+          rows: [],
+          subGroups: [
+            { id: 'dm-team:Content', label: 'Content', rows: [
+              { id: 'dm-ella', kind: 'dm', title: 'Ella' },
+            ] },
+          ],
+        },
+      ],
+    });
+    expect(screen.getByText('Teams')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByTestId('conv-row-dm-ella')).toBeInTheDocument();
+
+    // Collapse the Teams parent → nested team + member disappear.
+    await userEvent.click(screen.getByTestId('conv-group-toggle-teams'));
+    expect(screen.queryByText('Content')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('conv-row-dm-ella')).not.toBeInTheDocument();
+  });
 });

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -84,7 +84,7 @@ export function ConversationListPanel({
   className = '',
 }: ConversationListPanelProps): JSX.Element {
   const totalRows = useMemo(
-    () => groups.reduce((acc, g) => acc + g.rows.length, 0),
+    () => groups.reduce((acc, g) => acc + countRows(g), 0),
     [groups],
   );
 
@@ -126,14 +126,14 @@ export function ConversationListPanel({
           </div>
         ) : (
           groups.map((group) =>
-            group.rows.length > 0 ? (
+            groupHasContent(group) ? (
               <ConversationGroupSection
                 key={group.id}
                 group={group}
                 activeConversationId={activeConversationId}
                 onSelectConversation={onSelectConversation}
-                collapsed={collapsed.has(group.id)}
-                onToggleCollapse={() => toggleCollapse(group.id)}
+                collapsed={collapsed}
+                onToggleCollapse={toggleCollapse}
                 isPinned={isPinned}
                 onTogglePin={onTogglePin}
               />
@@ -145,6 +145,18 @@ export function ConversationListPanel({
   );
 }
 
+/** Total rows in a group, including nested sub-groups. */
+function countRows(group: ConversationGroup): number {
+  return (
+    group.rows.length + (group.subGroups?.reduce((acc, g) => acc + countRows(g), 0) ?? 0)
+  );
+}
+
+/** Whether a group has any conversation to render (own rows or nested). */
+function groupHasContent(group: ConversationGroup): boolean {
+  return countRows(group) > 0;
+}
+
 function ConversationGroupSection({
   group,
   activeConversationId,
@@ -153,18 +165,25 @@ function ConversationGroupSection({
   onToggleCollapse,
   isPinned,
   onTogglePin,
+  depth = 0,
 }: {
   group: ConversationGroup;
   activeConversationId: string | null;
   onSelectConversation?: (row: ConversationRow) => void;
-  collapsed: boolean;
-  onToggleCollapse: () => void;
+  /** The set of collapsed group ids, so nested sections manage themselves. */
+  collapsed: Set<string>;
+  onToggleCollapse: (id: string) => void;
   isPinned?: (row: ConversationRow) => boolean;
   onTogglePin?: (row: ConversationRow) => void;
+  /** Nesting depth — drives header indentation for sub-groups. */
+  depth?: number;
 }): JSX.Element {
+  const isCollapsed = collapsed.has(group.id);
+  const subGroups = (group.subGroups ?? []).filter(groupHasContent);
+
   return (
     <section
-      className="border-b border-slate-200 py-2 last:border-b-0 dark:border-slate-800"
+      className={depth === 0 ? 'border-b border-slate-200 py-2 last:border-b-0 dark:border-slate-800' : ''}
       aria-labelledby={`conv-group-${group.id}`}
       data-testid={`conv-group-${group.id}`}
     >
@@ -172,29 +191,47 @@ function ConversationGroupSection({
       <button
         type="button"
         id={`conv-group-${group.id}`}
-        onClick={onToggleCollapse}
-        aria-expanded={!collapsed}
+        onClick={() => onToggleCollapse(group.id)}
+        aria-expanded={!isCollapsed}
         data-testid={`conv-group-toggle-${group.id}`}
-        className="flex w-full items-center gap-1 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        className="flex w-full items-center gap-1 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        style={{ paddingLeft: `${0.75 + depth * 0.75}rem`, paddingRight: '0.75rem' }}
       >
-        <Chevron collapsed={collapsed} />
+        <Chevron collapsed={isCollapsed} />
         <span className="truncate">{group.label}</span>
-        <span className="ml-auto text-slate-400 dark:text-slate-500">{group.rows.length}</span>
+        <span className="ml-auto text-slate-400 dark:text-slate-500">{countRows(group)}</span>
       </button>
-      {!collapsed && (
-        <ul role="list" className="flex flex-col">
-          {group.rows.map((row) => (
-            <li key={row.id}>
-              <ConversationRowItem
-                row={row}
-                isActive={activeConversationId === row.id}
-                onSelect={onSelectConversation}
-                pinned={isPinned?.(row) ?? false}
-                onTogglePin={onTogglePin}
-              />
-            </li>
+      {!isCollapsed && (
+        <>
+          {group.rows.length > 0 && (
+            <ul role="list" className="flex flex-col">
+              {group.rows.map((row) => (
+                <li key={row.id}>
+                  <ConversationRowItem
+                    row={row}
+                    isActive={activeConversationId === row.id}
+                    onSelect={onSelectConversation}
+                    pinned={isPinned?.(row) ?? false}
+                    onTogglePin={onTogglePin}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+          {subGroups.map((sub) => (
+            <ConversationGroupSection
+              key={sub.id}
+              group={sub}
+              activeConversationId={activeConversationId}
+              onSelectConversation={onSelectConversation}
+              collapsed={collapsed}
+              onToggleCollapse={onToggleCollapse}
+              isPinned={isPinned}
+              onTogglePin={onTogglePin}
+              depth={depth + 1}
+            />
           ))}
-        </ul>
+        </>
       )}
     </section>
   );

--- a/packages/chat-ui/src/types/team-chat.types.ts
+++ b/packages/chat-ui/src/types/team-chat.types.ts
@@ -114,6 +114,12 @@ export interface ConversationGroup {
   /** Section heading copy, e.g. "Direct Messages". */
   label: string;
   rows: ConversationRow[];
+  /**
+   * Optional nested sub-sections rendered (and independently collapsible)
+   * under this group's header — e.g. a "Teams" group whose sub-groups are
+   * the per-team conversation lists. One level of nesting only.
+   */
+  subGroups?: ConversationGroup[];
 }
 
 // =============================================================================


### PR DESCRIPTION
Wraps the per-team sections under a single collapsible "Teams" group (Pinned Chats → Huddles → Teams ▸ team sections). chat-ui ConversationGroup gains optional subGroups (one level of nesting); panel renders nested, indented, independently-collapsible sub-sections. Additive (Portal-safe). Tests + build green.