### PR TITLE
feat: team page Mission/OKR + Norms/SOP, chat clarity, wiki canonical grouping

### DIFF
--- a/backend/src/services/slack/slack-orchestrator-bridge.test.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.test.ts
@@ -12,6 +12,7 @@ import {
   resetSlackOrchestratorBridge,
   suppressTrivialOrShort,
   suppressFileOnly,
+  deriveSlackThreadName,
 } from './slack-orchestrator-bridge.js';
 import { resetSlackService } from './slack.service.js';
 import { resetChatService } from '../chat/chat.service.js';
@@ -2313,4 +2314,25 @@ describe('SlackOrchestratorBridge', () => {
   // `ChatService.sendMessage` is now a façade over
   // `ChatV2Service.recordTurn`. The chat-v2 jest.mock at module scope
   // is retained for any future re-instrumentation of the bridge.
+});
+
+describe('deriveSlackThreadName', () => {
+  it('titles a thread by its first message (collapsed whitespace, truncated)', () => {
+    expect(deriveSlackThreadName('ship the v2 launch deck')).toBe('Slack: ship the v2 launch deck');
+    expect(deriveSlackThreadName('  multi\n   line   text ')).toBe('Slack: multi line text');
+  });
+
+  it('truncates long messages with an ellipsis', () => {
+    const long = 'a'.repeat(80);
+    const out = deriveSlackThreadName(long);
+    expect(out.startsWith('Slack: ')).toBe(true);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBeLessThan(60);
+  });
+
+  it('falls back to "Slack thread" for empty/whitespace content', () => {
+    expect(deriveSlackThreadName('')).toBe('Slack thread');
+    expect(deriveSlackThreadName('   ')).toBe('Slack thread');
+    expect(deriveSlackThreadName(undefined)).toBe('Slack thread');
+  });
 });

