### PR TITLE
fix(wiki/reconciler): stop the wiki-bridge orchestrator spam loop

### DIFF
--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -1012,6 +1012,21 @@ describe('LiveReconcilerDataProvider', () => {
         expect(mockSubscriber.redispatch).not.toHaveBeenCalled();
       });
 
+      it('redelivers a queued WI once, then suppresses repeats within the cooldown (anti-flood)', async () => {
+        // The fast loop re-emits redeliver every ~10s; the per-WI cooldown
+        // must cap re-POSTs so a queued-but-unclaimed WI cannot flood the PTY.
+        mockPool.findWorkItem.mockResolvedValue(queuedWi);
+
+        const first = await provider.executeWakeAction(buildAction());
+        const second = await provider.executeWakeAction(buildAction());
+        const third = await provider.executeWakeAction(buildAction());
+
+        expect(first).toBe(true);
+        expect(second).toBe(false);
+        expect(third).toBe(false);
+        expect(mockSubscriber.redispatch).toHaveBeenCalledTimes(1);
+      });
+
       it('returns false when the WI no longer exists', async () => {
         mockPool.findWorkItem.mockResolvedValueOnce(null);
 

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -41,6 +41,17 @@ import { WEB_CONSTANTS, AGENT_SUSPEND_CONSTANTS } from '../../constants.js';
 const AGENT_STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
 /**
+ * Minimum gap between redelivering the SAME WorkItem brief. The reconciler
+ * fast loop fires every ~10s; this caps a queued WI's re-POSTs to once per
+ * window so an unclaimed-but-read WI can't flood the agent's PTY. Override
+ * with `CREWLY_RECONCILER_REDELIVER_COOLDOWN_MS`.
+ */
+const REDELIVER_COOLDOWN_MS = (() => {
+  const raw = Number(process.env['CREWLY_RECONCILER_REDELIVER_COOLDOWN_MS']);
+  return Number.isFinite(raw) && raw > 0 ? raw : 5 * 60 * 1000; // 5 min
+})();
+
+/**
  * Heuristic: detect "storage not yet hydrated" errors so the data
  * provider can demote them from `error` to `debug` log level.
  *
@@ -177,6 +188,18 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
   // EventBus deduplicates on event id).
   private consecutivePressureSkips = 0;
   private lastPressureNotifiedAt = 0;
+
+  /**
+   * Per-WorkItem redeliver cooldown. The reconciler fast loop runs every
+   * ~10s and re-emits a `redeliver` wake for any queued WI whose target is
+   * active-but-idle — with NO per-WI rate-limit in the rule. Without this
+   * gate a queued-but-unclaimed WI (e.g. one the orc has read but not yet
+   * claimed) is re-POSTed to its PTY every 10s (~50-60/hr), which is the
+   * wiki-bridge "spam" the user saw and the same class as the 2026-05-27
+   * PTY-flood incident. We cap redelivery of a given WI to once per
+   * {@link REDELIVER_COOLDOWN_MS}.
+   */
+  private readonly lastRedeliverAt = new Map<string, number>();
 
   constructor() {
     this.logger = LoggerService.getInstance().createComponentLogger('ReconcilerDataProvider');
@@ -1027,10 +1050,24 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
             workItemId: action.workItemId,
             currentStatus: wi?.status,
           });
+          // WI left the queue (claimed/terminal) — drop its cooldown record.
+          this.lastRedeliverAt.delete(action.workItemId);
+          return false;
+        }
+        // Per-WI redeliver cooldown — the fast loop re-emits this every ~10s
+        // while the WI stays queued; without the gate that floods the PTY.
+        const lastAt = this.lastRedeliverAt.get(action.workItemId);
+        if (lastAt !== undefined && Date.now() - lastAt < REDELIVER_COOLDOWN_MS) {
+          this.logger.debug('Redeliver suppressed — within cooldown', {
+            agent: agentSessionName,
+            workItemId: action.workItemId,
+            sinceMs: Date.now() - lastAt,
+          });
           return false;
         }
         const subscriber = WorkItemDispatchSubscriber.getInstance();
         const delivered = await subscriber.redispatch(wi);
