### PR TITLE
feat(chat): workspace-rail IA — Home + orchestrator + per-team icons

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -34,9 +34,27 @@ import {
   type CreateChannelInput,
   type MentionTarget,
 } from '@crewly/chat-ui';
-import { LiveTeamChatPage, __test__ } from './LiveTeamChatPage';
+import { LiveTeamChatPage, __test__, type ChatTeam } from './LiveTeamChatPage';
+import { ORCHESTRATOR_SESSION } from '../../utils/team-chat.utils';
 
 const ISO = '2026-04-25T20:00:00.000Z';
+
+/** A product team used by the interaction tests so their channel is reachable. */
+const PRODUCT_TEAM: ChatTeam = {
+  id: 'team-product',
+  name: 'Crewly Product',
+  leaderSessions: [],
+  memberSessions: [],
+};
+/** A team channel that becomes the team's huddle (auto-selected on team view). */
+const TEAM_GENERAL: Channel = {
+  id: 'ch-general',
+  agentSession: '',
+  name: 'general',
+  createdAt: ISO,
+  type: 'channel',
+  teamId: 'team-product',
+};
 
 beforeEach(() => {
   // jsdom lacks scrollIntoView — patch it so MessageThread's auto-scroll
@@ -134,157 +152,125 @@ function makeStubClient(channels: Channel[], messages: Record<string, Message[]>
   };
 }
 
-describe('LiveTeamChatPage — Phase C acceptance', () => {
-  it('AC#5: WorkspaceRail renders one entry per observed teamId', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-product-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-      {
-        id: 'ch-product-onboarding',
-        agentSession: '',
-        name: 'proj-onboarding',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-      {
-        id: 'ch-marketing-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-marketing',
-      },
-    ];
-    const { client } = makeStubClient(channels);
+describe('LiveTeamChatPage — workspace rail IA', () => {
+  const orcDm: Channel = {
+    id: 'orc-dm',
+    agentSession: ORCHESTRATOR_SESSION,
+    name: 'Orchestrator',
+    createdAt: ISO,
+    type: 'dm',
+    presence: 'online',
+  };
 
+  it('rail shows Home + orchestrator + one icon per team', async () => {
+    const { client } = makeStubClient([orcDm]);
     render(
       <LiveTeamChatPage
         client={client}
-        teamLabels={{ 'team-product': 'Crewly Product', 'team-marketing': 'Crewly Marketing' }}
         mentionables={MENTIONABLES}
+        teams={[
+          PRODUCT_TEAM,
+          { id: 'team-marketing', name: 'Crewly Marketing', leaderSessions: [], memberSessions: [] },
+        ]}
       />,
     );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('workspace-row-team-product')).toBeInTheDocument();
-      expect(screen.getByTestId('workspace-row-team-marketing')).toBeInTheDocument();
-    });
-    // Two unique teamIds → exactly two rail entries (despite three channels).
-    expect(screen.queryAllByTestId(/^workspace-row-/).length).toBe(2);
+    await waitFor(() => expect(screen.getByTestId('workspace-row-home')).toBeInTheDocument());
+    expect(screen.getByTestId('workspace-row-orc')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-team:team-product')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-team:team-marketing')).toBeInTheDocument();
+    // home + orc + 2 teams
+    expect(screen.queryAllByTestId(/^workspace-row-/).length).toBe(4);
   });
 
-  it('AC#3 + AC#4: groups channels vs DMs by `type` and uses correct `kind`', async () => {
+  it('Home shows the orchestrator by default (top, pinned group)', async () => {
+    const { client } = makeStubClient([orcDm]);
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
+    await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
+    expect(screen.getByTestId('conv-row-orc-dm')).toBeInTheDocument();
+  });
+
+  it('renders Home (no dead-end) even with zero channels', async () => {
+    const { client } = makeStubClient([]);
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
+    await waitFor(() => expect(screen.getByTestId('team-chat-page')).toBeInTheDocument());
+    expect(screen.getByTestId('workspace-row-home')).toBeInTheDocument();
+    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
+  });
+
+  it('a selected team shows huddle → lead → members, lead first', async () => {
     const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-      {
-        id: 'dm-sam',
-        agentSession: 'crewly-product-sam',
-        name: 'Sam',
-        createdAt: ISO,
-        type: 'dm',
-        targetMemberId: 'member-sam',
-        presence: 'online',
-      },
+      orcDm,
+      TEAM_GENERAL,
+      { id: 'dm-maya', agentSession: 'sess-maya', name: 'Maya', createdAt: ISO, type: 'dm', presence: 'online' },
+      { id: 'dm-alex', agentSession: 'sess-alex', name: 'Alex', createdAt: ISO, type: 'dm', presence: 'online' },
     ];
     const { client } = makeStubClient(channels);
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Channels')).toBeInTheDocument();
-      expect(screen.getByText('Direct Messages')).toBeInTheDocument();
-    });
-    // Channel row uses kind=channel, DM row uses kind=dm — verified via the
-    // data-kind attribute the panel already emits.
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[
+          {
+            id: 'team-product',
+            name: 'Crewly Product',
+            leaderSessions: ['sess-maya'],
+            memberSessions: ['sess-maya', 'sess-alex'],
+          },
+        ]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('conv-group-team-huddle')).toBeInTheDocument());
     expect(screen.getByTestId('conv-row-ch-general')).toHaveAttribute('data-kind', 'channel');
-    expect(screen.getByTestId('conv-row-dm-sam')).toHaveAttribute('data-kind', 'dm');
+    expect(screen.getByTestId('conv-group-team-lead')).toBeInTheDocument();
+    expect(screen.getByTestId('conv-group-team-members')).toBeInTheDocument();
+    // Lead (Maya) renders before member (Alex).
+    const lead = screen.getByTestId('conv-row-dm-maya');
+    const member = screen.getByTestId('conv-row-dm-alex');
+    expect(lead.compareDocumentPosition(member) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('AC#1: MentionComposer onSend posts a string[] of mention IDs', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-    ];
-    const { client, sendCalls } = makeStubClient(channels);
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
-
-    // Wait for the composer to mount.
+    const { client, sendCalls } = makeStubClient([TEAM_GENERAL]);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[PRODUCT_TEAM]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
     const textarea = await screen.findByTestId('mention-textarea');
-
-    // Type a partial trigger so the popover opens, then click a team
-    // suggestion to insert a chip.
     await userEvent.type(textarea, '@');
     await userEvent.click(await screen.findByTestId('mention-suggestion-team-product'));
-
-    // Type more content + insert a second chip (agent).
     await userEvent.type(textarea, ' help me reach @');
     await userEvent.click(screen.getByTestId('mention-suggestion-agent-sam'));
-
-    // Hit send.
     await userEvent.click(screen.getByTestId('mention-send'));
 
     await waitFor(() => expect(sendCalls).toHaveLength(1));
     expect(sendCalls[0].channelId).toBe('ch-general');
-    // Mentions array on the wire is exactly the ids — never the labels,
-    // never null. Order = insertion order.
     expect(sendCalls[0].input.mentions).toEqual(['team-product', 'agent-sam']);
   });
 
   it('AC#1: empty mentions array is produced when no chips are inserted', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-    ];
