### PR TITLE
fix(chat): render message timeline oldest→newest (agent reply was hidden)

### DIFF
--- a/packages/chat-ui/src/hooks/useMessages.test.ts
+++ b/packages/chat-ui/src/hooks/useMessages.test.ts
@@ -3,7 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { ChatAPIProvider } from '../context/ChatAPIProvider';
 import { MockChatApiClient } from '../api/mock-client';
-import { useMessages, reconcileMessage, deriveAgentThinking } from './useMessages';
+import { useMessages, reconcileMessage, deriveAgentThinking, toAscendingBySeq } from './useMessages';
 import type { Message } from '../types/chat.types';
 
 describe('useMessages', () => {
@@ -222,5 +222,27 @@ describe('deriveAgentThinking', () => {
 
   it('returns false for stale user messages loaded from history', () => {
     expect(deriveAgentThinking([userHistory])).toBe(false);
+  });
+});
+
+describe('toAscendingBySeq', () => {
+  const mk = (seq: number): Message => ({
+    id: `m-${seq}`,
+    channelId: 'c1',
+    seq,
+    author: { role: 'user', id: 'me' },
+    content: `msg ${seq}`,
+    createdAt: '2026-04-25T01:00:00.000Z',
+    mentions: [],
+  });
+
+  it('orders a newest-first (descending) page into ascending seq order', () => {
+    // The backend default page is newest → oldest; the timeline must render
+    // oldest → newest so the latest message lands at the bottom.
+    const desc = [mk(26), mk(25), mk(24), mk(2), mk(1)];
+    const asc = toAscendingBySeq(desc);
+    expect(asc.map((m) => m.seq)).toEqual([1, 2, 24, 25, 26]);
+    // Does not mutate the input.
+    expect(desc.map((m) => m.seq)).toEqual([26, 25, 24, 2, 1]);
   });
 });

--- a/packages/chat-ui/src/hooks/useMessages.ts
+++ b/packages/chat-ui/src/hooks/useMessages.ts
@@ -89,6 +89,22 @@ export function reconcileMessage(prev: Message[], incoming: Message): Message[] 
  * @param messages - Current ordered timeline
  * @returns Whether to show the "agent is thinking" indicator
  */
+/**
+ * Normalize a fetched page to ascending-by-seq (oldest → newest).
+ *
+ * The backend's default ("backward") page is ordered newest → oldest for
+ * cursor pagination, but the whole timeline contract here is ASCENDING:
+ * new messages append to the end, `deriveAgentThinking` inspects the last
+ * element, and the thread renders top → bottom and auto-scrolls to the
+ * bottom. Without this normalization the timeline renders inverted (newest
+ * at the top, hidden after the scroll-to-bottom) and the "thinking"
+ * indicator reads the wrong end. Sorting by `seq` is robust regardless of
+ * the order the API happens to return.
+ */
+export function toAscendingBySeq(messages: Message[]): Message[] {
+  return [...messages].sort((a, b) => a.seq - b.seq);
+}
+
 export function deriveAgentThinking(messages: Message[]): boolean {
   if (messages.length === 0) return false;
   const last = messages[messages.length - 1];
@@ -124,7 +140,7 @@ export function useMessages(channelId: string | null): UseMessagesResult {
       .listMessages(channelId)
       .then((page) => {
         if (cancelled) return;
-        setMessages(page.messages);
+        setMessages(toAscendingBySeq(page.messages));
         cursorRef.current = page.nextCursor;
         setHasMore(page.nextCursor !== null);
       })
@@ -164,7 +180,9 @@ export function useMessages(channelId: string | null): UseMessagesResult {
     const cursor = cursorRef.current;
     try {
       const page = await client.listMessages(channelId, { cursor });
-      setMessages((prev) => [...page.messages, ...prev]);
+      // Older page is also newest → oldest; normalize then prepend so the
+      // combined timeline stays ascending.
+      setMessages((prev) => [...toAscendingBySeq(page.messages), ...prev]);
       cursorRef.current = page.nextCursor;
       setHasMore(page.nextCursor !== null);
     } catch (err) {


### PR DESCRIPTION
## The bug
Users reported the chat hangs on "Orchestrator is thinking…" and the agent's reply never appears. **The reply was actually there — just rendered off-screen at the top.**

The backend's default message page is ordered **newest→oldest** (standard cursor pagination). But the frontend timeline contract is **ascending**: new messages append to the end, `deriveAgentThinking` inspects the *last* element, and the thread renders top→bottom + auto-scrolls to the bottom.

`useMessages` set the fetched page directly **without reversing**, so:
- The timeline rendered **inverted** — the agent's reply landed at the **top** (hidden after scroll-to-bottom), the oldest message at the bottom → looked like "no reply".
- `deriveAgentThinking` read the **oldest** message → the **"thinking…" indicator never cleared**, even though the reply was already in the DB.

## The fix
Normalize every fetched page to **ascending-by-seq** (initial load + the `loadMore` prepend). Sorting by `seq` is robust regardless of the order the API returns.

## Verified end-to-end (Claude-in-Chrome)
Sent live messages to the orchestrator in `/team-chat`:
- Before: reply (`OK`) sat in `chat.db` but the page stayed on "thinking".
- After: the orc's replies (`OK`, `VERIFIED`) render at the **bottom** in correct order and the **"thinking" indicator clears**.

## Tests
chat-ui `useMessages` 12/12 (added `toAscendingBySeq` ordering test), build clean.

> Note: a separate, secondary gap remains — the **live WebSocket push** of an agent reply doesn't always update an already-open conversation (a reload shows it correctly). Tracking that as a follow-up; this PR fixes the ordering bug that was the actual cause of the "no reply / stuck thinking" symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)