### PR TITLE
feat(wiki): promote search to a page-level global control

### DIFF
--- a/frontend/src/pages/Wiki.css
+++ b/frontend/src/pages/Wiki.css
@@ -9,7 +9,152 @@
 }
 
 .wiki-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
   margin-bottom: 18px;
+}
+
+.wiki-header-main {
+  min-width: 0;
+}
+
+/* Page-level global search — anchored top-right of the header */
+.wiki-global-search {
+  position: relative;
+  flex-shrink: 0;
+  width: 340px;
+  max-width: 42vw;
+  margin-top: 2px;
+}
+
+.wiki-gsearch-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: var(--color-surface-raised, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: 9px;
+}
+
+.wiki-gsearch-box:focus-within,
+.wiki-gsearch-box.open {
+  border-color: rgba(129, 140, 248, 0.6);
+  background: var(--color-surface, #1a1d23);
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.15);
+}
+
+.wiki-gsearch-input {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--color-text-primary, #e8eaee);
+  font-size: 13.5px;
+}
+
+.wiki-gsearch-input::placeholder {
+  color: var(--color-text-tertiary, #6b7280);
+}
+
+/* Command-palette overlay — floats below the input, over the grid */
+.wiki-search-overlay {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(560px, 90vw);
+  max-height: min(60vh, 520px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #1a1d23);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.14));
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.55);
+  z-index: 60;
+  overflow: hidden;
+  animation: wiki-overlay-in 0.12s ease;
+}
+
+@keyframes wiki-overlay-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.wiki-overlay-scope {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+  flex-shrink: 0;
+}
+
+.wiki-overlay-scope-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-tertiary, #6b7280);
+  margin-right: 4px;
+  font-weight: 600;
+}
+
+.wiki-overlay-scope-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  font-size: 11.5px;
+  border-radius: 6px;
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  color: var(--color-text-secondary, #9ba2af);
+  cursor: pointer;
+}
+
+.wiki-overlay-scope-btn.active {
+  background: var(--color-primary, #6366f1);
+  border-color: var(--color-primary, #6366f1);
+  color: #fff;
+}
+
+.wiki-overlay-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.wiki-overlay-body .wiki-search-results {
+  flex: none;
+}
+
+.wiki-search-hit.kbd-active {
+  background: rgba(129, 140, 248, 0.16);
+}
+
+.wiki-overlay-footer {
+  flex-shrink: 0;
+  padding: 7px 12px;
+  border-top: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+  font-size: 11px;
+  color: var(--color-text-tertiary, #6b7280);
+  background: var(--color-background, rgba(0, 0, 0, 0.2));
+}
+
+@media (max-width: 900px) {
+  .wiki-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .wiki-global-search {
+    width: 100%;
+    max-width: none;
+  }
+  .wiki-search-overlay {
+    width: 100%;
+  }
 }
 
 .wiki-header-title {

--- a/frontend/src/pages/Wiki.test.tsx
+++ b/frontend/src/pages/Wiki.test.tsx
@@ -9,8 +9,11 @@
  * @module pages/Wiki.test
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import {
+  Wiki,
   resolveWikilink,
   pickInitialVault,
   partitionVaultTree,
@@ -177,5 +180,53 @@ describe('allCanonicalFoldersEmpty', () => {
       children: [{ name: 'a.md', relativePath: 'sop/a.md', type: 'file' as const }],
     };
     expect(allCanonicalFoldersEmpty([filled, emptyDir('team-norm')])).toBe(false);
+  });
+});
+
+describe('Wiki global search (page-level header)', () => {
+  const okJson = (body: Record<string, unknown>) =>
+    ({ ok: true, status: 200, json: async () => ({ success: true, ...body }) }) as Response;
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        const u = String(url);
+        if (u.includes('/api/wiki/vaults')) return okJson({ vaults: [] });
+        if (u.includes('/api/wiki/search-all')) return okJson({ hits: [], truncated: false, vaultPath: '', query: 'q' });
+        if (u.includes('/api/wiki/migrate/scan')) return okJson({ legacyDetected: false, proposedPages: [] });
+        return okJson({});
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const renderWiki = () => render(<MemoryRouter><Wiki /></MemoryRouter>);
+
+  it('renders the global search in the header (not the column)', async () => {
+    renderWiki();
+    expect(await screen.findByLabelText('Search wiki')).toBeInTheDocument();
+  });
+
+  it('opens the results overlay on type and closes on Escape', async () => {
+    renderWiki();
+    const input = await screen.findByLabelText('Search wiki');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'pricing' } });
+    // Overlay (with the scope control) appears as soon as there's a query.
+    await waitFor(() => expect(screen.getByTestId('search-scope-all')).toBeInTheDocument());
+    fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByTestId('search-scope-all')).not.toBeInTheDocument());
+  });
+
+  it('defaults the scope to all vaults', async () => {
+    renderWiki();
+    const input = await screen.findByLabelText('Search wiki');
+    fireEvent.change(input, { target: { value: 'x' } });
+    await waitFor(() => expect(screen.getByTestId('search-scope-all')).toHaveAttribute('aria-checked', 'true'));
+    expect(screen.getByTestId('search-scope-this')).toHaveAttribute('aria-checked', 'false');
   });
 });