-    const { client, sendCalls } = makeStubClient(channels);
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
+    const { client, sendCalls } = makeStubClient([TEAM_GENERAL]);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[PRODUCT_TEAM]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
     const textarea = await screen.findByTestId('mention-textarea');
     await userEvent.type(textarea, 'hello world');
     await userEvent.click(screen.getByTestId('mention-send'));
 
     await waitFor(() => expect(sendCalls).toHaveLength(1));
-    // Empty array — never null.
     expect(sendCalls[0].input.mentions).toEqual([]);
   });
 
   it('AC#2: incoming messages with threadId surface the "Reply in thread" affordance', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-    ];
     const messagesById: Record<string, Message[]> = {
       'ch-general': [
         {
@@ -308,24 +294,19 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
         },
       ],
     };
-    const { client } = makeStubClient(channels, messagesById);
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
-    // The page reads the threadId off the timeline and offers the entry chip.
+    const { client } = makeStubClient([TEAM_GENERAL], messagesById);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[PRODUCT_TEAM]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
     expect(await screen.findByTestId('thread-enter')).toBeInTheDocument();
   });
 
   it('AC#2: composer sends `threadId: <root msg id>` after entering thread mode', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-    ];
     const messagesById: Record<string, Message[]> = {
       'ch-general': [
         {
@@ -340,9 +321,15 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
         },
       ],
     };
-    const { client, sendCalls } = makeStubClient(channels, messagesById);
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
+    const { client, sendCalls } = makeStubClient([TEAM_GENERAL], messagesById);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[PRODUCT_TEAM]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
     await userEvent.click(await screen.findByTestId('thread-enter'));
     expect(screen.getByTestId('thread-reply-banner')).toBeInTheDocument();
 
@@ -355,17 +342,7 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
   });
 
   it('AC#2: validation_error 400 surfaces as a toast that is dismissable', async () => {
-    const channels: Channel[] = [
-      {
-        id: 'ch-general',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-product',
-      },
-    ];
-    const { client, injectError } = makeStubClient(channels);
+    const { client, injectError } = makeStubClient([TEAM_GENERAL]);
     injectError(
       new ChatApiError({
         code: 'validation_error',
@@ -373,8 +350,14 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
         message: 'threadId references a non-existent message',
       }),
     );
-
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[PRODUCT_TEAM]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
     await userEvent.type(await screen.findByTestId('mention-textarea'), 'hi');
     await userEvent.click(screen.getByTestId('mention-send'));
 
@@ -384,157 +367,39 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
       'threadId references a non-existent message',
     );
 
-    // Dismiss clears the toast.
     await userEvent.click(screen.getByTestId('chat-error-toast-dismiss'));
     await waitFor(() => {
       expect(screen.queryByTestId('chat-error-toast')).not.toBeInTheDocument();
     });
   });
 