+        if (delivered) this.lastRedeliverAt.set(action.workItemId, Date.now());
         if (delivered) {
           this.logger.info('Redelivered WorkItem brief to active-but-idle agent', {
             agent: agentSessionName,

--- a/backend/src/services/wiki/wiki-cleanup.service.test.ts
+++ b/backend/src/services/wiki/wiki-cleanup.service.test.ts
@@ -99,6 +99,26 @@ describe('WikiCleanupService.scan', () => {
     await fs.rm(vault, { recursive: true });
   });
 
+  it('never flags the orchestrator’s own notes for cleanup (self-loop guard)', async () => {
+    // Root cause B: orc notes mis-filed into a (customer) vault, flagged
+    // low-quality, re-dispatched as cleanup → orc writes more → loop. The
+    // orc-authored page must be excluded even though its confidence is low.
+    const vault = await makeVault([
+      { relPath: 'llm-curated/patterns/orc-note.md', confidence: 0.2, originalAuthor: 'crewly-orc', originalId: 'orc-1' },
+      { relPath: 'llm-curated/patterns/user-junk.md', confidence: 0.2, originalAuthor: 'alice', originalId: 'usr-1' },
+    ]);
+
+    const result = await WikiCleanupService.getInstance().scan({
+      vaultPath: vault,
+      rules: { minConfidence: 0.5, dropAgentMemoryDumps: false },
+    });
+
+    if (!result.ok || !('candidates' in result)) throw new Error('expected scan result');
+    // Only the non-orc low-confidence page is a candidate.
+    expect(result.candidates.map((c) => c.relPath)).toEqual(['llm-curated/patterns/user-junk.md']);
+    await fs.rm(vault, { recursive: true });
+  });
+
   it('flags pages migrated_from "agent/.../memory.json"', async () => {
     const vault = await makeVault([
       { relPath: 'llm-curated/patterns/a.md', migratedFrom: 'agent/crewly-orc/memory.json', confidence: 0.9, originalId: 'mem-a' },

--- a/backend/src/services/wiki/wiki-cleanup.service.ts
+++ b/backend/src/services/wiki/wiki-cleanup.service.ts
@@ -35,6 +35,7 @@ import * as path from 'path';
 import { existsSync } from 'fs';
 import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { atomicWriteJson, safeReadJson, ensureDir } from '../../utils/file-io.utils.js';
+import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -208,6 +209,16 @@ export class WikiCleanupService {
 
     for (const page of allPages) {
       const fm = page.frontmatter;
+
+      // SELF-LOOP GUARD (root cause B): never auto-flag the orchestrator's own
+      // notes for cleanup. The orc's working notes were mis-filed into customer
+      // vaults, flagged low-quality, and dispatched back to the orc as cleanup
+      // → it wrote more notes → re-filed → re-flagged (a self-reinforcing
+      // loop). Excluding orc-authored pages breaks that loop. (The durable fix
+      // is upstream: stop routing internal orc notes into customer KBs.)
+      const author = typeof fm['original_author'] === 'string' ? fm['original_author'] : null;
+      if (author === ORCHESTRATOR_SESSION_NAME) continue;
+
       const reasons: string[] = [];
 
       const conf = parseConfidence(fm['confidence']);
@@ -243,6 +254,7 @@ export class WikiCleanupService {
         const fm = page.frontmatter;
         const author = typeof fm['original_author'] === 'string' ? fm['original_author'] : null;
         if (!author) continue;
+        if (author === ORCHESTRATOR_SESSION_NAME) continue; // self-loop guard (see first pass)
         const conf = parseConfidence(fm['confidence']) ?? 0;
         const date = typeof fm['original_date'] === 'string' ? fm['original_date'] : '';
         const arr = byAuthor.get(author) ?? [];

--- a/backend/src/services/wiki/wiki-workitem-bridge.service.ts
+++ b/backend/src/services/wiki/wiki-workitem-bridge.service.ts
@@ -335,6 +335,13 @@ export class WikiWorkItemBridgeService {
   /** Start the periodic scan. Idempotent. Fires an immediate tick. */
   start(): void {
     if (this.timer) return;
+    // Off-switch (ops kill-switch). Set WIKI_BRIDGE_ENABLED=false to pause all
+    // wiki maintenance dispatch (drain/migrate/cleanup) without a code change
+    // or losing the feature — e.g. to stop a runaway loop while a fix ships.
+    if (process.env['WIKI_BRIDGE_ENABLED'] === 'false') {
+      this.logger.warn('WikiWorkItemBridge disabled via WIKI_BRIDGE_ENABLED=false — not starting');
+      return;
+    }
     void this.tick();
     this.timer = setInterval(() => void this.tick(), this.intervalMs);
     this.logger.info('WikiWorkItemBridge started', {
@@ -529,6 +536,12 @@ export class WikiWorkItemBridgeService {
     const inflightCleanupVaults = new Set<string>();
     const allItems = await this.pool.getAllItems();
     for (const wi of allItems) {
+      // Terminal WIs don't block re-creation here BY DESIGN (e.g. draining the
+      // next queue chunk after the prior drain completes). The per-key cooldown
+      // (default 30 min, persisted) is what spaces successive creates; the
+      // "terminal tasks reviving" the orc saw was the reconciler redeliver
+      // flood + the orc-notes self-loop, fixed separately (reconciler cooldown
+      // + cleanup author guard), not a gap here.
       if (TERMINAL_STATUSES.has(wi.status)) continue;
       const meta = wi.metadata ?? {};
       const kind = meta['kind'];


### PR DESCRIPTION
Diagnosed + fixed the wiki "bridge cron" spamming the orchestrator (50+ re-dispatches/hr). Answers to the three questions:

1. **Spamming?** Yes — but the orc misattributed it. The seconds-scale flood is the **reconciler redeliver loop** (fast loop ~10s re-POSTs any queued-but-unclaimed WI with no per-WI rate-limit; `redispatch()` clears the dedup key), not the bridge (which can only fire every 10 min). The bridge re-proposal is a separate, slower (30-min cooldown) path, fueled by the self-loop below.
2. **Idle-gate?** Nothing was idle-gated. The redeliver fired whenever the orc was "idle" — including read-but-not-yet-claimed — so being idle *triggered* the flood. The new per-WI cooldown caps it.
3. **Why the orc complains if legit?** Mostly legit-but-mis-presented (its prompt supersedes the old "silent containment" and tells it to *process*, not cancel) + two real bugs: the redeliver flood, and a contamination self-loop (its own notes mis-filed into a customer KB → flagged low-quality → re-dispatched as cleanup → loop).

**Fixes (2 commits):**
- `reconciler`: per-WI redeliver cooldown (default 5 min; env `CREWLY_RECONCILER_REDELIVER_COOLDOWN_MS`) — kills the 50/hr flood.
- `wiki`: `WIKI_BRIDGE_ENABLED=false` off-switch; cleanup never flags the orchestrator's own notes (breaks the self-loop).

Tests: reconciler redeliver-cooldown anti-flood, cleanup self-loop guard; 127 affected tests green; backend build green.

**Owed (flagged):** durable root-cause-B fix — stop routing internal orc notes into customer KBs at the wiki-queue-add layer (the cleanup guard is a band-aid). And fuller idle-gating of maintenance dispatch.