### PR TITLE
feat(wiki): SOP catalog — install SOPs into a team (not show all)

### DIFF
--- a/backend/src/controllers/wiki/wiki.controller.ts
+++ b/backend/src/controllers/wiki/wiki.controller.ts
@@ -35,6 +35,7 @@ import {
   overlayRootFor,
   resolveOverlayFilePath,
 } from '../../services/wiki/wiki-overlay.resolver.js';
+import { SopCatalogService } from '../../services/wiki/sop-catalog.service.js';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs/promises';
@@ -974,6 +975,104 @@ export async function searchVault(
       .json({ success: false, error: outcome.reason, message: outcome.message });
   } catch (err) {
     logger.error('wiki/search threw', { error: (err as Error).message });
+    next(err);
+  }
+}
+
+const sopCatalog = new SopCatalogService();
+
+/**
+ * GET /api/wiki/sop-catalog?vaultPath=…
+ *
+ * List the SOP catalog (`config/sops/`), annotated with whether the given team
+ * (resolved from its vault path) has each entry installed.
+ */
+export async function listSopCatalog(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const vaultPath = typeof req.query.vaultPath === 'string' ? req.query.vaultPath : undefined;
+    if (!vaultPath || !path.isAbsolute(vaultPath)) {
+      res.status(400).json({ success: false, error: 'vaultPath (absolute) is required' });
+      return;
+    }
+    const catalog = await sopCatalog.list(vaultPath);
+    res.status(200).json({ success: true, catalog });
+  } catch (err) {
+    logger.error('wiki/sop-catalog threw', { error: (err as Error).message });
+    next(err);
+  }
+}
+
+/**
+ * POST /api/wiki/sop-catalog/install   { vaultPath, sopPath }
+ *
+ * Copy a catalog SOP into the team's installed store. Idempotent.
+ */
+export async function installSop(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { vaultPath, sopPath } = req.body ?? {};
+    if (typeof vaultPath !== 'string' || !path.isAbsolute(vaultPath)) {
+      res.status(400).json({ success: false, error: 'vaultPath (absolute) is required' });
+      return;
+    }
+    if (typeof sopPath !== 'string' || sopPath.length === 0) {
+      res.status(400).json({ success: false, error: 'sopPath is required' });
+      return;
+    }
+    const result = await sopCatalog.install(vaultPath, sopPath);
+    res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    const message = (err as Error).message;
+    if (/escapes|\.md|sopPath/.test(message)) {
+      res.status(400).json({ success: false, error: message });
+      return;
+    }
+    if (/ENOENT/.test(message)) {
+      res.status(404).json({ success: false, error: 'catalog_sop_not_found' });
+      return;
+    }
+    logger.error('wiki/sop-install threw', { error: message });
+    next(err);
+  }
+}
+
+/**
+ * POST /api/wiki/sop-catalog/uninstall   { vaultPath, sopPath }
+ *
+ * Remove a SOP from the team's installed store (catalog original untouched).
+ * Idempotent.
+ */
+export async function uninstallSop(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { vaultPath, sopPath } = req.body ?? {};
+    if (typeof vaultPath !== 'string' || !path.isAbsolute(vaultPath)) {
+      res.status(400).json({ success: false, error: 'vaultPath (absolute) is required' });
+      return;
+    }
+    if (typeof sopPath !== 'string' || sopPath.length === 0) {
+      res.status(400).json({ success: false, error: 'sopPath is required' });
+      return;
+    }
+    const result = await sopCatalog.uninstall(vaultPath, sopPath);
+    res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    const message = (err as Error).message;
+    if (/escapes|\.md|sopPath/.test(message)) {
+      res.status(400).json({ success: false, error: message });
+      return;
+    }
+    logger.error('wiki/sop-uninstall threw', { error: message });
     next(err);
   }
 }

