### PR TITLE
feat(chat): surface Slack threads in the consolidated chat list

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -372,6 +372,25 @@ describe('ChatV2Service', () => {
       expect(service.listChannels({ principal: otherUser })).toHaveLength(1);
     });
 
+    it('surfaces bridged Slack channels the caller does not own', () => {
+      // Slack bridge persists under the synthetic 'system' owner.
+      service.ensureChannelForLegacyConversation({
+        conversationId: 'slack-D0-1',
+        agentSession: 'crewly-orc',
+      });
+      const list = service.listChannels({ principal: owner });
+      expect(list.some((c) => c.id === 'slack-D0-1')).toBe(true);
+    });
+
+    it('excludes bridged channels when a type filter is applied', () => {
+      service.ensureChannelForLegacyConversation({
+        conversationId: 'slack-D0-2',
+        agentSession: 'crewly-orc',
+      });
+      const list = service.listChannels({ principal: owner, type: 'channel' });
+      expect(list.some((c) => c.id === 'slack-D0-2')).toBe(false);
+    });
+
     // Phase C — channel-rail listing refinements: type + teamId filters.
     describe('Phase C filters', () => {
       function seedMixedFixture() {

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -145,6 +145,13 @@ export interface ListChannelsArgs {
    * team_id) drop out of the result.
    */
   teamId?: string;
+  /**
+   * Include "bridged" channels (Slack inbound, owned by `'system'`) in the
+   * result. Defaults to true. Only applies to the unfiltered list (no
+   * `type`/`teamId` filter) — bridged threads are surfaced alongside the
+   * user's own DMs/channels in the consolidated chat list.
+   */
+  includeBridged?: boolean;
 }
 
 /** Arguments for `sendMessage`. */
@@ -1026,6 +1033,19 @@ export class ChatV2Service extends EventEmitter {
       type: args.type,
       teamId: teamIdFilter,
     });
+
+    // Surface bridged (Slack) threads alongside the user's own channels on
+    // the unfiltered list. They are owned by `'system'`, so listByOwner
+    // never returns them; merge + dedupe by id (the user's own row wins).
+    const includeBridged =
+      (args.includeBridged ?? true) && args.type === undefined && teamIdFilter === undefined;
+    if (includeBridged) {
+      const seen = new Set(rows.map((r) => r.id));
+      const bridged = this.channels
+        .listBridged({ includeArchived: args.includeArchived, limit: args.limit })
+        .filter((r) => !seen.has(r.id));
+      return [...rows, ...bridged].map((r) => this.toChannelDTO(r));
+    }
     return rows.map((r) => this.toChannelDTO(r));
   }
 

--- a/backend/src/services/chat-v2/sqlite/channel.store.test.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.test.ts
@@ -311,6 +311,32 @@ describe('ChannelStore', () => {
     });
   });
 
