### PR TITLE
style(chat): align chat surfaces with Crewly's dark token palette

### DIFF
--- a/frontend/src/components/Chat-team/EmptyStates.tsx
+++ b/frontend/src/components/Chat-team/EmptyStates.tsx
@@ -31,8 +31,8 @@ function EmptyShell({ headline, body, cta, testId }: EmptyShellProps): JSX.Eleme
       data-testid={testId}
       className="flex h-full flex-col items-center justify-center gap-3 px-8 py-12 text-center"
     >
-      <h3 className="text-base font-semibold text-slate-700 dark:text-slate-200">{headline}</h3>
-      <div className="max-w-md text-sm text-slate-500 dark:text-slate-400">{body}</div>
+      <h3 className="text-base font-semibold text-text-primary-dark">{headline}</h3>
+      <div className="max-w-md text-sm text-text-secondary-dark">{body}</div>
       {cta && <div className="mt-2">{cta}</div>}
     </div>
   );
@@ -52,7 +52,7 @@ export function NoTeamsEmptyState(): JSX.Element {
       cta={
         <button
           type="button"
-          className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700"
+          className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary/90"
         >
           Open team builder
         </button>
@@ -80,19 +80,19 @@ export function NoChannelsEmptyState({ teamName }: { teamName: string }): JSX.El
         <div className="flex flex-wrap items-center justify-center gap-2 text-xs">
           <button
             type="button"
-            className="rounded-md bg-slate-200 px-3 py-1.5 font-medium text-slate-700 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+            className="rounded-md bg-surface-dark px-3 py-1.5 font-medium text-text-primary-dark ring-1 ring-border-dark hover:bg-border-dark"
           >
             Message team lead
           </button>
           <button
             type="button"
-            className="rounded-md bg-slate-200 px-3 py-1.5 font-medium text-slate-700 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+            className="rounded-md bg-surface-dark px-3 py-1.5 font-medium text-text-primary-dark ring-1 ring-border-dark hover:bg-border-dark"
           >
             Open project channel
           </button>
           <button
             type="button"
-            className="rounded-md bg-slate-200 px-3 py-1.5 font-medium text-slate-700 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+            className="rounded-md bg-surface-dark px-3 py-1.5 font-medium text-text-primary-dark ring-1 ring-border-dark hover:bg-border-dark"
           >
             Start DM
           </button>
@@ -158,7 +158,7 @@ export function AgentOfflineBanner({ agentName }: { agentName: string }): JSX.El
     <div
       role="alert"
       data-testid="banner-agent-offline"
-      className="border-b border-amber-300 bg-amber-50 px-4 py-2 text-xs text-amber-800 dark:border-amber-600/40 dark:bg-amber-900/20 dark:text-amber-100"
+      className="border-b border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-200"
     >
       <strong>{agentName} is currently inactive.</strong> Sending a message will activate{' '}
       {agentName} and deliver it once the session is up.

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -527,7 +527,7 @@ function LiveTeamChatPageBody({
   if (workspaces.length === 0 && !channelsLoading) {
     return (
       <div
-        className="flex h-full w-full items-center justify-center bg-slate-50 dark:bg-slate-950"
+        className="flex h-full w-full items-center justify-center bg-background-dark"
         data-testid="team-chat-page"
       >
         <NoTeamsEmptyState />
@@ -537,7 +537,7 @@ function LiveTeamChatPageBody({
 
   return (
     <div
-      className="flex h-full w-full bg-slate-50 dark:bg-slate-950"
+      className="flex h-full w-full bg-background-dark"
       data-testid="team-chat-page"
       data-loading={channelsLoading ? 'true' : 'false'}
       data-error={channelsError ? 'true' : 'false'}
@@ -568,7 +568,7 @@ function LiveTeamChatPageBody({
           <button
             type="button"
             onClick={() => setShowCreateGroup(true)}
-            className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-600 hover:bg-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            className="rounded-md border border-border-dark px-2 py-1 text-xs font-medium text-text-secondary-dark hover:bg-surface-dark hover:text-text-primary-dark"
             data-testid="new-group-button"
             title="Create a multi-agent group chat"
           >
@@ -627,7 +627,7 @@ function LiveTeamChatRightPanel({
   if (!conversation) {
     return (
       <section
-        className="flex flex-1 items-center justify-center bg-slate-50 text-sm text-slate-500 dark:bg-slate-950"
+        className="flex flex-1 items-center justify-center bg-background-dark text-sm text-text-secondary-dark"
         data-testid="team-chat-right-panel"
         aria-label="Conversation thread"
       >
@@ -728,18 +728,18 @@ function LiveTeamChatRightPanelInner({
 
   return (
     <section
-      className="flex flex-1 flex-col bg-white dark:bg-slate-900"
+      className="flex flex-1 flex-col bg-background-dark"
       data-testid="team-chat-right-panel"
       aria-label={`Conversation with ${conversation.title}`}
       data-thread-active={threadRoot ? 'true' : 'false'}
     >
-      <header className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+      <header className="flex items-center justify-between border-b border-border-dark px-4 py-3">
         <div className="min-w-0">
-          <h2 className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+          <h2 className="truncate text-sm font-semibold text-text-primary-dark">
             {conversation.kind === 'channel' ? `#${conversation.title}` : conversation.title}
           </h2>
           {conversation.subtitle && (
-            <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+            <p className="truncate text-xs text-text-secondary-dark">
               {conversation.subtitle}
             </p>
           )}
@@ -752,7 +752,7 @@ function LiveTeamChatRightPanelInner({
             type="button"
             onClick={handleEnterThread}
             data-testid="thread-enter"
-            className="rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            className="rounded-md border border-border-dark px-2 py-1 text-xs text-text-secondary-dark hover:bg-surface-dark hover:text-text-primary-dark"
           >
             Reply in thread
           </button>
@@ -761,7 +761,7 @@ function LiveTeamChatRightPanelInner({
 
       {showSlackBar && (
         <div
-          className="border-b border-slate-200 dark:border-slate-700"
+          className="border-b border-border-dark"
           data-testid="slack-threads-bar"
         >
           <div className="flex items-center justify-between px-4 py-2">
@@ -770,7 +770,7 @@ function LiveTeamChatRightPanelInner({
               onClick={() => setSlackOpen((o) => !o)}
               aria-expanded={slackOpen}
               data-testid="slack-threads-toggle"
-              className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+              className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-secondary-dark"
             >
               {slackOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
               Slack threads · {slackThreads.length}
@@ -780,7 +780,7 @@ function LiveTeamChatRightPanelInner({
                 type="button"
                 onClick={() => onSelectConversation(orcRow)}
                 data-testid="slack-back-to-orc"
-                className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                className="text-xs text-primary hover:underline"
               >
                 ← Orchestrator
               </button>
@@ -796,8 +796,8 @@ function LiveTeamChatRightPanelInner({
                     data-testid={`slack-thread-${t.id}`}
                     className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
                       t.id === conversation.id
-                        ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
-                        : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-text-secondary-dark hover:bg-surface-dark hover:text-text-primary-dark'
                     }`}
                   >
                     <MessageSquare size={13} className="shrink-0 opacity-60" />
@@ -870,16 +870,16 @@ function ThreadReplyBanner({
     <div
       role="note"
       data-testid="thread-reply-banner"
-      className="flex items-center justify-between gap-2 border-t border-slate-200 bg-slate-100 px-4 py-1.5 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
+      className="flex items-center justify-between gap-2 border-t border-border-dark bg-surface-dark px-4 py-1.5 text-xs text-text-secondary-dark"
     >
       <span>
-        Replying to thread <code className="rounded bg-slate-200 px-1 dark:bg-slate-700">{threadRootId}</code>
+        Replying to thread <code className="rounded bg-background-dark px-1">{threadRootId}</code>
       </span>
       <button
         type="button"
         onClick={onExit}
         data-testid="thread-exit"
-        className="rounded px-2 py-0.5 text-slate-500 hover:bg-slate-200 dark:hover:bg-slate-700"
+        className="rounded px-2 py-0.5 text-text-secondary-dark hover:bg-background-dark hover:text-text-primary-dark"
       >
         Cancel
       </button>

--- a/packages/chat-ui/src/components/AgentStatusBadge.tsx
+++ b/packages/chat-ui/src/components/AgentStatusBadge.tsx
@@ -80,19 +80,19 @@ const STATUS_TEXT: Record<ResolvedStatus, string> = {
 };
 
 const STATUS_DOT: Record<ResolvedStatus, string> = {
-  online: 'bg-emerald-500',
+  online: 'bg-emerald-400',
   busy: 'bg-amber-400',
-  idle: 'bg-amber-300',
-  offline: 'bg-slate-400',
-  inactive: 'bg-slate-300',
+  idle: 'bg-amber-400',
+  offline: 'bg-gray-500',
+  inactive: 'bg-gray-500',
 };
 
 const STATUS_TEXT_COLOR: Record<ResolvedStatus, string> = {
-  online: 'text-emerald-600',
-  busy: 'text-amber-600',
-  idle: 'text-amber-600',
-  offline: 'text-slate-500',
-  inactive: 'text-slate-500',
+  online: 'text-emerald-400',
+  busy: 'text-amber-400',
+  idle: 'text-amber-400',
+  offline: 'text-text-secondary-dark',
+  inactive: 'text-text-secondary-dark',
 };
 
 export function AgentStatusBadge({

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -117,13 +117,13 @@ export function ConversationListPanel({
 
   return (
     <aside
-      className={`flex h-full w-72 flex-col border-r border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900 ${className}`}
+      className={`flex h-full w-72 flex-col border-r border-border-dark bg-surface-dark ${className}`}
       aria-label={workspaceName ? `${workspaceName} conversations` : 'Conversations'}
       data-testid="conversation-list-panel"
     >
       {(workspaceName || headerAction) && (
-        <header className="flex items-center justify-between gap-2 border-b border-slate-200 px-4 py-3 dark:border-slate-700">
-          <h2 className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+        <header className="flex items-center justify-between gap-2 border-b border-border-dark px-4 py-3">
+          <h2 className="truncate text-sm font-semibold text-text-primary-dark">
             {workspaceName ?? ''}
           </h2>
           {headerAction}
@@ -132,7 +132,7 @@ export function ConversationListPanel({
 
       <div className="flex-1 overflow-y-auto">
         {totalRows === 0 ? (
-          <div className="px-4 py-6 text-sm text-slate-500" role="status">
+          <div className="px-4 py-6 text-sm text-text-secondary-dark" role="status">
             {emptyState ?? 'No conversations in this workspace yet.'}
           </div>
         ) : (
@@ -194,7 +194,7 @@ function ConversationGroupSection({
 
   return (
     <section
-      className={depth === 0 ? 'border-b border-slate-200 py-2 last:border-b-0 dark:border-slate-800' : ''}
+      className={depth === 0 ? 'border-b border-border-dark py-2 last:border-b-0' : ''}
       aria-labelledby={`conv-group-${group.id}`}
       data-testid={`conv-group-${group.id}`}
     >
@@ -205,12 +205,12 @@ function ConversationGroupSection({
         onClick={() => onToggleCollapse(group.id)}
         aria-expanded={!isCollapsed}
         data-testid={`conv-group-toggle-${group.id}`}
-        className="flex w-full items-center gap-1 py-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+        className="flex w-full items-center gap-1 py-1 text-[11px] font-semibold uppercase tracking-wide text-text-secondary-dark hover:text-text-primary-dark"
         style={{ paddingLeft: `${0.75 + depth * 0.75}rem`, paddingRight: '0.75rem' }}
       >
         <Chevron collapsed={isCollapsed} />
         <span className="truncate">{group.label}</span>
-        <span className="ml-auto text-slate-400 dark:text-slate-500">{countRows(group)}</span>
+        <span className="ml-auto text-text-secondary-dark">{countRows(group)}</span>
       </button>
       {!isCollapsed && (
         <>
@@ -282,8 +282,8 @@ function ConversationRowItem({
       className={[
         'group/row relative flex w-full items-center border-l-2 transition',
         isActive
-          ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-          : 'border-transparent hover:bg-slate-100 dark:hover:bg-slate-800',
+          ? 'border-primary bg-primary/10'
+          : 'border-transparent hover:bg-background-dark',
       ].join(' ')}
     >
       <button
@@ -304,15 +304,15 @@ function ConversationRowItem({
             className={[
               'truncate text-sm',
               hasUnread
-                ? 'font-semibold text-slate-900 dark:text-slate-50'
-                : 'text-slate-700 dark:text-slate-300',
+                ? 'font-semibold text-text-primary-dark'
+                : 'text-text-secondary-dark',
             ].join(' ')}
           >
             {row.title}
           </span>
           {row.badge && (
             <span
-              className="shrink-0 rounded bg-indigo-100 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300"
+              className="shrink-0 rounded bg-primary/15 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide text-primary"
               data-testid={`conv-badge-${row.id}`}
             >
               {row.badge}
@@ -320,7 +320,7 @@ function ConversationRowItem({
           )}
           {row.lastMessageAt && (
             <time
-              className="ml-auto shrink-0 text-[10px] text-slate-400 dark:text-slate-500"
+              className="ml-auto shrink-0 text-[10px] text-text-secondary-dark"
               dateTime={row.lastMessageAt}
             >
               {formatRelativeTime(row.lastMessageAt)}
@@ -332,15 +332,15 @@ function ConversationRowItem({
             className={[
               'truncate text-xs',
               hasUnread
-                ? 'text-slate-600 dark:text-slate-300'
-                : 'text-slate-500 dark:text-slate-400',
+                ? 'text-text-primary-dark'
+                : 'text-text-secondary-dark',
             ].join(' ')}
           >
             {row.lastMessagePreview}
           </div>
         )}
         {row.subtitle && !row.lastMessagePreview && (
-          <div className="truncate text-xs text-slate-400 dark:text-slate-500">
+          <div className="truncate text-xs text-text-secondary-dark">
             {row.subtitle}
           </div>
         )}
@@ -357,7 +357,7 @@ function ConversationRowItem({
         </span>
       ) : hasUnread ? (
         <span
-          className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-slate-700 px-1 text-[10px] font-semibold text-white dark:bg-slate-300 dark:text-slate-900"
+          className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-white"
           data-testid={`conv-unread-pill-${row.id}`}
           aria-label={`${row.unreadCount} unread`}
         >
@@ -378,9 +378,9 @@ function ConversationRowItem({
           aria-pressed={pinned}
           title={pinned ? 'Unpin' : 'Pin'}
           className={[
-            'mr-2 shrink-0 rounded p-1 text-slate-400 hover:text-amber-500',
+            'mr-2 shrink-0 rounded p-1 text-text-secondary-dark hover:text-amber-400',
             // Pinned: always visible. Unpinned: reveal on row hover.
-            pinned ? 'text-amber-500' : 'opacity-0 group-hover/row:opacity-100',
+            pinned ? 'text-amber-400' : 'opacity-0 group-hover/row:opacity-100',
           ].join(' ')}
         >
           <PinIcon filled={pinned ?? false} />
@@ -414,7 +414,7 @@ function ConversationKindIcon({ row }: { row: ConversationRow }): JSX.Element {
     return (
       <span
         aria-hidden="true"
-        className="flex h-6 w-6 shrink-0 items-center justify-center text-base font-medium text-slate-500 dark:text-slate-400"
+        className="flex h-6 w-6 shrink-0 items-center justify-center text-base font-medium text-text-secondary-dark"
         data-testid={`conv-icon-${row.id}`}
       >
         #
@@ -425,12 +425,12 @@ function ConversationKindIcon({ row }: { row: ConversationRow }): JSX.Element {
     return (
       <span
         aria-hidden="true"
-        className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 text-[10px] font-semibold uppercase text-white"
+        className="relative flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary to-[#1e5fc7] text-[10px] font-semibold uppercase text-white"
         data-testid={`conv-icon-${row.id}`}
       >
         {deriveDmInitials(row.title)}
         {row.presence && (
-          <span className="absolute -bottom-0.5 -right-0.5 rounded-full bg-white p-[1px] dark:bg-slate-900">
+          <span className="absolute -bottom-0.5 -right-0.5 rounded-full bg-surface-dark p-[1px]">
             <AgentStatusBadge status={row.presence} compact />
           </span>
         )}
@@ -441,7 +441,7 @@ function ConversationKindIcon({ row }: { row: ConversationRow }): JSX.Element {
   return (
     <span
       aria-hidden="true"
-      className="flex h-6 w-6 shrink-0 items-center justify-center text-xs text-slate-400"
+      className="flex h-6 w-6 shrink-0 items-center justify-center text-xs text-text-secondary-dark"
       data-testid={`conv-icon-${row.id}`}
     >
       ⟳

--- a/packages/chat-ui/src/components/MentionComposer.tsx
+++ b/packages/chat-ui/src/components/MentionComposer.tsx
@@ -57,11 +57,11 @@ export interface MentionComposerProps {
 
 const DEFAULT_PLACEHOLDER = 'Message — try @ to mention a team or agent';
 const PRESENCE_DOT: Record<ChatPresenceStatus, string> = {
-  online: 'bg-emerald-500',
+  online: 'bg-emerald-400',
   busy: 'bg-amber-400',
-  idle: 'bg-amber-300',
-  offline: 'bg-slate-400',
-  inactive: 'bg-slate-300',
+  idle: 'bg-amber-400',
+  offline: 'bg-gray-500',
+  inactive: 'bg-gray-500',
 };
 
 export function MentionComposer({
@@ -164,7 +164,7 @@ export function MentionComposer({
 
   return (
     <div
-      className={`relative border-t border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900 ${className}`}
+      className={`relative border-t border-border-dark bg-surface-dark p-3 ${className}`}
       data-testid="mention-composer"
     >
       {mentions.length > 0 && (
@@ -191,14 +191,14 @@ export function MentionComposer({
           placeholder={placeholder}
           rows={2}
           data-testid="mention-textarea"
-          className="flex-1 resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          className="flex-1 resize-none rounded-lg border border-border-dark bg-background-dark px-3 py-2 text-sm text-text-primary-dark placeholder:text-text-secondary-dark shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
         />
         <button
           type="button"
           onClick={handleSend}
           disabled={!canSend}
           data-testid="mention-send"
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Send
         </button>
@@ -206,7 +206,7 @@ export function MentionComposer({
 
       {helperText && (
         <p
-          className="mt-1 text-[11px] text-slate-500 dark:text-slate-400"
+          className="mt-1 text-[11px] text-text-secondary-dark"
           data-testid="mention-helper"
         >
           {helperText}
@@ -241,7 +241,7 @@ function SuggestionPopover({
     <div
       role="listbox"
       data-testid="mention-suggestions"
-      className="absolute bottom-[110%] left-3 right-3 z-10 max-h-72 overflow-y-auto rounded-lg border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800"
+      className="absolute bottom-[110%] left-3 right-3 z-10 max-h-72 overflow-y-auto rounded-lg border border-border-dark bg-surface-dark shadow-lg"
     >
       {teams.length > 0 && (
         <SuggestionGroup label="Teams" items={teams} onSelect={onSelect} testid="teams" />
@@ -266,7 +266,7 @@ function SuggestionGroup({
 }): JSX.Element {
   return (
     <div data-testid={`mention-group-${testid}`}>
-      <div className="border-b border-slate-200 bg-slate-50 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+      <div className="border-b border-border-dark bg-background-dark px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-secondary-dark">
         {label}
       </div>
       <ul role="list">
@@ -276,14 +276,14 @@ function SuggestionGroup({
               type="button"
               onClick={() => onSelect(it)}
               data-testid={`mention-suggestion-${it.id}`}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-700"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-background-dark"
             >
               <MentionKindGlyph target={it} />
-              <span className="min-w-0 flex-1 truncate text-slate-800 dark:text-slate-100">
+              <span className="min-w-0 flex-1 truncate text-text-primary-dark">
                 {it.label}
               </span>
               {it.routingHint && (
-                <span className="shrink-0 text-[11px] text-slate-400 dark:text-slate-500">
+                <span className="shrink-0 text-[11px] text-text-secondary-dark">
                   {it.routingHint}
                 </span>
               )}
@@ -314,8 +314,8 @@ function MentionChip({
       className={[
         'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1',
         isTeam
-          ? 'bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-200 dark:ring-indigo-700'
-          : 'bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:ring-emerald-700',
+          ? 'bg-primary/15 text-primary ring-primary/30'
+          : 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/30',
       ].join(' ')}
     >
       <MentionKindGlyph target={target} compact />
@@ -345,7 +345,7 @@ function MentionKindGlyph({
         aria-hidden="true"
         className={`inline-flex items-center justify-center rounded ${
           compact ? 'h-3 w-3 text-[8px]' : 'h-5 w-5 text-[10px]'
-        } bg-indigo-200 font-semibold text-indigo-700 dark:bg-indigo-700 dark:text-indigo-100`}
+        } bg-primary/20 font-semibold text-primary`}
       >
         T
       </span>
@@ -354,7 +354,7 @@ function MentionKindGlyph({
   return (
     <span
       aria-hidden="true"
-      className={`relative inline-flex items-center justify-center rounded-full bg-emerald-200 font-semibold text-emerald-700 dark:bg-emerald-700 dark:text-emerald-100 ${
+      className={`relative inline-flex items-center justify-center rounded-full bg-emerald-500/20 font-semibold text-emerald-300 ${
         compact ? 'h-3 w-3 text-[8px]' : 'h-5 w-5 text-[10px]'
       }`}
     >
@@ -362,7 +362,7 @@ function MentionKindGlyph({
       {target.presence && (
         <span
           aria-hidden="true"
-          className={`absolute -bottom-0.5 -right-0.5 inline-block h-1.5 w-1.5 rounded-full ring-2 ring-white dark:ring-slate-900 ${
+          className={`absolute -bottom-0.5 -right-0.5 inline-block h-1.5 w-1.5 rounded-full ring-2 ring-surface-dark ${
             PRESENCE_DOT[target.presence]
           }`}
         />

--- a/packages/chat-ui/src/components/MessageInput.tsx
+++ b/packages/chat-ui/src/components/MessageInput.tsx
@@ -92,7 +92,7 @@ export function MessageInput({
 
   return (
     <div
-      className={`border-t border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900 ${className}`}
+      className={`border-t border-border-dark bg-surface-dark p-3 ${className}`}
       onDrop={handleDrop}
       onDragOver={handleDragOver}
       data-testid="message-input"
@@ -109,7 +109,7 @@ export function MessageInput({
               <button
                 type="button"
                 onClick={() => removeAttachment(a.id)}
-                className="absolute -right-1 -top-1 rounded-full bg-slate-900/80 px-1 text-[10px] leading-4 text-white"
+                className="absolute -right-1 -top-1 rounded-full bg-background-dark/80 px-1 text-[10px] leading-4 text-white"
                 aria-label={`Remove ${a.filename ?? 'attachment'}`}
               >
                 ×
@@ -128,13 +128,13 @@ export function MessageInput({
           disabled={!channelId || sending}
           placeholder={channelId ? placeholder : 'Select a channel to send a message.'}
           rows={2}
-          className="flex-1 resize-none rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          className="flex-1 resize-none rounded-lg border border-border-dark bg-background-dark px-3 py-2 text-sm text-text-primary-dark placeholder:text-text-secondary-dark shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
         />
         <button
           type="button"
           onClick={() => void handleSend()}
           disabled={!canSend}
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {sending ? 'Sending…' : 'Send'}
         </button>

--- a/packages/chat-ui/src/components/MessageThread.test.tsx
+++ b/packages/chat-ui/src/components/MessageThread.test.tsx
@@ -128,7 +128,8 @@ describe('MessageThread', () => {
     await waitFor(() => expect(screen.getByText(/Welcome/i)).toBeInTheDocument());
     // No iMessage bubble styling in flat mode.
     expect(container.querySelector('.rounded-2xl')).toBeNull();
-    expect(container.querySelector('.bg-blue-500')).toBeNull();
+    // The own-message bubble fill (brand primary) must not appear in flat mode.
+    expect(container.querySelector('.bg-primary')).toBeNull();
   });
 });
 

--- a/packages/chat-ui/src/components/MessageThread.tsx
+++ b/packages/chat-ui/src/components/MessageThread.tsx
@@ -85,7 +85,7 @@ export function MessageThread({
   if (!channelId) {
     return (
       <div
-        className={`flex h-full items-center justify-center text-sm text-slate-500 ${className}`}
+        className={`flex h-full items-center justify-center text-sm text-text-secondary-dark ${className}`}
         role="status"
       >
         {emptyState ?? 'Select a channel to start chatting.'}
@@ -95,16 +95,16 @@ export function MessageThread({
 
   return (
     <div
-      className={`flex h-full flex-col overflow-y-auto bg-slate-50 dark:bg-slate-950 ${className}`}
+      className={`flex h-full flex-col overflow-y-auto bg-background-dark ${className}`}
       aria-label="Message thread"
       data-testid="message-thread"
     >
       {hasMore && (
-        <div className="sticky top-0 z-10 flex justify-center bg-slate-50/80 py-2 backdrop-blur dark:bg-slate-950/80">
+        <div className="sticky top-0 z-10 flex justify-center bg-background-dark/80 py-2 backdrop-blur">
           <button
             type="button"
             onClick={() => void loadMore()}
-            className="rounded-full border border-slate-300 px-3 py-1 text-xs text-slate-600 hover:bg-white dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            className="rounded-full border border-border-dark px-3 py-1 text-xs text-text-secondary-dark hover:bg-surface-dark"
           >
             Load older
           </button>
@@ -120,7 +120,7 @@ export function MessageThread({
         {renderTimeline({ messages, unreadAfterSeq, unreadDividerLabel, layout })}
         {agentThinking && <AgentThinkingRow agentName={agentName} />}
         {loading && (
-          <li className="text-xs text-slate-400" role="status">
+          <li className="text-xs text-text-secondary-dark" role="status">
             Loading messages…
           </li>
         )}
@@ -212,8 +212,8 @@ function MessageRow({
   const alignment = isUser ? 'items-end' : 'items-start';
   const status = message.deliveryStatus;
   const baseBubble = isUser
-    ? 'bg-blue-500 text-white'
-    : 'bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100';
+    ? 'bg-primary text-white'
+    : 'bg-surface-dark text-text-primary-dark';
   const bubble =
     status === 'pending'
       ? `${baseBubble} opacity-60`
@@ -227,7 +227,7 @@ function MessageRow({
       data-author-role={message.author.role}
       data-delivery-status={status ?? 'sent'}
     >
-      <div className="mb-0.5 text-xs text-slate-500 dark:text-slate-400">
+      <div className="mb-0.5 text-xs text-text-secondary-dark">
         {message.author.name ?? message.author.id}
       </div>
       <div className={`max-w-prose rounded-2xl px-3 py-2 text-sm shadow-sm ${bubble}`}>
@@ -267,7 +267,7 @@ function FlatMessageRow({
 
   return (
     <li
-      className={`group flex gap-2 rounded px-2 hover:bg-slate-100 dark:hover:bg-slate-900 ${
+      className={`group flex gap-2 rounded px-2 hover:bg-surface-dark ${
         groupStart ? 'mt-3 pt-0.5' : ''
       }`}
       data-author-role={message.author.role}
@@ -277,7 +277,7 @@ function FlatMessageRow({
         {groupStart ? (
           <Avatar name={name} />
         ) : (
-          <time className="block w-9 pt-0.5 text-right text-[10px] leading-5 text-transparent group-hover:text-slate-400">
+          <time className="block w-9 pt-0.5 text-right text-[10px] leading-5 text-transparent group-hover:text-text-secondary-dark">
             {formatTimestamp(message.createdAt)}
           </time>
         )}
@@ -285,15 +285,15 @@ function FlatMessageRow({
       <div className="min-w-0 flex-1 pb-0.5">
         {groupStart && (
           <div className="flex items-baseline gap-2">
-            <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+            <span className="text-sm font-semibold text-text-primary-dark">
               {name}
             </span>
-            <time className="text-[11px] text-slate-400 dark:text-slate-500">
+            <time className="text-[11px] text-text-secondary-dark">
               {formatTimestamp(message.createdAt)}
             </time>
           </div>
         )}
-        <div className={`text-sm leading-relaxed text-slate-700 dark:text-slate-200 ${faded}`}>
+        <div className={`text-sm leading-relaxed text-text-primary-dark ${faded}`}>
           {renderMinimalMarkdown(message.content)}
           {message.attachments?.map((a) =>
             a.kind === 'image' ? (
@@ -307,7 +307,7 @@ function FlatMessageRow({
           )}
         </div>
         {status === 'pending' && (
-          <span className="text-[10px] italic text-slate-400 dark:text-slate-500">
+          <span className="text-[10px] italic text-text-secondary-dark">
             Sending…
           </span>
         )}
@@ -373,7 +373,7 @@ function Avatar({ name }: { name: string }): JSX.Element {
 function DeliveryFooter({ message }: { message: Message }): JSX.Element {
   if (message.deliveryStatus === 'pending') {
     return (
-      <span className="mt-0.5 text-[10px] italic text-slate-400 dark:text-slate-500">
+      <span className="mt-0.5 text-[10px] italic text-text-secondary-dark">
         Sending…
       </span>
     );
@@ -389,7 +389,7 @@ function DeliveryFooter({ message }: { message: Message }): JSX.Element {
     );
   }
   return (
-    <time className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
+    <time className="mt-0.5 text-[10px] text-text-secondary-dark">
       {formatTimestamp(message.createdAt)}
     </time>
   );
@@ -405,12 +405,12 @@ function AgentThinkingRow({ agentName }: { agentName?: string }): JSX.Element {
       aria-live="polite"
       data-testid="agent-thinking"
     >
-      <div className="rounded-2xl bg-white px-3 py-2 text-sm text-slate-500 shadow-sm dark:bg-slate-800 dark:text-slate-400">
+      <div className="rounded-2xl bg-surface-dark px-3 py-2 text-sm text-text-secondary-dark shadow-sm">
         <span className="inline-flex items-center gap-1">
           <span aria-hidden="true" className="flex gap-0.5">
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.3s]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400 [animation-delay:-0.15s]" />
-            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-slate-400" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-text-secondary-dark [animation-delay:-0.3s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-text-secondary-dark [animation-delay:-0.15s]" />
+            <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-text-secondary-dark" />
           </span>
           <span>{label}…</span>
         </span>

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -69,11 +69,11 @@ export interface WorkspaceRailProps {
 }
 
 const PRESENCE_DOT: Record<ChatPresenceStatus, string> = {
-  online: 'bg-emerald-500',
+  online: 'bg-emerald-400',
   busy: 'bg-amber-400',
-  idle: 'bg-amber-300',
-  offline: 'bg-slate-400',
-  inactive: 'bg-slate-300',
+  idle: 'bg-amber-400',
+  offline: 'bg-gray-500',
+  inactive: 'bg-gray-500',
 };
 
 export function WorkspaceRail({
@@ -118,7 +118,7 @@ export function WorkspaceRail({
 
   return (
     <nav
-      className={`flex h-full flex-col items-stretch gap-1 overflow-y-auto border-r border-slate-200 bg-slate-900 py-3 ${width} ${className}`}
+      className={`flex h-full flex-col items-stretch gap-1 overflow-y-auto border-r border-border-dark bg-background-dark py-3 ${width} ${className}`}
       aria-label="Workspace rail"
       data-testid="workspace-rail"
       data-expanded={expanded ? 'true' : 'false'}
@@ -187,19 +187,19 @@ function WorkspaceRow({
   const dot = workspace.hasMentions ? (
     <span
       aria-hidden="true"
-      className="absolute -right-0.5 -top-0.5 inline-block h-2.5 w-2.5 rounded-full bg-rose-500 ring-2 ring-slate-900"
+      className="absolute -right-0.5 -top-0.5 inline-block h-2.5 w-2.5 rounded-full bg-rose-500 ring-2 ring-background-dark"
       data-testid={`workspace-mention-${workspace.id}`}
     />
   ) : hasUnread ? (
     <span
       aria-hidden="true"
-      className="absolute -right-0.5 -top-0.5 inline-block h-2 w-2 rounded-full bg-blue-400 ring-2 ring-slate-900"
+      className="absolute -right-0.5 -top-0.5 inline-block h-2 w-2 rounded-full bg-primary ring-2 ring-background-dark"
       data-testid={`workspace-unread-${workspace.id}`}
     />
   ) : workspace.presence ? (
     <span
       aria-hidden="true"
-      className={`absolute -right-0.5 -top-0.5 inline-block h-1.5 w-1.5 rounded-full ring-2 ring-slate-900 ${
+      className={`absolute -right-0.5 -top-0.5 inline-block h-1.5 w-1.5 rounded-full ring-2 ring-background-dark ${
         PRESENCE_DOT[workspace.presence]
       }`}
       data-testid={`workspace-presence-${workspace.id}`}
@@ -223,8 +223,8 @@ function WorkspaceRow({
           ? 'mx-1.5 flex flex-col items-center gap-1 px-1 py-1.5 text-center'
           : 'mx-2 flex items-center gap-3 px-2 py-2 pr-4 text-left',
         isActive
-          ? 'bg-blue-600/20 text-white ring-1 ring-blue-400/40'
-          : 'text-slate-200 hover:bg-slate-800',
+          ? 'bg-primary/15 text-text-primary-dark ring-1 ring-primary/50'
+          : 'text-text-secondary-dark hover:bg-surface-dark hover:text-text-primary-dark',
         // Indent nested children one notch (beside layout only).
         isNested && !caption ? 'ml-4' : '',
         // Caption child: inset the tile so the connector spine sits at its left.
@@ -245,10 +245,10 @@ function WorkspaceRow({
             // A vector icon / emoji glyph is not uppercased; initials are.
             hasGlyph ? (childInset ? 'text-base' : 'text-lg') : childInset ? 'text-[10px] uppercase' : 'text-sm uppercase',
             isHome
-              ? 'bg-slate-700 text-white ring-1 ring-slate-500'
+              ? 'bg-surface-dark text-text-primary-dark ring-1 ring-border-dark'
               : isActivity
-                ? 'bg-slate-700 text-slate-100'
-                : 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white',
+                ? 'bg-surface-dark text-text-primary-dark'
+                : 'bg-gradient-to-br from-primary to-[#1e5fc7] text-white',
           ].join(' ')}
         >
           {workspace.icon ?? workspace.avatar ?? initials}
@@ -278,7 +278,7 @@ function WorkspaceRow({
       {childInset && (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute bottom-1 left-3 top-0 w-px bg-slate-700"
+          className="pointer-events-none absolute bottom-1 left-3 top-0 w-px bg-border-dark"
           data-testid={`workspace-spine-${workspace.id}`}
         />
       )}
@@ -291,7 +291,7 @@ function WorkspaceRow({
           aria-label={isCollapsed ? `Expand ${workspace.name}` : `Collapse ${workspace.name}`}
           aria-expanded={!isCollapsed}
           title={isCollapsed ? 'Expand sub-teams' : 'Collapse sub-teams'}
-          className="absolute right-1 top-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-700 hover:text-slate-100"
+          className="absolute right-1 top-1 rounded p-0.5 text-text-secondary-dark transition hover:bg-surface-dark hover:text-text-primary-dark"
         >
           <RailChevron collapsed={isCollapsed} />
         </button>
@@ -322,7 +322,7 @@ function RailChevron({ collapsed }: { collapsed: boolean }): JSX.Element {
 
 function RailEmpty(): JSX.Element {
   return (
-    <div className="px-2 py-4 text-center text-xs text-slate-500" role="status">
+    <div className="px-2 py-4 text-center text-xs text-text-secondary-dark" role="status">
       No teams yet.
     </div>
   );


### PR DESCRIPTION
## Why
The chat was built with `bg-slate-50 dark:bg-slate-900` class pairs, but the OSS app is **dark-only and never toggles a `.dark` class** — so the chat rendered its *light* branch inside a dark app (light-gray panels, white bubbles, generic blue/indigo accents). That's the main reason it looked bolted-on, not the accent color.

## What
Retokenize every **active** chat surface to Crewly's real Tailwind tokens, making the dark value the **base** (dropping dead `dark:` variants):

| Token | Hex | Used for |
|---|---|---|
| `background-dark` | `#111721` | rail, thread canvas, deepest surfaces |
| `surface-dark` | `#1a222c` | panels, rows, bubbles, composer, header |
| `border-dark` | `#313a48` | all dividers |
| `text-primary-dark` / `text-secondary-dark` | `#f6f7f8` / `#9ab0d9` | text |
| `primary` | `#2a73ea` | active/selected/links/send/unread + brand avatar gradient (was indigo→purple); Lead & mention-team pills primary-tinted |
| `emerald-400` | — | presence (matches Dashboard "active") |

Semantic colors kept: mention dots stay **rose**; agent mention chip stays **emerald**; inactive banner → dark **amber**.

## Surfaces touched
`WorkspaceRail`, `ConversationListPanel`, `MessageThread`, `MentionComposer` (the live composer), `MessageInput`, `AgentStatusBadge`, `LiveTeamChatPage` host wrappers (header, Slack-threads bar, reply bar), `EmptyStates`.

`TeamChatPage`/`ChannelList` are **not routed** (legacy) and left untouched.

## Approach
OSS-only token classes (per owner decision) — **no** CSS-variable seam. The package source is already in `frontend/tailwind.config.js`'s `content` path, so the classes emit; Portal is unaffected (unknown tokens no-op gracefully). No JSX / logic / `data-testid` changes.

## Verification
- chat-ui: 190/190 · frontend Chat-team: 64/64 · build clean.
- Confirmed `#2a73ea`, `#1a222c`, `#111721` are emitted into the built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)