--- a/backend/src/controllers/wiki/wiki.routes.ts
+++ b/backend/src/controllers/wiki/wiki.routes.ts
@@ -21,6 +21,9 @@ import {
   getVaultTree,
   getPage,
   searchVault,
+  listSopCatalog,
+  installSop,
+  uninstallSop,
   getBacklinks,
   lintVault,
   getRecent,
@@ -68,6 +71,10 @@ export function createWikiRouter(): Router {
   router.get('/tree', getVaultTree);
   router.get('/page', getPage);
   router.get('/search', searchVault);
+  // SOP catalog (marketplace): browse config/sops + install/uninstall per team.
+  router.get('/sop-catalog', listSopCatalog);
+  router.post('/sop-catalog/install', installSop);
+  router.post('/sop-catalog/uninstall', uninstallSop);
   router.get('/backlinks', getBacklinks);
   router.get('/recent', getRecent);
   router.post('/migrate/scan', migrateScan);

--- a/backend/src/services/wiki/sop-catalog.service.test.ts
+++ b/backend/src/services/wiki/sop-catalog.service.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for SopCatalogService — list / install / uninstall against a temp
+ * catalog and a temp team vault.
+ *
+ * @module services/wiki/sop-catalog.service.test
+ */
+
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs/promises';
+import { existsSync } from 'fs';
+import { SopCatalogService, teamSopsDir } from './sop-catalog.service';
+
+describe('SopCatalogService', () => {
+  let tmp: string;
+  let configDir: string;
+  let vaultPath: string;
+  const svc = new SopCatalogService();
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sop-catalog-'));
+    configDir = path.join(tmp, 'config');
+    // Catalog: config/sops/{common,pm}/*.md
+    await fs.mkdir(path.join(configDir, 'sops', 'common'), { recursive: true });
+    await fs.mkdir(path.join(configDir, 'sops', 'pm'), { recursive: true });
+    await fs.writeFile(
+      path.join(configDir, 'sops', 'common', 'blocker-handling.md'),
+      '---\ntitle: Blocker Handling\n---\nbody',
+    );
+    await fs.writeFile(
+      path.join(configDir, 'sops', 'pm', 'progress-tracking.md'),
+      '# Progress Tracking\nbody',
+    );
+    // Team vault at <tmp>/teams/abc/wiki (installed store is the sibling sops/).
+    vaultPath = path.join(tmp, 'teams', 'abc', 'wiki');
+    await fs.mkdir(vaultPath, { recursive: true });
+    process.env.CREWLY_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    delete process.env.CREWLY_CONFIG_DIR;
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('lists the catalog with categories and titles, none installed initially', async () => {
+    const list = await svc.list(vaultPath);
+    expect(list.map((e) => e.path)).toEqual([
+      'common/blocker-handling.md',
+      'pm/progress-tracking.md',
+    ]);
+    expect(list[0]).toMatchObject({ category: 'common', title: 'Blocker Handling', installed: false });
+    // Filename fallback title.
+    expect(list[1].title).toBe('progress tracking');
+    expect(list.every((e) => !e.installed)).toBe(true);
+  });
+
+  it('install copies into the team sops dir and flips installed=true', async () => {
+    const res = await svc.install(vaultPath, 'pm/progress-tracking.md');
+    expect(res).toEqual({ installed: true, path: 'pm/progress-tracking.md' });
+    expect(existsSync(path.join(teamSopsDir(vaultPath), 'pm', 'progress-tracking.md'))).toBe(true);
+    const list = await svc.list(vaultPath);
+    expect(list.find((e) => e.path === 'pm/progress-tracking.md')?.installed).toBe(true);
+    expect(list.find((e) => e.path === 'common/blocker-handling.md')?.installed).toBe(false);
+  });
+
+  it('uninstall removes the team copy (catalog untouched) and is idempotent', async () => {
+    await svc.install(vaultPath, 'pm/progress-tracking.md');
+    await svc.uninstall(vaultPath, 'pm/progress-tracking.md');
+    expect(existsSync(path.join(teamSopsDir(vaultPath), 'pm', 'progress-tracking.md'))).toBe(false);
+    // emptied category dir is pruned
+    expect(existsSync(path.join(teamSopsDir(vaultPath), 'pm'))).toBe(false);
+    // catalog original still there
+    expect(existsSync(path.join(configDir, 'sops', 'pm', 'progress-tracking.md'))).toBe(true);
+    // idempotent second call
+    await expect(svc.uninstall(vaultPath, 'pm/progress-tracking.md')).resolves.toEqual({
+      installed: false,
+      path: 'pm/progress-tracking.md',
+    });
+  });
+
+  it('rejects unsafe paths', async () => {
+    await expect(svc.install(vaultPath, '../../../etc/passwd')).rejects.toThrow();
+    await expect(svc.install(vaultPath, 'notmd.txt')).rejects.toThrow(/\.md/);
+  });
+
+  it('install throws when the catalog file is missing', async () => {
+    await expect(svc.install(vaultPath, 'pm/nonexistent.md')).rejects.toThrow();
+  });
+});

--- a/backend/src/services/wiki/sop-catalog.service.ts
+++ b/backend/src/services/wiki/sop-catalog.service.ts
@@ -1,0 +1,203 @@
+/**
+ * SOP catalog service.
+ *
+ * `config/sops/` is a *catalog* of reusable SOPs (a marketplace), NOT content a
+ * team owns automatically. A team owns a SOP only once it is INSTALLED — copied
+ * into the team's own `~/.crewly/teams/<id>/sops/` store, which the wiki then
+ * surfaces (via the overlay resolver) under the team's `sop/` folder.
+ *
+ * This service lists the catalog, reports which entries a given team has
+ * installed, and performs install / uninstall (copy / remove of the per-team
+ * copy — the catalog original is never touched).
+ *
+ * @module services/wiki/sop-catalog.service
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+/** A single SOP available in the catalog. */
+export interface SopCatalogEntry {
+  /** Catalog-relative path, e.g. `pm/progress-tracking.md`. Stable id. */
+  path: string;
+  /** Display title (from frontmatter `title:` or the filename). */
+  title: string;
+  /** Top-level category folder (`common`, `developer`, …) or `general`. */
+  category: string;
+  /** File size in bytes. */
+  bytes: number;
+  /** Whether the queried team has this SOP installed. */
+  installed: boolean;
+}
+
+/**
+ * Resolve the catalog directory (`<configDir>/sops`). `<configDir>` mirrors the
+ * convention used by other services (`<cwd>/config`), overridable via
+ * `CREWLY_CONFIG_DIR`.
+ *
+ * @returns Absolute path to the SOP catalog directory.
+ */
+export function sopCatalogDir(): string {
+  const configDir = process.env.CREWLY_CONFIG_DIR
+    ? path.resolve(process.env.CREWLY_CONFIG_DIR)
+    : path.resolve(process.cwd(), 'config');
+  return path.join(configDir, 'sops');
+}
+
+/**
+ * Resolve a team's installed-SOP store from its vault path. The store is a
+ * sibling of the vault (`<vault>/../sops`), matching the overlay resolver.
+ *
+ * @param vaultPath - Absolute path to the team vault (`.../teams/<id>/wiki`).
+ * @returns Absolute path to the team's installed-SOP directory.
+ */
+export function teamSopsDir(vaultPath: string): string {
+  return path.resolve(vaultPath, '..', 'sops');
+}
+
+/** Recursively collect `.md` files under `root`, returned as root-relative POSIX paths. */
+async function listMarkdown(root: string): Promise<string[]> {
+  const out: string[] = [];
+  const walk = async (dir: string, prefix: string): Promise<void> => {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(path.join(dir, entry.name), rel);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        out.push(rel);
+      }
+    }
+  };
+  await walk(root, '');
+  return out;
+}
+
+/** Pull a human title from a SOP's frontmatter `title:`, falling back to the filename. */
+async function titleFor(absFile: string, relPath: string): Promise<string> {
+  try {
+    const head = (await fs.readFile(absFile, 'utf8')).slice(0, 600);
+    const m = head.match(/^\s*title:\s*(.+?)\s*$/m);
+    if (m) return m[1].replace(/^["']|["']$/g, '').trim();
+  } catch {
+    // ignore — fall through to filename
+  }
+  return path
+    .basename(relPath, '.md')
+    .replace(/\.v\d+$/, '')
+    .replace(/[-_]/g, ' ');
+}
+
+/**
+ * Reject relative paths that are unsafe (absolute, traversal, or non-markdown).
+ *
+ * @param relPath - Candidate catalog-relative SOP path.
+ * @throws Error when the path is empty, not `.md`, or escapes its root.
+ */
+function assertSafeRel(relPath: string): string {
+  const normalized = (relPath ?? '').replace(/\\/g, '/').replace(/^\/+/, '');
+  if (!normalized || !normalized.endsWith('.md')) {
+    throw new Error('sopPath must be a .md file');
+  }
+  if (normalized.split('/').some((seg) => seg === '..' || seg === '')) {
+    throw new Error('sopPath escapes catalog root');
+  }
+  return normalized;
+}
+
+/**
+ * The SOP catalog service. Stateless; methods take the team vault path so the
+ * same instance serves any team.
+ */
+export class SopCatalogService {
+  /**
+   * List the catalog, annotated with whether the given team has each installed.
+   *
+   * @param vaultPath - The team vault path (to resolve its installed store).
+   * @returns Catalog entries sorted by category then path.
+   */
+  async list(vaultPath: string): Promise<SopCatalogEntry[]> {
+    const catalogRoot = sopCatalogDir();
+    const installedSet = new Set(await listMarkdown(teamSopsDir(vaultPath)));
+    const rels = await listMarkdown(catalogRoot);
+    const entries = await Promise.all(
+      rels.map(async (rel) => {
+        const abs = path.join(catalogRoot, rel);
+        let bytes = 0;
+        try {
+          bytes = (await fs.stat(abs)).size;
+        } catch {
+          // ignore
+        }
+        const category = rel.includes('/') ? rel.split('/')[0] : 'general';
+        return {
+          path: rel,
+          title: await titleFor(abs, rel),
+          category,
+          bytes,
+          installed: installedSet.has(rel),
+        } satisfies SopCatalogEntry;
+      }),
+    );
+    return entries.sort(
+      (a, b) => a.category.localeCompare(b.category) || a.path.localeCompare(b.path),
+    );
+  }
+
+  /**
+   * Install a catalog SOP into the team's store (copy, preserving the relative
+   * path). Idempotent — re-installing refreshes the copy to the catalog version.
+   *
+   * @param vaultPath - The team vault path.
+   * @param sopPath - Catalog-relative SOP path (e.g. `pm/progress-tracking.md`).
+   * @returns `{ installed: true, path }`.
+   * @throws Error when the path is unsafe or the catalog file is missing.
+   */
+  async install(vaultPath: string, sopPath: string): Promise<{ installed: true; path: string }> {
+    const rel = assertSafeRel(sopPath);
+    const src = path.join(sopCatalogDir(), rel);
+    await fs.access(src); // throws if the catalog file doesn't exist
+    const dest = path.join(teamSopsDir(vaultPath), rel);
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await fs.copyFile(src, dest);
+    return { installed: true, path: rel };
+  }
+
+  /**
+   * Remove a SOP from the team's store. The catalog original is untouched.
+   * Idempotent — removing a not-installed SOP is a no-op.
+   *
+   * @param vaultPath - The team vault path.
+   * @param sopPath - Catalog-relative SOP path.
+   * @returns `{ installed: false, path }`.
+   * @throws Error when the path is unsafe.
+   */
+  async uninstall(vaultPath: string, sopPath: string): Promise<{ installed: false; path: string }> {
+    const rel = assertSafeRel(sopPath);
+    const root = teamSopsDir(vaultPath);
+    const dest = path.join(root, rel);
+    try {
+      await fs.unlink(dest);
+    } catch {
+      // already absent — idempotent
+    }
+    // Prune now-empty parent dirs (e.g. an emptied `pm/`) up to the store root
+    // so the wiki tree doesn't show hollow category folders.
+    let dir = path.dirname(dest);
+    while (dir.startsWith(root + path.sep) && dir !== root) {
+      try {
+        await fs.rmdir(dir); // throws if non-empty — stop pruning then
+      } catch {
+        break;
+      }
+      dir = path.dirname(dir);
+    }
+    return { installed: false, path: rel };
+  }
+}

--- a/backend/src/services/wiki/wiki-overlay.resolver.test.ts
+++ b/backend/src/services/wiki/wiki-overlay.resolver.test.ts
@@ -10,18 +10,15 @@ import { overlayRootFor, resolveOverlayFilePath } from './wiki-overlay.resolver'
 describe('overlayRootFor', () => {
   const vault = '/home/u/.crewly/teams/abc/wiki';
 
-  afterEach(() => {
-    delete process.env.CREWLY_CONFIG_DIR;
-  });
-
   it('returns null for non-overlay folders', () => {
     expect(overlayRootFor(vault, 'llm-curated')).toBeNull();
     expect(overlayRootFor(vault, 'memory')).toBeNull();
   });
 
-  it('maps sop/ to <configDir>/sops', () => {
-    process.env.CREWLY_CONFIG_DIR = '/opt/crewly/config';
-    expect(overlayRootFor(vault, 'sop')).toBe(path.join('/opt/crewly/config', 'sops'));
+  it('maps sop/ to the per-team installed sops sibling dir', () => {
+    expect(overlayRootFor(vault, 'sop')).toBe(
+      path.resolve('/home/u/.crewly/teams/abc/sops'),
+    );
   });
 
   it('maps team-norm/ to the sibling norms dir', () => {
@@ -34,21 +31,14 @@ describe('overlayRootFor', () => {
 describe('resolveOverlayFilePath', () => {
   const vault = '/home/u/.crewly/teams/abc/wiki';
 
-  beforeEach(() => {
-    process.env.CREWLY_CONFIG_DIR = '/opt/crewly/config';
-  });
-  afterEach(() => {
-    delete process.env.CREWLY_CONFIG_DIR;
-  });
-
   it('returns null when the path is not under an overlay folder', () => {
     expect(resolveOverlayFilePath(vault, 'llm-curated/log.md')).toBeNull();
     expect(resolveOverlayFilePath(vault, 'SCHEMA.md')).toBeNull();
   });
 
-  it('resolves a sop/ page to the real config file', () => {
+  it('resolves a sop/ page to the per-team installed file', () => {
     expect(resolveOverlayFilePath(vault, 'sop/pm/progress-tracking.md')).toBe(
-      path.resolve('/opt/crewly/config/sops', 'pm/progress-tracking.md'),
+      path.resolve('/home/u/.crewly/teams/abc/sops', 'pm/progress-tracking.md'),
     );
   });
 

--- a/backend/src/services/wiki/wiki-overlay.resolver.ts
+++ b/backend/src/services/wiki/wiki-overlay.resolver.ts
@@ -8,8 +8,10 @@
  * (which would drift), the wiki tree + page endpoints read THROUGH to the real
  * source so the folders always reflect live content.
  *
- * Overlay sources:
- *   - `sop/`       → `<configDir>/sops/`                 (shared, role-based SOP library)
+ * Overlay sources (both PER-TEAM siblings of the vault, so the wiki shows only
+ * what the team actually owns — config/sops/ is a catalog you install FROM,
+ * never shown directly in a team folder):
+ *   - `sop/`       → `<vault>/../sops/`                  (SOPs the team has installed from the catalog)
  *   - `team-norm/` → `<vault>/../norms/`                 (per-team norms written by update-team-norm)
  *
  * @module services/wiki/wiki-overlay.resolver
@@ -23,21 +25,9 @@ export type OverlayFolder = 'sop' | 'team-norm';
 const OVERLAY_FOLDERS: ReadonlySet<string> = new Set<OverlayFolder>(['sop', 'team-norm']);
 
 /**
- * Resolve the config directory that holds the shared SOP library. Mirrors the
- * convention used by other services (`<cwd>/config`), overridable via
- * `CREWLY_CONFIG_DIR` for non-standard deployments.
- *
- * @returns Absolute path to the config directory.
- */
-function configDir(): string {
-  return process.env.CREWLY_CONFIG_DIR
-    ? path.resolve(process.env.CREWLY_CONFIG_DIR)
-    : path.resolve(process.cwd(), 'config');
-}
-
-/**
  * Return the real on-disk directory backing a top-level canonical folder, or
  * null when the folder is not overlayed (the vault's own directory is used).
+ * Both overlay folders resolve to a per-team sibling of the vault.
  *
  * @param vaultPath - Absolute path to the vault root (e.g. `.../teams/<id>/wiki`).
  * @param topFolder - The top-level folder name (e.g. `sop`, `team-norm`, `llm-curated`).
@@ -45,9 +35,9 @@ function configDir(): string {
  */
 export function overlayRootFor(vaultPath: string, topFolder: string): string | null {
   if (!OVERLAY_FOLDERS.has(topFolder)) return null;
-  if (topFolder === 'sop') return path.join(configDir(), 'sops');
-  // team-norm → the sibling `norms/` dir next to the vault.
-  return path.resolve(vaultPath, '..', 'norms');
+  // sop → installed SOPs sibling dir; team-norm → norms sibling dir.
+  const sibling = topFolder === 'sop' ? 'sops' : 'norms';
+  return path.resolve(vaultPath, '..', sibling);
 }
 
 /**

--- a/frontend/src/components/Wiki/SopCatalogModal.css
+++ b/frontend/src/components/Wiki/SopCatalogModal.css
@@ -1,0 +1,148 @@
+/* SOP catalog modal — browse + install SOPs into a team. */
+
+.sop-catalog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.sop-catalog-modal {
+  width: min(620px, 92vw);
+  max-height: 82vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #1a1d23);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.sop-catalog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+}
+
+.sop-catalog-header h2 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--color-text-primary, #e8eaee);
+}
+
+.sop-catalog-sub {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--color-text-secondary, #9ba2af);
+}
+
+.sop-catalog-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary, #9ba2af);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.sop-catalog-close:hover {
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+}
+
+.sop-catalog-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 18px 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #ff7b72;
+  background: rgba(255, 123, 114, 0.1);
+  border-radius: 6px;
+}
+
+.sop-catalog-body {
+  overflow-y: auto;
+  padding: 8px 18px 18px;
+}
+
+.sop-catalog-loading,
+.sop-catalog-empty {
+  padding: 24px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--color-text-secondary, #9ba2af);
+}
+
+.sop-catalog-group {
+  margin-top: 14px;
+}
+
+.sop-catalog-group-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-tertiary, #6b7280);
+  padding: 4px 0;
+}
+
+.sop-catalog-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.sop-catalog-row:hover {
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.04));
+}
+
+.sop-catalog-row-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.sop-catalog-row-title {
+  font-size: 13px;
+  color: var(--color-text-primary, #e8eaee);
+  text-transform: capitalize;
+}
+
+.sop-catalog-row-path {
+  font-size: 11px;
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+.sop-catalog-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--color-primary, #6366f1);
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+  cursor: pointer;
+}
+
+.sop-catalog-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.sop-catalog-btn.installed {
+  background: transparent;
+  color: var(--color-text-secondary, #9ba2af);
+  border-color: var(--color-border, rgba(255, 255, 255, 0.15));
+}

--- a/frontend/src/components/Wiki/SopCatalogModal.test.tsx
+++ b/frontend/src/components/Wiki/SopCatalogModal.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for SopCatalogModal — lists the catalog, installs/uninstalls, and
+ * notifies the caller to refresh.
+ *
+ * @module components/Wiki/SopCatalogModal.test
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SopCatalogModal } from './SopCatalogModal';
+
+const CATALOG = [
+  { path: 'common/blocker-handling.md', title: 'Blocker Handling', category: 'common', bytes: 100, installed: false },
+  { path: 'pm/progress-tracking.md', title: 'Progress Tracking', category: 'pm', bytes: 200, installed: true },
+];
+
+describe('SopCatalogModal', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetch(catalog = CATALOG) {
+    return vi.fn(async (url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/sop-catalog?')) {
+        return { ok: true, json: async () => ({ success: true, catalog }) } as Response;
+      }
+      // install / uninstall
+      return { ok: true, json: async () => ({ success: true }) } as Response;
+    });
+  }
+
+  it('lists catalog entries grouped, with installed state', async () => {
+    vi.stubGlobal('fetch', mockFetch());
+    render(<SopCatalogModal vaultPath="/v/wiki" onClose={vi.fn()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Blocker Handling')).toBeInTheDocument());
+    expect(screen.getByTestId('sop-toggle-common/blocker-handling.md')).toHaveTextContent('Install');
+    expect(screen.getByTestId('sop-toggle-pm/progress-tracking.md')).toHaveTextContent('Installed');
+  });
+
+  it('installs a SOP and notifies onChanged', async () => {
+    const fetchMock = mockFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const onChanged = vi.fn();
+    render(<SopCatalogModal vaultPath="/v/wiki" onClose={vi.fn()} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByText('Blocker Handling')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('sop-toggle-common/blocker-handling.md'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('sop-toggle-common/blocker-handling.md')).toHaveTextContent('Installed'),
+    );
+    expect(onChanged).toHaveBeenCalled();
+    const installCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/sop-catalog/install'));
+    expect(installCall).toBeTruthy();
+    expect(JSON.parse((installCall![1] as RequestInit).body as string)).toEqual({
+      vaultPath: '/v/wiki',
+      sopPath: 'common/blocker-handling.md',
+    });
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    vi.stubGlobal('fetch', mockFetch());
+    const onClose = vi.fn();
+    render(<SopCatalogModal vaultPath="/v/wiki" onClose={onClose} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Blocker Handling')).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows an error when the catalog fails to load', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({ success: false, error: 'boom' }) }) as Response),
+    );
+    render(<SopCatalogModal vaultPath="/v/wiki" onClose={vi.fn()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/Wiki/SopCatalogModal.tsx
+++ b/frontend/src/components/Wiki/SopCatalogModal.tsx
@@ -1,0 +1,164 @@
+/**
+ * SopCatalogModal — browse the SOP catalog (config/sops) and install/uninstall
+ * SOPs into the current team. A team only "owns" a SOP once installed; the
+ * wiki's sop/ folder then mirrors the team's installed set.
+ *
+ * @module components/Wiki/SopCatalogModal
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { X, Download, Check, AlertCircle } from 'lucide-react';
+import './SopCatalogModal.css';
+
+/** A catalog entry as returned by GET /api/wiki/sop-catalog. */
+interface CatalogEntry {
+  path: string;
+  title: string;
+  category: string;
+  bytes: number;
+  installed: boolean;
+}
+
+export interface SopCatalogModalProps {
+  /** Absolute team vault path the install targets. */
+  vaultPath: string;
+  /** Close the modal. */
+  onClose: () => void;
+  /** Called after any install/uninstall so the caller can refresh the tree. */
+  onChanged: () => void;
+}
+
+/**
+ * Modal listing the SOP catalog with per-entry Install / Installed toggle.
+ *
+ * @param props - See {@link SopCatalogModalProps}.
+ * @returns The catalog modal.
+ */
+export function SopCatalogModal({ vaultPath, onClose, onChanged }: SopCatalogModalProps): JSX.Element {
+  const [entries, setEntries] = useState<CatalogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/wiki/sop-catalog?vaultPath=${encodeURIComponent(vaultPath)}`);
+      const body = await res.json();
+      if (!res.ok || !body.success) throw new Error(body.error || `HTTP ${res.status}`);
+      setEntries(body.catalog as CatalogEntry[]);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [vaultPath]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = useCallback(
+    async (entry: CatalogEntry) => {
+      setBusy(entry.path);
+      setError(null);
+      const action = entry.installed ? 'uninstall' : 'install';
+      try {
+        const res = await fetch(`/api/wiki/sop-catalog/${action}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ vaultPath, sopPath: entry.path }),
+        });
+        const body = await res.json();
+        if (!res.ok || !body.success) throw new Error(body.error || `HTTP ${res.status}`);
+        setEntries((prev) =>
+          prev.map((e) => (e.path === entry.path ? { ...e, installed: !entry.installed } : e)),
+        );
+        onChanged();
+      } catch (e) {
+        setError((e as Error).message);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [vaultPath, onChanged],
+  );
+
+  // Group entries by category for display.
+  const grouped = entries.reduce<Record<string, CatalogEntry[]>>((acc, e) => {
+    (acc[e.category] ??= []).push(e);
+    return acc;
+  }, {});
+  const installedCount = entries.filter((e) => e.installed).length;
+
+  return (
+    <div className="sop-catalog-backdrop" onClick={onClose} role="presentation">
+      <div
+        className="sop-catalog-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="SOP catalog"
+        data-testid="sop-catalog-modal"
+      >
+        <div className="sop-catalog-header">
+          <div>
+            <h2>SOP Catalog</h2>
+            <p className="sop-catalog-sub">
+              Install SOPs from the shared catalog into this team. {installedCount} installed.
+            </p>
+          </div>
+          <button type="button" className="sop-catalog-close" onClick={onClose} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="sop-catalog-error">
+            <AlertCircle size={14} /> {error}
+          </div>
+        )}
+
+        <div className="sop-catalog-body">
+          {loading && <div className="sop-catalog-loading">Loading catalog…</div>}
+          {!loading && entries.length === 0 && (
+            <div className="sop-catalog-empty">No SOPs in the catalog.</div>
+          )}
+          {!loading &&
+            Object.entries(grouped).map(([category, items]) => (
+              <div key={category} className="sop-catalog-group">
+                <div className="sop-catalog-group-label">{category}</div>
+                {items.map((entry) => (
+                  <div key={entry.path} className="sop-catalog-row" data-testid={`sop-row-${entry.path}`}>
+                    <div className="sop-catalog-row-info">
+                      <span className="sop-catalog-row-title">{entry.title}</span>
+                      <span className="sop-catalog-row-path">{entry.path}</span>
+                    </div>
+                    <button
+                      type="button"
+                      className={`sop-catalog-btn${entry.installed ? ' installed' : ''}`}
+                      disabled={busy === entry.path}
+                      onClick={() => toggle(entry)}
+                      data-testid={`sop-toggle-${entry.path}`}
+                    >
+                      {entry.installed ? (
+                        <>
+                          <Check size={13} /> Installed
+                        </>
+                      ) : (
+                        <>
+                          <Download size={13} /> Install
+                        </>
+                      )}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SopCatalogModal;

--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -328,6 +328,28 @@
   padding-top: 4px;
 }
 
+.wiki-tree-group-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding: 2px 7px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-primary, #818cf8);
+  background: transparent;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.14));
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.wiki-tree-group-action:hover {
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+  color: var(--color-text-primary, #e8eaee);
+}
+
 /* Search */
 
 .wiki-search-bar {

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -29,12 +29,14 @@ import {
   Clock,
   X,
   Upload,
+  Download,
   CheckCircle2,
   Lightbulb,
   ChevronRight,
   ChevronDown,
 } from 'lucide-react';
 import { WikiMarkdown } from '../components/Wiki/WikiMarkdown.js';
+import { SopCatalogModal } from '../components/Wiki/SopCatalogModal.js';
 import './Wiki.css';
 
 /** Debounce delay (ms) between keystrokes and firing the search. */
@@ -278,6 +280,8 @@ export function Wiki(): JSX.Element {
   const [selectedPage, setSelectedPage] = useState<string | null>(null);
   // Tracks which (vault, focus) deep-link has been applied so it fires once.
   const [focusApplied, setFocusApplied] = useState<string | null>(null);
+  // Whether the SOP catalog (install/uninstall) modal is open.
+  const [catalogOpen, setCatalogOpen] = useState(false);
   const [pageContent, setPageContent] = useState<PagePayload | null>(null);
   const [pageLoading, setPageLoading] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
@@ -878,6 +882,17 @@ export function Wiki(): JSX.Element {
                 <>
                   <div className="wiki-tree-group-label" title="Schema-frozen folders — the source of truth referenced by the engine. Agents can't overwrite these via the wiki.">
                     <Lock size={11} /> Canonical · source of truth
+                    {canonicalNodes.some((n) => n.name === 'sop') && (
+                      <button
+                        type="button"
+                        className="wiki-tree-group-action"
+                        onClick={() => setCatalogOpen(true)}
+                        data-testid="open-sop-catalog"
+                        title="Browse the SOP catalog and install SOPs into this team"
+                      >
+                        <Download size={11} /> SOPs
+                      </button>
+                    )}
                   </div>
                   {allCanonicalFoldersEmpty(canonicalNodes) && (
                     <p className="wiki-tree-canonical-note">
@@ -975,6 +990,14 @@ export function Wiki(): JSX.Element {
           )}
         </main>
       </div>
+
+      {catalogOpen && selectedVault && (
+        <SopCatalogModal
+          vaultPath={selectedVault.vaultPath}
+          onClose={() => setCatalogOpen(false)}
+          onChanged={() => loadTree(selectedVault.vaultPath)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #637. Implements the catalog→install→own model: `config/sops/` is a **catalog** (marketplace), and a team only owns a SOP once **installed**.

## What changed
- **Repointed the `sop/` overlay** from the global `config/sops/` to the per-team sibling `~/.crewly/teams/<id>/sops/` (mirrors `team-norm/`). A team's `sop/` folder now shows **only its installed SOPs** — teams start empty.
- **`SopCatalogService`**: `list` (catalog annotated with per-team installed state), `install` (copy into the team store), `uninstall` (remove the team copy + prune emptied category dirs — catalog original untouched). Path-traversal guarded.
- **Endpoints**: `GET /api/wiki/sop-catalog`, `POST /api/wiki/sop-catalog/install`, `POST /api/wiki/sop-catalog/uninstall`.
- **UI**: a "SOPs" button on the wiki's Canonical group opens `SopCatalogModal` to browse the catalog and install/remove per entry; the tree refreshes on change.

## Decisions (per owner)
- Installed SOPs live in a **per-team sibling dir**, read-through into the wiki.
- Install is **owner-driven via the wiki catalog UI**.
- New teams **start empty**.

## Verified live
- catalog lists 12 entries, none installed
- install `pm/progress-tracking.md` → team `sop/` shows only that SOP (not the whole catalog)
- uninstall removes it and prunes the emptied `pm/` dir

Tests: `sop-catalog.service` (5), `wiki-overlay.resolver` (7, repointed), `SopCatalogModal` (4), `Wiki`/`TeamObjectives` updated. Full build green; Quality Gates passed.

Note: `get-sops` (runtime SOP delivery to agents) still reads its own store — wiring agents to read the team's installed set is a deliberate follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)