### PR TITLE
feat(skills): agent update-sop skill (author custom team SOPs)

### DIFF
--- a/config/skills/agent/core/update-sop/SKILL.md
+++ b/config/skills/agent/core/update-sop/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: Update SOP
+description: Author or update a custom SOP (a reusable procedure / playbook) for your team.
+version: 1.0.0
+category: system
+skillType: claude-skill
+assignableRoles:
+  - team-leader
+  - tpm
+  - product-manager
+  - architect
+  - generalist
+  - developer
+  - qa
+  - qa-engineer
+  - backend-developer
+  - frontend-developer
+  - fullstack-dev
+triggers:
+  - update sop
+  - write a sop
+  - document the procedure
+  - create a playbook
+  - standardize how we
+tags:
+  - system
+  - sops
+  - procedures
+  - team
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
+# Update SOP
+
+Create or update a **custom SOP** for your team — a reusable procedure /
+playbook for *how to do a class of work* (e.g. "publishing an XHS post",
+"running a release"). The SOP is written into the team's own SOP store
+(`~/.crewly/teams/<id>/sops/`) and surfaces in the wiki under the team's
+**SOPs** folder, alongside SOPs installed from the catalog. The owner can edit
+it in the wiki UI.
+
+Use this for durable, repeatable procedures — not one-off task notes (use the
+wiki/memory) and not team governance rules (those are **team norms** — use
+`update-team-norm`). Prefer installing an existing catalog SOP when one fits;
+author a custom SOP only when the team needs something the catalog lacks.
+
+## Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `sopId` | Yes | Stable kebab-case id / filename, e.g. `"xhs-posting"`. |
+| `content` | Yes | The SOP body (markdown). The steps/procedure. |
+| `title` | No | Human title, e.g. `"XHS Posting Checklist"`. Required when creating. |
+| `category` | No | Optional sub-folder, e.g. `"common"`, `"marketing"`. |
+| `append` | No | `"true"` to append to an existing SOP instead of overwriting. |
+| `teamId` | No | Team to write to. Defaults to the team resolved from `sessionName`. |
+| `sessionName` | No | Your session name, used to resolve the team when `teamId` is omitted. |
+| `updatedBy` | No | Who authored the change (your agent/session name). |
+
+## Example
+
+```bash
+bash config/skills/agent/core/update-sop/execute.sh '{"sopId":"xhs-posting","title":"XHS Posting Checklist","category":"marketing","content":"1. Draft hook.\n2. Add 3-5 tags.\n3. Post 7-9pm."}'
+```
+
+## Output
+
+JSON `{ success, action: "created" | "updated", sopId, title, category, path, relativePath }`.

