### PR TITLE
fix(chat): drop the 'agent inactive' warning + hide terminal button on chat

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -203,6 +203,17 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     expect(screen.getByLabelText('Conversation info')).toBeInTheDocument();
   });
 
+  it('does not warn that the agent is inactive (sending wakes it anyway)', async () => {
+    const { client } = makeStubClient([orcDm]);
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
+    await waitFor(() => expect(screen.getByLabelText('Search')).toBeInTheDocument());
+    // The "currently inactive" banner + footer hint were removed — typing a
+    // message activates the agent, so the warning was just noise.
+    expect(screen.queryByTestId('banner-agent-offline')).not.toBeInTheDocument();
+    expect(screen.queryByText(/currently inactive/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/is inactive — sending will activate/i)).not.toBeInTheDocument();
+  });
+
   it('renders Home (no dead-end) even with zero channels', async () => {
     const { client } = makeStubClient([]);
     render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -62,7 +62,6 @@ import {
   type Workspace,
 } from '@crewly/chat-ui';
 import {
-  AgentOfflineBanner,
   NoChannelsEmptyState,
   NoMessagesEmptyState,
   NoTeamsEmptyState,
@@ -700,9 +699,6 @@ function LiveTeamChatRightPanelInner({
   // optimistic bubble in `failed` state via the client's emit path.
   const toast = useMemo(() => buildToastMessage(sendError), [sendError]);
 
-  const isInactiveDm =
-    conversation.kind === 'dm' &&
-    (conversation.presence === 'inactive' || conversation.presence === 'offline');
   const recipientName = conversation.kind === 'dm' ? conversation.title : undefined;
 
   // Slack threads all belong to the orchestrator, so they're navigated from
@@ -847,8 +843,6 @@ function LiveTeamChatRightPanelInner({
         </div>
       )}
 
-      {isInactiveDm && recipientName && <AgentOfflineBanner agentName={recipientName} />}
-
       <MessageThread
         channelId={conversation.id}
         agentName={recipientName}
@@ -868,13 +862,7 @@ function LiveTeamChatRightPanelInner({
       <MentionComposer
         mentionables={mentionables}
         onSend={handleSend}
-        inactiveHelper={
-          isInactiveDm && recipientName
-            ? `${recipientName} is inactive — sending will activate them and deliver your message.`
-            : threadRoot
-              ? `Replying in thread ${threadRoot}`
-              : undefined
-        }
+        inactiveHelper={threadRoot ? `Replying in thread ${threadRoot}` : undefined}
       />
 
       {toast && (

--- a/frontend/src/components/Layout/AppLayout.test.tsx
+++ b/frontend/src/components/Layout/AppLayout.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { AppLayout } from './AppLayout';
 import { TerminalProvider } from '../../contexts/TerminalContext';
@@ -74,6 +74,21 @@ describe('AppLayout', () => {
 
     const toggleButton = screen.getByRole('button', { name: /terminal/i });
     expect(toggleButton).toBeInTheDocument();
+  });
+
+  it('hides the terminal toggle on the full-bleed chat route', () => {
+    render(
+      <MemoryRouter initialEntries={['/team-chat']}>
+        <TerminalProvider>
+          <SidebarProvider>
+            <AppLayout />
+          </SidebarProvider>
+        </TerminalProvider>
+      </MemoryRouter>,
+    );
+    // The fixed bottom-right terminal button overlaps the chat composer's
+    // Send button, so it's hidden on /team-chat.
+    expect(screen.queryByRole('button', { name: /open terminal/i })).not.toBeInTheDocument();
   });
 
   it('opens terminal panel when terminal button is clicked', () => {

--- a/frontend/src/components/Layout/AppLayout.tsx
+++ b/frontend/src/components/Layout/AppLayout.tsx
@@ -93,15 +93,19 @@ export const AppLayout: React.FC = () => {
         </main>
       </div>
 
-      {/* Terminal Toggle Button */}
-      <IconButton
-        className={`fixed bottom-6 right-6 z-40 ${isTerminalOpen ? 'bg-primary/90' : ''}`}
-        icon={Terminal}
-        onClick={toggleTerminal}
-        variant="primary"
-        title={isTerminalOpen ? 'Close Terminal' : 'Open Terminal'}
-        aria-label={isTerminalOpen ? 'Close Terminal' : 'Open Terminal'}
-      />
+      {/* Terminal Toggle Button — hidden on full-bleed routes (the chat),
+          where its fixed bottom-right position overlaps the composer's Send
+          button. */}
+      {!isFullBleed && (
+        <IconButton
+          className={`fixed bottom-6 right-6 z-40 ${isTerminalOpen ? 'bg-primary/90' : ''}`}
+          icon={Terminal}
+          onClick={toggleTerminal}
+          variant="primary"
+          title={isTerminalOpen ? 'Close Terminal' : 'Open Terminal'}
+          aria-label={isTerminalOpen ? 'Close Terminal' : 'Open Terminal'}
+        />
+      )}
 
       {/* Terminal Side Panel with Overlay */}
       <>


### PR DESCRIPTION
## Two chat-page tweaks

### 1. Remove the "agent is inactive" warning
Dropped the amber **"Orchestrator is currently inactive…"** banner and the matching composer footer hint. Sending a message already activates the agent and delivers once the session is up, so the warning was redundant noise. (`AgentOfflineBanner` stays defined in `EmptyStates` for potential reuse — the chat just no longer renders it.)

### 2. Hide the Terminal button on the chat route
The floating Terminal toggle (`fixed bottom-6 right-6`) overlapped the chat composer's **Send** button. It's now hidden on the full-bleed `/team-chat` route; every other route keeps it.

## Tests
- LiveTeamChatPage + AppLayout: 41/41 (added: no inactive banner/hint; terminal toggle hidden on `/team-chat`).
- Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)