### PR TITLE
feat(wiki): BM25 ranking for wiki search (+ CJK + overlay content)

### DIFF
--- a/backend/src/services/wiki/wiki-search.service.test.ts
+++ b/backend/src/services/wiki/wiki-search.service.test.ts
@@ -158,11 +158,53 @@ describe('WikiSearchService', () => {
     });
 
     it('returns empty hits when nothing matches', async () => {
-      const result = await svc.search({ vaultPath: vaultRoot, query: 'zzzzz-not-present' });
+      // Single nonsense token: BM25 matches at the term level, so use a query
+      // that tokenises to one term present in no document.
+      const result = await svc.search({ vaultPath: vaultRoot, query: 'zzzzzqqqqq' });
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.hits).toEqual([]);
       expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe('BM25 scoring', () => {
+    it('exposes a positive BM25 score on hits', async () => {
+      const result = await svc.search({ vaultPath: vaultRoot, query: 'anthropic' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.hits[0].score).toBeGreaterThan(0);
+    });
+
+    it('matches at the term level (multi-word query is OR over terms)', async () => {
+      const result = await svc.search({ vaultPath: vaultRoot, query: 'anthropic pricing' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const paths = result.hits.map((h) => h.relativePath);
+      expect(paths).toContain('llm-curated/customers/anthropic.md');
+      expect(paths).toContain('llm-curated/decisions/pricing.md');
+    });
+
+    it('ranks a rare term above a doc that only matches a common term', async () => {
+      // "the" is common (appears everywhere we add); "zephyr" is rare → higher idf.
+      await writePage('llm-curated/common-a.md', 'the the the the the the the the');
+      await writePage('llm-curated/common-b.md', 'the the the the the the the the');
+      await writePage('llm-curated/rare.md', 'the zephyr protocol');
+      const result = await svc.search({ vaultPath: vaultRoot, query: 'zephyr the' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // The doc containing the rare term should rank first.
+      expect(result.hits[0].relativePath).toBe('llm-curated/rare.md');
+    });
+
+    it('tokenises and matches CJK (Chinese) content', async () => {
+      await writePage('llm-curated/zh.md', '小红书运营策略：每天发布三篇笔记。\n');
+      const result = await svc.search({ vaultPath: vaultRoot, query: '小红书' });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const zh = result.hits.find((h) => h.relativePath.endsWith('zh.md'));
+      expect(zh).toBeDefined();
+      expect(zh!.snippets.length).toBeGreaterThan(0);
     });
   });
 
@@ -203,5 +245,56 @@ describe('WikiSearchService', () => {
       const idxOne = result.hits.findIndex((h) => h.relativePath.endsWith('one-hit.md'));
       expect(idxMany).toBeLessThan(idxOne);
     });
+  });
+});
+
+describe('WikiSearchService — overlay (sop/team-norm) content', () => {
+  let teamRoot: string;
+  let vault: string;
+  let svc: WikiSearchService;
+
+  beforeEach(async () => {
+    // Vault at <teamRoot>/wiki so the overlay siblings (sops/, norms/) sit
+    // under <teamRoot> — matching the real ~/.crewly/teams/<id>/ layout.
+    teamRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'wiki-search-overlay-'));
+    vault = path.join(teamRoot, 'wiki');
+    await fs.mkdir(vault, { recursive: true });
+    await fs.writeFile(path.join(vault, 'SCHEMA.md'), 'vault_scope: team\n', 'utf8');
+    // Installed/custom SOP + a team norm live in sibling dirs.
+    await fs.mkdir(path.join(teamRoot, 'sops', 'common'), { recursive: true });
+    await fs.writeFile(
+      path.join(teamRoot, 'sops', 'common', 'blocker-handling.md'),
+      '# Blocker Handling\nEscalate blockers within 30 minutes.\n',
+      'utf8',
+    );
+    await fs.mkdir(path.join(teamRoot, 'norms'), { recursive: true });
+    await fs.writeFile(
+      path.join(teamRoot, 'norms', 'delegation.md'),
+      '# Delegation\nLeads delegate within their own team only.\n',
+      'utf8',
+    );
+    WikiSearchService.resetInstance();
+    svc = WikiSearchService.getInstance();
+  });
+
+  afterEach(async () => {
+    await fs.rm(teamRoot, { recursive: true, force: true });
+  });
+
+  it('finds SOP content under the sop/ overlay prefix', async () => {
+    const result = await svc.search({ vaultPath: vault, query: 'escalate' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const hit = result.hits.find((h) => h.relativePath === 'sop/common/blocker-handling.md');
+    expect(hit).toBeDefined();
+    expect(hit!.matchCount).toBeGreaterThan(0);
+  });
+
+  it('finds team-norm content under the team-norm/ overlay prefix', async () => {
+    const result = await svc.search({ vaultPath: vault, query: 'delegate' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const hit = result.hits.find((h) => h.relativePath === 'team-norm/delegation.md');
+    expect(hit).toBeDefined();
   });
 });

--- a/backend/src/services/wiki/wiki-search.service.ts
+++ b/backend/src/services/wiki/wiki-search.service.ts
@@ -5,10 +5,16 @@
  * per-file matches with line numbers + short snippets so the UI can render
  * a result list and let the user jump straight to a page.
  *
- * Phase 1: simple case-insensitive substring search. No tokenization,
- * stemming, or inverted index. The vaults here are O(100s) of pages so
- * walking + grepping per request is fine; we'll revisit when volumes
- * justify a real index.
+ * Ranking: Okapi **BM25** (term-frequency saturation via `k1`, length
+ * normalisation via `b`, inverse-document-frequency weighting) computed
+ * per request. No external index — the vaults here are O(100s) of pages so
+ * a per-request scan + score is fine; revisit with a persisted index when
+ * volumes justify it. Tokenisation is Unicode-aware: Latin word tokens plus
+ * individual CJK characters, so Chinese/Japanese content is searchable.
+ *
+ * Scope: walks the vault directory AND the per-team overlay sources
+ * (`sop/` → installed/custom SOPs, `team-norm/` → team norms) so SOP and
+ * norm content is searchable even though it lives outside the vault.
  *
  * @module services/wiki/wiki-search.service
  */
@@ -16,6 +22,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { existsSync } from 'fs';
+import { overlayRootFor } from './wiki-overlay.resolver.js';
 
 /** Cap on how many .md files are inspected per search. */
 export const WIKI_SEARCH_MAX_FILES = 500;
@@ -27,6 +34,13 @@ export const WIKI_SEARCH_MAX_SNIPPETS_PER_FILE = 3;
 export const WIKI_SEARCH_MAX_QUERY_LENGTH = 200;
 /** Cap on per-file size we will read; larger files are skipped. */
 export const WIKI_SEARCH_MAX_FILE_BYTES = 256 * 1024;
+
+/** BM25 term-frequency saturation parameter (standard default). */
+const BM25_K1 = 1.2;
+/** BM25 length-normalisation parameter (standard default). */
+const BM25_B = 0.75;
+/** Weight applied to filename/title tokens when folded into a doc's terms. */
+const FILENAME_TOKEN_WEIGHT = 3;
 
 export interface WikiSearchSnippet {
   /** 1-based line number where the match was found. */
@@ -42,6 +56,8 @@ export interface WikiSearchHit {
   filenameMatch: boolean;
   /** Number of total content matches across the file. */
   matchCount: number;
+  /** BM25 relevance score (higher = better). */
+  score: number;
   /** Up to `WIKI_SEARCH_MAX_SNIPPETS_PER_FILE` matching lines. */
   snippets: WikiSearchSnippet[];
 }
@@ -66,10 +82,54 @@ export interface WikiSearchInput {
   query: string;
 }
 
+/** A document gathered for scoring: where it lives + its term statistics. */
+interface ScoredDoc {
+  relativePath: string;
+  absPath: string;
+  filenameMatch: boolean;
+  /** Token count (document length, including weighted filename tokens). */
+  length: number;
+  /** Per-query-term frequency in this doc. */
+  termFreq: Map<string, number>;
+}
+
 /**
- * Service exposing `search()`. Stateless singleton — the constructor is
- * empty but we use the class pattern to match the rest of the wiki
- * services (`WikiBookkeepService.getInstance()`, etc.).
+ * Tokenise text into searchable terms: lowercase Latin word runs
+ * (`[a-z0-9]+`) plus individual CJK characters (Han, Hiragana, Katakana),
+ * so both English and Chinese/Japanese content is matched.
+ *
+ * @param text - Raw text to tokenise.
+ * @returns Array of lowercase tokens (order preserved, duplicates kept).
+ */
+export function tokenize(text: string): string[] {
+  const lower = text.toLowerCase();
+  const latin = lower.match(/[a-z0-9]+/g) ?? [];
+  const cjk =
+    lower.match(/[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/g) ?? [];
+  return [...latin, ...cjk];
+}
+
+/** Whether a query term is a Latin word (eligible for prefix matching). */
+function isLatin(term: string): boolean {
+  return /^[a-z0-9]+$/.test(term);
+}
+
+/**
+ * Does a document token satisfy a query term? Exact match always; for Latin
+ * query terms of length ≥ 3 a prefix match also counts (so `deploy` finds
+ * `deployment`), preserving the leniency of the old substring search.
+ */
+function tokenMatches(docToken: string, queryTerm: string): boolean {
+  if (docToken === queryTerm) return true;
+  if (queryTerm.length >= 3 && isLatin(queryTerm) && docToken.startsWith(queryTerm)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Service exposing `search()`. Stateless singleton — matches the pattern of
+ * the other wiki services (`WikiBookkeepService.getInstance()`, etc.).
  */
 export class WikiSearchService {
   private static instance: WikiSearchService | null = null;
@@ -86,20 +146,16 @@ export class WikiSearchService {
   }
 
   /**
-   * Search a vault. Returns either `{ok:true, hits}` or a structured
-   * failure. The handler never throws on filesystem read errors — they
-   * are silently skipped so one bad file doesn't blank the whole result.
+   * Search a vault and rank results with BM25. Returns either
+   * `{ok:true, hits}` or a structured failure. Filesystem read errors are
+   * silently skipped so one bad file doesn't blank the whole result.
    */
   async search(input: WikiSearchInput): Promise<WikiSearchResult | WikiSearchFailure> {
     const vaultPath = input.vaultPath;
     const rawQuery = input.query ?? '';
 
     if (!vaultPath || !path.isAbsolute(vaultPath)) {
-      return {
-        ok: false,
-        reason: 'invalid_input',
-        message: 'vaultPath must be an absolute path',
-      };
+      return { ok: false, reason: 'invalid_input', message: 'vaultPath must be an absolute path' };
     }
     if (!existsSync(vaultPath)) {
       return { ok: false, reason: 'vault_missing', message: `vault not found: ${vaultPath}` };
@@ -121,117 +177,235 @@ export class WikiSearchService {
       };
     }
 
-    const needle = query.toLowerCase();
-    const allFiles: string[] = [];
-    await this.collectMdFiles(vaultPath, vaultPath, allFiles);
-    const truncatedFiles = allFiles.length >= WIKI_SEARCH_MAX_FILES;
-    const slice = allFiles.slice(0, WIKI_SEARCH_MAX_FILES);
+    // Distinct query terms drive scoring; keep the raw lowercase query for
+    // substring snippet detection (handles phrases the tokenizer splits).
+    const queryTerms = Array.from(new Set(tokenize(query)));
+    const needleLower = query.toLowerCase();
 
-    const hits: WikiSearchHit[] = [];
-    for (const relativePath of slice) {
-      const hit = await this.searchFile(vaultPath, relativePath, needle);
-      if (hit) hits.push(hit);
+    const docRefs = await this.collectDocs(vaultPath);
+    const truncatedFiles = docRefs.length >= WIKI_SEARCH_MAX_FILES;
+    const slice = docRefs.slice(0, WIKI_SEARCH_MAX_FILES);
+
+    // Pass 1: read + tokenise each doc, accumulate term frequencies for the
+    // query terms and document lengths. (We only track query-term frequencies,
+    // not a full term map, to keep memory bounded.)
+    const docs: ScoredDoc[] = [];
+    for (const ref of slice) {
+      const doc = await this.statDoc(ref, queryTerms);
+      if (doc) docs.push(doc);
     }
 
-    // Rank: filename matches first, then matchCount desc, then path asc for stability.
-    hits.sort((a, b) => {
-      if (a.filenameMatch !== b.filenameMatch) return a.filenameMatch ? -1 : 1;
-      if (a.matchCount !== b.matchCount) return b.matchCount - a.matchCount;
-      return a.relativePath.localeCompare(b.relativePath);
+    if (queryTerms.length === 0) {
+      return { ok: true, vaultPath, query, hits: [], truncated: truncatedFiles };
+    }
+
+    const N = docs.length || 1;
+    const avgdl = docs.reduce((s, d) => s + d.length, 0) / N || 1;
+
+    // Document frequency per query term, then IDF (always positive).
+    const df = new Map<string, number>();
+    for (const term of queryTerms) {
+      let count = 0;
+      for (const d of docs) if ((d.termFreq.get(term) ?? 0) > 0) count++;
+      df.set(term, count);
+    }
+    const idf = new Map<string, number>();
+    for (const term of queryTerms) {
+      const n = df.get(term) ?? 0;
+      idf.set(term, Math.log(1 + (N - n + 0.5) / (n + 0.5)));
+    }
+
+    // Score every doc; keep only those that matched at least one term (score>0).
+    const scored = docs
+      .map((d) => ({ doc: d, score: this.bm25Score(d, queryTerms, idf, avgdl) }))
+      .filter((s) => s.score > 0);
+
+    // Rank: filename/title matches first (a strong product signal kept from
+    // the previous behaviour), then by BM25 score, then path for stability.
+    scored.sort((a, b) => {
+      if (a.doc.filenameMatch !== b.doc.filenameMatch) return a.doc.filenameMatch ? -1 : 1;
+      if (b.score !== a.score) return b.score - a.score;
+      return a.doc.relativePath.localeCompare(b.doc.relativePath);
     });
 
-    const truncatedResults = hits.length > WIKI_SEARCH_MAX_RESULTS;
-    const capped = hits.slice(0, WIKI_SEARCH_MAX_RESULTS);
-    const truncated = truncatedFiles || truncatedResults;
-    return { ok: true, vaultPath, query, hits: capped, truncated };
+    const truncatedResults = scored.length > WIKI_SEARCH_MAX_RESULTS;
+    const top = scored.slice(0, WIKI_SEARCH_MAX_RESULTS);
+
+    // Pass 2: build snippets only for the top results (re-read those files).
+    const hits: WikiSearchHit[] = [];
+    for (const { doc, score } of top) {
+      const { matchCount, snippets } = await this.buildSnippets(doc.absPath, queryTerms, needleLower);
+      hits.push({
+        relativePath: doc.relativePath,
+        filenameMatch: doc.filenameMatch,
+        matchCount,
+        score: Math.round(score * 1000) / 1000,
+        snippets,
+      });
+    }
+
+    return { ok: true, vaultPath, query, hits, truncated: truncatedFiles || truncatedResults };
   }
 
   /**
-   * Recursive walk collecting `.md` files. Skips dotfile dirs (e.g.
-   * `.git`, `.queue`) and stops once `WIKI_SEARCH_MAX_FILES` is reached.
+   * Collect candidate `.md` documents: the vault tree plus the per-team
+   * overlay sources (`sop/`, `team-norm/`). Overlay paths are prefixed with
+   * the folder name so they resolve back through the page endpoint.
    *
-   * @param rootDir - vault root (used to compute relativePath).
-   * @param dir - current directory being walked.
-   * @param acc - accumulator populated with relative paths.
+   * @param vaultPath - Absolute vault root.
+   * @returns Deduped list of `{ relativePath, absPath }`, capped at the limit.
    */
-  private async collectMdFiles(rootDir: string, dir: string, acc: string[]): Promise<void> {
-    if (acc.length >= WIKI_SEARCH_MAX_FILES) return;
-    let entries: import('fs').Dirent[];
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return;
+  private async collectDocs(vaultPath: string): Promise<Array<{ relativePath: string; absPath: string }>> {
+    const seen = new Set<string>();
+    const out: Array<{ relativePath: string; absPath: string }> = [];
+
+    const add = (relativePath: string, absPath: string): void => {
+      if (seen.has(relativePath)) return;
+      seen.add(relativePath);
+      out.push({ relativePath, absPath });
+    };
+
+    for (const rel of await this.walkMd(vaultPath)) {
+      if (out.length >= WIKI_SEARCH_MAX_FILES) return out;
+      add(rel, path.join(vaultPath, rel));
     }
-    for (const entry of entries) {
-      if (acc.length >= WIKI_SEARCH_MAX_FILES) return;
-      if (entry.name.startsWith('.')) continue;
-      const abs = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        await this.collectMdFiles(rootDir, abs, acc);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        const rel = path.relative(rootDir, abs).replace(/\\/g, '/');
-        acc.push(rel);
+
+    for (const folder of ['sop', 'team-norm']) {
+      const root = overlayRootFor(vaultPath, folder);
+      if (!root || !existsSync(root)) continue;
+      for (const rel of await this.walkMd(root)) {
+        if (out.length >= WIKI_SEARCH_MAX_FILES) return out;
+        add(`${folder}/${rel}`, path.join(root, rel));
       }
     }
+
+    return out;
   }
 
   /**
-   * Read one file and accumulate up to `WIKI_SEARCH_MAX_SNIPPETS_PER_FILE`
-   * snippets. Returns null when the file matches nothing.
+   * Recursively collect `.md` files under `root`, returned as root-relative
+   * POSIX paths. Skips dotfile dirs (`.git`, `.queue`) and stops at the cap.
    */
-  private async searchFile(
-    vaultPath: string,
-    relativePath: string,
-    needle: string,
-  ): Promise<WikiSearchHit | null> {
-    const absPath = path.join(vaultPath, relativePath);
-    const filenameMatch = relativePath.toLowerCase().includes(needle);
+  private async walkMd(root: string): Promise<string[]> {
+    const acc: string[] = [];
+    const walk = async (dir: string): Promise<void> => {
+      if (acc.length >= WIKI_SEARCH_MAX_FILES) return;
+      let entries: import('fs').Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (acc.length >= WIKI_SEARCH_MAX_FILES) return;
+        if (entry.name.startsWith('.')) continue;
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(abs);
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          acc.push(path.relative(root, abs).replace(/\\/g, '/'));
+        }
+      }
+    };
+    await walk(root);
+    return acc;
+  }
 
-    let stat: import('fs').Stats;
+  /**
+   * Read a doc and compute its length + per-query-term frequencies. Filename
+   * tokens are folded in (weighted) so title relevance contributes to BM25.
+   * Returns null only on unreadable/oversize files with no filename match.
+   */
+  private async statDoc(
+    ref: { relativePath: string; absPath: string },
+    queryTerms: string[],
+  ): Promise<ScoredDoc | null> {
+    const { relativePath, absPath } = ref;
+    const filenameMatch = queryTerms.some((t) => relativePath.toLowerCase().includes(t));
+
+    // Filename/title tokens, folded in with a weight.
+    const nameTokens = tokenize(path.basename(relativePath, '.md'));
+    const termFreq = new Map<string, number>();
+    let length = 0;
+
+    const tally = (tokens: string[], weight: number): void => {
+      for (const tok of tokens) {
+        length += weight;
+        for (const term of queryTerms) {
+          if (tokenMatches(tok, term)) {
+            termFreq.set(term, (termFreq.get(term) ?? 0) + weight);
+          }
+        }
+      }
+    };
+
+    tally(nameTokens, FILENAME_TOKEN_WEIGHT);
+
+    let content = '';
     try {
-      stat = await fs.stat(absPath);
+      const stat = await fs.stat(absPath);
+      if (stat.size <= WIKI_SEARCH_MAX_FILE_BYTES) {
+        content = await fs.readFile(absPath, 'utf8');
+      }
     } catch {
-      return filenameMatch
-        ? { relativePath, filenameMatch: true, matchCount: 0, snippets: [] }
-        : null;
+      // unreadable — fall through with filename tokens only
     }
-    if (stat.size > WIKI_SEARCH_MAX_FILE_BYTES) {
-      return filenameMatch
-        ? { relativePath, filenameMatch: true, matchCount: 0, snippets: [] }
-        : null;
-    }
+    if (content) tally(tokenize(content), 1);
 
+    // Keep filename-only matches discoverable even with no body match.
+    if (length === 0) return filenameMatch ? { relativePath, absPath, filenameMatch, length: 1, termFreq } : null;
+    return { relativePath, absPath, filenameMatch, length, termFreq };
+  }
+
+  /**
+   * Standard Okapi BM25 score for a doc against the query terms.
+   */
+  private bm25Score(
+    doc: ScoredDoc,
+    queryTerms: string[],
+    idf: Map<string, number>,
+    avgdl: number,
+  ): number {
+    let score = 0;
+    for (const term of queryTerms) {
+      const f = doc.termFreq.get(term) ?? 0;
+      if (f === 0) continue;
+      const denom = f + BM25_K1 * (1 - BM25_B + (BM25_B * doc.length) / avgdl);
+      score += (idf.get(term) ?? 0) * ((f * (BM25_K1 + 1)) / denom);
+    }
+    return score;
+  }
+
+  /**
+   * Re-read a top-ranked file and extract matching-line snippets (a line
+   * matches when it contains any query term as a substring). Returns the
+   * total content match count + up to the snippet cap.
+   */
+  private async buildSnippets(
+    absPath: string,
+    queryTerms: string[],
+    needleLower: string,
+  ): Promise<{ matchCount: number; snippets: WikiSearchSnippet[] }> {
     let content: string;
     try {
       content = await fs.readFile(absPath, 'utf8');
     } catch {
-      return filenameMatch
-        ? { relativePath, filenameMatch: true, matchCount: 0, snippets: [] }
-        : null;
+      return { matchCount: 0, snippets: [] };
     }
-
     const lines = content.split(/\r?\n/);
     const snippets: WikiSearchSnippet[] = [];
     let matchCount = 0;
     for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      if (line.toLowerCase().includes(needle)) {
+      const lineLower = lines[i].toLowerCase();
+      const matched =
+        lineLower.includes(needleLower) || queryTerms.some((t) => lineLower.includes(t));
+      if (matched) {
         matchCount++;
         if (snippets.length < WIKI_SEARCH_MAX_SNIPPETS_PER_FILE) {
-          snippets.push({
-            lineNumber: i + 1,
-            text: line.trim().slice(0, 300),
-          });
+          snippets.push({ lineNumber: i + 1, text: lines[i].trim().slice(0, 300) });
         }
       }
     }
-
-    if (matchCount === 0 && !filenameMatch) return null;
-    return {
-      relativePath,
-      filenameMatch,
-      matchCount,
-      snippets,
-    };
+    return { matchCount, snippets };
   }
 }


### PR DESCRIPTION
Replaces the wiki's naive case-insensitive substring scan with **Okapi BM25** relevance ranking — the lexical core of QMD-style search — implemented natively in TypeScript (no new deps, no external index/runtime).

## What changed
- **BM25 scoring**: term-frequency saturation (`k1=1.2`), length normalisation (`b=0.75`), IDF weighting. Computed per request — fine at O(100s) of pages.
- **Unicode-aware tokenisation**: Latin word tokens + individual CJK characters, so **Chinese/Japanese content is searchable** (the old `[a-z0-9]` scan ranked fine on English but the substring match missed nothing — now CJK is tokenised and ranked properly).
- **Latin prefix leniency** (`deploy` → `deployment`) preserves the old substring feel; filename/title tokens are folded in (weighted) and **title matches still rank first**, keeping the prior ranking contract.
- **Overlay content now searched**: the scan also walks the per-team overlay sources (`sop/` → installed/custom SOPs, `team-norm/` → norms), closing the gap where SOP/norm text was invisible to search.
- Hits gain an additive `score` field; existing shape/fields unchanged (frontend unaffected).

## Verified live
- `watchdog` → ranks the llm-curated decision (score 2.69)
- `milestone` → finds installed SOP **overlay** content `sop/common/mid-flight-milestone-surface.md` (score 3.31, 23 matches)

20 service tests green (multi-term OR, IDF ranking, CJK, overlay prefixes); controller tests (31) green; full build green; Quality Gates passed.

Not included (the heavier QMD tiers, deferred by choice): vector/semantic search + LLM re-ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)