### PR TITLE
fix(wiki): compact search scope toggle + strip page frontmatter

### DIFF
--- a/frontend/src/components/Wiki/WikiMarkdown.test.tsx
+++ b/frontend/src/components/Wiki/WikiMarkdown.test.tsx
@@ -10,7 +10,38 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { WikiMarkdown } from './WikiMarkdown';
+import { WikiMarkdown, splitFrontmatter } from './WikiMarkdown';
+
+describe('splitFrontmatter', () => {
+  it('extracts the title and strips the frontmatter block', () => {
+    const raw = '---\ntitle: Lifecycle Norm\ntrigger: idle\nupdatedBy: Ella\n---\n\n# Rule\nbody text';
+    const { title, body } = splitFrontmatter(raw);
+    expect(title).toBe('Lifecycle Norm');
+    expect(body).toBe('# Rule\nbody text');
+    expect(body).not.toContain('trigger:');
+    expect(body).not.toContain('updatedBy:');
+  });
+
+  it('returns the content unchanged when there is no frontmatter', () => {
+    const raw = '# Just markdown\nno frontmatter here';
+    expect(splitFrontmatter(raw)).toEqual({ title: null, body: raw });
+  });
+
+  it('handles frontmatter with no title key', () => {
+    const { title, body } = splitFrontmatter('---\ntrigger: idle\n---\nbody');
+    expect(title).toBeNull();
+    expect(body).toBe('body');
+  });
+
+  it('does not render frontmatter keys as a heading (the reported bug)', () => {
+    render(
+      <WikiMarkdown content={'---\ntitle: My Norm\ntrigger: idle\nupdatedBy: Ella\n---\n\nReal body.'} />,
+    );
+    expect(screen.getByText('My Norm')).toBeInTheDocument();
+    expect(screen.queryByText(/updatedBy/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/trigger:/)).not.toBeInTheDocument();
+  });
+});
 
 describe('WikiMarkdown', () => {
   it('renders a paragraph as a <p>', () => {

--- a/frontend/src/components/Wiki/WikiMarkdown.tsx
+++ b/frontend/src/components/Wiki/WikiMarkdown.tsx
@@ -30,6 +30,23 @@ export interface WikiMarkdownProps {
 }
 
 /**
+ * Split a leading YAML frontmatter block (`---\n…\n---`) off the content.
+ * Without this, files written with frontmatter (team norms / SOPs) render the
+ * raw `key: value` lines as body — and the closing `---` turns them into a
+ * giant setext heading. We strip the block and surface its `title` separately.
+ *
+ * @param raw - Raw page markdown.
+ * @returns `{ title, body }` — title is the frontmatter `title:` if present.
+ */
+export function splitFrontmatter(raw: string): { title: string | null; body: string } {
+  const m = /^﻿?---\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n)*/.exec(raw);
+  if (!m) return { title: null, body: raw };
+  const titleMatch = /^title:\s*(.+?)\s*$/m.exec(m[1]);
+  const title = titleMatch ? titleMatch[1].replace(/^["']|["']$/g, '').trim() : null;
+  return { title, body: raw.slice(m[0].length) };
+}
+
+/**
  * Render markdown with GFM + syntax highlighting + wikilink navigation.
  *
  * @example
@@ -52,8 +69,11 @@ export function WikiMarkdown({ content, onWikilinkClick }: WikiMarkdownProps): J
     [onWikilinkClick],
   );
 
+  const { title, body } = splitFrontmatter(content);
+
   return (
     <div className="wiki-md">
+      {title && <h1 className="wiki-md-title">{title}</h1>}
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkWikilink()]}
         rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
@@ -88,7 +108,7 @@ export function WikiMarkdown({ content, onWikilinkClick }: WikiMarkdownProps): J
           },
         }}
       >
-        {content}
+        {body}
       </ReactMarkdown>
     </div>
   );

--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -356,27 +356,45 @@
   color: var(--color-text-primary, #e8eaee);
 }
 
-/* Search scope toggle (this vault / all vaults) */
+/* Search scope toggle — compact inline segmented control inside the search bar */
 .wiki-search-scope {
-  display: flex;
-  gap: 4px;
-  padding: 0 10px 8px;
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
 }
 
 .wiki-search-scope-btn {
-  flex: 1;
-  font-size: 11px;
-  padding: 4px 8px;
-  border-radius: 6px;
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
   background: transparent;
-  color: var(--color-text-secondary, #9ba2af);
+  color: var(--color-text-tertiary, #6b7280);
   cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
 }
 
-.wiki-search-scope-btn.active {
+.wiki-search-scope-btn:hover {
+  color: var(--color-text-secondary, #9ba2af);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.wiki-search-scope-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.55);
+}
+
+.wiki-search-scope-btn.active,
+.wiki-search-scope-btn.active:hover {
   background: var(--color-primary, #6366f1);
-  border-color: var(--color-primary, #6366f1);
   color: #fff;
 }
 
@@ -970,6 +988,16 @@
     'Segoe UI',
     sans-serif;
   max-width: 880px;
+}
+
+/* Title parsed from a page's frontmatter (rendered above the body, not as
+   raw `title:` text). */
+.wiki-md-title {
+  margin: 0 0 16px;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--color-text-primary, #e8eaee);
 }
 
 .wiki-md h1,

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -31,6 +31,8 @@ import {
   Upload,
   Download,
   Pencil,
+  Layers,
+  LayoutGrid,
   CheckCircle2,
   Lightbulb,
   ChevronRight,
@@ -868,28 +870,32 @@ export function Wiki(): JSX.Element {
                 <X size={13} />
               </button>
             )}
-          </div>
-          <div className="wiki-search-scope" role="tablist" aria-label="Search scope">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={!searchAll}
-              className={`wiki-search-scope-btn${!searchAll ? ' active' : ''}`}
-              onClick={() => setSearchAll(false)}
-              data-testid="search-scope-this"
-            >
-              This vault
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={searchAll}
-              className={`wiki-search-scope-btn${searchAll ? ' active' : ''}`}
-              onClick={() => setSearchAll(true)}
-              data-testid="search-scope-all"
-            >
-              All vaults
-            </button>
+            <div className="wiki-search-scope" role="radiogroup" aria-label="Search scope">
+              <button
+                type="button"
+                role="radio"
+                aria-checked={!searchAll}
+                aria-label="Search this vault"
+                title="This vault"
+                className={`wiki-search-scope-btn${!searchAll ? ' active' : ''}`}
+                onClick={() => setSearchAll(false)}
+                data-testid="search-scope-this"
+              >
+                <Layers size={13} />
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={searchAll}
+                aria-label="Search all vaults"
+                title="All vaults"
+                className={`wiki-search-scope-btn${searchAll ? ' active' : ''}`}
+                onClick={() => setSearchAll(true)}
+                data-testid="search-scope-all"
+              >
+                <LayoutGrid size={13} />
+              </button>
+            </div>
           </div>
           {searchError && (
             <div className="wiki-error">


### PR DESCRIPTION
Two fixes raised from the wiki UI.

## 1. Search scope toggle redesign (UX-designed)
The bulky stacked **This vault / All vaults** buttons (plus their row + divider) ate a vertical strip of the narrow pane and felt disconnected from the search box. Replaced with a **compact icon segmented control docked inside the search bar** — `Layers` (this vault) / `LayoutGrid` (all vaults), active segment filled indigo. Reclaims the space, couples scope to the field. Upgraded a11y to `radiogroup`/`aria-checked`; `data-testid`s unchanged so wiring/tests still pass.

## 2. Frontmatter rendered as a giant title (bug)
Team norm / SOP pages (written by `update-team-norm` / `update-sop`) start with a YAML `---` frontmatter block. `WikiMarkdown` did no frontmatter handling, so the raw `title:/trigger:/updatedBy:/updatedAt:` lines rendered as content — and the closing `---` turned them into a setext heading (the giant "title: …" you saw). Now `splitFrontmatter` strips the block, renders the parsed `title` as a clean `<h1>`, and renders only the real body.

Tests: `splitFrontmatter` + a render test proving frontmatter keys no longer appear (12 in WikiMarkdown suite); Wiki/SopCatalog suites green; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)