--- a/config/skills/agent/core/update-sop/execute.sh
+++ b/config/skills/agent/core/update-sop/execute.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Create or update a team's custom SOP.
+# Writes to ~/.crewly/teams/{teamId}/sops/[{category}/]{sopId}.md
+# (the per-team installed/custom SOP store the wiki surfaces under sop/).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../_common/lib.sh"
+
+CREWLY_HOME="${HOME}/.crewly"
+
+INPUT=$(read_json_input "${1:-}")
+[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"sopId\":\"xhs-posting\",\"title\":\"XHS Posting\",\"content\":\"...\",\"category\":\"common\"}'"
+
+SOP_ID=$(printf '%s' "$INPUT" | jq -r '.sopId // empty')
+TITLE=$(printf '%s' "$INPUT" | jq -r '.title // empty')
+CATEGORY=$(printf '%s' "$INPUT" | jq -r '.category // empty')
+CONTENT=$(printf '%s' "$INPUT" | jq -r '.content // empty')
+APPEND=$(printf '%s' "$INPUT" | jq -r '.append // "false"')
+TEAM_ID=$(printf '%s' "$INPUT" | jq -r '.teamId // empty')
+SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
+UPDATED_BY=$(printf '%s' "$INPUT" | jq -r '.updatedBy // empty')
+
+require_param "sopId" "$SOP_ID"
+require_param "content" "$CONTENT"
+
+# Sanitize id/category to safe path segments (no traversal, no slashes).
+SOP_ID=$(printf '%s' "$SOP_ID" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g; s/^-*//; s/-*$//')
+CATEGORY=$(printf '%s' "$CATEGORY" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g; s/^-*//; s/-*$//')
+[ -z "$SOP_ID" ] && error_exit "sopId resolved to empty after sanitization"
+
+# Resolve teamId: explicit param > lookup by sessionName > CREWLY_SESSION_NAME env
+resolve_team_id() {
+  local session="${1:-${CREWLY_SESSION_NAME:-}}"
+  [ -z "$session" ] && return 1
+  local teams_dir="${CREWLY_HOME}/teams"
+  [ ! -d "$teams_dir" ] && return 1
+  for config in "$teams_dir"/*/config.json; do
+    [ -f "$config" ] || continue
+    local found
+    found=$(jq -r --arg s "$session" '.members[]? | select(.sessionName == $s) | "found"' "$config" 2>/dev/null | head -1)
+    if [ "$found" = "found" ]; then
+      basename "$(dirname "$config")"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [ -z "$TEAM_ID" ]; then
+  TEAM_ID=$(resolve_team_id "$SESSION_NAME") || error_exit "Could not resolve teamId. Provide teamId or sessionName."
+fi
+
+SOPS_DIR="${CREWLY_HOME}/teams/${TEAM_ID}/sops"
+if [ -n "$CATEGORY" ]; then
+  SOPS_DIR="${SOPS_DIR}/${CATEGORY}"
+  REL_PATH="sop/${CATEGORY}/${SOP_ID}.md"
+else
+  REL_PATH="sop/${SOP_ID}.md"
+fi
+mkdir -p "$SOPS_DIR"
+
+SOP_FILE="${SOPS_DIR}/${SOP_ID}.md"
+TODAY=$(date +%Y-%m-%d)
+ACTION="created"
+
+if [ -f "$SOP_FILE" ]; then
+  ACTION="updated"
+  EXISTING_TITLE=$(sed -n '/^---$/,/^---$/{ /^---$/d; s/^title: *//p; }' "$SOP_FILE" | head -1)
+  EXISTING_UPDATED_BY=$(sed -n '/^---$/,/^---$/{ /^---$/d; s/^updatedBy: *//p; }' "$SOP_FILE" | head -1)
+  [ -z "$TITLE" ] && TITLE="$EXISTING_TITLE"
+  [ -z "$UPDATED_BY" ] && UPDATED_BY="$EXISTING_UPDATED_BY"
+
+  if [ "$APPEND" = "true" ]; then
+    EXISTING_CONTENT=""
+    FM_DONE=false
+    FM_COUNT=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      if [ "$line" = "---" ]; then
+        FM_COUNT=$((FM_COUNT + 1))
+        if [ "$FM_COUNT" -ge 2 ]; then
+          FM_DONE=true
+          continue
+        fi
+      elif [ "$FM_DONE" = true ]; then
+        EXISTING_CONTENT="${EXISTING_CONTENT}${line}
+"
+      fi
+    done < "$SOP_FILE"
+    EXISTING_CONTENT=$(echo "$EXISTING_CONTENT" | sed '/./,$!d')
+    CONTENT="${EXISTING_CONTENT}
+${CONTENT}"
+  fi
+else
+  [ -z "$TITLE" ] && error_exit "title is required when creating a new SOP"
+fi
+
+{
+  echo "---"
+  echo "title: ${TITLE}"
+  [ -n "$CATEGORY" ] && echo "category: ${CATEGORY}"
+  [ -n "$UPDATED_BY" ] && echo "updatedBy: ${UPDATED_BY}"
+  echo "updatedAt: ${TODAY}"
+  echo "---"
+  echo ""
+  echo "$CONTENT"
+} > "$SOP_FILE"
+
+jq -n \
+  --arg sopId "$SOP_ID" \
+  --arg title "$TITLE" \
+  --arg category "$CATEGORY" \
+  --arg action "$ACTION" \
+  --arg path "$SOP_FILE" \
+  --arg relativePath "$REL_PATH" \
+  '{success: true, action: $action, sopId: $sopId, title: $title, category: $category, path: $path, relativePath: $relativePath}'


### PR DESCRIPTION
Closes the asymmetry where agents could author **team norms** but only **read** SOPs. Now agents can author/update custom SOPs too (per owner decision).

- New `update-sop` agent skill (`config/skills/agent/core/update-sop/`): `execute.sh` mirrors `update-team-norm` (team resolution from sessionName, frontmatter, append mode) and writes to `~/.crewly/teams/<id>/sops/[category/]<sopId>.md` — the per-team SOP store the wiki surfaces under `sop/`, alongside catalog-installed SOPs. `sopId`/`category` are sanitized to safe path segments (no traversal).
- `SKILL.md` makes it discoverable — verified it now appears in `AGENT_SKILLS_CATALOG.md`.
- Owner still edits SOPs in the wiki UI; install-from-catalog unchanged.

Guidance baked into the SKILL.md: use for durable reusable procedures (not one-off notes, not governance rules → those are norms), and prefer installing a catalog SOP when one fits.

Verified live: skill writes `sops/marketing/<id>.md` with frontmatter + returns `relativePath: sop/marketing/<id>.md`; appears in the regenerated agent skills catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)