### PR TITLE
feat(chat): show team → sub-team hierarchy in the workspace rail

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -62,6 +62,9 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = function noop() {
     /* no-op */
   };
+  // Rail collapse + group-collapse state persist to localStorage; clear it so
+  // one test's collapse choices don't leak into another's initial render.
+  window.localStorage.clear();
 });
 
 const MENTIONABLES: MentionTarget[] = [
@@ -231,6 +234,44 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     const lead = screen.getByTestId('conv-row-dm-maya');
     const member = screen.getByTestId('conv-row-dm-alex');
     expect(lead.compareDocumentPosition(member) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('nests a sub-team under its parent in the rail (parentTeamId → parentId)', async () => {
+    const { client } = makeStubClient([orcDm]);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[
+          { id: 'crewly', name: 'Crewly', leaderSessions: [], memberSessions: [] },
+          {
+            id: 'mktg',
+            name: 'Crewly Marketing',
+            leaderSessions: [],
+            memberSessions: [],
+            parentTeamId: 'crewly',
+          },
+          // Orphan parent reference → renders as a clean top-level root.
+          {
+            id: 'evership',
+            name: 'Evership',
+            leaderSessions: [],
+            memberSessions: [],
+            parentTeamId: 'missing-team',
+          },
+        ]}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('workspace-row-home')).toBeInTheDocument());
+    // The sub-team is marked nested under Crewly; standalone teams are not.
+    expect(screen.getByTestId('workspace-row-team:mktg')).toHaveAttribute('data-nested', 'true');
+    expect(screen.getByTestId('workspace-row-team:crewly')).toHaveAttribute('data-nested', 'false');
+    expect(screen.getByTestId('workspace-row-team:evership')).toHaveAttribute('data-nested', 'false');
+    // The parent gets a collapse chevron; collapsing it hides the sub-team.
+    expect(screen.getByTestId('workspace-collapse-team:crewly')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('workspace-collapse-team:crewly'));
+    expect(screen.queryByTestId('workspace-row-team:mktg')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workspace-row-team:crewly')).toBeInTheDocument();
   });
 
   it('AC#1: MentionComposer onSend posts a string[] of mention IDs', async () => {

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -27,7 +27,7 @@
  * @module components/Chat-team/LiveTeamChatPage
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Home, ChevronDown, ChevronRight, MessageSquare } from 'lucide-react';
 import {
   ChatAPIProvider,
@@ -64,6 +64,9 @@ import { ORCHESTRATOR_SESSION, ORCHESTRATOR_LABEL } from '../../utils/team-chat.
 /** Rail identifier for the Home (default) entry. */
 export const HOME_ID = 'home';
 
+/** localStorage key for the rail's collapsed parent-team ids. */
+const RAIL_COLLAPSE_KEY = 'crewly-chat-rail-collapsed';
+
 /** Build the rail workspace id for a team (so deep-links can target it). */
 export function teamRailId(teamId: string): string {
   return `team:${teamId}`;
@@ -80,6 +83,11 @@ export interface ChatTeam {
   leaderSessions: string[];
   /** Session names of every member of the team. */
   memberSessions: string[];
+  /**
+   * Parent team id, when this team is a sub-team. Drives the rail's nested
+   * parent → sub-team grouping. Undefined for a top-level (standalone) team.
+   */
+  parentTeamId?: string;
 }
 
 export interface LiveTeamChatPageProps {
@@ -278,11 +286,20 @@ function LiveTeamChatPageBody({
       icon: <Home className="h-5 w-5" />,
       tooltip: 'Home — orchestrator, pinned chats & huddles',
     };
-    const teamItems: Workspace[] = teams.map((t) => ({
-      id: `team:${t.id}`,
-      name: t.name,
-      kind: 'team' as const,
-    }));
+    // Only nest under a parent that is itself a present team in the rail —
+    // a parentTeamId pointing at a missing/hidden team renders as a clean root
+    // (defensive against stale config), and self-references are ignored.
+    const presentIds = new Set(teams.map((t) => t.id));
+    const teamItems: Workspace[] = teams.map((t) => {
+      const hasParent =
+        !!t.parentTeamId && t.parentTeamId !== t.id && presentIds.has(t.parentTeamId);
+      return {
+        id: teamRailId(t.id),
+        name: t.name,
+        kind: 'team' as const,
+        ...(hasParent ? { parentId: teamRailId(t.parentTeamId!) } : {}),
+      };
+    });
     return [home, ...teamItems];
   }, [teams]);
 
@@ -294,6 +311,54 @@ function LiveTeamChatPageBody({
   );
   // Home is the default landing.
   const resolvedWorkspaceId = activeWorkspaceId ?? HOME_ID;
+
+  // Collapsed parent-team rail tiles (their sub-teams are hidden). Persisted so
+  // the user's collapse choices survive reloads; default is everything expanded.
+  const [collapsedParentIds, setCollapsedParentIds] = useState<string[]>(() => {
+    try {
+      const raw = localStorage.getItem(RAIL_COLLAPSE_KEY);
+      if (raw) {
+        const arr = JSON.parse(raw);
+        if (Array.isArray(arr)) return arr.filter((x) => typeof x === 'string');
+      }
+    } catch {
+      // ignore — collapse state is best-effort
+    }
+    return [];
+  });
+
+  const toggleRailCollapse = useCallback((parentId: string) => {
+    setCollapsedParentIds((prev) => {
+      const next = prev.includes(parentId)
+        ? prev.filter((id) => id !== parentId)
+        : [...prev, parentId];
+      try {
+        localStorage.setItem(RAIL_COLLAPSE_KEY, JSON.stringify(next));
+      } catch {
+        // ignore — best-effort persistence
+      }
+      return next;
+    });
+  }, []);
+
+  // Deep-link safety: if the selected workspace is a sub-team whose parent is
+  // collapsed (e.g. via `?team=`), auto-expand the parent so the active tile is
+  // visible in the rail rather than hidden.
+  useEffect(() => {
+    const ws = workspaces.find((w) => w.id === resolvedWorkspaceId);
+    const parentId = ws?.parentId;
+    if (!parentId) return;
+    setCollapsedParentIds((prev) => {
+      if (!prev.includes(parentId)) return prev;
+      const next = prev.filter((id) => id !== parentId);
+      try {
+        localStorage.setItem(RAIL_COLLAPSE_KEY, JSON.stringify(next));
+      } catch {
+        // ignore — best-effort persistence
+      }
+      return next;
+    });
+  }, [resolvedWorkspaceId, workspaces]);
 
   // All conversations, unscoped — re-bucketed per rail selection below.
   const allGroups = useGroupedChannels(mergedChannels, { workspaceId: undefined });
@@ -484,6 +549,8 @@ function LiveTeamChatPageBody({
           activeWorkspaceId={resolvedWorkspaceId}
           onSelectWorkspace={handleSelectWorkspace}
           showLabels
+          collapsedParentIds={collapsedParentIds}
+          onToggleCollapse={toggleRailCollapse}
         />
       )}
 

--- a/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
@@ -8,16 +8,23 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Team } from '../../types';
-import { DM_WORKSPACE_ID, ORCHESTRATOR_SESSION } from '../../utils/team-chat.utils';
+import { ORCHESTRATOR_SESSION } from '../../utils/team-chat.utils';
+import { HOME_ID, teamRailId } from './LiveTeamChatPage';
 
-// Capture the props LiveTeamChatPage is rendered with.
+// Capture the props LiveTeamChatPage is rendered with. Keep the module's real
+// exports (HOME_ID / teamRailId, which TeamChatRoute imports) and only stub the
+// component so we don't mount the full chat surface.
 const liveProps = vi.fn();
-vi.mock('./LiveTeamChatPage', () => ({
-  LiveTeamChatPage: (props: Record<string, unknown>) => {
-    liveProps(props);
-    return <div data-testid="live-team-chat" />;
-  },
-}));
+vi.mock('./LiveTeamChatPage', async (importActual) => {
+  const actual = await importActual<typeof import('./LiveTeamChatPage')>();
+  return {
+    ...actual,
+    LiveTeamChatPage: (props: Record<string, unknown>) => {
+      liveProps(props);
+      return <div data-testid="live-team-chat" />;
+    },
+  };
+});
 
 // Control the teams the wrapper derives labels/mentionables from.
 const teamsRef: { teams: Team[] } = { teams: [] };
@@ -84,7 +91,7 @@ describe('TeamChatRoute', () => {
     vi.unstubAllGlobals();
   });
 
-  it('ensures the orchestrator DM and defaults to it in the DM workspace (no ?team=)', async () => {
+  it('ensures the orchestrator DM and lands on Home by default (no ?team=)', async () => {
     renderAt('/team-chat');
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
@@ -92,15 +99,18 @@ describe('TeamChatRoute', () => {
     const dmCall = fetchMock.mock.calls.find((c) => c[0] === '/api/chat/channels/dm/ensure');
     expect(dmCall).toBeTruthy();
     expect(bodyOf(dmCall!)).toMatchObject({ agentSession: ORCHESTRATOR_SESSION });
-    // No team ensure when there's no ?team=.
-    expect(fetchMock.mock.calls.some((c) => c[0] === '/api/chat/channels/team/ensure')).toBe(false);
+    // Every team's huddle is ensured up-front (so each rail icon has its
+    // all-members channel), even without a ?team= deep-link.
+    const teamEnsures = fetchMock.mock.calls
+      .filter((c) => c[0] === '/api/chat/channels/team/ensure')
+      .map((c) => bodyOf(c).teamId);
+    expect(teamEnsures).toEqual(expect.arrayContaining(['t1', 't2']));
 
     await screen.findByTestId('live-team-chat');
     expect(liveProps).toHaveBeenCalledWith(
       expect.objectContaining({
-        initialWorkspaceId: DM_WORKSPACE_ID,
+        initialWorkspaceId: HOME_ID,
         initialConversationId: 'orc-chan',
-        directMessagesWorkspace: { id: DM_WORKSPACE_ID, name: expect.any(String) },
       }),
     );
   });
@@ -111,13 +121,16 @@ describe('TeamChatRoute', () => {
     await waitFor(() =>
       expect(fetchMock.mock.calls.some((c) => c[0] === '/api/chat/channels/team/ensure')).toBe(true),
     );
-    const teamCall = fetchMock.mock.calls.find((c) => c[0] === '/api/chat/channels/team/ensure');
-    expect(bodyOf(teamCall!)).toEqual({ teamId: 't2' });
+    // The deep-linked team's huddle is ensured (among all teams' huddles).
+    const teamEnsures = fetchMock.mock.calls
+      .filter((c) => c[0] === '/api/chat/channels/team/ensure')
+      .map((c) => bodyOf(c).teamId);
+    expect(teamEnsures).toContain('t2');
 
     await screen.findByTestId('live-team-chat');
-    // Deep-link focuses the team; conversation auto-selects within it.
+    // Deep-link focuses the team's rail icon; conversation auto-selects within it.
     expect(liveProps).toHaveBeenCalledWith(
-      expect.objectContaining({ initialWorkspaceId: 't2', initialConversationId: null }),
+      expect.objectContaining({ initialWorkspaceId: teamRailId('t2'), initialConversationId: null }),
     );
   });
 
@@ -126,7 +139,7 @@ describe('TeamChatRoute', () => {
     renderAt('/team-chat');
     await screen.findByTestId('live-team-chat');
     expect(liveProps).toHaveBeenCalledWith(
-      expect.objectContaining({ initialWorkspaceId: DM_WORKSPACE_ID }),
+      expect.objectContaining({ initialWorkspaceId: HOME_ID }),
     );
   });
 

--- a/frontend/src/components/Chat-team/TeamChatRoute.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.tsx
@@ -113,7 +113,7 @@ export function TeamChatRoute(): JSX.Element {
         .filter((m) => m.sessionName && (leadIdSet.has(m.id) || m.hierarchyLevel === 1))
         .map((m) => m.sessionName);
       const memberSessions = members.filter((m) => m.sessionName).map((m) => m.sessionName);
-      return { id: t.id, name: t.name, leaderSessions, memberSessions };
+      return { id: t.id, name: t.name, leaderSessions, memberSessions, parentTeamId: t.parentTeamId };
     });
   }, [teams]);
 

--- a/packages/chat-ui/src/components/WorkspaceRail.test.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.test.tsx
@@ -135,6 +135,46 @@ describe('WorkspaceRail', () => {
     expect(screen.getByText('Customer Engineering')).toBeInTheDocument();
   });
 
+  it('renders a parent collapse chevron only in caption mode with onToggleCollapse', () => {
+    // No chevron in the default (icon) layout / without the collapse handler.
+    const { rerender } = render(<WorkspaceRail workspaces={fixture} showLabels />);
+    expect(screen.queryByTestId('workspace-collapse-org-crewly')).not.toBeInTheDocument();
+    // With showLabels (caption) AND a toggle handler, the parent gets a chevron.
+    rerender(<WorkspaceRail workspaces={fixture} showLabels onToggleCollapse={() => {}} />);
+    expect(screen.getByTestId('workspace-collapse-org-crewly')).toBeInTheDocument();
+    // A leaf child does not get a chevron.
+    expect(screen.queryByTestId('workspace-collapse-team-product')).not.toBeInTheDocument();
+  });
+
+  it('renders a connector spine on nested child tiles in caption mode', () => {
+    render(<WorkspaceRail workspaces={fixture} showLabels onToggleCollapse={() => {}} />);
+    expect(screen.getByTestId('workspace-spine-team-product')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-spine-team-marketing')).toBeInTheDocument();
+    // Roots/parents have no spine.
+    expect(screen.queryByTestId('workspace-spine-org-crewly')).not.toBeInTheDocument();
+  });
+
+  it('hides children of a collapsed parent but keeps the parent visible', () => {
+    render(
+      <WorkspaceRail
+        workspaces={fixture}
+        showLabels
+        onToggleCollapse={() => {}}
+        collapsedParentIds={['org-crewly']}
+      />,
+    );
+    expect(screen.getByTestId('workspace-row-org-crewly')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-row-team-product')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-row-team-marketing')).not.toBeInTheDocument();
+  });
+
+  it('invokes onToggleCollapse with the parent id when the chevron is clicked', async () => {
+    const onToggle = vi.fn();
+    render(<WorkspaceRail workspaces={fixture} showLabels onToggleCollapse={onToggle} />);
+    await userEvent.click(screen.getByTestId('workspace-collapse-org-crewly'));
+    expect(onToggle).toHaveBeenCalledWith('org-crewly');
+  });
+
   it('renders a host-injected icon node over avatar/initials', () => {
     render(
       <WorkspaceRail

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -52,6 +52,19 @@ export interface WorkspaceRailProps {
    * `expanded`. Default false preserves the icon-only rail for existing callers.
    */
   showLabels?: boolean;
+  /**
+   * ADDITIVE. Parent workspace ids the user has collapsed — their child
+   * workspaces are hidden until expanded. When omitted, nothing is collapsed
+   * (every child visible), preserving today's behavior for callers (incl.
+   * Portal) that don't manage collapse state.
+   */
+  collapsedParentIds?: string[];
+  /**
+   * ADDITIVE. Called when the user clicks a parent's collapse chevron. Only
+   * when provided (and in caption layout) does a parent render the chevron —
+   * so callers that don't pass it get the flat, always-expanded rail.
+   */
+  onToggleCollapse?(parentId: string): void;
   className?: string;
 }
 
@@ -69,12 +82,33 @@ export function WorkspaceRail({
   onSelectWorkspace,
   expanded = false,
   showLabels = false,
+  collapsedParentIds,
+  onToggleCollapse,
   className = '',
 }: WorkspaceRailProps): JSX.Element {
   // Deterministic order: roots in their original order, each followed by
   // its children. Preserves caller intent while keeping the visual
   // grouping in §6.1 ("Crewly" parent contains Product, Marketing).
   const ordered = useMemo(() => orderByParent(workspaces), [workspaces]);
+
+  // Workspaces that are a parent of at least one child — they get the
+  // collapse chevron + act as a group header for their nested tiles.
+  const parentIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const w of workspaces) if (w.parentId) set.add(w.parentId);
+    return set;
+  }, [workspaces]);
+
+  const collapsed = useMemo(
+    () => new Set(collapsedParentIds ?? []),
+    [collapsedParentIds],
+  );
+
+  // Hide children whose parent is collapsed. Parents and roots always show.
+  const visible = useMemo(
+    () => ordered.filter((w) => !(w.parentId && collapsed.has(w.parentId))),
+    [ordered, collapsed],
+  );
 
   // Three layouts: `beside` (tablet `expanded`, label to the right, wide),
   // `caption` (host `showLabels` — Slack-style icon with a small label beneath,
@@ -91,17 +125,20 @@ export function WorkspaceRail({
       data-labelled={layout !== 'icon' ? 'true' : 'false'}
       data-layout={layout}
     >
-      {ordered.map((ws) => (
+      {visible.map((ws) => (
         <WorkspaceRow
           key={ws.id}
           workspace={ws}
           isActive={activeWorkspaceId === ws.id}
           isNested={!!ws.parentId}
+          isParent={parentIds.has(ws.id)}
+          isCollapsed={collapsed.has(ws.id)}
           layout={layout}
           onSelect={onSelectWorkspace}
+          onToggleCollapse={onToggleCollapse}
         />
       ))}
-      {ordered.length === 0 && <RailEmpty />}
+      {visible.length === 0 && <RailEmpty />}
     </nav>
   );
 }
@@ -113,14 +150,22 @@ function WorkspaceRow({
   workspace,
   isActive,
   isNested,
+  isParent = false,
+  isCollapsed = false,
   layout,
   onSelect,
+  onToggleCollapse,
 }: {
   workspace: Workspace;
   isActive: boolean;
   isNested: boolean;
+  /** True when this workspace has child workspaces nested under it. */
+  isParent?: boolean;
+  /** True when this parent is collapsed (children hidden). */
+  isCollapsed?: boolean;
   layout: RailLayout;
   onSelect?: (w: Workspace) => void;
+  onToggleCollapse?: (parentId: string) => void;
 }): JSX.Element {
   const initials = workspace.initials ?? deriveInitials(workspace.name);
   const isActivity = workspace.kind === 'activity';
@@ -130,6 +175,13 @@ function WorkspaceRow({
   const hasGlyph = workspace.icon != null || workspace.avatar != null;
   const caption = layout === 'caption';
   const beside = layout === 'beside';
+  // A nested child in the caption rail gets a connector spine + slight inset +
+  // a smaller glyph, so the parent → sub-team relationship reads at a glance
+  // without aggressive indentation at the narrow w-24 width.
+  const childInset = caption && isNested;
+  // Parents render a collapse chevron only when the host wires collapse and
+  // we're in the labelled caption rail (the OSS chat host's layout).
+  const showChevron = caption && isParent && !!onToggleCollapse;
 
   // Indicator dot — mention > unread > presence (§8.2). Positioned on the glyph.
   const dot = workspace.hasMentions ? (
@@ -154,7 +206,7 @@ function WorkspaceRow({
     />
   ) : null;
 
-  return (
+  const rowButton = (
     <button
       type="button"
       onClick={() => onSelect?.(workspace)}
@@ -175,6 +227,8 @@ function WorkspaceRow({
           : 'text-slate-200 hover:bg-slate-800',
         // Indent nested children one notch (beside layout only).
         isNested && !caption ? 'ml-4' : '',
+        // Caption child: inset the tile so the connector spine sits at its left.
+        childInset ? 'ml-3' : '',
       ].join(' ')}
       aria-current={isActive ? 'page' : undefined}
       aria-label={
@@ -185,9 +239,11 @@ function WorkspaceRow({
         <span
           aria-hidden="true"
           className={[
-            'flex h-9 w-9 items-center justify-center rounded-lg font-semibold',
+            'flex items-center justify-center rounded-lg font-semibold',
+            // Child tiles are a notch smaller than parents/roots.
+            childInset ? 'h-7 w-7' : 'h-9 w-9',
             // A vector icon / emoji glyph is not uppercased; initials are.
-            hasGlyph ? 'text-lg' : 'text-sm uppercase',
+            hasGlyph ? (childInset ? 'text-base' : 'text-lg') : childInset ? 'text-[10px] uppercase' : 'text-sm uppercase',
             isHome
               ? 'bg-slate-700 text-white ring-1 ring-slate-500'
               : isActivity
@@ -211,6 +267,56 @@ function WorkspaceRow({
         </span>
       )}
     </button>
+  );
+
+  // Bare button is the common case. In the caption rail, a child tile gets a
+  // connector spine up to its parent, and a parent tile gets a collapse
+  // chevron — both need a positioned wrapper around the button.
+  if (!childInset && !showChevron) return rowButton;
+  return (
+    <div className="relative">
+      {childInset && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-1 left-3 top-0 w-px bg-slate-700"
+          data-testid={`workspace-spine-${workspace.id}`}
+        />
+      )}
+      {rowButton}
+      {showChevron && (
+        <button
+          type="button"
+          onClick={() => onToggleCollapse?.(workspace.id)}
+          data-testid={`workspace-collapse-${workspace.id}`}
+          aria-label={isCollapsed ? `Expand ${workspace.name}` : `Collapse ${workspace.name}`}
+          aria-expanded={!isCollapsed}
+          title={isCollapsed ? 'Expand sub-teams' : 'Collapse sub-teams'}
+          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-700 hover:text-slate-100"
+        >
+          <RailChevron collapsed={isCollapsed} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Collapse chevron for a parent rail tile — points right (collapsed) / down. */
+function RailChevron({ collapsed }: { collapsed: boolean }): JSX.Element {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 12 12"
+      className={`h-3 w-3 transition-transform ${collapsed ? '' : 'rotate-90'}`}
+    >
+      <path
+        d="M4 2l4 4-4 4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## What
A parent team (e.g. **Crewly**) now visually groups its sub-teams (Marketing, Product, Support) directly beneath it in the chat workspace rail, instead of a flat list. Child tiles are inset on a 1px connector **spine** with a slightly smaller glyph; the parent tile gets a **collapse chevron**. Standalone teams (Evership, Think Tank) stay as flat top-level tiles.

```
🏠 Home
CR ▾  Crewly          ← parent, chevron toggles collapse
│ MK •   Marketing     ← spine + inset child
│ PR     Product
│ SP ●   Support
EV    Evership         ← standalone, no spine
```

## How (reuses existing infra)
- `Workspace.parentId` + `orderByParent()` (already parent-before-children, orphan-safe) drive the grouping. The host sets `parentId` from the **existing** `Team.parentTeamId`.
- `WorkspaceRail` gains additive, **Portal-safe** `collapsedParentIds` + `onToggleCollapse` props. The chevron only renders in the caption layout when a handler is wired, so other callers (incl. Portal) are unchanged.
- The caption-layout indent + spine were unlocked (previously `beside`-layout only).

## Host wiring
- `ChatTeam` carries `parentTeamId`; nesting applies only when the parent is itself a present rail team (orphan / self references fall back to a clean root).
- Collapse state persists to `localStorage`; a `?team=` deep-link to a collapsed sub-team **auto-expands** its parent so the tile is visible.

## Also
Repairs `TeamChatRoute.test.tsx`, which was **stale** against the earlier `HOME_ID` rail refactor (it asserted the removed `DM_WORKSPACE_ID` / `directMessagesWorkspace` model, and its mock omitted `HOME_ID`/`teamRailId`, so it module-errored on `main`). Rewritten to the current behavior via `importActual`.

## Tests
- chat-ui: 190/190 (added rail chevron / spine / collapse / hide-children tests).
- frontend Chat-team: 64/64 (added parent→sub-team nesting + collapse test; fixed stale route test).
- Full build clean.

> Note: nesting only appears once teams actually have `parentTeamId` set in config — none are nested yet in the current data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)