### PR TITLE
fix(chat): drop doubled channel '#' + show agent roles in the roster

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -246,6 +246,38 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     expect(lead.compareDocumentPosition(member) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('shows each member\'s role under their name in the team roster', async () => {
+    const channels: Channel[] = [
+      orcDm,
+      TEAM_GENERAL,
+      { id: 'dm-maya', agentSession: 'sess-maya', name: 'Maya', createdAt: ISO, type: 'dm' },
+      { id: 'dm-alex', agentSession: 'sess-alex', name: 'Alex', createdAt: ISO, type: 'dm' },
+    ];
+    const { client } = makeStubClient(channels);
+    render(
+      <LiveTeamChatPage
+        client={client}
+        mentionables={MENTIONABLES}
+        teams={[
+          {
+            id: 'team-product',
+            name: 'Crewly Product',
+            leaderSessions: ['sess-maya'],
+            memberSessions: ['sess-maya', 'sess-alex'],
+          },
+        ]}
+        directoryAgents={[
+          { agentSession: 'sess-maya', name: 'Maya', role: 'eng-lead' },
+          { agentSession: 'sess-alex', name: 'Alex', role: 'designer' },
+        ]}
+        initialWorkspaceId="team:team-product"
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('conv-group-team-members')).toBeInTheDocument());
+    expect(screen.getByText('eng-lead')).toBeInTheDocument();
+    expect(screen.getByText('designer')).toBeInTheDocument();
+  });
+
   it('nests a sub-team under its parent in the rail (parentTeamId → parentId)', async () => {
     const { client } = makeStubClient([orcDm]);
     render(

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -158,6 +158,8 @@ export interface DirectoryAgentEntry {
   presence?: ChatPresenceStatus;
   /** Team this agent belongs to — used to group the DM list by team. */
   teamName?: string;
+  /** Agent's role (e.g. `content-strategist`) — shown under the name. */
+  role?: string;
 }
 
 export function LiveTeamChatPage({
@@ -275,6 +277,8 @@ function LiveTeamChatPageBody({
         id: `${VIRTUAL_DM_PREFIX}${a.agentSession}`,
         agentSession: a.agentSession,
         name: a.name,
+        // Surface the agent's role under their name in the roster.
+        purpose: a.role,
         createdAt: '',
         type: 'dm' as const,
         // Channel presence is the narrower online|busy|offline vocabulary.
@@ -443,13 +447,23 @@ function LiveTeamChatPageBody({
     if (!team) return orcRow ? [{ id: 'pinned', label: ORCHESTRATOR_LABEL, rows: [orcRow] }] : [];
     const leadSet = new Set(team.leaderSessions);
     const memberSet = new Set(team.memberSessions);
-    const huddleRows = allChannelRows.filter((r) => channelTeamId.get(r.id) === team.id);
-    const memberRows = allDmRows.filter(
-      (r) =>
-        r.agentSession &&
-        r.agentSession !== ORCHESTRATOR_SESSION &&
-        memberSet.has(r.agentSession),
+    // session → role, so every member row shows the agent's role under their
+    // name (uniform whether or not they already have a real DM channel).
+    const roleBySession = new Map(
+      directoryAgents.map((a) => [a.agentSession, a.role] as const),
     );
+    const huddleRows = allChannelRows.filter((r) => channelTeamId.get(r.id) === team.id);
+    const memberRows = allDmRows
+      .filter(
+        (r) =>
+          r.agentSession &&
+          r.agentSession !== ORCHESTRATOR_SESSION &&
+          memberSet.has(r.agentSession),
+      )
+      .map((r) => {
+        const role = r.agentSession ? roleBySession.get(r.agentSession) : undefined;
+        return role ? { ...r, subtitle: role } : r;
+      });
     // Single Members list, leads first, each lead tagged with a "Lead" badge
     // so the roster reads as one Slack-style list rather than split sections.
     const leads = memberRows
@@ -470,6 +484,7 @@ function LiveTeamChatPageBody({
     allChannelRows,
     channelTeamId,
     pinnedChats,
+    directoryAgents,
   ]);
 
   const totalRows = useMemo(
@@ -748,7 +763,9 @@ function LiveTeamChatRightPanelInner({
       <header className="flex items-center justify-between gap-4 border-b border-border-dark bg-background-dark/30 px-6 py-3 backdrop-blur-md">
         <div className="min-w-0 leading-tight">
           <h2 className="truncate text-base font-bold text-text-primary-dark">
-            {conversation.kind === 'channel' ? `#${conversation.title}` : conversation.title}
+            {conversation.kind === 'channel'
+              ? `#${conversation.title.replace(/^#+\s*/, '')}`
+              : conversation.title}
           </h2>
           {conversation.subtitle && (
             <p className="truncate text-[11px] text-text-secondary-dark">

--- a/frontend/src/components/Chat-team/TeamChatRoute.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.tsx
@@ -95,6 +95,7 @@ export function TeamChatRoute(): JSX.Element {
           name: member.name,
           presence: agentStatusToPresence(member.agentStatus),
           teamName: team.name,
+          role: member.role,
         });
       }
     }

--- a/packages/chat-ui/src/components/ConversationListPanel.test.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.test.tsx
@@ -95,6 +95,18 @@ describe('ConversationListPanel', () => {
     expect(screen.getByTestId('conv-unread-pill-c-proj-onboarding')).toHaveTextContent('3');
   });
 
+  it('does not double the `#` when a channel name already carries one', () => {
+    const groups: ConversationGroup[] = [
+      { id: 'channels', label: 'Channels', rows: [{ id: 'c-gen', kind: 'channel', title: '#general' }] },
+    ];
+    renderPanel({ groups });
+    const row = screen.getByTestId('conv-row-c-gen');
+    // The `#` glyph is the icon; the title text must not repeat it.
+    expect(screen.getByTestId('conv-icon-c-gen')).toHaveTextContent('#');
+    expect(row).not.toHaveTextContent('##');
+    expect(row).toHaveTextContent('general');
+  });
+
   it('renders a role badge pill next to the title when row.badge is set', () => {
     const groups: ConversationGroup[] = [
       {

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -359,7 +359,9 @@ function ConversationRowItem({
               hasUnread ? 'font-semibold text-text-primary-dark' : '',
             ].join(' ')}
           >
-            {row.title}
+            {/* The leading `#` glyph is rendered separately, so strip any `#`
+                the channel name itself carries to avoid a doubled `##`. */}
+            {row.title.replace(/^#+\s*/, '')}
           </span>
         ) : (
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Two fixes

### 1. Doubled `#` on channels
Channel rows and the header showed `# #general` / `##general` — the UI renders a `#` glyph (and the header prefixes `#`), but the channel name itself already carries a leading `#`. Now the displayed channel title strips a leading `#`, so the glyph/prefix is the only one.

### 2. Agent roles in the Members roster
The team Members list showed only names. Each agent's `role` now flows through `DirectoryAgentEntry` (populated from the team member's `role` in `TeamChatRoute`) and renders as the row subtitle under the name — both as the synthetic DM row's `purpose` and via a session→role map applied to every member row (so it shows uniformly, whether or not a real DM channel exists).

## Tests
- chat-ui ConversationListPanel 18/18 (added no-double-`#` test).
- frontend LiveTeamChatPage 20/20 (added role-subtitle test).
- Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)