### PR TITLE
feat(chat): label the workspace rail + drop emoji glyphs

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -28,6 +28,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react';
+import { Home, Bot } from 'lucide-react';
 import {
   ChatAPIProvider,
   ConversationListPanel,
@@ -273,14 +274,14 @@ function LiveTeamChatPageBody({
       id: HOME_ID,
       name: 'Home',
       kind: 'home',
-      avatar: '🏠',
+      icon: <Home className="h-5 w-5" />,
       tooltip: 'Home — orchestrator, pinned chats & huddles',
     };
     const orc: Workspace = {
       id: ORC_RAIL_ID,
       name: ORCHESTRATOR_LABEL,
       kind: 'team',
-      avatar: '🧭',
+      icon: <Bot className="h-5 w-5" />,
       tooltip: ORCHESTRATOR_LABEL,
     };
     const teamItems: Workspace[] = teams.map((t) => ({
@@ -478,6 +479,7 @@ function LiveTeamChatPageBody({
           workspaces={workspaces}
           activeWorkspaceId={resolvedWorkspaceId}
           onSelectWorkspace={handleSelectWorkspace}
+          showLabels
         />
       )}
 

--- a/packages/chat-ui/src/components/WorkspaceRail.test.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.test.tsx
@@ -120,4 +120,39 @@ describe('WorkspaceRail', () => {
     expect(screen.getByTestId('workspace-row-orc')).toHaveTextContent('\u{1F9ED}');
   });
 
+
+  it('renders labels beside icons in showLabels mode (wider column)', () => {
+    render(
+      <WorkspaceRail
+        workspaces={[{ id: 'team-x', name: 'Customer Engineering', initials: 'CE' }]}
+        showLabels
+      />,
+    );
+    const rail = screen.getByTestId('workspace-rail');
+    expect(rail).toHaveAttribute('data-labelled', 'true');
+    expect(rail.className).toContain('w-56');
+    // The full team name is visible (not just the initials).
+    expect(screen.getByText('Customer Engineering')).toBeInTheDocument();
+  });
+
+  it('renders a host-injected icon node over avatar/initials', () => {
+    render(
+      <WorkspaceRail
+        workspaces={[
+          {
+            id: 'home',
+            name: 'Home',
+            kind: 'home',
+            icon: <svg data-testid="home-icon" />,
+            avatar: '\u{1F3E0}',
+          },
+        ]}
+        showLabels
+      />,
+    );
+    // The vector icon renders; the emoji avatar is NOT used when icon is present.
+    expect(screen.getByTestId('home-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-home')).not.toHaveTextContent('\u{1F3E0}');
+  });
+
 });

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -46,6 +46,12 @@ export interface WorkspaceRailProps {
    * false keeps the icon-only Slack rail.
    */
   expanded?: boolean;
+  /**
+   * ADDITIVE. When true, always render the workspace name beside every icon at
+   * a wider, label-first width (chat host's long-list mode). Independent of
+   * `expanded`. Default false preserves the icon-only rail for existing callers.
+   */
+  showLabels?: boolean;
   className?: string;
 }
 
@@ -62,6 +68,7 @@ export function WorkspaceRail({
   activeWorkspaceId = null,
   onSelectWorkspace,
   expanded = false,
+  showLabels = false,
   className = '',
 }: WorkspaceRailProps): JSX.Element {
   // Deterministic order: roots in their original order, each followed by
@@ -69,14 +76,18 @@ export function WorkspaceRail({
   // grouping in §6.1 ("Crewly" parent contains Product, Marketing).
   const ordered = useMemo(() => orderByParent(workspaces), [workspaces]);
 
+  // Labels show in either the tablet `expanded` mode or the host `showLabels`
+  // long-list mode; the latter uses a wider column for full names.
+  const labelled = expanded || showLabels;
+  const width = expanded ? 'w-48' : showLabels ? 'w-56' : 'w-16';
+
   return (
     <nav
-      className={`flex h-full flex-col items-stretch gap-1 border-r border-slate-200 bg-slate-900 py-3 ${
-        expanded ? 'w-48' : 'w-16'
-      } ${className}`}
+      className={`flex h-full flex-col items-stretch gap-1 overflow-y-auto border-r border-slate-200 bg-slate-900 py-3 ${width} ${className}`}
       aria-label="Workspace rail"
       data-testid="workspace-rail"
       data-expanded={expanded ? 'true' : 'false'}
+      data-labelled={labelled ? 'true' : 'false'}
     >
       {ordered.map((ws) => (
         <WorkspaceRow
@@ -84,7 +95,7 @@ export function WorkspaceRail({
           workspace={ws}
           isActive={activeWorkspaceId === ws.id}
           isNested={!!ws.parentId}
-          expanded={expanded}
+          showLabel={labelled}
           onSelect={onSelectWorkspace}
         />
       ))}
@@ -97,19 +108,21 @@ function WorkspaceRow({
   workspace,
   isActive,
   isNested,
-  expanded,
+  showLabel,
   onSelect,
 }: {
   workspace: Workspace;
   isActive: boolean;
   isNested: boolean;
-  expanded: boolean;
+  showLabel: boolean;
   onSelect?: (w: Workspace) => void;
 }): JSX.Element {
   const initials = workspace.initials ?? deriveInitials(workspace.name);
   const isActivity = workspace.kind === 'activity';
   const isHome = workspace.kind === 'home';
   const hasUnread = (workspace.unreadCount ?? 0) > 0;
+  // Glyph precedence: host-injected vector icon → emoji avatar → derived initials.
+  const hasGlyph = workspace.icon != null || workspace.avatar != null;
 
   return (
     <button
@@ -124,7 +137,7 @@ function WorkspaceRow({
       // tooltip override when provided).
       title={workspace.tooltip ?? workspace.name}
       className={[
-        'group relative mx-2 flex items-center gap-3 rounded-lg px-2 py-2 text-left transition',
+        'group relative mx-2 flex items-center gap-3 rounded-lg px-2 py-2 pr-4 text-left transition',
         // Active state is full-width per §6.1, not just a tint.
         isActive
           ? 'bg-blue-600/20 text-white ring-1 ring-blue-400/40'
@@ -143,8 +156,8 @@ function WorkspaceRow({
         aria-hidden="true"
         className={[
           'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg font-semibold',
-          // Avatar glyph (emoji) is not uppercased; initials are.
-          workspace.avatar ? 'text-lg' : 'text-sm uppercase',
+          // A vector icon / emoji glyph is not uppercased; initials are.
+          hasGlyph ? 'text-lg' : 'text-sm uppercase',
           isHome
             ? 'bg-slate-700 text-white ring-1 ring-slate-500'
             : isActivity
@@ -152,12 +165,12 @@ function WorkspaceRow({
               : 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white',
         ].join(' ')}
       >
-        {workspace.avatar ?? initials}
+        {workspace.icon ?? workspace.avatar ?? initials}
       </span>
 
-      {expanded && (
-        <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-sm font-medium">
-          <span className="truncate">{workspace.name}</span>
+      {showLabel && (
+        <span className="min-w-0 flex-1 truncate text-sm font-medium leading-9">
+          {workspace.name}
         </span>
       )}
 

--- a/packages/chat-ui/src/types/team-chat.types.ts
+++ b/packages/chat-ui/src/types/team-chat.types.ts
@@ -19,6 +19,7 @@
  * @module types/team-chat
  */
 
+import type { ReactNode } from 'react';
 import type { ChatPresenceStatus } from '../components/AgentStatusBadge';
 
 // =============================================================================
@@ -56,6 +57,13 @@ export interface Workspace {
    * single char. When absent the rail falls back to `initials`/derived initials.
    */
   avatar?: string;
+  /**
+   * Optional pre-rendered icon node (e.g. a lucide-react vector icon) supplied
+   * by the host. ADDITIVE: takes precedence over `avatar` and derived
+   * `initials`. Kept as ReactNode so chat-ui needs no icon-library dependency —
+   * the host injects the node.
+   */
+  icon?: ReactNode;
   /** Hover tooltip override; defaults to `name`. */
   tooltip?: string;
   /** Total unread items in this workspace (channels + dms combined). */


### PR DESCRIPTION
Owner feedback on the new rail: it was hard to tell which icon is which (cryptic 2-letter initials), and the Home/orc emoji looked off. UX-designed fix:

- **Labels beside every icon** — new additive `showLabels` mode on `WorkspaceRail` (wider `w-56` column, names truncate cleanly). No more guessing what "CE" / "FL" mean.
- **No emoji** — Home + Orchestrator now render **lucide vector icons** (`Home` / `Bot`) instead of 🏠/🧭, injected via a new additive `Workspace.icon?: ReactNode`. Teams keep their gradient initials tile, now with a visible name.

## Portal-safe (additive)
- `Workspace.icon?: ReactNode` and `WorkspaceRail.showLabels?: boolean` are both **optional, default off**. chat-ui takes no icon-library dependency (the host injects the node). Portal's existing call sites omit both → render exactly as today (icon-only, `avatar`/`initials` fallback).

Tests: `showLabels` width + label visibility, icon-over-avatar precedence (14 in WorkspaceRail); LiveTeamChatPage suite green (17). Typecheck (chat-ui + frontend) + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)