--- a/frontend/src/pages/Wiki.tsx
+++ b/frontend/src/pages/Wiki.tsx
@@ -14,7 +14,7 @@
  * @module pages/Wiki
  */
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { TEAM_QUERY_PARAM } from '../utils/team-chat.utils';
 import {
@@ -304,9 +304,16 @@ export function Wiki(): JSX.Element {
   const [searchError, setSearchError] = useState<string | null>(null);
   const [searchTruncated, setSearchTruncated] = useState(false);
   // Search scope: false = current vault only, true = all vaults (merged ranking).
-  const [searchAll, setSearchAll] = useState(false);
+  // The page-level global search defaults to all-vaults (the natural mental model).
+  const [searchAll, setSearchAll] = useState(true);
+  // Whether the global search overlay (header) is open.
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  // Keyboard-highlighted hit index in the overlay (-1 = none).
+  const [activeHitIndex, setActiveHitIndex] = useState(-1);
   // Cross-vault click-through: page to open once the target vault is selected.
   const [pendingPage, setPendingPage] = useState<{ vaultPath: string; relativePath: string } | null>(null);
+  const searchWrapRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const [backlinks, setBacklinks] = useState<WikiBacklink[] | null>(null);
   const [backlinksLoading, setBacklinksLoading] = useState(false);
@@ -621,6 +628,62 @@ export function Wiki(): JSX.Element {
     }
   }, [pendingPage, selectedVault]);
 
