### PR TITLE
feat(wiki): live read-through for canonical sop/ and team-norm/ folders

### DIFF
--- a/backend/src/controllers/wiki/wiki.controller.ts
+++ b/backend/src/controllers/wiki/wiki.controller.ts
@@ -31,6 +31,10 @@ import { WikiLintService } from '../../services/wiki/wiki-lint.service.js';
 import { WikiRecentService } from '../../services/wiki/wiki-recent.service.js';
 import { WikiMigrateService } from '../../services/wiki/wiki-migrate.service.js';
 import { WikiCleanupService } from '../../services/wiki/wiki-cleanup.service.js';
+import {
+  overlayRootFor,
+  resolveOverlayFilePath,
+} from '../../services/wiki/wiki-overlay.resolver.js';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs/promises';
@@ -735,6 +739,57 @@ export async function getVaultTree(
     }
 
     let scanned = 0;
+
+    /**
+     * Walk an external overlay source dir (e.g. config/sops), producing nodes
+     * whose relativePath is rooted under `relPrefix` so the page endpoint can
+     * read them back through the same overlay. All nodes are marked frozen
+     * (read-through, read-only).
+     */
+    const buildOverlayTree = async (
+      absDir: string,
+      relPrefix: string,
+    ): Promise<WikiTreeNode[]> => {
+      const out: WikiTreeNode[] = [];
+      let entries: import('fs').Dirent[];
+      try {
+        entries = await fs.readdir(absDir, { withFileTypes: true });
+      } catch {
+        return [];
+      }
+      for (const entry of entries) {
+        if (scanned >= MAX_TREE_ENTRIES) break;
+        if (entry.name.startsWith('.')) continue;
+        scanned++;
+        const abs = path.join(absDir, entry.name);
+        const rel = `${relPrefix}/${entry.name}`;
+        if (entry.isDirectory()) {
+          out.push({
+            name: entry.name,
+            relativePath: rel,
+            type: 'directory',
+            frozen: true,
+            children: (await buildOverlayTree(abs, rel)).sort((a, b) => sortTree(a, b)),
+          });
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          try {
+            const stat = await fs.stat(abs);
+            out.push({
+              name: entry.name,
+              relativePath: rel,
+              type: 'file',
+              frozen: true,
+              bytes: stat.size,
+              modifiedAt: new Date(stat.mtimeMs).toISOString(),
+            });
+          } catch {
+            // ignore unreadable file
+          }
+        }
+      }
+      return out;
+    };
+
     const buildTree = async (absDir: string): Promise<WikiTreeNode[]> => {
       const out: WikiTreeNode[] = [];
       let entries: import('fs').Dirent[];
@@ -753,7 +808,14 @@ export async function getVaultTree(
           const folderKey = rel.replace(/[/\\]+$/, '');
           const isFrozen =
             frozenSet.has(folderKey) || frozenSet.has(`${folderKey}/`);
-          const children = await buildTree(abs);
+          // Live read-through: top-level canonical folders (sop/, team-norm/)
+          // are reserved homes whose content lives elsewhere on disk. Source
+          // their children from the real location instead of the empty vault dir.
+          const overlayRoot =
+            absDir === vaultPath ? overlayRootFor(vaultPath, folderKey) : null;
+          const children = overlayRoot
+            ? await buildOverlayTree(overlayRoot, folderKey)
+            : await buildTree(abs);
           out.push({
             name: entry.name,
             relativePath: rel,
@@ -836,10 +898,24 @@ export async function getPage(
       res.status(400).json({ success: false, error: 'only .md files can be read' });
       return;
     }
-    // Resolve and verify containment — path-traversal guard.
-    const requested = path.resolve(vaultPath, relativePath);
-    const vaultRoot = path.resolve(vaultPath);
-    if (!requested.startsWith(vaultRoot + path.sep) && requested !== vaultRoot) {
+    // Live read-through: pages under canonical overlay folders (sop/,
+    // team-norm/) live outside the vault; resolve them to their real source
+    // (the resolver applies its own traversal guard against the source root).
+    let requested: string;
+    try {
+      const overlayFile = resolveOverlayFilePath(vaultPath, relativePath);
+      if (overlayFile) {
+        requested = overlayFile;
+      } else {
+        // Resolve and verify containment — path-traversal guard.
+        requested = path.resolve(vaultPath, relativePath);
+        const vaultRoot = path.resolve(vaultPath);
+        if (!requested.startsWith(vaultRoot + path.sep) && requested !== vaultRoot) {
+          res.status(400).json({ success: false, error: 'relativePath escapes vault root' });
+          return;
+        }
+      }
+    } catch {
       res.status(400).json({ success: false, error: 'relativePath escapes vault root' });
       return;
     }

--- a/backend/src/services/wiki/wiki-overlay.resolver.test.ts
+++ b/backend/src/services/wiki/wiki-overlay.resolver.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the wiki canonical-folder overlay resolver.
+ *
+ * @module services/wiki/wiki-overlay.resolver.test
+ */
+
+import * as path from 'path';
+import { overlayRootFor, resolveOverlayFilePath } from './wiki-overlay.resolver';
+
+describe('overlayRootFor', () => {
+  const vault = '/home/u/.crewly/teams/abc/wiki';
+
+  afterEach(() => {
+    delete process.env.CREWLY_CONFIG_DIR;
+  });
+
+  it('returns null for non-overlay folders', () => {
+    expect(overlayRootFor(vault, 'llm-curated')).toBeNull();
+    expect(overlayRootFor(vault, 'memory')).toBeNull();
+  });
+
+  it('maps sop/ to <configDir>/sops', () => {
+    process.env.CREWLY_CONFIG_DIR = '/opt/crewly/config';
+    expect(overlayRootFor(vault, 'sop')).toBe(path.join('/opt/crewly/config', 'sops'));
+  });
+
+  it('maps team-norm/ to the sibling norms dir', () => {
+    expect(overlayRootFor(vault, 'team-norm')).toBe(
+      path.resolve('/home/u/.crewly/teams/abc/norms'),
+    );
+  });
+});
+
+describe('resolveOverlayFilePath', () => {
+  const vault = '/home/u/.crewly/teams/abc/wiki';
+
+  beforeEach(() => {
+    process.env.CREWLY_CONFIG_DIR = '/opt/crewly/config';
+  });
+  afterEach(() => {
+    delete process.env.CREWLY_CONFIG_DIR;
+  });
+
+  it('returns null when the path is not under an overlay folder', () => {
+    expect(resolveOverlayFilePath(vault, 'llm-curated/log.md')).toBeNull();
+    expect(resolveOverlayFilePath(vault, 'SCHEMA.md')).toBeNull();
+  });
+
+  it('resolves a sop/ page to the real config file', () => {
+    expect(resolveOverlayFilePath(vault, 'sop/pm/progress-tracking.md')).toBe(
+      path.resolve('/opt/crewly/config/sops', 'pm/progress-tracking.md'),
+    );
+  });
+
+  it('resolves a team-norm/ page to the sibling norms dir', () => {
+    expect(resolveOverlayFilePath(vault, 'team-norm/canDelegate.md')).toBe(
+      path.resolve('/home/u/.crewly/teams/abc/norms', 'canDelegate.md'),
+    );
+  });
+
+  it('throws overlay_escape on path traversal', () => {
+    expect(() => resolveOverlayFilePath(vault, 'sop/../../../etc/passwd')).toThrow(
+      /escapes source root/,
+    );
+  });
+});

--- a/backend/src/services/wiki/wiki-overlay.resolver.ts
+++ b/backend/src/services/wiki/wiki-overlay.resolver.ts
@@ -1,0 +1,83 @@
+/**
+ * Wiki canonical-folder overlay resolver.
+ *
+ * Some schema-frozen folders in a team vault (`sop/`, `team-norm/`) are
+ * reserved canonical homes whose content actually lives elsewhere on disk and
+ * is read directly by the engine — they were never wired to receive wiki
+ * writes, so they always render empty. Rather than copy/migrate that content
+ * (which would drift), the wiki tree + page endpoints read THROUGH to the real
+ * source so the folders always reflect live content.
+ *
+ * Overlay sources:
+ *   - `sop/`       → `<configDir>/sops/`                 (shared, role-based SOP library)
+ *   - `team-norm/` → `<vault>/../norms/`                 (per-team norms written by update-team-norm)
+ *
+ * @module services/wiki/wiki-overlay.resolver
+ */
+
+import * as path from 'path';
+
+/** Top-level vault folders that read through to a live external source. */
+export type OverlayFolder = 'sop' | 'team-norm';
+
+const OVERLAY_FOLDERS: ReadonlySet<string> = new Set<OverlayFolder>(['sop', 'team-norm']);
+
+/**
+ * Resolve the config directory that holds the shared SOP library. Mirrors the
+ * convention used by other services (`<cwd>/config`), overridable via
+ * `CREWLY_CONFIG_DIR` for non-standard deployments.
+ *
+ * @returns Absolute path to the config directory.
+ */
+function configDir(): string {
+  return process.env.CREWLY_CONFIG_DIR
+    ? path.resolve(process.env.CREWLY_CONFIG_DIR)
+    : path.resolve(process.cwd(), 'config');
+}
+
+/**
+ * Return the real on-disk directory backing a top-level canonical folder, or
+ * null when the folder is not overlayed (the vault's own directory is used).
+ *
+ * @param vaultPath - Absolute path to the vault root (e.g. `.../teams/<id>/wiki`).
+ * @param topFolder - The top-level folder name (e.g. `sop`, `team-norm`, `llm-curated`).
+ * @returns Absolute source directory for read-through, or null.
+ */
+export function overlayRootFor(vaultPath: string, topFolder: string): string | null {
+  if (!OVERLAY_FOLDERS.has(topFolder)) return null;
+  if (topFolder === 'sop') return path.join(configDir(), 'sops');
+  // team-norm → the sibling `norms/` dir next to the vault.
+  return path.resolve(vaultPath, '..', 'norms');
+}
+
+/**
+ * Resolve the absolute file path to read for an overlayed page request, with a
+ * traversal guard against escaping the overlay source root. Returns null when
+ * the relativePath is not under an overlay folder; callers then fall back to
+ * the normal in-vault resolution.
+ *
+ * @param vaultPath - Absolute path to the vault root.
+ * @param relativePath - Vault-relative page path, e.g. `sop/pm/progress-tracking.md`.
+ * @returns Absolute real file path, or null if not overlayed.
+ * @throws Error tagged `overlay_escape` when the path would escape the source root.
+ */
+export function resolveOverlayFilePath(
+  vaultPath: string,
+  relativePath: string,
+): string | null {
+  const normalized = relativePath.replace(/\\/g, '/').replace(/^\/+/, '');
+  const slash = normalized.indexOf('/');
+  if (slash <= 0) return null;
+  const topFolder = normalized.slice(0, slash);
+  const root = overlayRootFor(vaultPath, topFolder);
+  if (!root) return null;
+  const subPath = normalized.slice(slash + 1);
+  const resolved = path.resolve(root, subPath);
+  const rootResolved = path.resolve(root);
+  if (resolved !== rootResolved && !resolved.startsWith(rootResolved + path.sep)) {
+    const err = new Error('overlay path escapes source root');
+    err.name = 'overlay_escape';
+    throw err;
+  }
+  return resolved;
+}

--- a/frontend/src/components/TeamDetail/TeamObjectives.test.tsx
+++ b/frontend/src/components/TeamDetail/TeamObjectives.test.tsx
@@ -61,9 +61,9 @@ describe('TeamObjectives', () => {
     render(<TeamObjectives teamId="team-a" />);
     await waitFor(() => expect(screen.getByTestId('team-norms-link')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('team-norms-link'));
-    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a');
+    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a&focus=team-norm');
     fireEvent.click(screen.getByTestId('team-sops-link'));
-    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a');
+    expect(navigateMock).toHaveBeenCalledWith('/wiki?team=team-a&focus=sop');
   });
 
   it('still renders knowledge links when getMissions fails', async () => {

--- a/frontend/src/components/TeamDetail/TeamObjectives.tsx
+++ b/frontend/src/components/TeamDetail/TeamObjectives.tsx
@@ -67,6 +67,9 @@ export function TeamObjectives({ teamId }: TeamObjectivesProps): JSX.Element {
   }, [teamId]);
 
   const wikiHref = `/wiki?${TEAM_QUERY_PARAM}=${teamId}`;
+  // Deep-link straight to the relevant canonical folder in the team wiki.
+  const normsHref = `${wikiHref}&focus=team-norm`;
+  const sopsHref = `${wikiHref}&focus=sop`;
 
   return (
     <div className="space-y-4">
@@ -122,7 +125,7 @@ export function TeamObjectives({ teamId }: TeamObjectivesProps): JSX.Element {
         <div className="flex flex-col gap-2">
           <button
             type="button"
-            onClick={() => navigate(wikiHref)}
+            onClick={() => navigate(normsHref)}
             data-testid="team-norms-link"
             className="flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-text-primary-dark hover:bg-background-dark"
           >
@@ -132,7 +135,7 @@ export function TeamObjectives({ teamId }: TeamObjectivesProps): JSX.Element {
           </button>
           <button
             type="button"
-            onClick={() => navigate(wikiHref)}
+            onClick={() => navigate(sopsHref)}
             data-testid="team-sops-link"
             className="flex items-center gap-2 rounded-lg px-2 py-2 text-left text-sm text-text-primary-dark hover:bg-background-dark"
           >

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -262,6 +262,9 @@ export function Wiki(): JSX.Element {
   // (see wiki.controller listVaults), so we match on it directly.
   const [searchParams] = useSearchParams();
   const teamParam = searchParams.get(TEAM_QUERY_PARAM);
+  // Deep-link: ?focus=sop|team-norm jumps straight to the first page under that
+  // canonical folder once the tree loads (used by the team-page Norms/SOPs links).
+  const focusParam = searchParams.get('focus');
 
   const [vaults, setVaults] = useState<WikiVault[]>([]);
   const [vaultsLoading, setVaultsLoading] = useState(true);
@@ -273,6 +276,8 @@ export function Wiki(): JSX.Element {
   const [treeError, setTreeError] = useState<string | null>(null);
 
   const [selectedPage, setSelectedPage] = useState<string | null>(null);
+  // Tracks which (vault, focus) deep-link has been applied so it fires once.
+  const [focusApplied, setFocusApplied] = useState<string | null>(null);
   const [pageContent, setPageContent] = useState<PagePayload | null>(null);
   const [pageLoading, setPageLoading] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
@@ -675,6 +680,24 @@ export function Wiki(): JSX.Element {
     () => partitionVaultTree(tree),
     [tree],
   );
+
+  /**
+   * Apply the ?focus=<folder> deep-link: once the tree for the requested vault
+   * has loaded, select the first page under that canonical folder. Fires once
+   * per (vault, focus) pair; if the folder is empty (e.g. norms not authored
+   * yet) it just marks the focus applied so the folder is shown but nothing is
+   * force-selected.
+   */
+  useEffect(() => {
+    if (!focusParam || !selectedVault || !tree) return;
+    const key = `${selectedVault.vaultPath}:${focusParam}`;
+    if (focusApplied === key) return;
+    const first = allFilePaths.find(
+      (p) => p === focusParam || p.startsWith(`${focusParam}/`),
+    );
+    if (first) setSelectedPage(first);
+    setFocusApplied(key);
+  }, [focusParam, selectedVault, tree, allFilePaths, focusApplied]);
 
   const handleWikilinkClick = useCallback(
     (target: string) => {


### PR DESCRIPTION
Follow-up to #635/#636. Answers "why are the SOP/Team-Norm folders empty?" by actually filling them — via live read-through, not migration.

## Root cause
The schema-frozen `sop/` and `team-norm/` folders in every team vault were reserved canonical homes that **no code path ever writes to**, so they always rendered empty. The real content lives elsewhere and is read directly by the engine:
- **SOPs** → `config/sops/<role>/*.md` (served to agents via `get-sops`)
- **Team Norms** → `~/.crewly/teams/<id>/norms/*.md` (written by `update-team-norm`, read by `get-team-norms`)

## Fix — read-through (no copy, no drift)
New `wiki-overlay.resolver` (`overlayRootFor` + `resolveOverlayFilePath`, with a traversal guard against the source root) drives both endpoints:
- `getVaultTree`: a top-level `sop/`/`team-norm/` folder sources its children from the real dir instead of the empty vault dir.
- `getPage`: a page path under those folders resolves to the real file (`sop/pm/x.md` → `config/sops/pm/x.md`).

Single source of truth stays where the engine reads it; the wiki just reflects it live.

## Team-page links
`?focus=sop|team-norm` deep-link jumps to the first page in that folder once the tree loads. The team-page **Norms**/**SOPs** links (from #635) now use it, so they land on real content.

## Verified live
- `sop/` → 5 children from `config/sops` (common, developer, pm, qa, xhs log)
- page read-through returns real SOP markdown
- traversal escape (`sop/../../../tmp/evil.md`) rejected
- `team-norm/` → empty for teams with no norms authored yet (correct), with the "No pages yet" hint from #636

Unit tests: `wiki-overlay.resolver` (7) + `TeamObjectives`/`Wiki` helpers updated. Full build green; pre-commit Quality Gates passed.

Note: full-text search doesn't yet index overlay content (it walks the vault dir only) — minor, can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)