### PR TITLE
fix(sop): get-sops reads the team SOP library (close read/write mismatch)

### DIFF
--- a/backend/src/controllers/system/system.controller.ts
+++ b/backend/src/controllers/system/system.controller.ts
@@ -394,7 +394,7 @@ export async function querySOPs(
   res: Response
 ): Promise<void> {
   try {
-    const { context, category, role } = req.body;
+    const { context, category, role, teamId } = req.body;
 
     if (!context) {
       res.status(400).json({
@@ -409,6 +409,7 @@ export async function querySOPs(
       role: role || 'developer',
       taskContext: context,
       taskType: category,
+      teamId: typeof teamId === 'string' && teamId ? teamId : undefined,
     });
 
     res.json({

--- a/backend/src/services/sop/sop-team-library.test.ts
+++ b/backend/src/services/sop/sop-team-library.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for SOPService team-library merge: generateSOPContext({ teamId }) must
+ * surface SOPs written to ~/.crewly/teams/<id>/sops/ (the team library the wiki
+ * editor / update-sop skill write to), closing the read/write mismatch where
+ * get-sops only read the global store.
+ *
+ * Uses a real temp CREWLY_HOME (no fs mock) so the directory walk is exercised.
+ *
+ * @module services/sop/sop-team-library.test
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { SOPService } from './sop.service.js';
+
+describe('SOPService — team SOP library merge', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'sop-team-lib-'));
+    process.env.CREWLY_HOME = home;
+    // Global store dirs must exist so the index can be (re)built/written.
+    await fs.mkdir(path.join(home, 'sops', 'system'), { recursive: true });
+    await fs.mkdir(path.join(home, 'sops', 'custom'), { recursive: true });
+    // A team SOP written by update-sop / the wiki editor.
+    await fs.mkdir(path.join(home, 'teams', 't1', 'sops', 'marketing'), { recursive: true });
+    await fs.writeFile(
+      path.join(home, 'teams', 't1', 'sops', 'marketing', 'xhs-posting.md'),
+      '---\ntitle: XHS Posting Checklist\ncategory: marketing\n---\n\n1. Draft hook.\n2. Post 7-9pm.\n',
+      'utf-8',
+    );
+  });
+
+  /** Fresh service bound to this test's temp home (avoids singleton basePath staleness). */
+  const freshService = (): SOPService => SOPService.createWithPath(path.join(home, 'sops'));
+
+  afterEach(async () => {
+    delete process.env.CREWLY_HOME;
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  it('includes the team library SOP when teamId is provided', async () => {
+    const svc = freshService();
+    const ctx = await svc.generateSOPContext({
+      role: 'generalist',
+      taskContext: 'posting on xhs',
+      teamId: 't1',
+    });
+    expect(ctx).toContain('## Team SOPs');
+    expect(ctx).toContain('XHS Posting Checklist');
+    expect(ctx).toContain('Draft hook');
+    // frontmatter category is parsed, not dumped as body
+    expect(ctx).toContain('Category: marketing');
+    expect(ctx).not.toContain('title: XHS Posting Checklist');
+  });
+
+  it('omits the Team SOPs section when teamId is not provided', async () => {
+    const svc = freshService();
+    const ctx = await svc.generateSOPContext({ role: 'generalist', taskContext: 'posting on xhs' });
+    expect(ctx).not.toContain('## Team SOPs');
+  });
+
+  it('tolerates a team with no SOP library (returns no Team SOPs section)', async () => {
+    const svc = freshService();
+    const ctx = await svc.generateSOPContext({
+      role: 'generalist',
+      taskContext: 'anything',
+      teamId: 'team-with-no-sops',
+    });
+    expect(ctx).not.toContain('## Team SOPs');
+  });
+});

--- a/backend/src/services/sop/sop.service.ts
+++ b/backend/src/services/sop/sop.service.ts
@@ -553,29 +553,85 @@ export class SOPService implements ISOPService {
    */
   public async generateSOPContext(params: SOPMatchParams): Promise<string> {
     const sops = await this.findRelevantSOPs(params);
+    // Surface the team's own installed/custom SOPs (written to the team library
+    // by the wiki editor / update-sop skill) — the read path historically only
+    // read the global store, so team SOPs were invisible to get-sops.
+    const teamSops = params.teamId ? await this.readTeamSOPs(params.teamId) : [];
 
-    if (sops.length === 0) {
+    if (sops.length === 0 && teamSops.length === 0) {
       return '';
     }
 
+    const render = (title: string, category: string, priority: string | number, raw: string): string => {
+      const content =
+        raw.length > SOP_CONSTANTS.LIMITS.MAX_SOP_CONTENT_LENGTH
+          ? raw.substring(0, SOP_CONSTANTS.LIMITS.MAX_SOP_CONTENT_LENGTH) + '\n\n*[Content truncated]*'
+          : raw;
+      return `### ${title}\n\n*Category: ${category} | Priority: ${priority}*\n\n${content}\n\n---\n\n`;
+    };
+
     let context = '## Relevant Standard Operating Procedures\n\n';
     context += 'Follow these procedures for your current work:\n\n';
-
     for (const sop of sops) {
-      // Truncate content if too long
-      const content =
-        sop.content.length > SOP_CONSTANTS.LIMITS.MAX_SOP_CONTENT_LENGTH
-          ? sop.content.substring(0, SOP_CONSTANTS.LIMITS.MAX_SOP_CONTENT_LENGTH) +
-            '\n\n*[Content truncated]*'
-          : sop.content;
+      context += render(sop.title, sop.category, sop.priority, sop.content);
+    }
 
-      context += `### ${sop.title}\n\n`;
-      context += `*Category: ${sop.category} | Priority: ${sop.priority}*\n\n`;
-      context += content;
-      context += '\n\n---\n\n';
+    if (teamSops.length > 0) {
+      context += '## Team SOPs\n\n';
+      context += "Your team's own SOPs:\n\n";
+      for (const sop of teamSops) {
+        context += render(sop.title, sop.category, 'team', sop.content);
+      }
     }
 
     return context;
+  }
+
+  /**
+   * Read a team's installed/custom SOP library from
+   * `~/.crewly/teams/<teamId>/sops/` (recursively). Each `.md` file becomes a
+   * SOP entry with its frontmatter `title`/`category` (falling back to the
+   * filename / parent folder). Read-only; tolerant of a missing directory.
+   *
+   * @param teamId - The team whose SOP library to read.
+   * @returns Team SOP entries (possibly empty).
+   */
+  private async readTeamSOPs(
+    teamId: string,
+  ): Promise<Array<{ title: string; category: string; content: string }>> {
+    const root = path.join(this.getCrewlyHome(), 'teams', teamId, 'sops');
+    const out: Array<{ title: string; category: string; content: string }> = [];
+    const walk = async (dir: string, categoryHint: string): Promise<void> => {
+      let entries: import('fs').Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.name.startsWith('.')) continue;
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(abs, entry.name);
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+          try {
+            const raw = await fs.readFile(abs, 'utf-8');
+            const titleMatch = raw.match(/^\s*title:\s*(.+?)\s*$/m);
+            const catMatch = raw.match(/^\s*category:\s*(.+?)\s*$/m);
+            const body = raw.replace(/^---\n[\s\S]*?\n---\n?/, '').trim();
+            out.push({
+              title: titleMatch ? titleMatch[1].replace(/^["']|["']$/g, '') : path.basename(entry.name, '.md'),
+              category: catMatch ? catMatch[1].trim() : categoryHint || 'team',
+              content: body || raw,
+            });
+          } catch {
+            // skip unreadable file
+          }
+        }
+      }
+    };
+    await walk(root, '');
+    return out;
   }
 
   /**
@@ -739,6 +795,10 @@ export class SOPService implements ISOPService {
    * Save the index to disk
    */
   private async saveIndex(): Promise<void> {
+    // Ensure the store dir exists — on a fresh machine ~/.crewly/sops may not
+    // exist yet, and the first query rebuilds the index before initialize()
+    // has created it (otherwise saveIndex throws ENOENT → 500 on first call).
+    await fs.mkdir(path.dirname(this.indexPath), { recursive: true });
     await fs.writeFile(this.indexPath, JSON.stringify(this.index, null, 2), 'utf-8');
   }
 

--- a/backend/src/types/sop.types.ts
+++ b/backend/src/types/sop.types.ts
@@ -168,6 +168,13 @@ export interface SOPMatchParams {
   filePatterns?: string[];
   /** Maximum number of SOPs to return */
   limit?: number;
+  /**
+   * Team whose installed/custom SOP library should also be surfaced. When set,
+   * SOPs under `~/.crewly/teams/<teamId>/sops/` (written by the wiki `+ SOP`
+   * editor / `update-sop` skill) are merged into the result — closing the
+   * write-to-team-library / read-from-global-store mismatch.
+   */
+  teamId?: string;
 }
 
 /**

--- a/config/skills/agent/core/get-sops/SKILL.md
+++ b/config/skills/agent/core/get-sops/SKILL.md
@@ -47,13 +47,17 @@ Query standard operating procedures (SOPs) relevant to your current context or t
 | `context` | Yes | Description of what you need SOPs for (e.g., `"deploying to production"`) |
 | `category` | No | Filter by SOP category (e.g., `"deployment"`, `"testing"`, `"code-review"`) |
 | `role` | No | Filter by role relevance (e.g., `"developer"`, `"qa"`) |
+| `sessionName` | No | Your session name. Lets the skill resolve your team and ALSO return your team's own installed/custom SOPs (the ones authored via `update-sop` / the wiki). |
+| `teamId` | No | Explicit team id (skips the sessionName lookup). |
+
+The result includes both the global SOPs and — when your team is resolved — a **Team SOPs** section from your team's library (`~/.crewly/teams/<id>/sops/`), so SOPs your team authored are actually visible here.
 
 ## Example
 
 ```bash
-bash config/skills/agent/get-sops/execute.sh '{"context":"deploying a new backend service","category":"deployment","role":"developer"}'
+bash config/skills/agent/core/get-sops/execute.sh '{"context":"publishing an XHS post","category":"marketing","sessionName":"crewly-marketing-ella"}'
 ```
 
 ## Output
 
-JSON with matching SOPs including their titles, content, and applicability metadata.
+JSON with matching SOPs including their titles, content, and applicability metadata, plus a Team SOPs section when a team is resolved.

--- a/config/skills/agent/core/get-sops/execute.sh
+++ b/config/skills/agent/core/get-sops/execute.sh
@@ -12,13 +12,38 @@ require_param "context" "$CONTEXT"
 
 CATEGORY=$(printf '%s' "$INPUT" | jq -r '.category // empty')
 ROLE=$(printf '%s' "$INPUT" | jq -r '.role // empty')
+TEAM_ID=$(printf '%s' "$INPUT" | jq -r '.teamId // empty')
+SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
+
+# Resolve teamId so the backend can also surface THIS team's installed/custom
+# SOP library (~/.crewly/teams/<id>/sops/), not just the global store.
+CREWLY_HOME="${HOME}/.crewly"
+resolve_team_id() {
+  local session="${1:-${CREWLY_SESSION_NAME:-}}"
+  [ -z "$session" ] && return 1
+  local teams_dir="${CREWLY_HOME}/teams"
+  [ ! -d "$teams_dir" ] && return 1
+  for config in "$teams_dir"/*/config.json; do
+    [ -f "$config" ] || continue
+    if [ "$(jq -r --arg s "$session" '.members[]? | select(.sessionName == $s) | "found"' "$config" 2>/dev/null | head -1)" = "found" ]; then
+      basename "$(dirname "$config")"
+      return 0
+    fi
+  done
+  return 1
+}
+if [ -z "$TEAM_ID" ]; then
+  TEAM_ID=$(resolve_team_id "$SESSION_NAME" || true)
+fi
 
 BODY=$(jq -n \
   --arg context "$CONTEXT" \
   --arg category "$CATEGORY" \
   --arg role "$ROLE" \
+  --arg teamId "$TEAM_ID" \
   '{context: $context} +
    (if $category != "" then {category: $category} else {} end) +
-   (if $role != "" then {role: $role} else {} end)')
+   (if $role != "" then {role: $role} else {} end) +
+   (if $teamId != "" then {teamId: $teamId} else {} end)')
 
 api_call POST "/system/sops/query" "$BODY"


### PR DESCRIPTION
Closes the gap Ella flagged during the marketing SOP consolidation: SOPs are **written** to the team library (`~/.crewly/teams/<id>/sops/` via the wiki `+ SOP` editor / `update-sop` skill) but `get-sops` only **read** the global store (`~/.crewly/sops`), so team-authored SOPs were invisible to agents.

## Fix
- `SOPMatchParams` gains `teamId`; `generateSOPContext` now merges a **Team SOPs** section read from `~/.crewly/teams/<id>/sops/` (recursive, frontmatter `title`/`category` parsed, body extracted).
- `POST /api/system/sops/query` accepts `teamId`; the `get-sops` skill resolves `teamId` from `sessionName` (same lookup as `update-team-norm`) and passes it.
- **Bonus latent fix:** hardened `saveIndex` with `mkdir -p` — on a fresh machine `~/.crewly/sops` may not exist, so the *first* `/sops/query` after restart 500'd at index write (then cached). Now it's 200.

## Verified live
- team SOP written via `update-sop` → returned by `get-sops` when `teamId`/`sessionName` is provided (under a "Team SOPs" section)
- absent when no team is resolved (no leak)
- first call after restart with no global sops dir → 200 (was 500)

Tests: new `sop-team-library.test.ts` (3, real temp dir) + existing SOP suite (35 total) green.

## Not fixed (couldn't reproduce)
Ella also mentioned a "multi-word search errors" bug. I checked the main paths live — wiki search (`200`), SOP query (`200`), `wiki-query` (uses safe `indexOf`, not regex) — none throw on multi-word. Likely a shell-quoting issue passing a multi-word `--query` to a skill, not a backend bug. Flagging for the exact error/skill before chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)