### PR TITLE
feat(chat): mark team leads with a Lead badge in a single members list

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -223,8 +223,10 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     );
     await waitFor(() => expect(screen.getByTestId('conv-group-team-huddle')).toBeInTheDocument());
     expect(screen.getByTestId('conv-row-ch-general')).toHaveAttribute('data-kind', 'channel');
-    expect(screen.getByTestId('conv-group-team-lead')).toBeInTheDocument();
+    // Leads and members share a single Members list; leads carry a "Lead" badge.
     expect(screen.getByTestId('conv-group-team-members')).toBeInTheDocument();
+    expect(screen.getByTestId('conv-badge-dm-maya')).toHaveTextContent('Lead');
+    expect(screen.queryByTestId('conv-badge-dm-alex')).not.toBeInTheDocument();
     // Lead (Maya) renders before member (Alex).
     const lead = screen.getByTestId('conv-row-dm-maya');
     const member = screen.getByTestId('conv-row-dm-alex');

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -374,12 +374,16 @@ function LiveTeamChatPageBody({
         r.agentSession !== ORCHESTRATOR_SESSION &&
         memberSet.has(r.agentSession),
     );
-    const leads = memberRows.filter((r) => r.agentSession && leadSet.has(r.agentSession));
+    // Single Members list, leads first, each lead tagged with a "Lead" badge
+    // so the roster reads as one Slack-style list rather than split sections.
+    const leads = memberRows
+      .filter((r) => r.agentSession && leadSet.has(r.agentSession))
+      .map((r) => ({ ...r, badge: 'Lead' }));
     const rest = memberRows.filter((r) => !(r.agentSession && leadSet.has(r.agentSession)));
     const out: ConversationGroup[] = [];
     if (huddleRows.length > 0) out.push({ id: 'team-huddle', label: 'Team huddle', rows: huddleRows });
-    if (leads.length > 0) out.push({ id: 'team-lead', label: 'Team lead', rows: leads });
-    if (rest.length > 0) out.push({ id: 'team-members', label: 'Members', rows: rest });
+    const members = [...leads, ...rest];
+    if (members.length > 0) out.push({ id: 'team-members', label: 'Members', rows: members });
     return out;
   }, [
     resolvedWorkspaceId,

--- a/packages/chat-ui/src/components/ConversationListPanel.test.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.test.tsx
@@ -95,6 +95,22 @@ describe('ConversationListPanel', () => {
     expect(screen.getByTestId('conv-unread-pill-c-proj-onboarding')).toHaveTextContent('3');
   });
 
+  it('renders a role badge pill next to the title when row.badge is set', () => {
+    const groups: ConversationGroup[] = [
+      {
+        id: 'members',
+        label: 'Members',
+        rows: [
+          { id: 'dm-lead', kind: 'dm', title: 'Maya', badge: 'Lead' },
+          { id: 'dm-plain', kind: 'dm', title: 'Alex' },
+        ],
+      },
+    ];
+    renderPanel({ groups });
+    expect(screen.getByTestId('conv-badge-dm-lead')).toHaveTextContent('Lead');
+    expect(screen.queryByTestId('conv-badge-dm-plain')).not.toBeInTheDocument();
+  });
+
   it('marks the active row with data-active=true and aria-current', () => {
     renderPanel({ activeConversationId: 'c-general' });
     const row = screen.getByTestId('conv-row-c-general');

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -310,6 +310,14 @@ function ConversationRowItem({
           >
             {row.title}
           </span>
+          {row.badge && (
+            <span
+              className="shrink-0 rounded bg-indigo-100 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300"
+              data-testid={`conv-badge-${row.id}`}
+            >
+              {row.badge}
+            </span>
+          )}
           {row.lastMessageAt && (
             <time
               className="ml-auto shrink-0 text-[10px] text-slate-400 dark:text-slate-500"

--- a/packages/chat-ui/src/types/team-chat.types.ts
+++ b/packages/chat-ui/src/types/team-chat.types.ts
@@ -118,6 +118,12 @@ export interface ConversationRow {
    * through to AgentStatusBadge for live presence subscription.
    */
   agentSession?: string;
+  /**
+   * Optional short role tag rendered as an inline pill next to the title —
+   * e.g. `Lead` to mark a team lead inside the members list. ADDITIVE and
+   * Portal-safe; rows without it render unchanged.
+   */
+  badge?: string;
 }
 
 /**


### PR DESCRIPTION
## What
A selected team's roster used to split into separate **Team lead** and **Members** sections. This merges them into one Slack-style **Members** list — leads first, each lead carrying an inline **Lead** badge pill — matching the single-list layout users see in the chat panel.

## Changes
- `ConversationRow` gains an additive, Portal-safe `badge?: string`.
- `ConversationListPanel` renders the badge as a small pill beside the title (`conv-badge-<id>`).
- `LiveTeamChatPage` tags lead rows with `badge: 'Lead'`, keeps lead-first ordering, and drops the separate `team-lead` group.

## Tests
- chat-ui: badge pill renders only when `row.badge` is set (17 passed).
- frontend: leads appear in the single Members list with a Lead badge, lead-first ordering preserved (17 passed).
- Full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)