+  describe('listBridged', () => {
+    it('returns active slack-prefixed channels regardless of owner', () => {
+      store.create({
+        id: 'slack-D0-1',
+        agentSession: 'crewly-orc',
+        ownerUserId: 'system',
+        name: 'slack-D0-1',
+        type: 'dm',
+      });
+      store.create({ agentSession: 'sess-a', ownerUserId: 'user-a', name: 'DM' });
+      expect(store.listBridged().map((r) => r.id)).toEqual(['slack-D0-1']);
+    });
+
+    it('skips archived bridged channels', () => {
+      const row = store.create({
+        id: 'slack-D0-2',
+        agentSession: 'crewly-orc',
+        ownerUserId: 'system',
+        name: 'slack-D0-2',
+        type: 'dm',
+      });
+      store.archive(row.id);
+      expect(store.listBridged()).toHaveLength(0);
+    });
+  });
+
   describe('listByOwner', () => {
     it('returns only this user\'s channels', () => {
       store.create({ agentSession: 'sess-a', ownerUserId: 'user-a', name: 'A', nowMs: 100 });

--- a/backend/src/services/chat-v2/sqlite/channel.store.ts
+++ b/backend/src/services/chat-v2/sqlite/channel.store.ts
@@ -306,6 +306,32 @@ export class ChannelStore {
   }
 
   /**
+   * List active "bridged" channels — inbound conversations from external
+   * surfaces (currently Slack), persisted by the bridge under the synthetic
+   * `'system'` owner and keyed by a `slack-…` id. These belong to no single
+   * Crewly user, so they are surfaced in the consolidated chat list across
+   * the (single-user OSS) account rather than via `listByOwner`.
+   *
+   * @param options.includeArchived - Include archived rows (default false).
+   * @param options.limit - Max rows (capped at 200).
+   * @returns Bridged channel rows, most-recent first.
+   */
+  listBridged(options?: { includeArchived?: boolean; limit?: number }): ChatChannelRow[] {
+    const includeArchived = options?.includeArchived ?? false;
+    const limit = Math.min(options?.limit ?? 100, 200);
+    const where: string[] = ["id LIKE 'slack-%'"];
+    if (!includeArchived) where.push('archived_at IS NULL');
+    const sql = `
+      SELECT ${CHANNEL_SELECT_COLUMNS}
+      FROM chat_channels
+      WHERE ${where.join(' AND ')}
+      ORDER BY COALESCE(last_message_at, created_at) DESC
+      LIMIT ?
+    `;
+    return this.db.prepare(sql).all(limit) as ChatChannelRow[];
+  }
+
+  /**
    * Mark a channel as archived (soft-delete). No-op if already archived.
    *
    * @param id - The channel id

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -493,6 +493,31 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     expect(screen.getByText('Grace')).toBeInTheDocument();
   });
 
+  it('surfaces Slack-bridged threads in a dedicated Slack section', async () => {
+    const channels: Channel[] = [
+      {
+        id: 'slack-D0AC7-1778',
+        agentSession: 'crewly-orc',
+        name: 'slack-D0AC7-1778',
+        createdAt: ISO,
+        type: 'dm',
+        presence: 'online',
+      },
+    ];
+    const { client } = makeStubClient(channels);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+      />,
+    );
+    // A "Slack" section header with the prettified thread row (the row also
+    // appears in the right-panel header once auto-selected — hence getAllByText).
+    expect(await screen.findByText('Slack')).toBeInTheDocument();
+    expect(screen.getAllByText(/Slack · D0AC7/).length).toBeGreaterThan(0);
+  });
+
   it('calls onEnsureDm when a directory agent without a channel is opened', async () => {
     const onEnsureDm = vi.fn().mockResolvedValue('real-chan');
     const { client } = makeStubClient([]);

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -170,9 +170,27 @@ interface BodyProps {
 /** Prefix marking a synthetic DM row for a directory agent without a channel. */
 const VIRTUAL_DM_PREFIX = 'agent:';
 
-/** Stable pin key for a row: agent session for DMs, channel id for groups. */
+/** Prefix marking a Slack-bridged channel id (`slack-<chan>-<ts>`). */
+const SLACK_ID_PREFIX = 'slack-';
+
+/**
+ * Stable pin key for a row: channel id for Slack threads / groups (each is its
+ * own conversation), agent session for plain agent DMs. Slack threads must NOT
+ * key by session — they all share the orchestrator session and would collapse.
+ */
 function pinKeyOf(row: ConversationRow): string {
+  if (row.id.startsWith(SLACK_ID_PREFIX)) return row.id;
   return row.agentSession || row.id;
+}
+
+/**
+ * Friendlier label for a Slack thread whose raw title is the synthesized
+ * `slack-<channelId>-<ts>` id. We can't resolve the human channel name without
+ * the Slack API, so surface the channel id portion.
+ */
+function prettySlackTitle(raw: string): string {
+  const m = raw.match(/^slack-([^-]+)-/);
+  return m ? `Slack · ${m[1]}` : raw;
 }
 
 /** Count rows in a group including nested sub-groups. */
@@ -279,11 +297,17 @@ function LiveTeamChatPageBody({
 
   const sectioned = useMemo(() => {
     const dms = baseGroups.find((g) => g.id === 'dms');
-    if (!dms || sessionToTeam.size === 0) return baseGroups;
+    if (!dms) return baseGroups;
 
+    const slackRows: ConversationRow[] = [];
     const byTeam = new Map<string, typeof dms.rows>();
     const noTeam: typeof dms.rows = [];
     for (const row of dms.rows) {
+      // Slack-bridged threads → their own "Slack" section (not a team DM).
+      if (row.id.startsWith(SLACK_ID_PREFIX)) {
+        slackRows.push({ ...row, title: prettySlackTitle(row.title) });
+        continue;
+      }
       const team = row.agentSession ? sessionToTeam.get(row.agentSession) : undefined;
       if (team) {
         const list = byTeam.get(team) ?? [];
@@ -298,12 +322,12 @@ function LiveTeamChatPageBody({
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([team, rows]) => ({ id: `dm-team:${team}`, label: team, rows }));
 
-    // Per-team sections nest under a single collapsible "Teams" parent.
-    // Order: channels, huddles, teamless DMs, then Teams.
+    // Order: channels, huddles, teamless DMs, Slack, then Teams.
     return baseGroups.flatMap<ConversationGroup>((g) => {
       if (g.id !== 'dms') return [g];
       const out: ConversationGroup[] = [];
       if (noTeam.length > 0) out.push({ id: 'dms', label: 'Direct Messages', rows: noTeam });
+      if (slackRows.length > 0) out.push({ id: 'slack', label: 'Slack', rows: slackRows });
       if (teamSections.length > 0) {
         out.push({ id: 'teams', label: 'Teams', rows: [], subGroups: teamSections });
       }


### PR DESCRIPTION
Slack inbound is persisted in chat-v2 under the 'system' owner (keyed slack-<chan>-<ts>), so the per-user list never showed it. Now: ChannelStore.listBridged() + listChannels merges bridged channels (deduped, unfiltered list only, includeBridged default true); the FE routes slack-* channels into a dedicated 'Slack' section with a friendly label and keys pins by channel id. Viewing only — replying to Slack from the UI is a separate concern. Tests + build green.