-  it('mounts the NoTeamsEmptyState when the BE returns zero channels', async () => {
-    const { client } = makeStubClient([]);
-    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} />);
-    expect(await screen.findByTestId('empty-no-teams')).toBeInTheDocument();
-  });
-
-  it('renders without crashing when the MockChatApiClient default seed is used', async () => {
-    // The default seed has DM-only channels; the workspace rail should
-    // be empty (no observed teamIds) and the page renders the
-    // NoTeamsEmptyState. This is a smoke-test for the dev path.
-    render(
-      <LiveTeamChatPage
-        client={new MockChatApiClient()}
-        mentionables={MENTIONABLES}
-      />,
-    );
-    await waitFor(() =>
-      expect(screen.getByTestId('empty-no-teams')).toBeInTheDocument(),
-    );
-  });
-
-  it('injects a Direct Messages workspace when the user has DMs (rail shown alongside a team)', async () => {
-    // A team channel + a DM → two workspaces, so the rail is visible and we
-    // can assert the synthetic DM workspace was prepended.
+  it('surfaces Slack threads in a collapsed Slack section under Home, labeled by time', async () => {
+    const slackId = 'slack-D0AC7NF5N7L-1777760999-956969';
     const channels: Channel[] = [
-      {
-        id: 'ch-team',
-        agentSession: '',
-        name: 'general',
-        createdAt: ISO,
-        type: 'channel',
-        teamId: 'team-x',
-      },
-      {
-        id: 'orc-dm',
-        agentSession: 'crewly-orc',
-        name: 'Orchestrator',
-        createdAt: ISO,
-        type: 'dm',
-        presence: 'online',
-      },
+      orcDm,
+      { id: slackId, agentSession: ORCHESTRATOR_SESSION, name: slackId, createdAt: ISO, type: 'dm', presence: 'online' },
     ];
     const { client } = makeStubClient(channels);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-      />,
-    );
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId('workspace-row-__direct__')).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('workspace-row-team-x')).toBeInTheDocument();
-  });
-
-  it('shows directory agents (online + offline) even without an existing DM channel', async () => {
-    // No channels at all — agents come purely from the directory.
-    const { client } = makeStubClient([]);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-        directoryAgents={[
-          { agentSession: 'sess-ella', name: 'Ella', presence: 'online' },
-          { agentSession: 'sess-grace', name: 'Grace', presence: 'offline' },
-        ]}
-        onEnsureDm={async () => 'real-chan'}
-      />,
-    );
-    // Both agents are listed despite having no channel yet.
-    expect(await screen.findByText('Ella')).toBeInTheDocument();
-    expect(screen.getByText('Grace')).toBeInTheDocument();
-    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
-  });
-
-  it('groups the DM list into per-team sections when agents carry a team', async () => {
-    const { client } = makeStubClient([]);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-        directoryAgents={[
-          { agentSession: 's-ella', name: 'Ella', presence: 'online', teamName: 'Content' },
-          { agentSession: 's-luna', name: 'Luna', presence: 'offline', teamName: 'Content' },
-          { agentSession: 's-grace', name: 'Grace', presence: 'offline', teamName: 'Sales' },
-        ]}
-        onEnsureDm={async () => 'real-chan'}
-      />,
-    );
-    // Team sections nest under a "Teams" parent, each with its agents.
-    expect(await screen.findByText('Teams')).toBeInTheDocument();
-    expect(screen.getByText('Content')).toBeInTheDocument();
-    expect(screen.getByText('Sales')).toBeInTheDocument();
-    expect(screen.getByText('Ella')).toBeInTheDocument();
-    expect(screen.getByText('Luna')).toBeInTheDocument();
-    expect(screen.getByText('Grace')).toBeInTheDocument();
-  });
-
-  it('surfaces Slack threads in a collapsed Slack section, labeled by thread time', async () => {
-    const channels: Channel[] = [
-      {
-        // Legacy id-named thread: slack-<channel>-<tsSeconds>-<tsMicros>.
-        id: 'slack-D0AC7NF5N7L-1777760999-956969',
-        agentSession: 'crewly-orc',
-        name: 'slack-D0AC7NF5N7L-1777760999-956969',
-        createdAt: ISO,
-        type: 'dm',
-        presence: 'online',
-      },
-    ];
-    const { client } = makeStubClient(channels);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-      />,
-    );
-    // The Slack section header is present, collapsed by default.
     const toggle = await screen.findByTestId('conv-group-toggle-slack');
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByTestId('conv-row-slack-D0AC7NF5N7L-1777760999-956969')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`conv-row-${slackId}`)).not.toBeInTheDocument();
 
-    // Expanding it reveals the thread, labeled by its start time (not the
-    // identical channel id) so multiple threads are distinguishable.
     fireEvent.click(toggle);
-    expect(
-      await screen.findByTestId('conv-row-slack-D0AC7NF5N7L-1777760999-956969'),
-    ).toBeInTheDocument();
+    expect(await screen.findByTestId(`conv-row-${slackId}`)).toBeInTheDocument();
     expect(screen.getAllByText(/Slack thread ·/).length).toBeGreaterThan(0);
   });
 
