### PR TITLE
fix(chat): balance header padding + drop the meaningless call icon

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -193,6 +193,16 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     expect(screen.getByTestId('conv-row-orc-dm')).toBeInTheDocument();
   });
 
+  it('conversation header offers Search but no Call action', async () => {
+    const { client } = makeStubClient([orcDm]);
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
+    // The active conversation's header renders its action buttons.
+    await waitFor(() => expect(screen.getByLabelText('Search')).toBeInTheDocument());
+    // There's nothing to dial in an agent chat — the Call icon must be gone.
+    expect(screen.queryByLabelText('Call')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Conversation info')).toBeInTheDocument();
+  });
+
   it('renders Home (no dead-end) even with zero channels', async () => {
     const { client } = makeStubClient([]);
     render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -37,7 +37,6 @@ import {
   ChevronRight,
   MessageSquare,
   Search,
-  Phone,
   Info,
   Plus,
 } from 'lucide-react';
@@ -746,8 +745,8 @@ function LiveTeamChatRightPanelInner({
       aria-label={`Conversation with ${conversation.title}`}
       data-thread-active={threadRoot ? 'true' : 'false'}
     >
-      <header className="flex h-14 items-center justify-between border-b border-border-dark bg-background-dark/30 px-6 backdrop-blur-md">
-        <div className="min-w-0">
+      <header className="flex items-center justify-between gap-4 border-b border-border-dark bg-background-dark/30 px-6 py-3 backdrop-blur-md">
+        <div className="min-w-0 leading-tight">
           <h2 className="truncate text-base font-bold text-text-primary-dark">
             {conversation.kind === 'channel' ? `#${conversation.title}` : conversation.title}
           </h2>
@@ -771,13 +770,11 @@ function LiveTeamChatRightPanelInner({
               Reply in thread
             </button>
           )}
-          {/* Visual-only header actions — search/call/info. No backend wired,
-              so these are presentational affordances per the prototype. */}
+          {/* Header actions. (A "call" affordance was dropped — there's
+              nothing to dial in an agent chat.) Search/info are placeholders
+              for now until wired to in-conversation search + details. */}
           <HeaderActionButton label="Search">
             <Search size={18} />
-          </HeaderActionButton>
-          <HeaderActionButton label="Call">
-            <Phone size={18} />
           </HeaderActionButton>
           <HeaderActionButton label="Conversation info">
             <Info size={18} />


### PR DESCRIPTION
## What
- **Header padding:** the conversation header used a rigid `h-14` with no vertical padding, so its two-line title (name + subtitle) sat cramped against the top and misaligned with the "Home" list header. Now `px-6 py-3` (content-sized) — even breathing room, aligned.
- **Phone icon:** removed the "Call" header action — there's nothing to dial in an agent chat (leftover visual-only button from the prototype). Search/info placeholders remain for future wiring.
- Added a header test (Search/Info present, Call absent).

## Tests
LiveTeamChatPage 19/19, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)