### PR TITLE
feat(wiki): global 'all vaults' search (merged BM25 ranking)

### DIFF
--- a/backend/src/controllers/wiki/wiki.controller.ts
+++ b/backend/src/controllers/wiki/wiki.controller.ts
@@ -602,6 +602,75 @@ interface WikiTreeNode {
 }
 
 /**
+ * Resolve a human-readable label for a vault. Team vaults use the team's
+ * `name` from `<team-dir>/config.json` (the schema vault_id is a UUID);
+ * project vaults look up `~/.crewly/projects.json` by path; otherwise the
+ * schema vault_id (or path basename) is used.
+ *
+ * @param vaultPath - Absolute vault path.
+ * @param scope - Vault scope.
+ * @param vaultId - Schema vault_id (fallback label).
+ * @returns The resolved label.
+ */
+async function resolveVaultLabel(
+  vaultPath: string,
+  scope: 'project' | 'team' | 'global' | 'unknown',
+  vaultId: string,
+): Promise<string> {
+  let label = vaultId || path.basename(path.dirname(vaultPath));
+  if (scope === 'team') {
+    try {
+      const cfg = JSON.parse(
+        await fs.readFile(path.join(path.dirname(vaultPath), 'config.json'), 'utf8'),
+      ) as { name?: string; teamName?: string };
+      const friendly = cfg.name ?? cfg.teamName;
+      if (typeof friendly === 'string' && friendly.length > 0) label = friendly;
+    } catch {
+      // fall back to UUID label
+    }
+  } else if (scope === 'project') {
+    try {
+      const projects = JSON.parse(
+        await fs.readFile(path.join(os.homedir(), '.crewly/projects.json'), 'utf8'),
+      ) as Array<{ name?: string; path?: string }>;
+      const projectRoot = path.dirname(path.dirname(vaultPath));
+      const hit = projects.find((p) => p.path === projectRoot);
+      if (hit && typeof hit.name === 'string' && hit.name.length > 0) label = hit.name;
+    } catch {
+      // fall back to vault_id / basename
+    }
+  }
+  return label;
+}
+
+/**
+ * Discover all vaults with scope + human label (no stats). Shared by
+ * `/vaults` and `/search-all`.
+ *
+ * @returns Vault descriptors.
+ */
+async function discoverVaultsWithLabels(): Promise<
+  Array<{ vaultPath: string; scope: 'project' | 'team' | 'global' | 'unknown'; label: string }>
+> {
+  const vaultPaths = await discoverWikiVaults();
+  const schemaLoader = new SchemaLoaderService();
+  return Promise.all(
+    vaultPaths.map(async (vaultPath) => {
+      let scope = 'unknown' as 'project' | 'team' | 'global' | 'unknown';
+      let vaultId = '';
+      try {
+        const schema = await schemaLoader.load(vaultPath);
+        scope = schema.vault_scope;
+        vaultId = schema.vault_id;
+      } catch {
+        // malformed schema — still surface
+      }
+      return { vaultPath, scope, label: await resolveVaultLabel(vaultPath, scope, vaultId) };
+    }),
+  );
+}
+
+/**
  * GET /api/wiki/vaults
  *
  * Returns the list of all known vaults (project + team + global) with
@@ -646,44 +715,8 @@ export async function listVaults(
           // ignore — show vault anyway with null stats
         }
 
-        // Human-readable label.
-        //
-        // Default: schema vault_id (good for global + project where the id IS
-        // a human-readable slug). For TEAM vaults the schema's vault_id is
-        // the team UUID, which makes the sidebar unreadable — fall back to
-        // the team's `name` field from `<team-dir>/config.json` when we can.
-        // For PROJECT vaults whose vault_id is generic (e.g. "project"), look
-        // it up in `~/.crewly/projects.json` by path so the sidebar shows
-        // the registered project name (Closie / Flopost / CE / Stevesprompt).
-        let label = vaultId || path.basename(path.dirname(vaultPath));
-        if (scope === 'team') {
-          const teamDir = path.dirname(vaultPath);
-          try {
-            const cfgRaw = await fs.readFile(path.join(teamDir, 'config.json'), 'utf8');
-            const cfg = JSON.parse(cfgRaw) as { name?: string; teamName?: string };
-            const friendly = cfg.name ?? cfg.teamName;
-            if (typeof friendly === 'string' && friendly.length > 0) {
-              label = friendly;
-            }
-          } catch {
-            // ignore — fall back to UUID label
-          }
-        } else if (scope === 'project') {
-          // Look up project name from projects.json by matching the vault
-          // path's parent (project root). Falls back to vault_id/path.
-          try {
-            const projectsJsonPath = path.join(os.homedir(), '.crewly/projects.json');
-            const raw = await fs.readFile(projectsJsonPath, 'utf8');
-            const projects = JSON.parse(raw) as Array<{ name?: string; path?: string }>;
-            const projectRoot = path.dirname(path.dirname(vaultPath)); // strip /.crewly/wiki
-            const hit = projects.find((p) => p.path === projectRoot);
-            if (hit && typeof hit.name === 'string' && hit.name.length > 0) {
-              label = hit.name;
-            }
-          } catch {
-            // ignore — fall back to vault_id / basename
-          }
-        }
+        // Human-readable label (team name / project name / vault_id).
+        const label = await resolveVaultLabel(vaultPath, scope, vaultId);
 
         return {
           vaultPath,
@@ -975,6 +1008,36 @@ export async function searchVault(
       .json({ success: false, error: outcome.reason, message: outcome.message });
   } catch (err) {
     logger.error('wiki/search threw', { error: (err as Error).message });
+    next(err);
+  }
+}
+
+/**
+ * GET /api/wiki/search-all?q=…
+ *
+ * Search EVERY vault and return one merged BM25-ranked list. Each hit carries
+ * its owning vaultPath + vaultLabel so the UI can show where it lives and jump
+ * to it. IDF is computed over the combined corpus for cross-vault comparability.
+ */
+export async function searchAllVaults(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const query = typeof req.query.q === 'string' ? req.query.q : '';
+    const vaults = await discoverVaultsWithLabels();
+    const outcome = await WikiSearchService.getInstance().searchAllVaults({
+      vaults: vaults.map((v) => ({ vaultPath: v.vaultPath, label: v.label })),
+      query,
+    });
+    if (outcome.ok) {
+      res.status(200).json({ success: true, ...outcome });
+      return;
+    }
+    res.status(400).json({ success: false, error: outcome.reason, message: outcome.message });
+  } catch (err) {
+    logger.error('wiki/search-all threw', { error: (err as Error).message });
     next(err);
   }
 }