--- a/backend/src/services/slack/slack-orchestrator-bridge.ts
+++ b/backend/src/services/slack/slack-orchestrator-bridge.ts
@@ -169,6 +169,22 @@ export function suppressFileOnly(rawText: string): string | null {
 let bridgeInstance: SlackOrchestratorBridge | null = null;
 
 /**
+ * Derive a short, readable chat-v2 channel name from a Slack thread's first
+ * message — so the consolidated chat shows a meaningful title rather than the
+ * synthesized `slack-<chan>-<ts>` id (which is identical across a channel's
+ * threads). Collapses whitespace and truncates; falls back to "Slack thread".
+ *
+ * @param content - The first inbound message of the thread.
+ * @returns A title like `Slack: ship the v2 launch deck`.
+ */
+export function deriveSlackThreadName(content: string | undefined): string {
+  const oneLine = (content ?? '').replace(/\s+/g, ' ').trim();
+  if (!oneLine) return 'Slack thread';
+  const snippet = oneLine.length > 48 ? `${oneLine.slice(0, 48)}…` : oneLine;
+  return `Slack: ${snippet}`;
+}
+
+/**
  * SlackOrchestratorBridge class
  *
  * Routes messages between Slack and the Crewly orchestrator.
@@ -2133,6 +2149,11 @@ Just type naturally to chat with the orchestrator!`;
     const channel = this.chatV2.ensureChannelForLegacyConversation({
       conversationId: cid,
       agentSession: args.agentSession,
+      // Name the thread by its first message so the consolidated chat shows a
+      // readable title (e.g. "Slack: ship the v2 launch…") instead of N
+      // identical synthesized ids. ensure… only sets the name on create, so
+      // this stamps the thread's opening message. Falls back to the id.
+      name: deriveSlackThreadName(args.content),
     });
     const { message } = this.chatV2.recordTurn({
       channelId: channel.id,

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -493,12 +493,13 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     expect(screen.getByText('Grace')).toBeInTheDocument();
   });
 
-  it('surfaces Slack-bridged threads in a dedicated Slack section', async () => {
+  it('surfaces Slack threads in a collapsed Slack section, labeled by thread time', async () => {
     const channels: Channel[] = [
       {
-        id: 'slack-D0AC7-1778',
+        // Legacy id-named thread: slack-<channel>-<tsSeconds>-<tsMicros>.
+        id: 'slack-D0AC7NF5N7L-1777760999-956969',
         agentSession: 'crewly-orc',
-        name: 'slack-D0AC7-1778',
+        name: 'slack-D0AC7NF5N7L-1777760999-956969',
         createdAt: ISO,
         type: 'dm',
         presence: 'online',
@@ -512,10 +513,18 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
         directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
       />,
     );
-    // A "Slack" section header with the prettified thread row (the row also
-    // appears in the right-panel header once auto-selected — hence getAllByText).
-    expect(await screen.findByText('Slack')).toBeInTheDocument();
-    expect(screen.getAllByText(/Slack · D0AC7/).length).toBeGreaterThan(0);
+    // The Slack section header is present, collapsed by default.
+    const toggle = await screen.findByTestId('conv-group-toggle-slack');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('conv-row-slack-D0AC7NF5N7L-1777760999-956969')).not.toBeInTheDocument();
+
+    // Expanding it reveals the thread, labeled by its start time (not the
+    // identical channel id) so multiple threads are distinguishable.
+    fireEvent.click(toggle);
+    expect(
+      await screen.findByTestId('conv-row-slack-D0AC7NF5N7L-1777760999-956969'),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Slack thread ·/).length).toBeGreaterThan(0);
   });
 
   it('calls onEnsureDm when a directory agent without a channel is opened', async () => {

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -184,13 +184,25 @@ function pinKeyOf(row: ConversationRow): string {
 }
 
 /**
- * Friendlier label for a Slack thread whose raw title is the synthesized
- * `slack-<channelId>-<ts>` id. We can't resolve the human channel name without
- * the Slack API, so surface the channel id portion.
+ * Friendlier label for a Slack thread. New threads are named after their first
+ * message (backend), so a non-`slack-…` title is used as-is. Legacy threads are
+ * titled by the synthesized `slack-<channelId>-<tsSeconds>-<tsMicros>` id — all
+ * threads in one channel share the channelId, so we surface the thread's
+ * start time to make them distinguishable (was: identical "Slack · <channel>").
  */
 function prettySlackTitle(raw: string): string {
-  const m = raw.match(/^slack-([^-]+)-/);
-  return m ? `Slack · ${m[1]}` : raw;
+  const m = raw.match(/^slack-([^-]+)-(\d{6,})/);
+  if (!m) return raw; // backend-named (first-message snippet) — already readable
+  const tsSeconds = Number(m[2]);
+  if (Number.isFinite(tsSeconds) && tsSeconds > 0) {
+    const d = new Date(tsSeconds * 1000);
+    if (!Number.isNaN(d.getTime())) {
+      const date = d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+      const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      return `Slack thread · ${date} ${time}`;
+    }
+  }
+  return `Slack · ${m[1]}`;
 }
 
 /** Count rows in a group including nested sub-groups. */
@@ -457,6 +469,9 @@ function LiveTeamChatPageBody({
         onSelectConversation={handleSelectConversation}
         isPinned={(row) => pinnedChats.isPinned(pinKeyOf(row))}
         onTogglePin={(row) => pinnedChats.toggle(pinKeyOf(row))}
+        // The Slack section can hold many threads from one channel — start it
+        // collapsed so it doesn't flood the list (user can expand + it persists).
+        defaultCollapsedGroupIds={['slack']}
         headerAction={
           <button
             type="button"

--- a/frontend/src/components/TeamDetail/TeamObjectives.test.tsx
+++ b/frontend/src/components/TeamDetail/TeamObjectives.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for TeamObjectives — verifies the team's missions are fetched and
+ * filtered by owner, KR counts render, and the wiki knowledge links resolve.
+ *
+ * @module components/TeamDetail/TeamObjectives.test
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TeamObjectives } from './TeamObjectives';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+const getMissionsMock = vi.fn();
+vi.mock('../../services/api.service', () => ({
+  apiService: {
+    getMissions: () => getMissionsMock(),
+  },
+}));
+
+describe('TeamObjectives', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    getMissionsMock.mockReset();
+  });
+
+  it('renders only missions owned by the team, with KR counts', async () => {
+    getMissionsMock.mockResolvedValue([
+      { id: 'm1', objective: 'Grow XHS following', ownerTeamId: 'team-a', status: 'active', keyResults: [{ id: 'k1', title: 'x', status: 'active' }] },
+      { id: 'm2', objective: 'Other team mission', ownerTeamId: 'team-b', status: 'active' },
+    ]);
+
+    render(<TeamObjectives teamId="team-a" />);
+
+    await waitFor(() => expect(screen.getByText('Grow XHS following')).toBeInTheDocument());
+    expect(screen.queryByText('Other team mission')).not.toBeInTheDocument();
+    expect(screen.getByText('1 key result')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the team owns no missions', async () => {
+    getMissionsMock.mockResolvedValue([]);
+    render(<TeamObjectives teamId="team-a" />);
+    await waitFor(() => expect(screen.getByText(/No missions/i)).toBeInTheDocument());
+  });
+
+  it('navigates to a mission on click', async () => {
+    getMissionsMock.mockResolvedValue([
+      { id: 'm1', objective: 'Grow XHS following', ownerTeamId: 'team-a', status: 'active' },
+    ]);
+    render(<TeamObjectives teamId="team-a" />);
+    await waitFor(() => expect(screen.getByTestId('team-mission-m1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('team-mission-m1'));
+    expect(navigateMock).toHaveBeenCalledWith('/missions/m1');
+  });
+
+  it('links norms and SOPs to the team wiki', async () => {
+    getMissionsMock.mockResolvedValue([]);
+    render(<TeamObjectives teamId="team-a" />);
+    await waitFor(() => expect(screen.getByTestId('team-norms-link')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('team-norms-link'));
+    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a');
+    fireEvent.click(screen.getByTestId('team-sops-link'));
+    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a');
+  });
+
+  it('still renders knowledge links when getMissions fails', async () => {
+    getMissionsMock.mockRejectedValue(new Error('boom'));
+    render(<TeamObjectives teamId="team-a" />);
+    await waitFor(() => expect(screen.getByTestId('team-knowledge')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/TeamDetail/TeamObjectives.tsx
+++ b/frontend/src/components/TeamDetail/TeamObjectives.tsx
@@ -1,0 +1,149 @@
+/**
+ * TeamObjectives — surfaces a team's strategic context on its detail page:
+ *   - Mission / OKR: the team's runtime Missions (owner = this team) + their
+ *     Key Results, linking into the Missions surface.
+ *   - Team Knowledge: links into the team's wiki for Norms and SOPs (the
+ *     canonical home — see the wiki `norms/`/`sop/` folders).
+ *
+ * Read-only; one network call (GET /api/missions, filtered to this team).
+ *
+ * @module components/TeamDetail/TeamObjectives
+ */
+
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Target, BookOpen, ScrollText } from 'lucide-react';
+import { apiService } from '../../services/api.service';
+import {
+  getMissionStatusType,
+  getMissionStatusLabel,
+  type MissionStatus,
+} from '../../types/mission.types';
+import { StatusBadge } from '../UI/StatusBadge';
+import { TEAM_QUERY_PARAM } from '../../utils/team-chat.utils';
+
+/** Minimal mission shape this panel renders (subset of the Missions page type). */
+interface TeamMission {
+  id: string;
+  objective: string;
+  ownerTeamId: string;
+  status: MissionStatus;
+  keyResults?: Array<{ id: string; title: string; status: string }>;
+}
+
+export interface TeamObjectivesProps {
+  /** The team whose missions + wiki to surface. */
+  teamId: string;
+}
+
+/**
+ * Mission/OKR + wiki-knowledge panel for the team detail page.
+ *
+ * @param props.teamId - Team id used to filter missions and scope wiki links.
+ * @returns The objectives panel.
+ */
+export function TeamObjectives({ teamId }: TeamObjectivesProps): JSX.Element {
+  const navigate = useNavigate();
+  const [missions, setMissions] = useState<TeamMission[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const all = (await apiService.getMissions()) as TeamMission[];
+        if (!cancelled) {
+          setMissions(all.filter((m) => m && m.ownerTeamId === teamId));
+        }
+      } catch {
+        // Non-fatal — the page still renders the knowledge links.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [teamId]);
+
+  const wikiHref = `/wiki?${TEAM_QUERY_PARAM}=${teamId}`;
+
+  return (
+    <div className="space-y-4">
+      {/* Mission / OKR */}
+      <div className="rounded-2xl border border-border-dark bg-surface-dark p-5" data-testid="team-objectives-okr">
+        <div className="mb-3 flex items-center gap-2">
+          <Target className="h-5 w-5 text-primary" />
+          <h3 className="text-lg font-semibold text-text-primary-dark">Mission / OKR</h3>
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-text-secondary-dark">Loading…</p>
+        ) : missions.length === 0 ? (
+          <p className="text-sm text-text-secondary-dark">
+            No missions own­ed by this team yet.{' '}
+            <button
+              type="button"
+              className="text-primary hover:underline"
+              onClick={() => navigate('/missions')}
+            >
+              Open Missions
+            </button>
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {missions.map((m) => (
+              <li key={m.id}>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/missions/${m.id}`)}
+                  data-testid={`team-mission-${m.id}`}
+                  className="flex w-full items-start justify-between gap-2 rounded-lg border border-transparent px-2 py-2 text-left hover:border-border-dark hover:bg-background-dark"
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-sm text-text-primary-dark">{m.objective}</span>
+                    <span className="text-xs text-text-secondary-dark">
+                      {(m.keyResults?.length ?? 0)} key result{(m.keyResults?.length ?? 0) === 1 ? '' : 's'}
+                    </span>
+                  </span>
+                  <StatusBadge status={getMissionStatusType(m.status)}>
+                    {getMissionStatusLabel(m.status)}
+                  </StatusBadge>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Team Knowledge — norms + SOPs live in the team wiki */}
+      <div className="rounded-2xl border border-border-dark bg-surface-dark p-5" data-testid="team-knowledge">
+        <h3 className="mb-3 text-lg font-semibold text-text-primary-dark">Team Knowledge</h3>
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => navigate(wikiHref)}
+            data-testid="team-norms-link"
+            className="flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-text-primary-dark hover:bg-background-dark"
+          >
+            <BookOpen className="h-4 w-4 text-text-secondary-dark" />
+            Team Norms
+            <span className="ml-auto text-xs text-text-secondary-dark">in wiki →</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate(wikiHref)}
+            data-testid="team-sops-link"
+            className="flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-text-primary-dark hover:bg-background-dark"
+          >
+            <ScrollText className="h-4 w-4 text-text-secondary-dark" />
+            SOPs
+            <span className="ml-auto text-xs text-text-secondary-dark">in wiki →</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TeamObjectives;

--- a/frontend/src/components/TeamDetail/index.ts
+++ b/frontend/src/components/TeamDetail/index.ts
@@ -5,4 +5,5 @@ export { AddMemberForm } from './AddMemberForm';
 export { MembersList } from './MembersList';
 export { TeamOverview } from './TeamOverview';
 export { AgentDetailModal } from './AgentDetailModal';
+export { TeamObjectives } from './TeamObjectives';
 export * from './types';

--- a/frontend/src/pages/TeamDetail.tsx
+++ b/frontend/src/pages/TeamDetail.tsx
@@ -5,7 +5,7 @@ import { Team, TeamMember, TeamMemberStatusChangeEvent } from '../types/index';
 import { useTerminal } from '../contexts/TerminalContext';
 import { StartTeamModal } from '../components/StartTeamModal';
 import { TeamModal } from '../components/Modals/TeamModal';
-import { TeamHeader, TeamOverview, TeamStatus, AgentDetailModal } from '../components/TeamDetail';
+import { TeamHeader, TeamOverview, TeamStatus, AgentDetailModal, TeamObjectives } from '../components/TeamDetail';
 import { HierarchyDashboard } from '../components/Hierarchy';
 import { ExecutionFeed } from '../components/ExecutionFeed';
 import { useAlert, useConfirm } from '../components/UI/Dialog';
@@ -653,6 +653,11 @@ export const TeamDetail: React.FC = () => {
         onViewAgent={handleViewAgent}
         isStartingTeam={startTeamLoading}
       />
+
+      {/* Mission / OKR + Team Knowledge (norms & SOPs in the wiki) */}
+      <div className="mt-6">
+        <TeamObjectives teamId={id!} />
+      </div>
 
       {/* Execution Feed — real-time agent activity for this team */}
       <div className="mt-6">

--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -279,6 +279,24 @@
   margin-left: auto;
 }
 
+/* Tree group labels — separate the canonical (frozen) source-of-truth folders
+   from the working / llm-curated notes so they no longer read as "scattered". */
+.wiki-tree-group-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-tertiary, #6b7280);
+  padding: 10px 8px 4px;
+}
+
+.wiki-tree-group-label:first-child {
+  padding-top: 4px;
+}
+
 /* Search */
 
 .wiki-search-bar {

--- a/frontend/src/pages/Wiki.test.tsx
+++ b/frontend/src/pages/Wiki.test.tsx
@@ -10,7 +10,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveWikilink, pickInitialVault, type WikiVault } from './Wiki';
+import {
+  resolveWikilink,
+  pickInitialVault,
+  partitionVaultTree,
+  type WikiVault,
+} from './Wiki';
 
 const VAULT = [
   'log.md',
@@ -113,5 +118,37 @@ describe('pickInitialVault', () => {
   it('falls back to the first vault when there is no project vault', () => {
     const vaults: WikiVault[] = [mk('global', 'g'), mk('team', 't1')];
     expect(pickInitialVault(vaults, null)?.vaultId).toBe('g');
+  });
+});
+
+describe('partitionVaultTree', () => {
+  const dir = (name: string, frozen?: boolean) => ({
+    name,
+    relativePath: name,
+    type: 'directory' as const,
+    frozen,
+  });
+  const file = (name: string) => ({
+    name,
+    relativePath: name,
+    type: 'file' as const,
+  });
+
+  it('returns empty groups for a null tree', () => {
+    expect(partitionVaultTree(null)).toEqual({ canonicalNodes: [], workingNodes: [] });
+  });
+
+  it('routes frozen top-level directories to canonical and the rest to working', () => {
+    const tree = [dir('sop', true), dir('team-norm', true), dir('llm-curated'), file('index.md')];
+    const { canonicalNodes, workingNodes } = partitionVaultTree(tree);
+    expect(canonicalNodes.map((n) => n.name)).toEqual(['sop', 'team-norm']);
+    expect(workingNodes.map((n) => n.name)).toEqual(['llm-curated', 'index.md']);
+  });
+
+  it('treats frozen files (not directories) as working content', () => {
+    const tree = [{ ...file('pinned.md'), frozen: true }];
+    const { canonicalNodes, workingNodes } = partitionVaultTree(tree);
+    expect(canonicalNodes).toHaveLength(0);
+    expect(workingNodes).toHaveLength(1);
   });
 });

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -92,6 +92,44 @@ interface WikiTreeNode {
   children?: WikiTreeNode[];
 }
 
+/**
+ * Friendly display names for the schema's frozen (canonical) top-level folders.
+ * Keyed by the raw folder name returned in the tree. Folders not listed fall
+ * back to their raw name. This de-scatters the "where do norms/SOPs live?"
+ * confusion by giving the source-of-truth folders human labels.
+ */
+const CANONICAL_FOLDER_LABELS: Record<string, string> = {
+  sop: 'SOPs',
+  'sop-overrides': 'SOP Overrides',
+  'team-norm': 'Team Norms',
+  norms: 'Team Norms',
+  okr: 'OKRs',
+  okrs: 'OKRs',
+  memory: 'Memory',
+};
+
+/**
+ * Split a vault's top-level tree into canonical (schema-frozen) folders and
+ * everything else. Pure so it can be unit-tested. Frozen top-level directories
+ * are the engine's source of truth (SOPs / Team Norms / OKRs); the rest is the
+ * working / llm-curated area.
+ *
+ * @param tree - Top-level tree nodes, or null while loading.
+ * @returns `{ canonicalNodes, workingNodes }` preserving original order.
+ */
+export function partitionVaultTree(tree: WikiTreeNode[] | null): {
+  canonicalNodes: WikiTreeNode[];
+  workingNodes: WikiTreeNode[];
+} {
+  const canonicalNodes: WikiTreeNode[] = [];
+  const workingNodes: WikiTreeNode[] = [];
+  for (const node of tree ?? []) {
+    if (node.type === 'directory' && node.frozen) canonicalNodes.push(node);
+    else workingNodes.push(node);
+  }
+  return { canonicalNodes, workingNodes };
+}
+
 interface PagePayload {
   vaultPath: string;
   relativePath: string;
@@ -612,6 +650,18 @@ export function Wiki(): JSX.Element {
     return out;
   }, [tree]);
 
+  /**
+   * Partition the top-level tree into the canonical (schema-frozen) folders —
+   * the single source of truth for SOPs / Team Norms / OKRs — and everything
+   * else (the working / llm-curated area). Surfacing the canonical folders in
+   * their own labelled group answers the "why are norms & SOPs scattered?"
+   * confusion: they aren't, the UI just used to bury them in the flat list.
+   */
+  const { canonicalNodes, workingNodes } = useMemo(
+    () => partitionVaultTree(tree),
+    [tree],
+  );
+
   const handleWikilinkClick = useCallback(
     (target: string) => {
       const match = resolveWikilink(target, allFilePaths);
@@ -787,9 +837,27 @@ export function Wiki(): JSX.Element {
                 </div>
               )}
               {treeLoading && <div className="wiki-loading">Loading tree…</div>}
-              {tree && (
+              {tree && canonicalNodes.length > 0 && (
+                <>
+                  <div className="wiki-tree-group-label" title="Schema-frozen folders — the source of truth referenced by the engine. Agents can't overwrite these via the wiki.">
+                    <Lock size={11} /> Canonical · source of truth
+                  </div>
+                  <TreeView
+                    nodes={canonicalNodes}
+                    selected={selectedPage}
+                    onSelect={(rel) => setSelectedPage(rel)}
+                    collapsed={collapsedFolders}
+                    onToggleFolder={toggleFolder}
+                    labelOverrides={CANONICAL_FOLDER_LABELS}
+                  />
+                  {workingNodes.length > 0 && (
+                    <div className="wiki-tree-group-label">Working notes</div>
+                  )}
+                </>
+              )}
+              {tree && workingNodes.length > 0 && (
                 <TreeView
-                  nodes={tree}
+                  nodes={workingNodes}
                   selected={selectedPage}
                   onSelect={(rel) => setSelectedPage(rel)}
                   collapsed={collapsedFolders}
@@ -882,6 +950,11 @@ interface TreeViewProps {
   collapsed: Set<string>;
   /** Toggle collapsed state for a folder (persists to localStorage). */
   onToggleFolder: (relativePath: string) => void;
+  /**
+   * Optional map of folder name → friendly display label. Applied only to
+   * top-level rows (depth 0) so canonical folders read "SOPs" not "sop".
+   */
+  labelOverrides?: Record<string, string>;
   depth?: number;
 }
 
@@ -891,6 +964,7 @@ function TreeView({
   onSelect,
   collapsed,
   onToggleFolder,
+  labelOverrides,
   depth = 0,
 }: TreeViewProps): JSX.Element {
   return (
@@ -917,7 +991,9 @@ function TreeView({
                   <ChevronDown size={12} className="wiki-tree-chevron" />
                 )}
                 <Folder size={14} />
-                <span className="wiki-tree-name">{node.name}</span>
+                <span className="wiki-tree-name">
+                  {(depth === 0 && labelOverrides?.[node.name]) || node.name}
+                </span>
                 {childCount > 0 && (
                   <span className="wiki-tree-child-count">{childCount}</span>
                 )}

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -31,7 +31,8 @@ import { AgentStatusBadge } from './AgentStatusBadge';
 /** localStorage key for collapsed conversation-group ids. */
 const COLLAPSED_GROUPS_KEY = 'crewly-chat-collapsed-groups';
 
-function loadCollapsedGroups(): Set<string> {
+/** Stored collapsed-group ids, or null when the user has no saved preference. */
+function loadCollapsedGroups(): Set<string> | null {
   try {
     const raw = localStorage.getItem(COLLAPSED_GROUPS_KEY);
     if (raw) {
@@ -39,9 +40,9 @@ function loadCollapsedGroups(): Set<string> {
       if (Array.isArray(arr)) return new Set(arr.filter((x) => typeof x === 'string'));
     }
   } catch {
-    // ignore — start expanded
+    // ignore — no saved preference
   }
-  return new Set();
+  return null;
 }
 
 export interface ConversationListPanelProps {
@@ -69,6 +70,12 @@ export interface ConversationListPanelProps {
   isPinned?: (row: ConversationRow) => boolean;
   /** Pin/unpin a conversation. Enables the per-row pin affordance. */
   onTogglePin?: (row: ConversationRow) => void;
+  /**
+   * Group ids collapsed by default when the user has no saved preference yet
+   * (e.g. a noisy "Slack" section). Once the user toggles anything, their
+   * persisted state wins.
+   */
+  defaultCollapsedGroupIds?: string[];
   className?: string;
 }
 
@@ -81,6 +88,7 @@ export function ConversationListPanel({
   headerAction,
   isPinned,
   onTogglePin,
+  defaultCollapsedGroupIds,
   className = '',
 }: ConversationListPanelProps): JSX.Element {
   const totalRows = useMemo(
@@ -88,8 +96,11 @@ export function ConversationListPanel({
     [groups],
   );
 
-  // Collapsed/expanded state per group id, persisted to localStorage.
-  const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsedGroups);
+  // Collapsed/expanded state per group id, persisted to localStorage. With no
+  // saved preference, fall back to the host's default-collapsed ids.
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () => loadCollapsedGroups() ?? new Set(defaultCollapsedGroupIds ?? []),
+  );
   const toggleCollapse = useCallback((id: string) => {
     setCollapsed((prev) => {
       const next = new Set(prev);

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -118,6 +118,9 @@ function WorkspaceRow({
       data-active={isActive ? 'true' : 'false'}
       data-nested={isNested ? 'true' : 'false'}
       data-kind={workspace.kind ?? 'team'}
+      // Hover tooltip — the rail is icon-only when collapsed, so the 2-letter
+      // initials (e.g. "DM"/"CM") are otherwise opaque. Title reveals the name.
+      title={workspace.name}
       className={[
         'group relative mx-2 flex items-center gap-3 rounded-lg px-2 py-2 text-left transition',
         // Active state is full-width per §6.1, not just a tint.


### PR DESCRIPTION
Addresses three related UX confusions raised together:

## 1. Chat clarity (Slice A)
- Workspace rail buttons now carry a `title` tooltip so cryptic DM/CM initials are legible on hover.
- Slack section is de-noised: legacy id-named threads now render as `Slack thread · <date> <time>` (and new inbound threads are named by their first message via `deriveSlackThreadName`), and the Slack group defaults to collapsed.

## 2. Team page Mission/OKR + Knowledge (Slice B)
- New `TeamObjectives` panel on the team detail page: the team's runtime Missions (filtered by `ownerTeamId`) with KR counts + status badges, linking into `/missions/:id`.
- A **Team Knowledge** sub-section links **Norms** and **SOPs** to the team wiki (their canonical home). Cron Jobs already render below.

## 3. Wiki canonical grouping (Slice C)
- The wiki tree used to dump schema-frozen folders (`sop/`, `team-norm/`, `okr/`) into the flat list alongside llm-curated notes — reading as "norms & SOPs are scattered everywhere".
- Split the top-level tree into a labelled **Canonical · source of truth** group (friendly labels: SOPs, Team Norms, OKRs) above a **Working notes** group. Pure `partitionVaultTree` helper + tests.
- **No content moved** — purely a navigational clarity fix. The actual de-duplication of scattered SOP/norm *files* across `.crewly/` and `ops/marketing/` remains a separate content task.

All co-located tests pass; full build (backend + frontend + cli) green; pre-commit Quality Gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)