### PR TITLE
feat(chat): mirror outbound Slack replies into chat-v2 (show both sides)

### DIFF
--- a/backend/src/services/slack/slack.service.test.ts
+++ b/backend/src/services/slack/slack.service.test.ts
@@ -12,6 +12,17 @@ import { EventEmitter } from 'events';
 const mockBoltStart = jest.fn().mockResolvedValue(undefined);
 const mockBoltStop = jest.fn().mockResolvedValue(undefined);
 
+// Capture chat-v2 mirror calls for the outbound-record test. The mirror
+// dynamic-imports this singleton; jest intercepts that import.
+const mockEnsureLegacyChannel = jest.fn(() => ({ id: 'chan-slack', agentSession: 'crewly-orc' }));
+const mockRecordTurn = jest.fn(() => ({ message: { id: 'm1' } }));
+jest.mock('../chat-v2/chat-v2.singleton.js', () => ({
+  getChatV2Service: () => ({
+    ensureChannelForLegacyConversation: mockEnsureLegacyChannel,
+    recordTurn: mockRecordTurn,
+  }),
+}));
+
 jest.mock('@slack/bolt', () => ({
   App: jest.fn().mockImplementation(() => ({
     client: {
@@ -94,6 +105,38 @@ describe('SlackService', () => {
       await expect(
         service.sendMessage({ channelId: 'C123', text: 'test' })
       ).rejects.toThrow('Slack client not initialized');
+    });
+
+    it('mirrors a threaded outbound reply into chat-v2 as an agent message', async () => {
+      mockEnsureLegacyChannel.mockClear();
+      mockRecordTurn.mockClear();
+      const service = new SlackService();
+      (service as any).client = {
+        chat: { postMessage: jest.fn().mockResolvedValue({ ts: '111.222' }) },
+      };
+
+      await service.sendMessage({ channelId: 'C123', text: 'agent reply', threadTs: '100.000' });
+      // Mirror is fire-and-forget (dynamic imports) — flush microtasks.
+      await new Promise((r) => setImmediate(r));
+
+      expect(mockEnsureLegacyChannel).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: 'slack-C123-100-000' }),
+      );
+      expect(mockRecordTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 'chan-slack', senderType: 'agent', content: 'agent reply' }),
+      );
+    });
+
+    it('does not mirror a non-threaded outbound message', async () => {
+      mockRecordTurn.mockClear();
+      const service = new SlackService();
+      (service as any).client = {
+        chat: { postMessage: jest.fn().mockResolvedValue({ ts: '111.222' }) },
+      };
+
+      await service.sendMessage({ channelId: 'C123', text: 'top-level' });
+      await new Promise((r) => setImmediate(r));
+      expect(mockRecordTurn).not.toHaveBeenCalled();
     });
 
     it('should throw when updateMessage called without initialization', async () => {

--- a/backend/src/services/slack/slack.service.ts
+++ b/backend/src/services/slack/slack.service.ts
@@ -22,7 +22,7 @@ import type {
 } from '../../types/slack.types.js';
 import { isUserAllowed } from '../../types/slack.types.js';
 import { CROSS_MACHINE_PREFIX } from '../../types/cross-machine.types.js';
-import { SLACK_IMAGE_CONSTANTS, SLACK_FILE_UPLOAD_CONSTANTS, SLACK_DEDUP_CONSTANTS, SLACK_RECONNECT_CONSTANTS } from '../../constants.js';
+import { SLACK_IMAGE_CONSTANTS, SLACK_FILE_UPLOAD_CONSTANTS, SLACK_DEDUP_CONSTANTS, SLACK_RECONNECT_CONSTANTS, ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 import { LoggerService } from '../core/logger.service.js';
 import { ContentApprovalService } from '../onboarding/content-approval.service.js';
 import { getAgentBehaviorLogService } from '../observability/agent-behavior-log.singleton.js';
@@ -880,6 +880,12 @@ export class SlackService extends EventEmitter {
       // Track this fingerprint for future dedup
       this.trackMessageFingerprint(fingerprint, now);
 
+      // Mirror the outbound reply into chat-v2 so the Slack thread shows both
+      // sides ("收和发") in the consolidated chat. Best-effort, thread-only.
+      if (message.threadTs) {
+        void this.recordOutboundToChatV2(message);
+      }
+
       return result.ts || '';
     } catch (error) {
       this.logger.error('Send message error', { error: error instanceof Error ? (error as Error).message : String(error) });
@@ -906,6 +912,48 @@ export class SlackService extends EventEmitter {
       }
 
       throw error;
+    }
+  }
+
+  /**
+   * Mirror an outbound Slack reply into the canonical chat-v2 store so the
+   * Slack thread shows both inbound (user) and outbound (agent) messages in
+   * the consolidated /team-chat surface. Records against the SAME channel the
+   * inbound persisted to — `synthesizeSlackConversationId(channelId, threadTs)`.
+   *
+   * Best-effort: dynamic imports + try/catch so a chat-v2 failure never
+   * affects Slack delivery. Only called for threaded replies (threadTs set).
+   *
+   * @param message - The outbound Slack message that was just sent.
+   */
+  private async recordOutboundToChatV2(message: SlackOutgoingMessage): Promise<void> {
+    try {
+      if (!message.channelId || !message.threadTs || !(message.text ?? '').trim()) return;
+      const [{ getChatV2Service }, { synthesizeSlackConversationId }] = await Promise.all([
+        import('../chat-v2/chat-v2.singleton.js'),
+        import('../chat-v2/legacy-dto.utils.js'),
+      ]);
+      const chatV2 = getChatV2Service();
+      const conversationId = synthesizeSlackConversationId(message.channelId, message.threadTs);
+      const channel = chatV2.ensureChannelForLegacyConversation({
+        conversationId,
+        agentSession: ORCHESTRATOR_SESSION_NAME,
+      });
+      chatV2.recordTurn({
+        channelId: channel.id,
+        senderType: 'agent',
+        senderId: channel.agentSession || ORCHESTRATOR_SESSION_NAME,
+        content: message.text,
+        metadata: {
+          source: 'slack',
+          slackChannelId: message.channelId,
+          slackThreadTs: message.threadTs,
+        },
+      });
+    } catch (err) {
+      this.logger.warn('Failed to mirror outbound Slack message to chat-v2', {
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 


### PR DESCRIPTION
Slack threads showed only inbound (user) messages — agent replies sent to Slack were never recorded. Now slack.service.sendMessage (the single outbound chokepoint) mirrors threaded replies into the same chat-v2 channel as senderType='agent', so the consolidated chat shows both 收 and 发. Best-effort/thread-only; broadcasts live over /ws/chat. Tests + build green.