### PR TITLE
fix(wiki): close canonical-group gap + explain empty frozen folders

### DIFF
--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -205,6 +205,37 @@
   min-height: 0;
 }
 
+/* Canonical group: size to its (usually tiny) content instead of claiming an
+   equal flex share of the pane — otherwise two sibling .wiki-tree lists split
+   the height 50/50 and the near-empty canonical list leaves a big gap. */
+.wiki-tree--flush {
+  flex: 0 0 auto;
+  overflow: visible;
+  padding-bottom: 0;
+}
+
+.wiki-tree-empty-hint {
+  padding: 2px 8px 4px 34px;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+.wiki-tree-canonical-note {
+  margin: 0;
+  padding: 0 10px 6px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+.wiki-tree-canonical-note code {
+  font-size: 10px;
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+  padding: 0 3px;
+  border-radius: 3px;
+}
+
 .wiki-tree li {
   margin: 0;
 }

--- a/frontend/src/pages/Wiki.test.tsx
+++ b/frontend/src/pages/Wiki.test.tsx
@@ -14,6 +14,7 @@ import {
   resolveWikilink,
   pickInitialVault,
   partitionVaultTree,
+  allCanonicalFoldersEmpty,
   type WikiVault,
 } from './Wiki';
 
@@ -150,5 +151,31 @@ describe('partitionVaultTree', () => {
     const { canonicalNodes, workingNodes } = partitionVaultTree(tree);
     expect(canonicalNodes).toHaveLength(0);
     expect(workingNodes).toHaveLength(1);
+  });
+});
+
+describe('allCanonicalFoldersEmpty', () => {
+  const emptyDir = (name: string) => ({
+    name,
+    relativePath: name,
+    type: 'directory' as const,
+    frozen: true,
+    children: [],
+  });
+
+  it('is false when there are no canonical folders', () => {
+    expect(allCanonicalFoldersEmpty([])).toBe(false);
+  });
+
+  it('is true when every canonical folder has no children', () => {
+    expect(allCanonicalFoldersEmpty([emptyDir('sop'), emptyDir('team-norm')])).toBe(true);
+  });
+
+  it('is false when at least one canonical folder has children', () => {
+    const filled = {
+      ...emptyDir('sop'),
+      children: [{ name: 'a.md', relativePath: 'sop/a.md', type: 'file' as const }],
+    };
+    expect(allCanonicalFoldersEmpty([filled, emptyDir('team-norm')])).toBe(false);
   });
 });

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -130,6 +130,20 @@ export function partitionVaultTree(tree: WikiTreeNode[] | null): {
   return { canonicalNodes, workingNodes };
 }
 
+/**
+ * Whether every canonical folder is empty (no child pages). Used to decide
+ * when to show the "served from config, not materialised here" explainer.
+ *
+ * @param canonicalNodes - The frozen top-level folders.
+ * @returns true when there is at least one canonical folder and all are empty.
+ */
+export function allCanonicalFoldersEmpty(canonicalNodes: WikiTreeNode[]): boolean {
+  return (
+    canonicalNodes.length > 0 &&
+    canonicalNodes.every((n) => (n.children?.length ?? 0) === 0)
+  );
+}
+
 interface PagePayload {
   vaultPath: string;
   relativePath: string;
@@ -842,6 +856,13 @@ export function Wiki(): JSX.Element {
                   <div className="wiki-tree-group-label" title="Schema-frozen folders — the source of truth referenced by the engine. Agents can't overwrite these via the wiki.">
                     <Lock size={11} /> Canonical · source of truth
                   </div>
+                  {allCanonicalFoldersEmpty(canonicalNodes) && (
+                    <p className="wiki-tree-canonical-note">
+                      Reserved folders. Team SOPs &amp; norms are currently
+                      served to agents straight from <code>config/sops/</code>;
+                      they haven&apos;t been materialised as wiki pages yet.
+                    </p>
+                  )}
                   <TreeView
                     nodes={canonicalNodes}
                     selected={selectedPage}
@@ -849,6 +870,7 @@ export function Wiki(): JSX.Element {
                     collapsed={collapsedFolders}
                     onToggleFolder={toggleFolder}
                     labelOverrides={CANONICAL_FOLDER_LABELS}
+                    rootClassName="wiki-tree--flush"
                   />
                   {workingNodes.length > 0 && (
                     <div className="wiki-tree-group-label">Working notes</div>
@@ -955,6 +977,8 @@ interface TreeViewProps {
    * top-level rows (depth 0) so canonical folders read "SOPs" not "sop".
    */
   labelOverrides?: Record<string, string>;
+  /** Extra class on the depth-0 root `<ul>` (e.g. to opt out of flex-grow). */
+  rootClassName?: string;
   depth?: number;
 }
 
@@ -965,10 +989,14 @@ function TreeView({
   collapsed,
   onToggleFolder,
   labelOverrides,
+  rootClassName,
   depth = 0,
 }: TreeViewProps): JSX.Element {
   return (
-    <ul className="wiki-tree" style={{ paddingLeft: depth === 0 ? 0 : 12 }}>
+    <ul
+      className={`wiki-tree${rootClassName ? ` ${rootClassName}` : ''}`}
+      style={{ paddingLeft: depth === 0 ? 0 : 12 }}
+    >
       {nodes.map((node) => {
         if (node.type === 'directory') {
           const frozenTooltip = node.frozenDescription
@@ -1003,15 +1031,18 @@ function TreeView({
                   </span>
                 )}
               </button>
-              {!isCollapsed && node.children && node.children.length > 0 && (
+              {!isCollapsed && childCount > 0 && (
                 <TreeView
-                  nodes={node.children}
+                  nodes={node.children ?? []}
                   selected={selected}
                   onSelect={onSelect}
                   collapsed={collapsed}
                   onToggleFolder={onToggleFolder}
                   depth={depth + 1}
                 />
+              )}
+              {!isCollapsed && childCount === 0 && (
+                <div className="wiki-tree-empty-hint">No pages yet</div>
               )}
             </li>
           );


### PR DESCRIPTION
Follow-up to #635.

**The gap:** the canonical and working trees each render a `.wiki-tree <ul>` with `flex: 1`, so they split the pane height 50/50 — the near-empty canonical list ballooned into a large blank gap (visible when `sop/` + `team-norm/` are empty). The canonical list now sizes to its content (`wiki-tree--flush`); only the working list grows + scrolls.

**Empty-folder clarity:** expanded-but-empty folders show a `No pages yet` hint instead of blank space, and when every canonical folder is empty a note explains *why*: team SOPs & norms are currently served to agents from `config/sops/` and haven't been materialised as wiki pages yet.

New pure `allCanonicalFoldersEmpty` helper + tests (21 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)