+  /** Open a search hit's page (switching vault on a cross-vault hit), then close. */
+  const handleHitSelect = useCallback(
+    (rel: string, vaultPath?: string) => {
+      if (vaultPath && vaultPath !== selectedVault?.vaultPath) {
+        const target = vaults.find((v) => v.vaultPath === vaultPath);
+        if (target) {
+          switchVault(target);
+          setPendingPage({ vaultPath, relativePath: rel });
+          setSearchQuery('');
+          setIsSearchOpen(false);
+          return;
+        }
+      }
+      setSelectedPage(rel);
+      setSearchQuery('');
+      setIsSearchOpen(false);
+    },
+    [selectedVault, vaults, switchVault],
+  );
+
+  /** Keyboard nav in the global search input: ↑/↓ highlight, Enter open, Esc close. */
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Escape') {
+        if (searchQuery) setSearchQuery('');
+        setIsSearchOpen(false);
+        searchInputRef.current?.blur();
+        return;
+      }
+      const hits = searchHits ?? [];
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveHitIndex((i) => Math.min(i + 1, hits.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveHitIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter') {
+        const hit = hits[activeHitIndex];
+        if (hit) handleHitSelect(hit.relativePath, hit.vaultPath);
+      }
+    },
+    [searchHits, activeHitIndex, searchQuery, handleHitSelect],
+  );
+
+  // Close the search overlay on an outside click.
+  useEffect(() => {
+    if (!isSearchOpen) return;
+    const onDown = (e: MouseEvent): void => {
+      if (searchWrapRef.current && !searchWrapRef.current.contains(e.target as Node)) {
+        setIsSearchOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [isSearchOpen]);
+
   useEffect(() => {
     if (selectedVault) {
       loadTree(selectedVault.vaultPath);
@@ -749,15 +812,139 @@ export function Wiki(): JSX.Element {
   return (
     <div className="wiki-page">
       <div className="wiki-header">
-        <div className="wiki-header-title">
-          <BookOpen size={22} />
-          <h1>Wiki</h1>
+        <div className="wiki-header-main">
+          <div className="wiki-header-title">
+            <BookOpen size={22} />
+            <h1>Wiki</h1>
+          </div>
+          <p className="wiki-header-subtitle">
+            Agent-curated knowledge across global, team, and project vaults. Reads
+            only — writes happen via the <code>wiki-queue-add</code> →{' '}
+            <code>wiki-process-queue</code> agent flow.
+          </p>
         </div>
-        <p className="wiki-header-subtitle">
-          Agent-curated knowledge across global, team, and project vaults. Reads
-          only — writes happen via the <code>wiki-queue-add</code> →{' '}
-          <code>wiki-process-queue</code> agent flow.
-        </p>
+
+        {/* Page-level global search */}
+        <div className="wiki-global-search" ref={searchWrapRef}>
+          <div className={`wiki-gsearch-box${isSearchOpen ? ' open' : ''}`}>
+            <SearchIcon size={15} className="wiki-search-icon" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              className="wiki-gsearch-input"
+              placeholder="Search the wiki…"
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setIsSearchOpen(true);
+                setActiveHitIndex(-1);
+              }}
+              onFocus={() => setIsSearchOpen(true)}
+              onKeyDown={handleSearchKeyDown}
+              aria-label="Search wiki"
+              aria-expanded={isSearchOpen}
+              role="combobox"
+              aria-controls="wiki-search-overlay"
+            />
+            {searchQuery ? (
+              <button
+                type="button"
+                className="wiki-search-clear"
+                onClick={() => {
+                  setSearchQuery('');
+                  setActiveHitIndex(-1);
+                  searchInputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+              >
+                <X size={14} />
+              </button>
+            ) : (
+              <div className="wiki-search-scope" role="radiogroup" aria-label="Search scope">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={!searchAll}
+                  aria-label="Search this vault"
+                  title="This vault"
+                  className={`wiki-search-scope-btn${!searchAll ? ' active' : ''}`}
+                  onClick={() => setSearchAll(false)}
+                >
+                  <Layers size={13} />
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={searchAll}
+                  aria-label="Search all vaults"
+                  title="All vaults"
+                  className={`wiki-search-scope-btn${searchAll ? ' active' : ''}`}
+                  onClick={() => setSearchAll(true)}
+                >
+                  <LayoutGrid size={13} />
+                </button>
+              </div>
+            )}
+          </div>
+
+          {isSearchOpen && searchQuery.trim().length > 0 && (
+            <div className="wiki-search-overlay" id="wiki-search-overlay" role="listbox">
+              <div className="wiki-overlay-scope" role="radiogroup" aria-label="Search scope">
+                <span className="wiki-overlay-scope-label">Scope</span>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={!searchAll}
+                  className={`wiki-overlay-scope-btn${!searchAll ? ' active' : ''}`}
+                  onClick={() => setSearchAll(false)}
+                  data-testid="search-scope-this"
+                >
+                  <Layers size={12} /> This vault
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={searchAll}
+                  className={`wiki-overlay-scope-btn${searchAll ? ' active' : ''}`}
+                  onClick={() => setSearchAll(true)}
+                  data-testid="search-scope-all"
+                >
+                  <LayoutGrid size={12} /> All vaults
+                </button>
+              </div>
+
+              <div className="wiki-overlay-body">
+                {searchError && (
+                  <div className="wiki-error">
+                    <AlertCircle size={14} /> {searchError}
+                  </div>
+                )}
+                {searchLoading && <div className="wiki-loading">Searching…</div>}
+                {!searchLoading && searchHits && searchHits.length > 0 && (
+                  <SearchResults
+                    hits={searchHits}
+                    selected={selectedPage}
+                    showVault={searchAll}
+                    activeIndex={activeHitIndex}
+                    onSelect={handleHitSelect}
+                  />
+                )}
+                {!searchLoading && searchHits && searchHits.length === 0 && (
+                  <div className="wiki-empty">
+                    No results for <code>{searchQuery}</code>.
+                  </div>
+                )}
+              </div>
+
+              {searchHits && searchHits.length > 0 && (
+                <div className="wiki-overlay-footer">
+                  {searchHits.length} match{searchHits.length === 1 ? '' : 'es'}
+                  {searchTruncated ? '+' : ''} · ↑↓ navigate · ↵ open · Esc close
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
 
       <MigrationBanner
@@ -836,113 +1023,18 @@ export function Wiki(): JSX.Element {
           <div className="wiki-pane-header">
             <span>
               {selectedVault ? selectedVault.label : 'Pick a vault'}
-              {selectedVault && tree && !searchQuery && (
+              {selectedVault && tree && (
                 <span className="wiki-page-count"> · {pageCount}</span>
-              )}
-              {searchHits && (
-                <span className="wiki-page-count">
-                  {' '}· {searchHits.length} match{searchHits.length === 1 ? '' : 'es'}
-                  {searchTruncated ? '+' : ''}
-                </span>
               )}
             </span>
           </div>
-          <div className="wiki-search-bar">
-            <SearchIcon size={13} className="wiki-search-icon" />
-            <input
-              type="text"
-              className="wiki-search-input"
-              placeholder={
-                searchAll ? 'Search all vaults…' : selectedVault ? 'Search this vault…' : 'Pick a vault first'
-              }
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              disabled={!searchAll && !selectedVault}
-              aria-label="Search wiki"
-            />
-            {searchQuery && (
-              <button
-                type="button"
-                className="wiki-search-clear"
-                onClick={() => setSearchQuery('')}
-                aria-label="Clear search"
-              >
-                <X size={13} />
-              </button>
-            )}
-            <div className="wiki-search-scope" role="radiogroup" aria-label="Search scope">
-              <button
-                type="button"
-                role="radio"
-                aria-checked={!searchAll}
-                aria-label="Search this vault"
-                title="This vault"
-                className={`wiki-search-scope-btn${!searchAll ? ' active' : ''}`}
-                onClick={() => setSearchAll(false)}
-                data-testid="search-scope-this"
-              >
-                <Layers size={13} />
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={searchAll}
-                aria-label="Search all vaults"
-                title="All vaults"
-                className={`wiki-search-scope-btn${searchAll ? ' active' : ''}`}
-                onClick={() => setSearchAll(true)}
-                data-testid="search-scope-all"
-              >
-                <LayoutGrid size={13} />
-              </button>
-            </div>
-          </div>
-          {searchError && (
+          {treeError && (
             <div className="wiki-error">
-              <AlertCircle size={14} /> {searchError}
+              <AlertCircle size={14} /> {treeError}
             </div>
           )}
-          {searchQuery && searchLoading && (
-            <div className="wiki-loading">Searching…</div>
-          )}
-          {searchQuery && !searchLoading && searchHits && (
-            <SearchResults
-              hits={searchHits}
-              selected={selectedPage}
-              showVault={searchAll}
-              onSelect={(rel, vaultPath) => {
-                // B-U4 (2026-05-27): clicking a search hit jumps to the
-                // page AND collapses search results back into tree view.
-                // For an all-vault hit in a DIFFERENT vault, switch to that
-                // vault first, then open the page once it's active.
-                if (vaultPath && vaultPath !== selectedVault?.vaultPath) {
-                  const target = vaults.find((v) => v.vaultPath === vaultPath);
-                  if (target) {
-                    switchVault(target);
-                    setPendingPage({ vaultPath, relativePath: rel });
-                    setSearchQuery('');
-                    return;
-                  }
-                }
-                setSelectedPage(rel);
-                setSearchQuery('');
-              }}
-            />
-          )}
-          {searchQuery && !searchLoading && searchHits && searchHits.length === 0 && (
-            <div className="wiki-empty">
-              No results for <code>{searchQuery}</code>.
-            </div>
-          )}
-          {!searchQuery && (
-            <>
-              {treeError && (
-                <div className="wiki-error">
-                  <AlertCircle size={14} /> {treeError}
-                </div>
-              )}
-              {treeLoading && <div className="wiki-loading">Loading tree…</div>}
-              {tree && canonicalNodes.length > 0 && (
+          {treeLoading && <div className="wiki-loading">Loading tree…</div>}
+          {tree && canonicalNodes.length > 0 && (
                 <>
                   <div className="wiki-tree-group-label" title="Schema-frozen folders — the source of truth referenced by the engine. Agents can't overwrite these via the wiki.">
                     <Lock size={11} /> Canonical · source of truth
@@ -1008,13 +1100,11 @@ export function Wiki(): JSX.Element {
                   onToggleFolder={toggleFolder}
                 />
               )}
-              {tree && tree.length === 0 && !treeLoading && (
-                <div className="wiki-empty">
-                  Empty vault — no <code>.md</code> pages yet. They land here once
-                  agents queue + ingest worth-saving content.
-                </div>
-              )}
-            </>
+          {tree && tree.length === 0 && !treeLoading && (
+            <div className="wiki-empty">
+              Empty vault — no <code>.md</code> pages yet. They land here once
+              agents queue + ingest worth-saving content.
+            </div>
           )}
         </section>
 
@@ -1078,7 +1168,10 @@ export function Wiki(): JSX.Element {
               {selectedVault && lint && lint.missingConcepts.length > 0 && (
                 <MissingConcepts
                   concepts={lint.missingConcepts}
-                  onSelect={(target) => setSearchQuery(target)}
+                  onSelect={(target) => {
+                    setSearchQuery(target);
+                    setIsSearchOpen(true);
+                  }}
                 />
               )}
               {selectedVault && (
@@ -1244,6 +1337,8 @@ interface SearchResultsProps {
   selected: string | null;
   /** Show each hit's owning vault label (all-vault search). */
   showVault?: boolean;
+  /** Keyboard-highlighted row index (-1/undefined = none). */
+  activeIndex?: number;
   onSelect: (relativePath: string, vaultPath?: string) => void;
 }
 
@@ -1252,16 +1347,19 @@ interface SearchResultsProps {
  * Each row is a single matching file with up to three snippet lines; in
  * all-vault mode each row is tagged with its owning vault.
  */
-function SearchResults({ hits, selected, showVault, onSelect }: SearchResultsProps): JSX.Element {
+function SearchResults({ hits, selected, showVault, activeIndex, onSelect }: SearchResultsProps): JSX.Element {
   return (
     <ul className="wiki-search-results">
-      {hits.map((hit) => {
+      {hits.map((hit, idx) => {
         const active = selected === hit.relativePath && !hit.vaultPath;
+        const kbd = idx === activeIndex;
         return (
           <li key={`${hit.vaultPath ?? ''}:${hit.relativePath}`}>
             <button
               type="button"
-              className={`wiki-search-hit${active ? ' active' : ''}`}
+              role="option"
+              aria-selected={kbd}
+              className={`wiki-search-hit${active ? ' active' : ''}${kbd ? ' kbd-active' : ''}`}
               onClick={() => onSelect(hit.relativePath, hit.vaultPath)}
             >
               <div className="wiki-search-path">


### PR DESCRIPTION
Per owner feedback — the earlier pass only restyled the in-column toggle; the ask was to **elevate search to a page-level control** (top-right of the page), like a global search across the knowledge base. UX-designed, then implemented.

## What changed
- **Global search in the page header** (top-right), defaulting to **all vaults** (the natural "search the knowledge base" model), with an inline this-vault/all-vaults scope toggle.
- **Command-palette results overlay** anchored under the input (floats over the grid, doesn't disturb the 3-column browse layout). Each hit shows page + match count + vault label + snippets; **keyboard nav** (↑/↓ highlight, ↵ open, Esc close), outside-click closes. Cross-vault hits switch vault then open the page.
- **Middle column simplified**: the in-column search bar and the in-tree results swap are gone; the tree now always renders.

## Notes
- Preserved state/handlers (`searchQuery`, `searchAll`, `selectedVault`, `searchHits`) and `data-testid`s (`search-scope-this/all`, now on the overlay scope buttons). All-vault works with no vault selected.
- Render tests added: overlay opens on type, closes on Esc, defaults to all-vaults (24 in the Wiki suite). Typecheck + full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)