### PR TITLE
fix(chat): full-bleed team-chat + sub-team tiles that fit the rail

### DIFF
--- a/frontend/src/components/Layout/AppLayout.test.tsx
+++ b/frontend/src/components/Layout/AppLayout.test.tsx
@@ -37,6 +37,18 @@ vi.mock('../TeamsRestorePopup', () => ({
   TeamsRestorePopup: () => null
 }));
 
+// AppLayout reads payment-wall state; stub the hook so the test doesn't need
+// the full PaymentWallProvider (and its API/auth dependencies).
+vi.mock('../../contexts/PaymentWallContext', () => ({
+  usePaymentWall: () => ({
+    activeLimitEvent: null,
+    escalationLevel: 'none',
+    isVisible: false,
+    dismiss: vi.fn(),
+    openModal: vi.fn(),
+  }),
+}));
+
 const renderWithProviders = (component: React.ReactElement) => {
   return render(
     <BrowserRouter>

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { Terminal, Menu, X } from 'lucide-react';
 import { Navigation } from './Navigation';
 import { TerminalPanel } from '../TerminalPanel/TerminalPanel';
@@ -22,6 +22,12 @@ export const AppLayout: React.FC = () => {
   const { isCollapsed } = useSidebar();
   const { activeLimitEvent, escalationLevel, isVisible, dismiss, openModal } = usePaymentWall();
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const location = useLocation();
+
+  // Full-bleed routes manage their own internal padding + scrolling (e.g. the
+  // 3-panel team chat). For those we drop the content-area padding and outer
+  // scroll so they fill the viewport edge-to-edge with no dead strips.
+  const isFullBleed = location.pathname.startsWith('/team-chat');
 
   const toggleTerminal = () => {
     if (isTerminalOpen) {
@@ -78,7 +84,10 @@ export const AppLayout: React.FC = () => {
         <main className="flex-1 flex flex-col min-h-0 overflow-hidden">
           <UpdateBanner />
           <OrchestratorStatusBanner />
-          <div className="flex-1 p-4 md:p-6 min-h-0 overflow-y-auto">
+          <div className={clsx(
+            'flex-1 min-h-0',
+            isFullBleed ? 'overflow-hidden' : 'p-4 md:p-6 overflow-y-auto'
+          )}>
             <Outlet />
           </div>
         </main>

--- a/packages/chat-ui/src/components/WorkspaceRail.test.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.test.tsx
@@ -147,14 +147,16 @@ describe('WorkspaceRail', () => {
     expect(screen.queryByTestId('workspace-collapse-team-product')).not.toBeInTheDocument();
   });
 
-  it('renders nested child tiles as indented rows in caption mode', () => {
+  it('renders nested sub-teams as centred caption tiles in caption mode', () => {
     render(<WorkspaceRail workspaces={fixture} showLabels onToggleCollapse={() => {}} />);
-    // Children render beneath their parent, marked data-nested=true and indented.
+    // Children render beneath their parent, marked data-nested=true and laid out
+    // as centred caption tiles (avatar over label) so they fit the narrow rail.
     const product = screen.getByTestId('workspace-row-team-product');
     const marketing = screen.getByTestId('workspace-row-team-marketing');
     expect(product).toHaveAttribute('data-nested', 'true');
     expect(marketing).toHaveAttribute('data-nested', 'true');
-    expect(product.className).toContain('ml-4');
+    expect(product.className).toContain('flex-col');
+    expect(product.className).toContain('items-center');
     // Roots/parents are not nested.
     expect(screen.getByTestId('workspace-row-org-crewly')).toHaveAttribute('data-nested', 'false');
   });

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -217,7 +217,7 @@ function CaptionRail({
 
   return (
     <nav
-      className={`chat-scrollbar flex h-full w-[84px] flex-col items-center gap-3 overflow-y-auto border-r border-border-dark bg-background-dark pt-4 ${className}`}
+      className={`chat-scrollbar flex h-full w-[84px] flex-col items-center gap-3 overflow-y-auto overflow-x-hidden border-r border-border-dark bg-background-dark py-4 ${className}`}
       aria-label="Workspace rail"
       data-testid="workspace-rail"
       data-expanded="false"
@@ -254,9 +254,11 @@ function CaptionRail({
                 onToggleCollapse={onToggleCollapse}
               />
             )}
-            {/* Parent's sub-teams, when expanded, as indented horizontal rows. */}
+            {/* Parent's sub-teams, when expanded, as centred caption tiles
+                (smaller avatar) — keeps them inside the narrow rail with no
+                horizontal overflow. */}
             {isParent && !isCollapsed && kids.length > 0 && (
-              <div className="mt-2 flex w-full flex-col gap-3 pl-4">
+              <div className="flex w-full flex-col items-center gap-3">
                 {kids.map((child) => (
                   <CaptionChildRow
                     key={child.id}
@@ -382,7 +384,12 @@ function CaptionTile({
   );
 }
 
-/** A nested sub-team rendered as an indented horizontal row in the rail. */
+/**
+ * A nested sub-team in the rail. Same centred caption shape as a top-level
+ * tile (avatar on top, small label beneath) but with a smaller avatar so the
+ * parent → child relationship reads at a glance — and, crucially, it stays
+ * inside the narrow 84px rail with no horizontal overflow.
+ */
 function CaptionChildRow({
   workspace,
   isActive,
@@ -433,9 +440,9 @@ function CaptionChildRow({
       aria-label={
         hasUnread ? `${workspace.name}, ${workspace.unreadCount} unread` : workspace.name
       }
-      className="group/item ml-4 flex w-full cursor-pointer items-center gap-3 rounded-lg p-1 hover:bg-white/5"
+      className="group/item flex cursor-pointer flex-col items-center gap-1"
     >
-      <span className="relative shrink-0">
+      <span className="relative">
         <span
           aria-hidden="true"
           className={`flex h-8 w-8 items-center justify-center rounded-full ${
@@ -447,7 +454,7 @@ function CaptionChildRow({
         {dot}
       </span>
       <span
-        className={`truncate text-[10px] ${
+        className={`max-w-[64px] text-center text-[10px] leading-tight ${
           isActive
             ? 'font-medium text-text-primary-dark'
             : 'text-text-secondary-dark group-hover/item:text-text-primary-dark'


### PR DESCRIPTION
## Two chat-page polish fixes

### 1. Dead padding strips (top & bottom)
`AppLayout` wrapped every route in `p-4 md:p-6 overflow-y-auto` — right for Dashboard, but it left the 3-panel chat floating with empty dark strips above the rail and below the composer. `/team-chat` is now **full-bleed** (no content padding, outer `overflow-hidden`) so it fills the viewport edge-to-edge; all other routes keep their padding.

### 2. Sub-teams overflowing the 84px rail
Nested sub-teams were laid out as **horizontal** avatar+label rows (`ml-4 w-full`), so in the narrow rail the labels truncated to "C.." and spilled past the right edge, adding a horizontal scrollbar. Sub-teams now render as **centred caption tiles** (smaller avatar over a centred, wrapping label) — the same shape as every other rail tile — and the rail gets `overflow-x-hidden`.

### Also
Repairs the **pre-existing** `AppLayout.test` (was 19/19 red on `main`: it renders `AppLayout`, which calls `usePaymentWall`, without wrapping `PaymentWallProvider`) by stubbing the hook — matching the file's existing mock pattern.

## Tests
- chat-ui 190/190 · frontend (incl. AppLayout + Chat-team) 83/83 · build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)