### PR TITLE
feat(wiki): owner-authored team norms + custom SOPs (+ agent-propose skills)

### DIFF
--- a/backend/src/controllers/wiki/wiki.controller.test.ts
+++ b/backend/src/controllers/wiki/wiki.controller.test.ts
@@ -362,3 +362,74 @@ describe('wiki.controller — /api/wiki/ingest', () => {
     });
   });
 });
+
+describe('wiki.controller — /api/wiki/overlay-page (owner-authored norms/SOPs)', () => {
+  let app: express.Express;
+  let tmpRoot: string;
+  let teamVault: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-overlay-test-'));
+    // Vault at <tmpRoot>/wiki so overlay siblings (norms/, sops/) land under <tmpRoot>.
+    teamVault = path.join(tmpRoot, 'wiki');
+    await fs.mkdir(teamVault, { recursive: true });
+    app = express();
+    app.use(express.json());
+    app.use('/api/wiki', createWikiRouter());
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes a team norm into the sibling norms dir, then reads it back', async () => {
+    const write = await request(app)
+      .post('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'team-norm/code-commit.md', content: '# Code Commit\nrules' });
+    expect(write.status).toBe(200);
+    // landed in <tmpRoot>/norms/code-commit.md
+    const onDisk = await fs.readFile(path.join(tmpRoot, 'norms', 'code-commit.md'), 'utf8');
+    expect(onDisk).toContain('Code Commit');
+    // and the page endpoint reads it through the overlay
+    const read = await request(app).get(
+      `/api/wiki/page?vaultPath=${encodeURIComponent(teamVault)}&relativePath=team-norm/code-commit.md`,
+    );
+    expect(read.status).toBe(200);
+    expect(read.body.content).toContain('rules');
+  });
+
+  it('writes a custom SOP into the sibling sops dir', async () => {
+    const res = await request(app)
+      .post('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'sop/xhs-posting.md', content: 'sop body' });
+    expect(res.status).toBe(200);
+    const onDisk = await fs.readFile(path.join(tmpRoot, 'sops', 'xhs-posting.md'), 'utf8');
+    expect(onDisk).toBe('sop body');
+  });
+
+  it('refuses to write outside overlay folders (agent-curated area)', async () => {
+    const res = await request(app)
+      .post('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'llm-curated/hack.md', content: 'x' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('not_writable');
+  });
+
+  it('rejects path traversal', async () => {
+    const res = await request(app)
+      .post('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'team-norm/../../../etc/evil.md', content: 'x' });
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes an overlay page and prunes the emptied dir', async () => {
+    await request(app)
+      .post('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'sop/cat/deep.md', content: 'x' });
+    const del = await request(app)
+      .delete('/api/wiki/overlay-page')
+      .send({ vaultPath: teamVault, relativePath: 'sop/cat/deep.md' });
+    expect(del.status).toBe(200);
+    await expect(fs.access(path.join(tmpRoot, 'sops', 'cat'))).rejects.toThrow();
+  });
+});

--- a/backend/src/controllers/wiki/wiki.controller.ts
+++ b/backend/src/controllers/wiki/wiki.controller.ts
@@ -1078,6 +1078,120 @@ export async function uninstallSop(
 }
 
 /**
+ * POST /api/wiki/overlay-page   { vaultPath, relativePath, content }
+ *
+ * Create or overwrite an owner-authored page in a per-team overlay folder
+ * (`team-norm/` or `sop/`). Only overlay folders are writable here — the rest
+ * of the vault is agent-curated / schema-frozen, so a relativePath that does
+ * not resolve to an overlay source is rejected. Used by the wiki editor for
+ * owner-authored team norms and custom SOPs.
+ */
+export async function writeOverlayPage(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { vaultPath, relativePath, content } = req.body ?? {};
+    if (typeof vaultPath !== 'string' || !path.isAbsolute(vaultPath)) {
+      res.status(400).json({ success: false, error: 'vaultPath (absolute) is required' });
+      return;
+    }
+    if (typeof relativePath !== 'string' || !relativePath.endsWith('.md')) {
+      res.status(400).json({ success: false, error: 'relativePath (.md) is required' });
+      return;
+    }
+    if (typeof content !== 'string') {
+      res.status(400).json({ success: false, error: 'content (string) is required' });
+      return;
+    }
+    if (Buffer.byteLength(content, 'utf8') > MAX_PAGE_BYTES) {
+      res.status(413).json({ success: false, error: 'page_too_large', maxBytes: MAX_PAGE_BYTES });
+      return;
+    }
+    let target: string | null;
+    try {
+      target = resolveOverlayFilePath(vaultPath, relativePath);
+    } catch {
+      res.status(400).json({ success: false, error: 'relativePath escapes overlay root' });
+      return;
+    }
+    if (!target) {
+      res.status(403).json({
+        success: false,
+        error: 'not_writable',
+        message: 'Only team-norm/ and sop/ folders are editable here.',
+      });
+      return;
+    }
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, content, 'utf8');
+    res.status(200).json({ success: true, relativePath });
+  } catch (err) {
+    logger.error('wiki/overlay-page write threw', { error: (err as Error).message });
+    next(err);
+  }
+}
+
+/**
+ * DELETE /api/wiki/overlay-page   { vaultPath, relativePath }
+ *
+ * Delete an owner-authored overlay page (team norm / custom SOP) and prune any
+ * emptied parent dirs. Idempotent. Only overlay folders are eligible.
+ */
+export async function deleteOverlayPage(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { vaultPath, relativePath } = req.body ?? {};
+    if (typeof vaultPath !== 'string' || !path.isAbsolute(vaultPath)) {
+      res.status(400).json({ success: false, error: 'vaultPath (absolute) is required' });
+      return;
+    }
+    if (typeof relativePath !== 'string' || !relativePath.endsWith('.md')) {
+      res.status(400).json({ success: false, error: 'relativePath (.md) is required' });
+      return;
+    }
+    let target: string | null;
+    try {
+      target = resolveOverlayFilePath(vaultPath, relativePath);
+    } catch {
+      res.status(400).json({ success: false, error: 'relativePath escapes overlay root' });
+      return;
+    }
+    if (!target) {
+      res.status(403).json({ success: false, error: 'not_writable' });
+      return;
+    }
+    const topFolder = relativePath.replace(/\\/g, '/').split('/')[0];
+    const root = overlayRootFor(vaultPath, topFolder);
+    try {
+      await fs.unlink(target);
+    } catch {
+      // already absent — idempotent
+    }
+    // Prune emptied parent dirs up to the overlay root.
+    if (root) {
+      let dir = path.dirname(target);
+      while (dir.startsWith(root + path.sep) && dir !== root) {
+        try {
+          await fs.rmdir(dir);
+        } catch {
+          break;
+        }
+        dir = path.dirname(dir);
+      }
+    }
+    res.status(200).json({ success: true, relativePath });
+  } catch (err) {
+    logger.error('wiki/overlay-page delete threw', { error: (err as Error).message });
+    next(err);
+  }
+}
+
+/**
  * GET /api/wiki/backlinks?vaultPath=…&relativePath=…
  *
  * For the target page, find every other page in the vault whose markdown

--- a/backend/src/controllers/wiki/wiki.routes.ts
+++ b/backend/src/controllers/wiki/wiki.routes.ts
@@ -24,6 +24,8 @@ import {
   listSopCatalog,
   installSop,
   uninstallSop,
+  writeOverlayPage,
+  deleteOverlayPage,
   getBacklinks,
   lintVault,
   getRecent,
@@ -75,6 +77,9 @@ export function createWikiRouter(): Router {
   router.get('/sop-catalog', listSopCatalog);
   router.post('/sop-catalog/install', installSop);
   router.post('/sop-catalog/uninstall', uninstallSop);
+  // Owner-authored overlay pages (team norms + custom SOPs).
+  router.post('/overlay-page', writeOverlayPage);
+  router.delete('/overlay-page', deleteOverlayPage);
   router.get('/backlinks', getBacklinks);
   router.get('/recent', getRecent);
   router.post('/migrate/scan', migrateScan);

--- a/config/skills/agent/core/get-team-norms/SKILL.md
+++ b/config/skills/agent/core/get-team-norms/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: Get Team Norms
+description: Read your team's norms (operating agreements — canDelegate, escalation, rules of engagement) relevant to the current moment.
+version: 1.0.0
+category: system
+skillType: claude-skill
+assignableRoles:
+  - developer
+  - qa
+  - tpm
+  - designer
+  - frontend-developer
+  - backend-developer
+  - fullstack-dev
+  - qa-engineer
+  - product-manager
+  - architect
+  - generalist
+  - team-leader
+  - sales
+  - support
+triggers:
+  - get team norms
+  - team norms
+  - rules of engagement
+  - can i delegate
+  - escalation policy
+tags:
+  - system
+  - norms
+  - governance
+  - team
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
+# Get Team Norms
+
+Read your **team norms** — the team's own operating agreement: who may delegate
+to whom (`canDelegate`), role conventions, escalation paths, decision rights,
+and rules of engagement. Norms are team-specific and authored by the team
+(by the owner in the wiki, or proposed by agents via `update-team-norm`).
+
+Norms differ from SOPs: a **SOP** is a reusable procedure ("how to do task X");
+a **norm** is "how THIS team operates together." Consult norms before acting on
+anything governance-related — delegating, escalating, deciding scope.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `trigger` | No | Filter to norms relevant to a moment (e.g. `"before_commit"`, `"before_delegate"`). Omit to read all. |
+| `teamId` | No | Team to read. Defaults to the team resolved from your `sessionName`. |
+| `sessionName` | No | Your session name, used to resolve the team when `teamId` is omitted. |
+
+## Example
+
+```bash
+bash config/skills/agent/core/get-team-norms/execute.sh '{"trigger":"before_delegate"}'
+```
+
+## Output
+
+JSON `{ success, count, data: [{ normId, title, trigger, content, updatedBy, updatedAt }] }`.
+Returns an empty list if the team has no norms yet.

--- a/config/skills/agent/core/update-team-norm/SKILL.md
+++ b/config/skills/agent/core/update-team-norm/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: Update Team Norm
+description: Propose or update a team norm (an operating agreement — canDelegate, escalation, rules of engagement) for your team.
+version: 1.0.0
+category: system
+skillType: claude-skill
+assignableRoles:
+  - team-leader
+  - tpm
+  - product-manager
+  - architect
+  - generalist
+  - developer
+  - qa
+triggers:
+  - update team norm
+  - propose a norm
+  - set a team rule
+  - we should always
+  - going forward the team should
+tags:
+  - system
+  - norms
+  - governance
+  - team
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
+# Update Team Norm
+
+Create or update a **team norm** — a durable operating agreement for your team
+(who may delegate to whom, escalation paths, decision rights, rules of
+engagement, recurring conventions). Use this when a lasting team-wide rule
+emerges that future work should follow — not for one-off task notes (use the
+wiki/memory for those) and not for reusable procedures (those are SOPs).
+
+Norms you write land in the team's norm store and surface in the wiki under the
+team's **Team Norms** folder, where the owner can review and edit them. Treat
+this as *proposing* a norm: keep it concise, state the rule and when it applies.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `normId` | Yes | Stable kebab-case id / filename, e.g. `"code-commit"`, `"delegation"`. |
+| `content` | Yes | The norm body (markdown). State the rule and its rationale. |
+| `title` | No | Human title, e.g. `"Code Commit Norm"`. |
+| `trigger` | No | When this norm applies, e.g. `"before_commit"`, `"before_delegate"`. |
+| `append` | No | `"true"` to append to an existing norm instead of overwriting. |
+| `teamId` | No | Team to write to. Defaults to the team resolved from `sessionName`. |
+| `sessionName` | No | Your session name, used to resolve the team when `teamId` is omitted. |
+| `updatedBy` | No | Who authored the change (your agent/session name). |
+
+## Example
+
+```bash
+bash config/skills/agent/core/update-team-norm/execute.sh '{"normId":"delegation","title":"Delegation","trigger":"before_delegate","content":"Leads may delegate to their own team only; cross-team work goes through the orchestrator."}'
+```
+
+## Output
+
+JSON `{ success, action: "created" | "updated", normId, path }`.

--- a/frontend/src/components/Wiki/WikiPageEditor.css
+++ b/frontend/src/components/Wiki/WikiPageEditor.css
@@ -1,0 +1,162 @@
+/* Owner-facing editor for team norms + custom SOPs. */
+
+.wiki-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.wiki-editor-modal {
+  width: min(680px, 94vw);
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #1a1d23);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.wiki-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+}
+
+.wiki-editor-header h2 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--color-text-primary, #e8eaee);
+}
+
+.wiki-editor-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary, #9ba2af);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.wiki-editor-close:hover {
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+}
+
+.wiki-editor-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 18px 0;
+  padding: 8px 10px;
+  font-size: 12px;
+  color: #ff7b72;
+  background: rgba(255, 123, 114, 0.1);
+  border-radius: 6px;
+}
+
+.wiki-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  overflow-y: auto;
+}
+
+.wiki-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.wiki-editor-field > span {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+.wiki-editor-field input {
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--color-text-primary, #e8eaee);
+  background: var(--color-background, #0f1115);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+}
+
+.wiki-editor-filename {
+  font-size: 11px;
+  color: var(--color-text-tertiary, #6b7280);
+  font-family: ui-monospace, monospace;
+}
+
+.wiki-editor-field.grow textarea {
+  min-height: 320px;
+  resize: vertical;
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  color: var(--color-text-primary, #e8eaee);
+  background: var(--color-background, #0f1115);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+}
+
+.wiki-editor-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-top: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+}
+
+.wiki-editor-footer-right {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.wiki-editor-cancel,
+.wiki-editor-save,
+.wiki-editor-delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  padding: 7px 14px;
+  border-radius: 7px;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.wiki-editor-cancel {
+  background: transparent;
+  border-color: var(--color-border, rgba(255, 255, 255, 0.15));
+  color: var(--color-text-secondary, #9ba2af);
+}
+
+.wiki-editor-save {
+  background: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
+.wiki-editor-delete {
+  background: transparent;
+  border-color: rgba(255, 123, 114, 0.4);
+  color: #ff7b72;
+}
+
+.wiki-editor-save:disabled,
+.wiki-editor-delete:disabled,
+.wiki-editor-cancel:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/frontend/src/components/Wiki/WikiPageEditor.test.tsx
+++ b/frontend/src/components/Wiki/WikiPageEditor.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for WikiPageEditor — create/edit/delete of owner-authored overlay pages.
+ *
+ * @module components/Wiki/WikiPageEditor.test
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WikiPageEditor } from './WikiPageEditor';
+
+describe('WikiPageEditor', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const okFetch = () =>
+    vi.fn(async () => ({ ok: true, json: async () => ({ success: true }) }) as Response);
+
+  it('creates a norm: slugified path + content posted, then onSaved', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const onSaved = vi.fn();
+    render(
+      <WikiPageEditor vaultPath="/v/wiki" folder="team-norm" mode="create" onClose={vi.fn()} onSaved={onSaved} />,
+    );
+
+    fireEvent.change(screen.getByTestId('wiki-editor-name'), { target: { value: 'Code Commit Norm' } });
+    fireEvent.change(screen.getByTestId('wiki-editor-content'), { target: { value: 'rules here' } });
+    fireEvent.click(screen.getByTestId('wiki-editor-save'));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('team-norm/code-commit-norm.md'));
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      vaultPath: '/v/wiki',
+      relativePath: 'team-norm/code-commit-norm.md',
+      content: 'rules here',
+    });
+  });
+
+  it('creates a custom SOP under the sop/ folder', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const onSaved = vi.fn();
+    render(<WikiPageEditor vaultPath="/v/wiki" folder="sop" mode="create" onClose={vi.fn()} onSaved={onSaved} />);
+    fireEvent.change(screen.getByTestId('wiki-editor-name'), { target: { value: 'XHS Posting' } });
+    fireEvent.click(screen.getByTestId('wiki-editor-save'));
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('sop/xhs-posting.md'));
+  });
+
+  it('edits an existing page (path fixed) and can delete it', async () => {
+    const fetchMock = okFetch();
+    vi.stubGlobal('fetch', fetchMock);
+    const onSaved = vi.fn();
+    render(
+      <WikiPageEditor
+        vaultPath="/v/wiki"
+        folder="team-norm"
+        mode="edit"
+        initialPath="team-norm/existing.md"
+        initialContent="old"
+        onClose={vi.fn()}
+        onSaved={onSaved}
+      />,
+    );
+    // no name field in edit mode
+    expect(screen.queryByTestId('wiki-editor-name')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('wiki-editor-delete'));
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith(null));
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).toBe('DELETE');
+  });
+
+  it('shows an error when save fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 403, json: async () => ({ success: false, error: 'not_writable' }) }) as Response),
+    );
+    render(<WikiPageEditor vaultPath="/v/wiki" folder="sop" mode="create" onClose={vi.fn()} onSaved={vi.fn()} />);
+    fireEvent.change(screen.getByTestId('wiki-editor-name'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByTestId('wiki-editor-save'));
+    await waitFor(() => expect(screen.getByText('not_writable')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/Wiki/WikiPageEditor.tsx
+++ b/frontend/src/components/Wiki/WikiPageEditor.tsx
@@ -1,0 +1,203 @@
+/**
+ * WikiPageEditor — owner-facing markdown editor for the per-team overlay
+ * folders (team-norm/ and sop/). Used to author/edit team norms and custom
+ * SOPs directly from the wiki, writing through to ~/.crewly/teams/<id>/{norms,sops}/.
+ *
+ * @module components/Wiki/WikiPageEditor
+ */
+
+import { useState, useCallback } from 'react';
+import { X, Save, Trash2, AlertCircle } from 'lucide-react';
+import './WikiPageEditor.css';
+
+/** Which overlay folder the editor targets. */
+export type OverlayFolder = 'sop' | 'team-norm';
+
+export interface WikiPageEditorProps {
+  /** Absolute team vault path. */
+  vaultPath: string;
+  /** Target overlay folder. */
+  folder: OverlayFolder;
+  /** 'create' for a new page, 'edit' for an existing one. */
+  mode: 'create' | 'edit';
+  /** Existing page relativePath (edit mode), e.g. `team-norm/code-commit.md`. */
+  initialPath?: string;
+  /** Existing content (edit mode). */
+  initialContent?: string;
+  /** Close without saving. */
+  onClose: () => void;
+  /** Called after a successful save/delete with the affected relativePath (or null on delete). */
+  onSaved: (relativePath: string | null) => void;
+}
+
+const LABELS: Record<OverlayFolder, string> = { sop: 'SOP', 'team-norm': 'Team Norm' };
+
+/** Slugify a human title into a safe `.md` filename stem. */
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+/**
+ * The overlay-page editor modal.
+ *
+ * @param props - See {@link WikiPageEditorProps}.
+ * @returns The editor modal.
+ */
+export function WikiPageEditor({
+  vaultPath,
+  folder,
+  mode,
+  initialPath,
+  initialContent,
+  onClose,
+  onSaved,
+}: WikiPageEditorProps): JSX.Element {
+  const [name, setName] = useState(() =>
+    mode === 'edit' && initialPath ? initialPath.split('/').pop()!.replace(/\.md$/, '') : '',
+  );
+  const [content, setContent] = useState(initialContent ?? '');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const label = LABELS[folder];
+
+  const save = useCallback(async () => {
+    const stem = mode === 'edit' && initialPath ? initialPath.split('/').pop()!.replace(/\.md$/, '') : slugify(name);
+    if (!stem) {
+      setError('Please enter a name.');
+      return;
+    }
+    const relativePath = mode === 'edit' && initialPath ? initialPath : `${folder}/${stem}.md`;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/wiki/overlay-page', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vaultPath, relativePath, content }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.success) throw new Error(body.error || `HTTP ${res.status}`);
+      onSaved(relativePath);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, [mode, initialPath, name, folder, vaultPath, content, onSaved]);
+
+  const remove = useCallback(async () => {
+    if (mode !== 'edit' || !initialPath) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/wiki/overlay-page', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vaultPath, relativePath: initialPath }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.success) throw new Error(body.error || `HTTP ${res.status}`);
+      onSaved(null);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }, [mode, initialPath, vaultPath, onSaved]);
+
+  return (
+    <div className="wiki-editor-backdrop" onClick={onClose} role="presentation">
+      <div
+        className="wiki-editor-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label={`${mode === 'create' ? 'New' : 'Edit'} ${label}`}
+        data-testid="wiki-page-editor"
+      >
+        <div className="wiki-editor-header">
+          <h2>
+            {mode === 'create' ? `New ${label}` : `Edit ${label}`}
+          </h2>
+          <button type="button" className="wiki-editor-close" onClick={onClose} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="wiki-editor-error">
+            <AlertCircle size={14} /> {error}
+          </div>
+        )}
+
+        <div className="wiki-editor-body">
+          {mode === 'create' ? (
+            <label className="wiki-editor-field">
+              <span>Name</span>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={folder === 'sop' ? 'e.g. XHS posting checklist' : 'e.g. Code commit norm'}
+                data-testid="wiki-editor-name"
+                autoFocus
+              />
+              {name && <span className="wiki-editor-filename">{folder}/{slugify(name)}.md</span>}
+            </label>
+          ) : (
+            <div className="wiki-editor-field">
+              <span>File</span>
+              <code className="wiki-editor-filename">{initialPath}</code>
+            </div>
+          )}
+
+          <label className="wiki-editor-field grow">
+            <span>Content (markdown)</span>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={`# ${label}\n\nDescribe the ${label.toLowerCase()}…`}
+              data-testid="wiki-editor-content"
+              spellCheck={false}
+            />
+          </label>
+        </div>
+
+        <div className="wiki-editor-footer">
+          {mode === 'edit' && (
+            <button
+              type="button"
+              className="wiki-editor-delete"
+              onClick={remove}
+              disabled={busy}
+              data-testid="wiki-editor-delete"
+            >
+              <Trash2 size={14} /> Delete
+            </button>
+          )}
+          <div className="wiki-editor-footer-right">
+            <button type="button" className="wiki-editor-cancel" onClick={onClose} disabled={busy}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="wiki-editor-save"
+              onClick={save}
+              disabled={busy}
+              data-testid="wiki-editor-save"
+            >
+              <Save size={14} /> {busy ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WikiPageEditor;

--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -328,11 +328,17 @@
   padding-top: 4px;
 }
 
+.wiki-canonical-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 8px 6px;
+}
+
 .wiki-tree-group-action {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  margin-left: auto;
   padding: 2px 7px;
   font-size: 10px;
   font-weight: 600;

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -30,6 +30,7 @@ import {
   X,
   Upload,
   Download,
+  Pencil,
   CheckCircle2,
   Lightbulb,
   ChevronRight,
@@ -37,6 +38,7 @@ import {
 } from 'lucide-react';
 import { WikiMarkdown } from '../components/Wiki/WikiMarkdown.js';
 import { SopCatalogModal } from '../components/Wiki/SopCatalogModal.js';
+import { WikiPageEditor, type OverlayFolder } from '../components/Wiki/WikiPageEditor.js';
 import './Wiki.css';
 
 /** Debounce delay (ms) between keystrokes and firing the search. */
@@ -282,6 +284,10 @@ export function Wiki(): JSX.Element {
   const [focusApplied, setFocusApplied] = useState<string | null>(null);
   // Whether the SOP catalog (install/uninstall) modal is open.
   const [catalogOpen, setCatalogOpen] = useState(false);
+  // Open overlay-page editor (team norm / custom SOP), or null when closed.
+  const [editor, setEditor] = useState<
+    { folder: OverlayFolder; mode: 'create' | 'edit'; path?: string; content?: string } | null
+  >(null);
   const [pageContent, setPageContent] = useState<PagePayload | null>(null);
   const [pageLoading, setPageLoading] = useState(false);
   const [pageError, setPageError] = useState<string | null>(null);
@@ -882,7 +888,9 @@ export function Wiki(): JSX.Element {
                 <>
                   <div className="wiki-tree-group-label" title="Schema-frozen folders — the source of truth referenced by the engine. Agents can't overwrite these via the wiki.">
                     <Lock size={11} /> Canonical · source of truth
-                    {canonicalNodes.some((n) => n.name === 'sop') && (
+                  </div>
+                  {canonicalNodes.some((n) => n.name === 'sop' || n.name === 'team-norm') && (
+                    <div className="wiki-canonical-actions">
                       <button
                         type="button"
                         className="wiki-tree-group-action"
@@ -890,10 +898,28 @@ export function Wiki(): JSX.Element {
                         data-testid="open-sop-catalog"
                         title="Browse the SOP catalog and install SOPs into this team"
                       >
-                        <Download size={11} /> SOPs
+                        <Download size={11} /> Install SOP
                       </button>
-                    )}
-                  </div>
+                      <button
+                        type="button"
+                        className="wiki-tree-group-action"
+                        onClick={() => setEditor({ folder: 'sop', mode: 'create' })}
+                        data-testid="new-sop"
+                        title="Author a custom SOP for this team"
+                      >
+                        + SOP
+                      </button>
+                      <button
+                        type="button"
+                        className="wiki-tree-group-action"
+                        onClick={() => setEditor({ folder: 'team-norm', mode: 'create' })}
+                        data-testid="new-norm"
+                        title="Author a team norm"
+                      >
+                        + Norm
+                      </button>
+                    </div>
+                  )}
                   {allCanonicalFoldersEmpty(canonicalNodes) && (
                     <p className="wiki-tree-canonical-note">
                       Reserved folders. Team SOPs &amp; norms are currently
@@ -938,6 +964,24 @@ export function Wiki(): JSX.Element {
         <main className="wiki-page-pane">
           <div className="wiki-pane-header">
             <span>{selectedPage ?? 'Pick a page'}</span>
+            {pageContent && selectedPage &&
+              (selectedPage.startsWith('sop/') || selectedPage.startsWith('team-norm/')) && (
+                <button
+                  type="button"
+                  className="wiki-tree-group-action"
+                  data-testid="edit-overlay-page"
+                  onClick={() =>
+                    setEditor({
+                      folder: selectedPage.startsWith('team-norm/') ? 'team-norm' : 'sop',
+                      mode: 'edit',
+                      path: selectedPage,
+                      content: pageContent.content,
+                    })
+                  }
+                >
+                  <Pencil size={11} /> Edit
+                </button>
+              )}
             {pageContent && (
               <span className="wiki-page-meta">
                 {pageContent.bytes} B · modified{' '}
@@ -996,6 +1040,23 @@ export function Wiki(): JSX.Element {
           vaultPath={selectedVault.vaultPath}
           onClose={() => setCatalogOpen(false)}
           onChanged={() => loadTree(selectedVault.vaultPath)}
+        />
+      )}
+
+      {editor && selectedVault && (
+        <WikiPageEditor
+          vaultPath={selectedVault.vaultPath}
+          folder={editor.folder}
+          mode={editor.mode}
+          initialPath={editor.path}
+          initialContent={editor.content}
+          onClose={() => setEditor(null)}
+          onSaved={(relativePath) => {
+            setEditor(null);
+            loadTree(selectedVault.vaultPath);
+            // Select the saved page (or clear if it was deleted).
+            setSelectedPage(relativePath);
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
Implements the chosen creation model: **norms = owner authors in UI + agents propose; SOPs = owner authors custom ones (alongside catalog install).**

## Owner authoring (UI)
- New `WikiPageEditor` modal — create / edit / delete **team norms** and **custom SOPs** as markdown, writing through to the per-team `~/.crewly/teams/<id>/{norms,sops}/`.
- New endpoints: `POST /api/wiki/overlay-page`, `DELETE /api/wiki/overlay-page`. **Only the `team-norm/` and `sop/` overlay folders are writable** — the agent-curated / schema-frozen vault rejects writes (`403 not_writable`). Path-traversal guarded; emptied dirs pruned on delete.
- Wiki UI: `Install SOP` / `+ SOP` / `+ Norm` actions on the Canonical group, and an `Edit` button when viewing an overlay page.

## Agent propose (skills)
- `update-team-norm` and `get-team-norms` had **only `execute.sh` and no `SKILL.md`**, so they never appeared in the agents' skills catalog — agents couldn't discover them. Added `SKILL.md` for both (name, description, assignableRoles, triggers, params).
- Verified the regenerated `AGENT_SKILLS_CATALOG.md` now lists **Get Team Norms** + **Update Team Norm** (next to Get SOPs) — so agents can now propose norms and read them.

## Why this split
Norms = the team's own operating agreement (authored by the team/owner). SOPs = reusable procedures (install from catalog, or author a team-custom one). Owner gets direct authoring for both; agents can propose norms.

## Verified live
- norm create → appears in `team-norm/` tree → read-through → delete (dir pruned)
- custom SOP create → appears in `sop/` alongside installed ones
- write to `llm-curated/` rejected (403); traversal rejected (400)
- skills catalog regenerated with the two norm skills

Tests: overlay-page controller (5), `WikiPageEditor` (4), existing wiki suites green. Full build green; Quality Gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)