--- a/backend/src/controllers/wiki/wiki.routes.ts
+++ b/backend/src/controllers/wiki/wiki.routes.ts
@@ -21,6 +21,7 @@ import {
   getVaultTree,
   getPage,
   searchVault,
+  searchAllVaults,
   listSopCatalog,
   installSop,
   uninstallSop,
@@ -73,6 +74,7 @@ export function createWikiRouter(): Router {
   router.get('/tree', getVaultTree);
   router.get('/page', getPage);
   router.get('/search', searchVault);
+  router.get('/search-all', searchAllVaults);
   // SOP catalog (marketplace): browse config/sops + install/uninstall per team.
   router.get('/sop-catalog', listSopCatalog);
   router.post('/sop-catalog/install', installSop);

--- a/backend/src/services/wiki/wiki-search.service.test.ts
+++ b/backend/src/services/wiki/wiki-search.service.test.ts
@@ -298,3 +298,50 @@ describe('WikiSearchService — overlay (sop/team-norm) content', () => {
     expect(hit).toBeDefined();
   });
 });
+
+describe('WikiSearchService.searchAllVaults — merged cross-vault ranking', () => {
+  let root: string;
+  let vaultA: string;
+  let vaultB: string;
+  let svc: WikiSearchService;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'wiki-search-all-'));
+    vaultA = path.join(root, 'a');
+    vaultB = path.join(root, 'b');
+    await fs.mkdir(vaultA, { recursive: true });
+    await fs.mkdir(vaultB, { recursive: true });
+    await fs.writeFile(path.join(vaultA, 'pricing.md'), '# Pricing\n$999/mo locked.\n', 'utf8');
+    await fs.writeFile(path.join(vaultB, 'roadmap.md'), 'Pricing experiments planned for Q3.\n', 'utf8');
+    WikiSearchService.resetInstance();
+    svc = WikiSearchService.getInstance();
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns hits from multiple vaults, each labelled with its vault', async () => {
+    const result = await svc.searchAllVaults({
+      vaults: [
+        { vaultPath: vaultA, label: 'Global' },
+        { vaultPath: vaultB, label: 'Team X' },
+      ],
+      query: 'pricing',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const byVault = Object.fromEntries(result.hits.map((h) => [h.vaultPath, h]));
+    expect(byVault[vaultA]).toBeDefined();
+    expect(byVault[vaultB]).toBeDefined();
+    expect(byVault[vaultA].vaultLabel).toBe('Global');
+    expect(byVault[vaultB].vaultLabel).toBe('Team X');
+    // top-level vaultPath is '' for an all-vault search
+    expect(result.vaultPath).toBe('');
+  });
+
+  it('rejects an empty query', async () => {
+    const result = await svc.searchAllVaults({ vaults: [{ vaultPath: vaultA }], query: '   ' });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/backend/src/services/wiki/wiki-search.service.ts
+++ b/backend/src/services/wiki/wiki-search.service.ts
@@ -60,10 +60,15 @@ export interface WikiSearchHit {
   score: number;
   /** Up to `WIKI_SEARCH_MAX_SNIPPETS_PER_FILE` matching lines. */
   snippets: WikiSearchSnippet[];
+  /** Owning vault path (set for all-vault search; absent for single-vault). */
+  vaultPath?: string;
+  /** Human label for the owning vault (all-vault search only). */
+  vaultLabel?: string;
 }
 
 export interface WikiSearchResult {
   ok: true;
+  /** Searched vault path, or '' for an all-vault search. */
   vaultPath: string;
   query: string;
   hits: WikiSearchHit[];
@@ -82,8 +87,27 @@ export interface WikiSearchInput {
   query: string;
 }
 
+/** A vault to include in an all-vault search. */
+export interface VaultRef {
+  vaultPath: string;
+  label?: string;
+}
+
+export interface WikiMultiSearchInput {
+  vaults: VaultRef[];
+  query: string;
+}
+
+/** A candidate document: where it lives (which vault) + how to read it. */
+interface DocRef {
+  vaultPath: string;
+  relativePath: string;
+  absPath: string;
+}
+
 /** A document gathered for scoring: where it lives + its term statistics. */
 interface ScoredDoc {
+  vaultPath: string;
   relativePath: string;
   absPath: string;
   filenameMatch: boolean;
@@ -145,83 +169,106 @@ export class WikiSearchService {
     this.instance = null;
   }
 
+  /** Validate + normalise a query, or return a structured failure. */
+  private validateQuery(raw: string): { query: string } | WikiSearchFailure {
+    const query = (raw ?? '').trim();
+    if (query.length === 0) {
+      return { ok: false, reason: 'invalid_query', message: 'query must be at least one non-whitespace character' };
+    }
+    if (query.length > WIKI_SEARCH_MAX_QUERY_LENGTH) {
+      return { ok: false, reason: 'invalid_query', message: `query exceeds ${WIKI_SEARCH_MAX_QUERY_LENGTH} characters` };
+    }
+    return { query };
+  }
+
   /**
-   * Search a vault and rank results with BM25. Returns either
+   * Search a single vault and rank results with BM25. Returns either
    * `{ok:true, hits}` or a structured failure. Filesystem read errors are
    * silently skipped so one bad file doesn't blank the whole result.
    */
   async search(input: WikiSearchInput): Promise<WikiSearchResult | WikiSearchFailure> {
     const vaultPath = input.vaultPath;
-    const rawQuery = input.query ?? '';
-
     if (!vaultPath || !path.isAbsolute(vaultPath)) {
       return { ok: false, reason: 'invalid_input', message: 'vaultPath must be an absolute path' };
     }
     if (!existsSync(vaultPath)) {
       return { ok: false, reason: 'vault_missing', message: `vault not found: ${vaultPath}` };
     }
+    const v = this.validateQuery(input.query);
+    if ('ok' in v) return v;
 
-    const query = rawQuery.trim();
-    if (query.length === 0) {
-      return {
-        ok: false,
-        reason: 'invalid_query',
-        message: 'query must be at least one non-whitespace character',
-      };
-    }
-    if (query.length > WIKI_SEARCH_MAX_QUERY_LENGTH) {
-      return {
-        ok: false,
-        reason: 'invalid_query',
-        message: `query exceeds ${WIKI_SEARCH_MAX_QUERY_LENGTH} characters`,
-      };
+    const refs = (await this.collectDocs(vaultPath)).map((r) => ({ vaultPath, ...r }));
+    const { hits, truncated } = await this._searchCorpus(refs, v.query);
+    return { ok: true, vaultPath, query: v.query, hits, truncated };
+  }
+
+  /**
+   * Search across MANY vaults and return one merged BM25-ranked list. IDF is
+   * computed over the combined corpus so scores are comparable across vaults.
+   * Each hit carries its owning `vaultPath` (+ `vaultLabel` when provided).
+   */
+  async searchAllVaults(input: WikiMultiSearchInput): Promise<WikiSearchResult | WikiSearchFailure> {
+    const v = this.validateQuery(input.query);
+    if ('ok' in v) return v;
+
+    const labelByPath = new Map<string, string>();
+    const refs: DocRef[] = [];
+    for (const vault of input.vaults) {
+      if (!vault.vaultPath || !existsSync(vault.vaultPath)) continue;
+      if (vault.label) labelByPath.set(vault.vaultPath, vault.label);
+      for (const r of await this.collectDocs(vault.vaultPath)) {
+        refs.push({ vaultPath: vault.vaultPath, ...r });
+        if (refs.length >= WIKI_SEARCH_MAX_FILES) break;
+      }
+      if (refs.length >= WIKI_SEARCH_MAX_FILES) break;
     }
 
-    // Distinct query terms drive scoring; keep the raw lowercase query for
-    // substring snippet detection (handles phrases the tokenizer splits).
+    const { hits, truncated } = await this._searchCorpus(refs, v.query);
+    for (const h of hits) {
+      if (h.vaultPath) h.vaultLabel = labelByPath.get(h.vaultPath);
+    }
+    return { ok: true, vaultPath: '', query: v.query, hits, truncated };
+  }
+
+  /**
+   * Core BM25 search over an arbitrary corpus of doc refs (one or many vaults).
+   * Builds the combined corpus statistics, scores, ranks, and attaches snippets
+   * for the top results. Each hit carries its owning `vaultPath`.
+   */
+  private async _searchCorpus(
+    docRefs: DocRef[],
+    query: string,
+  ): Promise<{ hits: WikiSearchHit[]; truncated: boolean }> {
     const queryTerms = Array.from(new Set(tokenize(query)));
     const needleLower = query.toLowerCase();
 
-    const docRefs = await this.collectDocs(vaultPath);
     const truncatedFiles = docRefs.length >= WIKI_SEARCH_MAX_FILES;
     const slice = docRefs.slice(0, WIKI_SEARCH_MAX_FILES);
 
-    // Pass 1: read + tokenise each doc, accumulate term frequencies for the
-    // query terms and document lengths. (We only track query-term frequencies,
-    // not a full term map, to keep memory bounded.)
+    // Pass 1: read + tokenise each doc, accumulate query-term frequencies + length.
     const docs: ScoredDoc[] = [];
     for (const ref of slice) {
       const doc = await this.statDoc(ref, queryTerms);
       if (doc) docs.push(doc);
     }
-
-    if (queryTerms.length === 0) {
-      return { ok: true, vaultPath, query, hits: [], truncated: truncatedFiles };
-    }
+    if (queryTerms.length === 0) return { hits: [], truncated: truncatedFiles };
 
     const N = docs.length || 1;
     const avgdl = docs.reduce((s, d) => s + d.length, 0) / N || 1;
 
     // Document frequency per query term, then IDF (always positive).
-    const df = new Map<string, number>();
-    for (const term of queryTerms) {
-      let count = 0;
-      for (const d of docs) if ((d.termFreq.get(term) ?? 0) > 0) count++;
-      df.set(term, count);
-    }
     const idf = new Map<string, number>();
     for (const term of queryTerms) {
-      const n = df.get(term) ?? 0;
+      let n = 0;
+      for (const d of docs) if ((d.termFreq.get(term) ?? 0) > 0) n++;
       idf.set(term, Math.log(1 + (N - n + 0.5) / (n + 0.5)));
     }
 
-    // Score every doc; keep only those that matched at least one term (score>0).
     const scored = docs
       .map((d) => ({ doc: d, score: this.bm25Score(d, queryTerms, idf, avgdl) }))
       .filter((s) => s.score > 0);
 
-    // Rank: filename/title matches first (a strong product signal kept from
-    // the previous behaviour), then by BM25 score, then path for stability.
+    // Rank: filename/title matches first, then BM25 score, then path for stability.
     scored.sort((a, b) => {
       if (a.doc.filenameMatch !== b.doc.filenameMatch) return a.doc.filenameMatch ? -1 : 1;
       if (b.score !== a.score) return b.score - a.score;
@@ -241,10 +288,10 @@ export class WikiSearchService {
         matchCount,
         score: Math.round(score * 1000) / 1000,
         snippets,
+        vaultPath: doc.vaultPath,
       });
     }
-
-    return { ok: true, vaultPath, query, hits, truncated: truncatedFiles || truncatedResults };
+    return { hits, truncated: truncatedFiles || truncatedResults };
   }
 
   /**
@@ -316,11 +363,8 @@ export class WikiSearchService {
    * tokens are folded in (weighted) so title relevance contributes to BM25.
    * Returns null only on unreadable/oversize files with no filename match.
    */
-  private async statDoc(
-    ref: { relativePath: string; absPath: string },
-    queryTerms: string[],
-  ): Promise<ScoredDoc | null> {
-    const { relativePath, absPath } = ref;
+  private async statDoc(ref: DocRef, queryTerms: string[]): Promise<ScoredDoc | null> {
+    const { vaultPath, relativePath, absPath } = ref;
     const filenameMatch = queryTerms.some((t) => relativePath.toLowerCase().includes(t));
 
     // Filename/title tokens, folded in with a weight.
@@ -353,8 +397,10 @@ export class WikiSearchService {
     if (content) tally(tokenize(content), 1);
 
     // Keep filename-only matches discoverable even with no body match.
-    if (length === 0) return filenameMatch ? { relativePath, absPath, filenameMatch, length: 1, termFreq } : null;
-    return { relativePath, absPath, filenameMatch, length, termFreq };
+    if (length === 0) {
+      return filenameMatch ? { vaultPath, relativePath, absPath, filenameMatch, length: 1, termFreq } : null;
+    }
+    return { vaultPath, relativePath, absPath, filenameMatch, length, termFreq };
   }
 
   /**

--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -356,6 +356,39 @@
   color: var(--color-text-primary, #e8eaee);
 }
 
+/* Search scope toggle (this vault / all vaults) */
+.wiki-search-scope {
+  display: flex;
+  gap: 4px;
+  padding: 0 10px 8px;
+}
+
+.wiki-search-scope-btn {
+  flex: 1;
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  background: transparent;
+  color: var(--color-text-secondary, #9ba2af);
+  cursor: pointer;
+}
+
+.wiki-search-scope-btn.active {
+  background: var(--color-primary, #6366f1);
+  border-color: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
+.wiki-search-vault {
+  margin-left: auto;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.08));
+  color: var(--color-text-secondary, #9ba2af);
+}
+
 /* Search */
 
 .wiki-search-bar {

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -166,6 +166,10 @@ interface WikiSearchHit {
   filenameMatch: boolean;
   matchCount: number;
   snippets: WikiSearchSnippet[];
+  /** Owning vault (all-vault search only). */
+  vaultPath?: string;
+  /** Owning vault label (all-vault search only). */
+  vaultLabel?: string;
 }
 
 interface WikiBacklinkSnippet {
@@ -297,6 +301,10 @@ export function Wiki(): JSX.Element {
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [searchTruncated, setSearchTruncated] = useState(false);
+  // Search scope: false = current vault only, true = all vaults (merged ranking).
+  const [searchAll, setSearchAll] = useState(false);
+  // Cross-vault click-through: page to open once the target vault is selected.
+  const [pendingPage, setPendingPage] = useState<{ vaultPath: string; relativePath: string } | null>(null);
 
   const [backlinks, setBacklinks] = useState<WikiBacklink[] | null>(null);
   const [backlinksLoading, setBacklinksLoading] = useState(false);
@@ -435,13 +443,14 @@ export function Wiki(): JSX.Element {
   }, []);
 
   const loadSearch = useCallback(
-    async (vaultPath: string, q: string) => {
+    async (vaultPath: string, q: string, allVaults: boolean) => {
       setSearchLoading(true);
       setSearchError(null);
       try {
-        const res = await fetch(
-          `/api/wiki/search?vaultPath=${encodeURIComponent(vaultPath)}&q=${encodeURIComponent(q)}`,
-        );
+        const url = allVaults
+          ? `/api/wiki/search-all?q=${encodeURIComponent(q)}`
+          : `/api/wiki/search?vaultPath=${encodeURIComponent(vaultPath)}&q=${encodeURIComponent(q)}`;
+        const res = await fetch(url);
         const body = await res.json();
         if (!res.ok || !body.success) {
           throw new Error(body.error ?? `HTTP ${res.status}`);
@@ -602,6 +611,14 @@ export function Wiki(): JSX.Element {
     setBacklinks(null);
   }, []);
 
+  // Open a cross-vault search hit once its target vault becomes active.
+  useEffect(() => {
+    if (pendingPage && selectedVault?.vaultPath === pendingPage.vaultPath) {
+      setSelectedPage(pendingPage.relativePath);
+      setPendingPage(null);
+    }
+  }, [pendingPage, selectedVault]);
+
   useEffect(() => {
     if (selectedVault) {
       loadTree(selectedVault.vaultPath);
@@ -622,9 +639,11 @@ export function Wiki(): JSX.Element {
     }
   }, [selectedVault, selectedPage, loadPage, loadBacklinks]);
 
-  // Debounced search — fires only after the user pauses typing.
+  // Debounced search — fires only after the user pauses typing. Re-runs when
+  // the scope toggle (this vault / all vaults) flips.
   useEffect(() => {
-    if (!selectedVault) return;
+    // All-vault search needs no selected vault; single-vault search does.
+    if (!searchAll && !selectedVault) return;
     const q = searchQuery.trim();
     if (q.length === 0) {
       setSearchHits(null);
@@ -633,10 +652,10 @@ export function Wiki(): JSX.Element {
       return;
     }
     const handle = setTimeout(() => {
-      loadSearch(selectedVault.vaultPath, q);
+      loadSearch(selectedVault?.vaultPath ?? '', q, searchAll);
     }, SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [searchQuery, selectedVault, loadSearch]);
+  }, [searchQuery, selectedVault, loadSearch, searchAll]);
 
   // Clear the active search whenever the user picks a different vault.
   useEffect(() => {
@@ -831,10 +850,12 @@ export function Wiki(): JSX.Element {
             <input
               type="text"
               className="wiki-search-input"
-              placeholder={selectedVault ? 'Search this vault…' : 'Pick a vault first'}
+              placeholder={
+                searchAll ? 'Search all vaults…' : selectedVault ? 'Search this vault…' : 'Pick a vault first'
+              }
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              disabled={!selectedVault}
+              disabled={!searchAll && !selectedVault}
               aria-label="Search wiki"
             />
             {searchQuery && (
@@ -848,6 +869,28 @@ export function Wiki(): JSX.Element {
               </button>
             )}
           </div>
+          <div className="wiki-search-scope" role="tablist" aria-label="Search scope">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={!searchAll}
+              className={`wiki-search-scope-btn${!searchAll ? ' active' : ''}`}
+              onClick={() => setSearchAll(false)}
+              data-testid="search-scope-this"
+            >
+              This vault
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={searchAll}
+              className={`wiki-search-scope-btn${searchAll ? ' active' : ''}`}
+              onClick={() => setSearchAll(true)}
+              data-testid="search-scope-all"
+            >
+              All vaults
+            </button>
+          </div>
           {searchError && (
             <div className="wiki-error">
               <AlertCircle size={14} /> {searchError}
@@ -860,12 +903,21 @@ export function Wiki(): JSX.Element {
             <SearchResults
               hits={searchHits}
               selected={selectedPage}
-              onSelect={(rel) => {
+              showVault={searchAll}
+              onSelect={(rel, vaultPath) => {
                 // B-U4 (2026-05-27): clicking a search hit jumps to the
                 // page AND collapses search results back into tree view.
-                // Previously search list stayed open competing for the
-                // same pane, leaving the user with an ambiguous "am I
-                // browsing or searching?" state.
+                // For an all-vault hit in a DIFFERENT vault, switch to that
+                // vault first, then open the page once it's active.
+                if (vaultPath && vaultPath !== selectedVault?.vaultPath) {
+                  const target = vaults.find((v) => v.vaultPath === vaultPath);
+                  if (target) {
+                    switchVault(target);
+                    setPendingPage({ vaultPath, relativePath: rel });
+                    setSearchQuery('');
+                    return;
+                  }
+                }
                 setSelectedPage(rel);
                 setSearchQuery('');
               }}
@@ -1184,29 +1236,35 @@ function TreeView({
 interface SearchResultsProps {
   hits: WikiSearchHit[];
   selected: string | null;
-  onSelect: (relativePath: string) => void;
+  /** Show each hit's owning vault label (all-vault search). */
+  showVault?: boolean;
+  onSelect: (relativePath: string, vaultPath?: string) => void;
 }
 
 /**
- * Render the flat list of search hits returned by `/api/wiki/search`. Each
- * row is a single matching file with up to three snippet lines.
+ * Render the flat list of search hits returned by `/api/wiki/search[-all]`.
+ * Each row is a single matching file with up to three snippet lines; in
+ * all-vault mode each row is tagged with its owning vault.
  */
-function SearchResults({ hits, selected, onSelect }: SearchResultsProps): JSX.Element {
+function SearchResults({ hits, selected, showVault, onSelect }: SearchResultsProps): JSX.Element {
   return (
     <ul className="wiki-search-results">
       {hits.map((hit) => {
-        const active = selected === hit.relativePath;
+        const active = selected === hit.relativePath && !hit.vaultPath;
         return (
-          <li key={hit.relativePath}>
+          <li key={`${hit.vaultPath ?? ''}:${hit.relativePath}`}>
             <button
               type="button"
               className={`wiki-search-hit${active ? ' active' : ''}`}
-              onClick={() => onSelect(hit.relativePath)}
+              onClick={() => onSelect(hit.relativePath, hit.vaultPath)}
             >
               <div className="wiki-search-path">
                 <FileText size={13} /> {hit.relativePath}
                 {hit.matchCount > 0 && (
                   <span className="wiki-search-count"> · {hit.matchCount}</span>
+                )}
+                {showVault && hit.vaultLabel && (
+                  <span className="wiki-search-vault">{hit.vaultLabel}</span>
                 )}
               </div>
               {hit.snippets.length > 0 && (


### PR DESCRIPTION
Adds the global search you asked for: a **This vault / All vaults** toggle by the search box.

## What it does
- In **All vaults** mode, `GET /api/wiki/search-all?q=…` searches every discovered vault and returns **one merged BM25-ranked list**. IDF is computed over the combined corpus so scores are comparable across vaults.
- Each hit carries its owning `vaultPath` + `vaultLabel`; the results list **tags each row with its vault** (Global / team name / project name).
- Clicking a hit in another vault **switches to that vault and opens the page** (pending-page handoff so the vault switch doesn't drop the selection).

## Backend
- `WikiSearchService.searchAllVaults` shares the `_searchCorpus` core with single-vault `search` (same BM25, CJK tokenizer, overlay coverage).
- Extracted `resolveVaultLabel` + `discoverVaultsWithLabels` — also de-dups the label logic that was inline in `listVaults`.

## Verified live
- `search-all?q=pricing` → 39 labelled hits across vaults, merged ranking (filename/title matches first, then by score).

Tests: `searchAllVaults` cross-vault merge + empty-query (22 total in the search suite, vitest) green; full build green; Quality Gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)