-  it('calls onEnsureDm when a directory agent without a channel is opened', async () => {
+  it('calls onEnsureDm when a team member without a channel is opened', async () => {
     const onEnsureDm = vi.fn().mockResolvedValue('real-chan');
     const { client } = makeStubClient([]);
     render(
       <LiveTeamChatPage
         client={client}
         mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+        teams={[{ id: 'team-x', name: 'Team X', leaderSessions: [], memberSessions: ['sess-ella'] }]}
+        initialWorkspaceId="team:team-x"
         directoryAgents={[{ agentSession: 'sess-ella', name: 'Ella', presence: 'offline' }]}
         onEnsureDm={onEnsureDm}
       />,
@@ -544,62 +409,10 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
     await waitFor(() => expect(onEnsureDm).toHaveBeenCalledWith('sess-ella'));
   });
 
-  it('does not inject the DM workspace when the user has no DM channels', async () => {
-    // Two team channels, no DMs → two team workspaces, no DM workspace.
-    const channels: Channel[] = [
-      { id: 'ch-a', agentSession: '', name: 'general', createdAt: ISO, type: 'channel', teamId: 'team-a' },
-      { id: 'ch-b', agentSession: '', name: 'general', createdAt: ISO, type: 'channel', teamId: 'team-b' },
-    ];
-    const { client } = makeStubClient(channels);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-      />,
-    );
-
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-row-team-a')).toBeInTheDocument(),
-    );
-    expect(screen.queryByTestId('workspace-row-__direct__')).not.toBeInTheDocument();
-  });
-
-  it('hides the workspace rail and dedupes the header when only the DM workspace exists', async () => {
-    // DM-only → a single workspace → Slack-style 3-column layout (no rail).
-    const channels: Channel[] = [
-      {
-        id: 'orc-dm',
-        agentSession: 'crewly-orc',
-        name: 'Orchestrator',
-        createdAt: ISO,
-        type: 'dm',
-        presence: 'online',
-      },
-    ];
-    const { client } = makeStubClient(channels);
-    render(
-      <LiveTeamChatPage
-        client={client}
-        mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
-      />,
-    );
-
-    await waitFor(() => expect(screen.getByTestId('team-chat-page')).toBeInTheDocument());
-    // No workspace rail when there's a single workspace.
-    expect(screen.queryAllByTestId(/^workspace-row-/).length).toBe(0);
-    // The orchestrator DM is reachable (not the no-teams dead-end).
-    expect(screen.queryByTestId('empty-no-teams')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Orchestrator').length).toBeGreaterThan(0);
-    // Orchestrator is pinned by default → surfaces under "Pinned Chats".
-    expect(screen.getByText('Pinned Chats')).toBeInTheDocument();
-  });
-
-  it('pins the orchestrator by default and lets you unpin it', async () => {
+  it('pinning a team member surfaces them under Home', async () => {
     window.localStorage.clear();
     const channels: Channel[] = [
-      { id: 'orc-dm', agentSession: 'crewly-orc', name: 'Orchestrator', createdAt: ISO, type: 'dm', presence: 'online' },
+      orcDm,
       { id: 'dm-ella', agentSession: 'sess-ella', name: 'Ella', createdAt: ISO, type: 'dm', presence: 'online' },
     ];
     const { client } = makeStubClient(channels);
@@ -607,14 +420,15 @@ describe('LiveTeamChatPage — Phase C acceptance', () => {
       <LiveTeamChatPage
         client={client}
         mentionables={MENTIONABLES}
-        directMessagesWorkspace={{ id: '__direct__', name: 'Direct Messages' }}
+        teams={[{ id: 'team-x', name: 'Team X', leaderSessions: [], memberSessions: ['sess-ella'] }]}
+        initialWorkspaceId="team:team-x"
       />,
     );
-    // Orchestrator pinned by default → Pinned Chats section present; Ella isn't pinned.
-    await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
-    // Unpin the orchestrator via its pin toggle.
-    fireEvent.click(screen.getByTestId('conv-pin-orc-dm'));
-    await waitFor(() => expect(screen.queryByTestId('conv-group-pinned')).not.toBeInTheDocument());
+    // Pin Ella from the team view, then switch to Home — she appears under Pinned.
+    await waitFor(() => expect(screen.getByTestId('conv-pin-dm-ella')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('conv-pin-dm-ella'));
+    fireEvent.click(screen.getByTestId('workspace-row-home'));
+    await waitFor(() => expect(screen.getByTestId('conv-row-dm-ella')).toBeInTheDocument());
   });
 });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -37,7 +37,6 @@ import {
   useChannels,
   useGroupedChannels,
   useMessages,
-  useObservedWorkspaces,
   useSendMessage,
   useChatApiClient,
   type ChatApiClient,
@@ -59,6 +58,29 @@ import {
 import { ChatErrorToast } from './ChatErrorToast';
 import { CreateGroupModal } from './CreateGroupModal';
 import { usePinnedChats } from '../../hooks/usePinnedChats';
+import { ORCHESTRATOR_SESSION, ORCHESTRATOR_LABEL } from '../../utils/team-chat.utils';
+
+/** Rail identifiers for the non-team entries. */
+export const HOME_ID = 'home';
+const ORC_RAIL_ID = 'orc';
+
+/** Build the rail workspace id for a team (so deep-links can target it). */
+export function teamRailId(teamId: string): string {
+  return `team:${teamId}`;
+}
+
+/**
+ * A team as the chat rail needs it: identity + the sessions of its lead(s)
+ * and all members (for the per-team huddle + lead-first roster). Host-derived.
+ */
+export interface ChatTeam {
+  id: string;
+  name: string;
+  /** Session names of the team lead(s) — sorted first in the roster. */
+  leaderSessions: string[];
+  /** Session names of every member of the team. */
+  memberSessions: string[];
+}
 
 export interface LiveTeamChatPageProps {
   /** OSS backend base URL. Required when no `client` is injected. */
@@ -88,21 +110,19 @@ export interface LiveTeamChatPageProps {
   /** Initial conversation selection. Defaults to the first row. */
   initialConversationId?: string | null;
   /**
-   * Optional always-present "Direct Messages" workspace. When provided AND
-   * the user has at least one DM channel, it is prepended to the rail so
-   * DMs (e.g. the orchestrator + agents) are reachable even when the user
-   * has no team channels — otherwise the page would dead-end on the
-   * NoTeams empty state. DMs are workspace-agnostic, so this synthetic
-   * workspace simply scopes the center panel to show only DMs.
-   */
-  directMessagesWorkspace?: { id: string; name: string } | null;
-  /**
    * Full agent directory (host-supplied). Every agent is shown in the DM
    * list — online or offline — even before a DM channel exists, so the user
    * can reach any agent. Agents that already have a real DM channel are
    * de-duplicated against it.
    */
   directoryAgents?: DirectoryAgentEntry[];
+  /**
+   * Teams for the workspace rail. Each rail icon = one team; selecting it
+   * scopes the list to that team's huddle + lead + members. Host-derived
+   * (lead detection from team config). When empty the rail shows just
+   * Home + the orchestrator.
+   */
+  teams?: ChatTeam[];
   /**
    * Ensure (find-or-create) a DM channel for an agent session, returning the
    * resolved channel id. Called when the user opens a directory agent that
@@ -125,12 +145,11 @@ export function LiveTeamChatPage({
   backendURL,
   authToken,
   client,
-  teamLabels,
   mentionables = [],
   initialWorkspaceId,
   initialConversationId,
-  directMessagesWorkspace,
   directoryAgents = [],
+  teams = [],
   onEnsureDm,
 }: LiveTeamChatPageProps): JSX.Element {
   return (
@@ -141,12 +160,11 @@ export function LiveTeamChatPage({
       client={client}
     >
       <LiveTeamChatPageBody
-        teamLabels={teamLabels}
         mentionables={mentionables}
         initialWorkspaceId={initialWorkspaceId}
         initialConversationId={initialConversationId}
-        directMessagesWorkspace={directMessagesWorkspace}
         directoryAgents={directoryAgents}
+        teams={teams}
         onEnsureDm={onEnsureDm}
       />
     </ChatAPIProvider>
@@ -158,12 +176,11 @@ export function LiveTeamChatPage({
 // ---------------------------------------------------------------------------
 
 interface BodyProps {
-  teamLabels?: Record<string, string>;
   mentionables: MentionTarget[];
   initialWorkspaceId?: string | null;
   initialConversationId?: string | null;
-  directMessagesWorkspace?: { id: string; name: string } | null;
   directoryAgents: DirectoryAgentEntry[];
+  teams: ChatTeam[];
   onEnsureDm?: (agentSession: string) => Promise<string>;
 }
 
@@ -205,23 +222,17 @@ function prettySlackTitle(raw: string): string {
   return `Slack · ${m[1]}`;
 }
 
-/** Count rows in a group including nested sub-groups. */
-function countGroupRows(group: ConversationGroup): number {
-  return group.rows.length + (group.subGroups?.reduce((a, g) => a + countGroupRows(g), 0) ?? 0);
-}
-
 /** Flatten all rows across groups + nested sub-groups, in render order. */
 function flattenRows(groups: ConversationGroup[]): ConversationRow[] {
   return groups.flatMap((g) => [...g.rows, ...flattenRows(g.subGroups ?? [])]);
 }
 
 function LiveTeamChatPageBody({
-  teamLabels,
   mentionables,
   initialWorkspaceId,
   initialConversationId,
-  directMessagesWorkspace,
   directoryAgents,
+  teams,
   onEnsureDm,
 }: BodyProps): JSX.Element {
   const { channels, loading: channelsLoading, error: channelsError, refresh } = useChannels();
@@ -254,119 +265,134 @@ function LiveTeamChatPageBody({
     return synthetic.length > 0 ? [...channels, ...synthetic] : channels;
   }, [channels, directoryAgents]);
 
-  const teamWorkspaces = useObservedWorkspaces(mergedChannels, { teamLabels });
-
-  // Prepend the synthetic "Direct Messages" workspace when the host supplies
-  // one and the user actually has DMs — so DMs (orchestrator + agents) are
-  // reachable even with zero team channels. DMs are not team-scoped, so this
-  // workspace just narrows the center panel to the DM group.
-  const hasDms = useMemo(
-    () => mergedChannels.some((c) => (c.type ?? 'dm') !== 'channel'),
-    [mergedChannels],
-  );
+  // Workspace rail: Home → orchestrator → one icon per team. Home is the
+  // personal/cross-cutting landing (orc + pinned + huddles + Slack); each team
+  // icon scopes the center column to that team's huddle + lead + members.
   const workspaces = useMemo<Workspace[]>(() => {
-    if (directMessagesWorkspace && hasDms) {
-      return [
-        {
-          id: directMessagesWorkspace.id,
-          name: directMessagesWorkspace.name,
-          initials: 'DM',
-          kind: 'activity',
-        },
-        ...teamWorkspaces,
-      ];
-    }
-    return teamWorkspaces;
-  }, [directMessagesWorkspace, hasDms, teamWorkspaces]);
+    const home: Workspace = {
+      id: HOME_ID,
+      name: 'Home',
+      kind: 'home',
+      avatar: '🏠',
+      tooltip: 'Home — orchestrator, pinned chats & huddles',
+    };
+    const orc: Workspace = {
+      id: ORC_RAIL_ID,
+      name: ORCHESTRATOR_LABEL,
+      kind: 'team',
+      avatar: '🧭',
+      tooltip: ORCHESTRATOR_LABEL,
+    };
+    const teamItems: Workspace[] = teams.map((t) => ({
+      id: `team:${t.id}`,
+      name: t.name,
+      kind: 'team' as const,
+    }));
+    return [home, orc, ...teamItems];
+  }, [teams]);
+
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
     initialWorkspaceId ?? null,
   );
   const [activeConversationId, setActiveConversationId] = useState<string | null>(
     initialConversationId ?? null,
   );
+  // Home is the default landing.
+  const resolvedWorkspaceId = activeWorkspaceId ?? HOME_ID;
 
-  // Settle the workspace selection: prefer explicit initial, else the
-  // first observed workspace. This runs each render but reaches a
-  // stable fixed-point because the setter compares values.
-  const resolvedWorkspaceId =
-    activeWorkspaceId ?? (workspaces[0]?.id ?? null);
+  // All conversations, unscoped — re-bucketed per rail selection below.
+  const allGroups = useGroupedChannels(mergedChannels, { workspaceId: undefined });
+  const allChannelRows = useMemo(
+    () => allGroups.find((g) => g.id === 'channels')?.rows ?? [],
+    [allGroups],
+  );
+  const allHuddleRows = useMemo(
+    () => allGroups.find((g) => g.id === 'huddles')?.rows ?? [],
+    [allGroups],
+  );
+  const allDmRows = useMemo(
+    () => allGroups.find((g) => g.id === 'dms')?.rows ?? [],
+    [allGroups],
+  );
 
-  const baseGroups = useGroupedChannels(mergedChannels, {
-    workspaceId: resolvedWorkspaceId,
-  });
+  // The orchestrator DM row — Home's default top conversation + the orc rail
+  // item. Exclude Slack-bridged threads (they share the orc session but are
+  // their own conversations).
+  const orcRow = useMemo(
+    () =>
+      allDmRows.find(
+        (r) => r.agentSession === ORCHESTRATOR_SESSION && !r.id.startsWith(SLACK_ID_PREFIX),
+      ),
+    [allDmRows],
+  );
 
-  // Split the flat "Direct Messages" group into one section per team (agents
-  // mapped via the directory). Agents with no team (e.g. the orchestrator)
-  // stay under "Direct Messages". Channels + Group Chats sections pass
-  // through unchanged. This is what makes the long agent list readable.
-  const sessionToTeam = useMemo(() => {
+  // channel-id → teamId, so a team's huddle (its all-members channel) is findable
+  // from the (teamId-less) conversation rows.
+  const channelTeamId = useMemo(() => {
     const m = new Map<string, string>();
-    for (const a of directoryAgents) {
-      if (a.agentSession && a.teamName) m.set(a.agentSession, a.teamName);
+    for (const c of mergedChannels) {
+      if ((c.type ?? 'dm') === 'channel' && c.teamId) m.set(c.id, c.teamId);
     }
     return m;
-  }, [directoryAgents]);
+  }, [mergedChannels]);
 
-  const sectioned = useMemo(() => {
-    const dms = baseGroups.find((g) => g.id === 'dms');
-    if (!dms) return baseGroups;
+  // Conversation groups for the SELECTED rail item.
+  const groups = useMemo<ConversationGroup[]>(() => {
+    const sel = resolvedWorkspaceId;
 
-    const slackRows: ConversationRow[] = [];
-    const byTeam = new Map<string, typeof dms.rows>();
-    const noTeam: typeof dms.rows = [];
-    for (const row of dms.rows) {
-      // Slack-bridged threads → their own "Slack" section (not a team DM).
-      if (row.id.startsWith(SLACK_ID_PREFIX)) {
-        slackRows.push({ ...row, title: prettySlackTitle(row.title) });
-        continue;
-      }
-      const team = row.agentSession ? sessionToTeam.get(row.agentSession) : undefined;
-      if (team) {
-        const list = byTeam.get(team) ?? [];
-        list.push(row);
-        byTeam.set(team, list);
-      } else {
-        noTeam.push(row);
-      }
+    // Orchestrator-only view.
+    if (sel === ORC_RAIL_ID) {
+      return orcRow ? [{ id: 'pinned', label: ORCHESTRATOR_LABEL, rows: [orcRow] }] : [];
     }
 
-    const teamSections: ConversationGroup[] = [...byTeam.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([team, rows]) => ({ id: `dm-team:${team}`, label: team, rows }));
-
-    // Order: channels, huddles, teamless DMs, Slack, then Teams.
-    return baseGroups.flatMap<ConversationGroup>((g) => {
-      if (g.id !== 'dms') return [g];
+    // Home: orchestrator (default, top) + pinned agents + huddles + Slack.
+    if (sel === HOME_ID) {
+      const pinnedRows = allDmRows.filter(
+        (r) =>
+          r.agentSession !== ORCHESTRATOR_SESSION &&
+          !r.id.startsWith(SLACK_ID_PREFIX) &&
+          pinnedChats.isPinned(pinKeyOf(r)),
+      );
+      const slackRows = allDmRows
+        .filter((r) => r.id.startsWith(SLACK_ID_PREFIX))
+        .map((r) => ({ ...r, title: prettySlackTitle(r.title) }));
+      const top = [...(orcRow ? [orcRow] : []), ...pinnedRows];
       const out: ConversationGroup[] = [];
-      if (noTeam.length > 0) out.push({ id: 'dms', label: 'Direct Messages', rows: noTeam });
+      if (top.length > 0) out.push({ id: 'pinned', label: 'Pinned', rows: top });
+      if (allHuddleRows.length > 0) out.push({ id: 'huddles', label: 'Huddles', rows: allHuddleRows });
       if (slackRows.length > 0) out.push({ id: 'slack', label: 'Slack', rows: slackRows });
-      if (teamSections.length > 0) {
-        out.push({ id: 'teams', label: 'Teams', rows: [], subGroups: teamSections });
-      }
       return out;
-    });
-  }, [baseGroups, sessionToTeam]);
+    }
 
-  // Lift pinned conversations into a top "Pinned Chats" section, removing them
-  // from their normal section (including nested team sub-groups) so they appear
-  // once. Orchestrator is pinned by default; the user can pin/unpin any chat.
-  const groups = useMemo(() => {
-    const pinnedRows: ConversationRow[] = [];
-    const prune = (g: ConversationGroup): ConversationGroup => {
-      const keep: ConversationRow[] = [];
-      for (const r of g.rows) {
-        if (pinnedChats.isPinned(pinKeyOf(r))) pinnedRows.push(r);
-        else keep.push(r);
-      }
-      const subs = (g.subGroups ?? [])
-        .map(prune)
-        .filter((sg) => countGroupRows(sg) > 0);
-      return { ...g, rows: keep, subGroups: subs.length > 0 ? subs : undefined };
-    };
-    const pruned = sectioned.map(prune).filter((g) => countGroupRows(g) > 0);
-    if (pinnedRows.length === 0) return pruned;
-    return [{ id: 'pinned', label: 'Pinned Chats', rows: pinnedRows }, ...pruned];
-  }, [sectioned, pinnedChats]);
+    // A team is selected: team huddle (all-members channel) → lead(s) → members.
+    const team = teams.find((t) => `team:${t.id}` === sel);
+    if (!team) return orcRow ? [{ id: 'pinned', label: ORCHESTRATOR_LABEL, rows: [orcRow] }] : [];
+    const leadSet = new Set(team.leaderSessions);
+    const memberSet = new Set(team.memberSessions);
+    const huddleRows = allChannelRows.filter((r) => channelTeamId.get(r.id) === team.id);
+    const memberRows = allDmRows.filter(
+      (r) =>
+        r.agentSession &&
+        r.agentSession !== ORCHESTRATOR_SESSION &&
+        memberSet.has(r.agentSession),
+    );
+    const leads = memberRows.filter((r) => r.agentSession && leadSet.has(r.agentSession));
+    const rest = memberRows.filter((r) => !(r.agentSession && leadSet.has(r.agentSession)));
+    const out: ConversationGroup[] = [];
+    if (huddleRows.length > 0) out.push({ id: 'team-huddle', label: 'Team huddle', rows: huddleRows });
+    if (leads.length > 0) out.push({ id: 'team-lead', label: 'Team lead', rows: leads });
+    if (rest.length > 0) out.push({ id: 'team-members', label: 'Members', rows: rest });
+    return out;
+  }, [
+    resolvedWorkspaceId,
+    teams,
+    orcRow,
+    allDmRows,
+    allHuddleRows,
+    allChannelRows,
+    channelTeamId,
+    pinnedChats,
+  ]);
 
   const totalRows = useMemo(
     () => groups.reduce((acc, g) => acc + g.rows.length, 0),
@@ -456,14 +482,7 @@ function LiveTeamChatPageBody({
       )}
 
       <ConversationListPanel
-        // Avoid a duplicate header: the DM workspace's group label ("Direct
-        // Messages") already heads the list, so don't also render it as the
-        // panel title. Real team workspaces still show their name.
-        workspaceName={
-          activeWorkspace && activeWorkspace.id !== directMessagesWorkspace?.id
-            ? activeWorkspace.name
-            : undefined
-        }
+        workspaceName={activeWorkspace?.name}
         groups={groups}
         activeConversationId={resolvedConversationId}
         onSelectConversation={handleSelectConversation}

--- a/frontend/src/components/Chat-team/TeamChatRoute.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.tsx
@@ -28,7 +28,13 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { LiveTeamChatPage, type DirectoryAgentEntry } from './LiveTeamChatPage';
+import {
+  LiveTeamChatPage,
+  HOME_ID,
+  teamRailId,
+  type DirectoryAgentEntry,
+  type ChatTeam,
+} from './LiveTeamChatPage';
 import { useTeams } from '../../hooks/useTeams';
 import { resolveBackendURL, resolveChatMode } from '../../utils/chat-backend';
 import {
@@ -38,8 +44,6 @@ import {
   TEAM_QUERY_PARAM,
   ORCHESTRATOR_SESSION,
   ORCHESTRATOR_LABEL,
-  DM_WORKSPACE_ID,
-  DM_WORKSPACE_LABEL,
 } from '../../utils/team-chat.utils';
 
 /** POST a chat-v2 ensure endpoint and return the resolved channel id, or null. */
@@ -97,6 +101,22 @@ export function TeamChatRoute(): JSX.Element {
     return out;
   }, [teams]);
 
+  // Teams for the workspace rail: identity + lead/member sessions. The lead is
+  // a member listed in `leaderIds` (or the deprecated `leaderId`), or a member
+  // at hierarchy level 1.
+  const chatTeams = useMemo<ChatTeam[]>(() => {
+    return teams.map((t) => {
+      const leaderIds = t.leaderIds?.length ? t.leaderIds : t.leaderId ? [t.leaderId] : [];
+      const leadIdSet = new Set(leaderIds);
+      const members = t.members ?? [];
+      const leaderSessions = members
+        .filter((m) => m.sessionName && (leadIdSet.has(m.id) || m.hierarchyLevel === 1))
+        .map((m) => m.sessionName);
+      const memberSessions = members.filter((m) => m.sessionName).map((m) => m.sessionName);
+      return { id: t.id, name: t.name, leaderSessions, memberSessions };
+    });
+  }, [teams]);
+
   const teamParam = searchParams.get(TEAM_QUERY_PARAM) || null;
 
   // Find-or-create a DM for an agent the user opens from the directory.
@@ -112,10 +132,13 @@ export function TeamChatRoute(): JSX.Element {
     [directoryAgents],
   );
 
-  // Ensure the channels the page needs exist before mounting it. `readyKey`
-  // tracks the team we've prepared for (or `__none__`) so a team switch
-  // re-runs the ensure and the loading gate shows again.
-  const targetKey = teamParam ?? '__none__';
+  // Ensure the channels the page needs exist before mounting it: the
+  // orchestrator DM + EVERY team's huddle channel (so each team rail icon has
+  // its all-members huddle). `readyKey` is keyed on the team-id set so it
+  // re-runs (and re-gates) once `useTeams` resolves, but is stable across
+  // presence-only updates.
+  const teamIds = useMemo(() => chatTeams.map((t) => t.id), [chatTeams]);
+  const targetKey = `${teamParam ?? '__none__'}|${teamIds.join(',')}`;
   const [readyKey, setReadyKey] = useState<string | null>(null);
   const [orcChannelId, setOrcChannelId] = useState<string | null>(null);
   const ready = mode !== 'real' || readyKey === targetKey;
@@ -130,10 +153,10 @@ export function TeamChatRoute(): JSX.Element {
         name: ORCHESTRATOR_LABEL,
         purpose: 'Talk to the orchestrator',
       });
-      // When deep-linked to a team, make sure that team has a channel too.
-      if (teamParam) {
-        await ensureChannel('/api/chat/channels/team/ensure', { teamId: teamParam });
-      }
+      // Ensure each team's huddle channel exists for its rail view.
+      await Promise.all(
+        teamIds.map((id) => ensureChannel('/api/chat/channels/team/ensure', { teamId: id })),
+      );
       if (!cancelled) {
         if (orcId) setOrcChannelId(orcId);
         setReadyKey(targetKey);
@@ -142,7 +165,7 @@ export function TeamChatRoute(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [mode, teamParam, targetKey]);
+  }, [mode, targetKey, teamIds]);
 
   if (!ready) {
     return (
@@ -155,9 +178,9 @@ export function TeamChatRoute(): JSX.Element {
     );
   }
 
-  // Default landing is the orchestrator (in the Direct Messages workspace);
-  // a `?team=` deep-link overrides both to focus that team.
-  const initialWorkspaceId = teamParam ?? DM_WORKSPACE_ID;
+  // Default landing is Home (orchestrator selected); a `?team=` deep-link
+  // focuses that team's rail icon instead.
+  const initialWorkspaceId = teamParam ? teamRailId(teamParam) : HOME_ID;
   const initialConversationId = teamParam ? null : orcChannelId;
 
   return (
@@ -167,8 +190,8 @@ export function TeamChatRoute(): JSX.Element {
       mentionables={mentionables}
       initialWorkspaceId={initialWorkspaceId}
       initialConversationId={initialConversationId}
-      directMessagesWorkspace={{ id: DM_WORKSPACE_ID, name: DM_WORKSPACE_LABEL }}
       directoryAgents={directoryAgents}
+      teams={chatTeams}
       onEnsureDm={onEnsureDm}
     />
   );

--- a/packages/chat-ui/src/components/WorkspaceRail.test.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.test.tsx
@@ -102,4 +102,22 @@ describe('WorkspaceRail', () => {
     expect(rows[1]).toHaveAttribute('data-testid', 'workspace-row-b');
     expect(rows[2]).toHaveAttribute('data-testid', 'workspace-row-orphan');
   });
+
+  it('renders a home workspace with its avatar glyph + tooltip override', () => {
+    render(
+      <WorkspaceRail
+        workspaces={[
+          { id: 'home', name: 'Home', kind: 'home', avatar: '\u{1F3E0}', tooltip: 'Home — orchestrator & pinned' },
+          { id: 'orc', name: 'Orchestrator', kind: 'team', avatar: '\u{1F9ED}' },
+        ]}
+      />,
+    );
+    const home = screen.getByTestId('workspace-row-home');
+    expect(home).toHaveAttribute('data-kind', 'home');
+    expect(home).toHaveAttribute('title', 'Home — orchestrator & pinned');
+    expect(home).toHaveTextContent('\u{1F3E0}');
+    // Avatar replaces derived initials on the orchestrator too.
+    expect(screen.getByTestId('workspace-row-orc')).toHaveTextContent('\u{1F9ED}');
+  });
+
 });

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -108,6 +108,7 @@ function WorkspaceRow({
 }): JSX.Element {
   const initials = workspace.initials ?? deriveInitials(workspace.name);
   const isActivity = workspace.kind === 'activity';
+  const isHome = workspace.kind === 'home';
   const hasUnread = (workspace.unreadCount ?? 0) > 0;
 
   return (
@@ -119,8 +120,9 @@ function WorkspaceRow({
       data-nested={isNested ? 'true' : 'false'}
       data-kind={workspace.kind ?? 'team'}
       // Hover tooltip — the rail is icon-only when collapsed, so the 2-letter
-      // initials (e.g. "DM"/"CM") are otherwise opaque. Title reveals the name.
-      title={workspace.name}
+      // initials are otherwise opaque. Title reveals the name (or a richer
+      // tooltip override when provided).
+      title={workspace.tooltip ?? workspace.name}
       className={[
         'group relative mx-2 flex items-center gap-3 rounded-lg px-2 py-2 text-left transition',
         // Active state is full-width per §6.1, not just a tint.
@@ -140,13 +142,17 @@ function WorkspaceRow({
       <span
         aria-hidden="true"
         className={[
-          'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-semibold uppercase',
-          isActivity
-            ? 'bg-slate-700 text-slate-100'
-            : 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white',
+          'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg font-semibold',
+          // Avatar glyph (emoji) is not uppercased; initials are.
+          workspace.avatar ? 'text-lg' : 'text-sm uppercase',
+          isHome
+            ? 'bg-slate-700 text-white ring-1 ring-slate-500'
+            : isActivity
+              ? 'bg-slate-700 text-slate-100'
+              : 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white',
         ].join(' ')}
       >
-        {initials}
+        {workspace.avatar ?? initials}
       </span>
 
       {expanded && (

--- a/packages/chat-ui/src/types/team-chat.types.ts
+++ b/packages/chat-ui/src/types/team-chat.types.ts
@@ -45,11 +45,19 @@ export interface Workspace {
   initials?: string;
   /**
    * Workspace category. `team` is the default; `activity` is the
-   * cross-team unified-inbox entry described in design §4.3.
+   * cross-team unified-inbox entry described in design §4.3; `home` is the
+   * personal/cross-cutting landing (orc + pinned + huddles).
    */
-  kind?: 'team' | 'activity';
+  kind?: 'team' | 'activity' | 'home';
   /** Parent workspace id for nested grouping. */
   parentId?: string;
+  /**
+   * Optional glyph for a richer rail icon than 2-letter initials — an emoji or
+   * single char. When absent the rail falls back to `initials`/derived initials.
+   */
+  avatar?: string;
+  /** Hover tooltip override; defaults to `name`. */
+  tooltip?: string;
   /** Total unread items in this workspace (channels + dms combined). */
   unreadCount?: number;
   /** True when at least one mention is unread — drives the rail dot color. */


### PR DESCRIPTION
Redesigns the chat left rail into a Slack-like workspace switcher, per the owner's vision (UX-designed, then implemented).

## Rail (top → bottom)
- 🏠 **Home** (default) — the personal/cross-cutting inbox: **orchestrator** (top) + **pinned agents** + **custom huddles** + **Slack** (collapsed).
- 🧭 **Orchestrator** — its own rail icon.
- One icon **per team** — selecting it scopes the center column to that team: **team huddle** (all members) → **team lead** (first) → **members**.

The center column is now driven by the selected rail item instead of one flat "Pinned / Slack / Teams(sub-groups)" mega-list. The synthetic "DM" workspace + per-team DM sub-grouping are removed.

## chat-ui (additive — Portal-safe)
- `Workspace` gains `kind:'home'` (additive enum member) + optional `avatar` + `tooltip`. `WorkspaceRail` renders the glyph + tooltip override, falling back to derived initials/name — **Portal's existing data hits the fallback path, no breaking change**. `ConversationListPanel` unchanged.

## Host (OSS `LiveTeamChatPage`)
- New `teams` prop (`id`, `name`, `leaderSessions`, `memberSessions`). Rail = `[Home, orc, ...teams]`; conversation groups derived per selection. Lead-first ordering. Team huddle = the team's all-members channel.
- `TeamChatRoute` derives `teams` from `useTeams()` (lead = `leaderIds`/level-1), ensures every team's huddle channel pre-mount, and defaults the landing to Home (`?team=` deep-links to that team's icon).

## Tests
Rail (Home+orc+teams), Home-default-orc, team view (huddle→lead→members, lead first), Slack-collapsed-under-Home, pin-a-member-into-Home, onEnsureDm, + all preserved mention/thread/toast cases (17) — plus `WorkspaceRail` home/avatar (12). Full build green; Quality Gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)