### PR TITLE
feat(chat): Slack-style message threads

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -792,6 +792,71 @@ describe('ChatV2Service', () => {
   });
 
   // -------------------------------------------------------------------------
+  // listMessages — Slack-style thread reply counts
+  // -------------------------------------------------------------------------
+
+  describe('listMessages thread reply counts', () => {
+    it('attaches replyCount + lastReplyAt to a root once a reply is posted', () => {
+      const ch = createSam();
+      const root = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'thread root',
+      });
+
+      // Before any reply: the root carries no reply summary.
+      const before = service.listMessages({ channelId: ch.id, principal: owner });
+      const rootBefore = before.messages.find((m) => m.id === root.id);
+      expect(rootBefore?.replyCount).toBeUndefined();
+      expect(rootBefore?.lastReplyAt).toBeUndefined();
+
+      // Post one reply into the thread.
+      service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'a reply',
+        threadId: root.id,
+      });
+
+      // After: the root has replyCount=1 and a populated lastReplyAt; the
+      // reply row itself never carries a count.
+      const after = service.listMessages({ channelId: ch.id, principal: owner });
+      const rootAfter = after.messages.find((m) => m.id === root.id);
+      expect(rootAfter?.replyCount).toBe(1);
+      expect(typeof rootAfter?.lastReplyAt).toBe('string');
+      expect(Number.isNaN(Date.parse(rootAfter!.lastReplyAt!))).toBe(false);
+
+      const replyRow = after.messages.find((m) => m.threadId === root.id);
+      expect(replyRow).toBeDefined();
+      expect(replyRow?.replyCount).toBeUndefined();
+    });
+
+    it('counts multiple replies and tracks the latest reply time', () => {
+      const ch = createSam();
+      const root = service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'root',
+      });
+      service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'r1',
+        threadId: root.id,
+      });
+      service.sendMessage({
+        channelId: ch.id,
+        principal: owner,
+        content: 'r2',
+        threadId: root.id,
+      });
+      const page = service.listMessages({ channelId: ch.id, principal: owner });
+      const rootDto = page.messages.find((m) => m.id === root.id);
+      expect(rootDto?.replyCount).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // listMessages
   // -------------------------------------------------------------------------
 

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -1478,9 +1478,26 @@ export class ChatV2Service extends EventEmitter {
       direction: args.direction,
     });
 
+    // Slack-style thread reply counts: one aggregate query for the whole
+    // channel, then attach `replyCount`/`lastReplyAt` to the root-message
+    // DTOs on this page. Root messages are those whose own `threadId` is
+    // unset; replies never carry a count.
+    const threadSummary = this.messages.threadReplySummary(args.channelId);
+    const messages = page.rows.map((r) => {
+      const dto = this.toMessageDTO(r, []);
+      if (dto.threadId === undefined) {
+        const summary = threadSummary.get(dto.id);
+        if (summary) {
+          dto.replyCount = summary.replyCount;
+          dto.lastReplyAt = new Date(summary.lastReplyAtMs).toISOString();
+        }
+      }
+      return dto;
+    });
+
     return {
       channelId: args.channelId,
-      messages: page.rows.map((r) => this.toMessageDTO(r, [])),
+      messages,
       nextCursor: page.nextCursor,
       prevCursor: page.prevCursor,
     };

--- a/backend/src/services/chat-v2/sqlite/message.store.ts
+++ b/backend/src/services/chat-v2/sqlite/message.store.ts
@@ -407,6 +407,41 @@ export class MessageStore {
   }
 
   /**
+   * Aggregate Slack-style thread reply counts for a channel in a single
+   * query.
+   *
+   * Replies carry `thread_id = <root message id>`; root messages have
+   * `thread_id IS NULL`. This groups every reply by its root and returns
+   * one entry per thread with the reply count and the timestamp (ms) of
+   * the most recent reply. The caller attaches these to the matching
+   * root-message DTOs.
+   *
+   * Kept as ONE aggregate query per page (O(rows-with-threads)) rather
+   * than a per-message lookup, so a page render stays a fixed two-query
+   * cost regardless of page size.
+   *
+   * @param channelId - The channel id to aggregate over
+   * @returns Map of `rootMessageId` to `{ replyCount, lastReplyAtMs }`
+   */
+  threadReplySummary(
+    channelId: string,
+  ): Map<string, { replyCount: number; lastReplyAtMs: number }> {
+    const rows = this.db
+      .prepare(
+        `SELECT thread_id AS rootId, COUNT(*) AS cnt, MAX(created_at) AS last
+         FROM chat_messages
+         WHERE channel_id = ? AND thread_id IS NOT NULL
+         GROUP BY thread_id`,
+      )
+      .all(channelId) as Array<{ rootId: string; cnt: number; last: number }>;
+    const out = new Map<string, { replyCount: number; lastReplyAtMs: number }>();
+    for (const r of rows) {
+      out.set(r.rootId, { replyCount: r.cnt, lastReplyAtMs: r.last });
+    }
+    return out;
+  }
+
+  /**
    * Return the current `MAX(seq)` for a channel, or 0 when empty.
    *
    * @param channelId - The channel id

--- a/backend/src/services/chat-v2/types.ts
+++ b/backend/src/services/chat-v2/types.ts
@@ -250,6 +250,20 @@ export interface ChatMessageDTO {
    * group by `threadId` to render the thread sub-pane.
    */
   threadId?: string;
+  /**
+   * Slack-style threading — number of replies whose `threadId` equals
+   * this message's `id`. Populated only for root messages (those whose
+   * own `threadId` is unset) that have at least one reply, via a single
+   * per-page aggregate query in `listMessages`. Undefined when there are
+   * no replies; reply rows never carry this field.
+   */
+  replyCount?: number;
+  /**
+   * Slack-style threading — ISO 8601 timestamp of the most recent reply
+   * in this message's thread. Paired with `replyCount`; undefined when
+   * there are no replies.
+   */
+  lastReplyAt?: string;
 }
 
 /** Outbound attachment shape — image only in Phase 1. */

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   MockChatApiClient,
@@ -367,7 +367,7 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     expect(sendCalls[0].input.mentions).toEqual([]);
   });
 
-  it('AC#2: incoming messages with threadId surface the "Reply in thread" affordance', async () => {
+  it('AC#2: a root with replies shows the "N replies" chip and opens the thread panel', async () => {
     const messagesById: Record<string, Message[]> = {
       'ch-general': [
         {
@@ -378,6 +378,9 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
           content: 'kicking off the thread',
           createdAt: ISO,
           mentions: [],
+          // Server-computed reply summary on the root message.
+          replyCount: 1,
+          lastReplyAt: ISO,
         },
         {
           id: 'm-reply',
@@ -400,12 +403,40 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
         initialWorkspaceId="team:team-product"
       />,
     );
-    expect(await screen.findByTestId('thread-enter')).toBeInTheDocument();
+    // The reply is hidden from the main timeline; the chip is shown on the root.
+    expect(await screen.findByText('kicking off the thread')).toBeInTheDocument();
+    expect(screen.queryByText('reply within thread')).not.toBeInTheDocument();
+    const summary = await screen.findByTestId('msg-thread-summary-m-root');
+    expect(summary).toHaveTextContent('1 reply');
+
+    // Clicking the chip opens the right-hand thread panel with root + reply.
+    await userEvent.click(summary);
+    const panel = await screen.findByTestId('thread-panel');
+    expect(panel).toBeInTheDocument();
+    expect(screen.getByTestId('thread-msg-m-root')).toBeInTheDocument();
+    expect(screen.getByTestId('thread-msg-m-reply')).toBeInTheDocument();
+
+    // The close button clears the panel.
+    await userEvent.click(screen.getByTestId('thread-close'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('thread-panel')).not.toBeInTheDocument(),
+    );
   });
 
-  it('AC#2: composer sends `threadId: <root msg id>` after entering thread mode', async () => {
+  it('AC#2: the thread panel composer sends `threadId: <root msg id>`', async () => {
     const messagesById: Record<string, Message[]> = {
       'ch-general': [
+        {
+          id: 'm-root',
+          channelId: 'ch-general',
+          seq: 1,
+          author: { role: 'agent', id: 'agent-sam', name: 'Sam' },
+          content: 'kicking off the thread',
+          createdAt: ISO,
+          mentions: [],
+          replyCount: 1,
+          lastReplyAt: ISO,
+        },
         {
           id: 'm-reply',
           channelId: 'ch-general',
@@ -427,12 +458,16 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
         initialWorkspaceId="team:team-product"
       />,
     );
-    await userEvent.click(await screen.findByTestId('thread-enter'));
-    expect(screen.getByTestId('thread-reply-banner')).toBeInTheDocument();
+    await userEvent.click(await screen.findByTestId('msg-thread-summary-m-root'));
+    const panel = await screen.findByTestId('thread-panel');
 
-    const textarea = screen.getByTestId('mention-textarea');
-    await userEvent.type(textarea, 'me too');
-    await userEvent.click(screen.getByTestId('mention-send'));
+    // The panel hosts its own composer; the textarea inside it posts the reply.
+    const textareas = screen.getAllByTestId('mention-textarea');
+    // Last textarea belongs to the thread panel (rendered after the main one).
+    const panelTextarea = textareas[textareas.length - 1];
+    await userEvent.type(panelTextarea, 'me too');
+    const sendButtons = within(panel).getAllByTestId('mention-send');
+    await userEvent.click(sendButtons[sendButtons.length - 1]);
 
     await waitFor(() => expect(sendCalls).toHaveLength(1));
     expect(sendCalls[0].input.threadId).toBe('m-root');

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -39,6 +39,7 @@ import {
   Search,
   Info,
   Plus,
+  X,
 } from 'lucide-react';
 import {
   ChatAPIProvider,
@@ -51,6 +52,7 @@ import {
   useMessages,
   useSendMessage,
   useChatApiClient,
+  selectThreadReplies,
   type ChatApiClient,
   type ChatApiError,
   type Channel,
@@ -59,6 +61,7 @@ import {
   type ConversationRow,
   type MentionComposerSendPayload,
   type MentionTarget,
+  type Message,
   type Workspace,
 } from '@crewly/chat-ui';
 import {
@@ -689,9 +692,17 @@ function LiveTeamChatRightPanelInner({
   const { messages } = useMessages(conversation.id);
   const { send, error: sendError, reset: resetSendError } = useSendMessage();
 
-  // Phase C thread-pane state — `threadRoot` is the message id we're
-  // composing replies against. Top-level posts have `threadRoot=null`.
-  const [threadRoot, setThreadRoot] = useState<string | null>(null);
+  // Slack-style thread panel state — `activeThreadRootId` is the root
+  // message id whose thread panel is open (null = closed). It doubles as
+  // the compose target: when the panel is open, replies POST with
+  // `threadId = activeThreadRootId`; top-level posts have it null.
+  const [activeThreadRootId, setActiveThreadRootId] = useState<string | null>(null);
+
+  // Reset the open thread whenever the conversation changes — a thread root
+  // from one channel is meaningless in another.
+  useEffect(() => {
+    setActiveThreadRootId(null);
+  }, [conversation.id]);
 
   // Surface validation_error and payload_too_large 400/413s as a toast.
   // Network errors (code 'network_error') get the same treatment so the
@@ -708,19 +719,16 @@ function LiveTeamChatRightPanelInner({
   const showSlackBar = (isOrc || isSlackThread) && slackThreads.length > 0;
   const [slackOpen, setSlackOpen] = useState(false);
 
-  /**
-   * Pick a sensible thread root from incoming messages. When any message
-   * in the timeline already carries a `threadId`, surface a small
-   * "Reply in thread" affordance keyed to that thread. The user clicks
-   * to enter thread-reply mode.
-   */
-  const lastObservedThreadId = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const t = messages[i].threadId;
-      if (t) return t;
-    }
-    return null;
-  }, [messages]);
+  // The root message of the open thread (found in the live timeline) + its
+  // replies derived live so a WS-delivered reply shows in the panel instantly.
+  const threadRootMessage = useMemo<Message | undefined>(
+    () => (activeThreadRootId ? messages.find((m) => m.id === activeThreadRootId) : undefined),
+    [messages, activeThreadRootId],
+  );
+  const threadReplies = useMemo<Message[]>(
+    () => (activeThreadRootId ? selectThreadReplies(messages, activeThreadRootId) : []),
+    [messages, activeThreadRootId],
+  );
 
   const handleSend = useCallback(
     async (payload: MentionComposerSendPayload) => {
@@ -731,139 +739,139 @@ function LiveTeamChatRightPanelInner({
         await send(conversation.id, {
           content: payload.content,
           mentions: mentionIds,
-          threadId: threadRoot ?? undefined,
+          threadId: activeThreadRootId ?? undefined,
         });
       } catch {
         // Error is captured in `sendError`; the toast renders below.
         // Swallow here so the composer doesn't double-report.
       }
     },
-    [conversation.id, send, threadRoot],
+    [conversation.id, send, activeThreadRootId],
   );
 
-  const handleEnterThread = useCallback(() => {
-    if (lastObservedThreadId) setThreadRoot(lastObservedThreadId);
-  }, [lastObservedThreadId]);
-
-  const handleExitThread = useCallback(() => {
-    setThreadRoot(null);
+  const handleOpenThread = useCallback((m: Message) => {
+    setActiveThreadRootId(m.id);
   }, []);
+
+  const handleCloseThread = useCallback(() => {
+    setActiveThreadRootId(null);
+  }, []);
+
+  const threadOpen = activeThreadRootId !== null;
 
   return (
     <section
-      className="flex flex-1 flex-col bg-background-dark"
+      className="flex flex-1 bg-background-dark"
       data-testid="team-chat-right-panel"
       aria-label={`Conversation with ${conversation.title}`}
-      data-thread-active={threadRoot ? 'true' : 'false'}
+      data-thread-active={threadOpen ? 'true' : 'false'}
     >
-      <header className="flex items-center justify-between gap-4 border-b border-border-dark bg-background-dark/30 px-6 py-3 backdrop-blur-md">
-        <div className="min-w-0 leading-tight">
-          <h2 className="truncate text-base font-bold text-text-primary-dark">
-            {conversation.kind === 'channel'
-              ? `#${conversation.title.replace(/^#+\s*/, '')}`
-              : conversation.title}
-          </h2>
-          {conversation.subtitle && (
-            <p className="truncate text-[11px] text-text-secondary-dark">
-              {conversation.subtitle}
-            </p>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          {/* Phase C minimal thread affordance — surfaces only when the
-              timeline contains a threaded reply, so we know there IS a
-              thread to drop into. */}
-          {lastObservedThreadId && !threadRoot && (
-            <button
-              type="button"
-              onClick={handleEnterThread}
-              data-testid="thread-enter"
-              className="mr-2 rounded-md border border-border-dark px-2 py-1 text-xs text-text-secondary-dark transition hover:bg-white/5 hover:text-text-primary-dark"
-            >
-              Reply in thread
-            </button>
-          )}
-          {/* Header actions. (A "call" affordance was dropped — there's
-              nothing to dial in an agent chat.) Search/info are placeholders
-              for now until wired to in-conversation search + details. */}
-          <HeaderActionButton label="Search">
-            <Search size={18} />
-          </HeaderActionButton>
-          <HeaderActionButton label="Conversation info">
-            <Info size={18} />
-          </HeaderActionButton>
-        </div>
-      </header>
-
-      {showSlackBar && (
-        <div className="border-b border-border-dark" data-testid="slack-threads-bar">
-          <div className="flex items-center justify-between px-4 py-2">
-            <button
-              type="button"
-              onClick={() => setSlackOpen((o) => !o)}
-              aria-expanded={slackOpen}
-              data-testid="slack-threads-toggle"
-              className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-secondary-dark"
-            >
-              {slackOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-              Slack threads · {slackThreads.length}
-            </button>
-            {isSlackThread && orcRow && (
-              <button
-                type="button"
-                onClick={() => onSelectConversation(orcRow)}
-                data-testid="slack-back-to-orc"
-                className="text-xs text-primary hover:underline"
-              >
-                ← Orchestrator
-              </button>
+      {/* Main message column — shrinks to make room for the thread panel. */}
+      <div className="flex min-w-0 flex-1 flex-col bg-background-dark">
+        <header className="flex items-center justify-between gap-4 border-b border-border-dark bg-background-dark/30 px-6 py-3 backdrop-blur-md">
+          <div className="min-w-0 leading-tight">
+            <h2 className="truncate text-base font-bold text-text-primary-dark">
+              {conversation.kind === 'channel'
+                ? `#${conversation.title.replace(/^#+\s*/, '')}`
+                : conversation.title}
+            </h2>
+            {conversation.subtitle && (
+              <p className="truncate text-[11px] text-text-secondary-dark">
+                {conversation.subtitle}
+              </p>
             )}
           </div>
-          {slackOpen && (
-            <ul className="chat-scrollbar max-h-48 overflow-y-auto px-2 pb-2" role="list">
-              {slackThreads.map((t) => (
-                <li key={t.id}>
-                  <button
-                    type="button"
-                    onClick={() => onSelectConversation(t)}
-                    data-testid={`slack-thread-${t.id}`}
-                    className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
-                      t.id === conversation.id
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-text-secondary-dark hover:bg-white/5 hover:text-text-primary-dark'
-                    }`}
-                  >
-                    <MessageSquare size={13} className="shrink-0 opacity-60" />
-                    <span className="truncate">{t.title}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+          <div className="flex items-center gap-1">
+            {/* Header actions. (A "call" affordance was dropped — there's
+                nothing to dial in an agent chat.) Search/info are placeholders
+                for now until wired to in-conversation search + details. */}
+            <HeaderActionButton label="Search">
+              <Search size={18} />
+            </HeaderActionButton>
+            <HeaderActionButton label="Conversation info">
+              <Info size={18} />
+            </HeaderActionButton>
+          </div>
+        </header>
+
+        {showSlackBar && (
+          <div className="border-b border-border-dark" data-testid="slack-threads-bar">
+            <div className="flex items-center justify-between px-4 py-2">
+              <button
+                type="button"
+                onClick={() => setSlackOpen((o) => !o)}
+                aria-expanded={slackOpen}
+                data-testid="slack-threads-toggle"
+                className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-secondary-dark"
+              >
+                {slackOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                Slack threads · {slackThreads.length}
+              </button>
+              {isSlackThread && orcRow && (
+                <button
+                  type="button"
+                  onClick={() => onSelectConversation(orcRow)}
+                  data-testid="slack-back-to-orc"
+                  className="text-xs text-primary hover:underline"
+                >
+                  ← Orchestrator
+                </button>
+              )}
+            </div>
+            {slackOpen && (
+              <ul className="chat-scrollbar max-h-48 overflow-y-auto px-2 pb-2" role="list">
+                {slackThreads.map((t) => (
+                  <li key={t.id}>
+                    <button
+                      type="button"
+                      onClick={() => onSelectConversation(t)}
+                      data-testid={`slack-thread-${t.id}`}
+                      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
+                        t.id === conversation.id
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-text-secondary-dark hover:bg-white/5 hover:text-text-primary-dark'
+                      }`}
+                    >
+                      <MessageSquare size={13} className="shrink-0 opacity-60" />
+                      <span className="truncate">{t.title}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {/* Main timeline: roots only (replies hidden — they live in the
+            thread panel). Hover "Reply in thread" + the "N replies" chip
+            both open the thread panel for that root. */}
+        <MessageThread
+          channelId={conversation.id}
+          agentName={recipientName}
+          layout="flat"
+          hideReplies
+          onReplyInThread={handleOpenThread}
+          emptyState={
+            <NoMessagesEmptyState
+              kind={conversation.kind === 'dm' ? 'dm' : 'channel'}
+              recipientName={recipientName}
+            />
+          }
+        />
+
+        <MentionComposer mentionables={mentionables} onSend={handleSend} />
+      </div>
+
+      {/* Right-hand Slack-style thread panel. */}
+      {threadOpen && (
+        <ThreadPanel
+          rootMessage={threadRootMessage}
+          replies={threadReplies}
+          mentionables={mentionables}
+          onClose={handleCloseThread}
+          onSend={handleSend}
+        />
       )}
-
-      <MessageThread
-        channelId={conversation.id}
-        agentName={recipientName}
-        layout="flat"
-        emptyState={
-          <NoMessagesEmptyState
-            kind={conversation.kind === 'dm' ? 'dm' : 'channel'}
-            recipientName={recipientName}
-          />
-        }
-      />
-
-      {threadRoot && (
-        <ThreadReplyBanner threadRootId={threadRoot} onExit={handleExitThread} />
-      )}
-
-      <MentionComposer
-        mentionables={mentionables}
-        onSend={handleSend}
-        inactiveHelper={threadRoot ? `Replying in thread ${threadRoot}` : undefined}
-      />
 
       {toast && (
         <ChatErrorToast
@@ -901,34 +909,133 @@ function HeaderActionButton({
 }
 
 /**
- * Small banner above the composer when a thread reply is active.
- * Mirrors Slack's "Replying to a thread in #general" affordance.
+ * Right-hand Slack-style Thread panel.
+ *
+ * Renders the thread's root message at the top, a divider, then every
+ * reply (derived live from the channel timeline so WS-delivered replies
+ * appear instantly), and a composer that posts replies with
+ * `threadId = root id` (the host's `onSend` already reads
+ * `activeThreadRootId`). The replies are rendered as a self-contained
+ * list rather than via `MessageThread` so the panel does not re-subscribe
+ * to the whole channel feed.
+ *
+ * @param rootMessage - The thread root (may be undefined if not yet loaded)
+ * @param replies - Replies for this thread, ascending by seq
+ * @param mentionables - Mention pool for the reply composer
+ * @param onClose - Close the panel (clears the active thread)
+ * @param onSend - Host send handler (composes with the active thread id)
  */
-function ThreadReplyBanner({
-  threadRootId,
-  onExit,
+function ThreadPanel({
+  rootMessage,
+  replies,
+  mentionables,
+  onClose,
+  onSend,
 }: {
-  threadRootId: string;
-  onExit: () => void;
+  rootMessage: Message | undefined;
+  replies: Message[];
+  mentionables: MentionTarget[];
+  onClose: () => void;
+  onSend: (payload: MentionComposerSendPayload) => void;
 }): JSX.Element {
+  const replyCount = replies.length;
+  return (
+    <aside
+      data-testid="thread-panel"
+      aria-label="Thread"
+      className="flex w-[380px] shrink-0 flex-col border-l border-border-dark bg-background-dark"
+    >
+      <header className="flex items-center justify-between gap-4 border-b border-border-dark bg-background-dark/30 px-4 py-3 backdrop-blur-md">
+        <div className="leading-tight">
+          <h3 className="text-sm font-bold text-text-primary-dark">Thread</h3>
+          {replyCount > 0 && (
+            <p className="text-[11px] text-text-secondary-dark">
+              {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          data-testid="thread-close"
+          aria-label="Close thread"
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary-dark transition hover:bg-white/5 hover:text-text-primary-dark"
+        >
+          <X size={18} />
+        </button>
+      </header>
+
+      <div className="chat-scrollbar flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4">
+        {rootMessage ? (
+          <ThreadMessageRow message={rootMessage} isRoot />
+        ) : (
+          <p className="text-xs text-text-secondary-dark">Thread root unavailable.</p>
+        )}
+        <div className="flex items-center gap-3 py-1">
+          <span className="h-[1px] flex-1 bg-border-dark/30" aria-hidden="true" />
+          <span className="text-[10px] font-bold uppercase tracking-widest text-text-secondary-dark">
+            {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+          </span>
+          <span className="h-[1px] flex-1 bg-border-dark/30" aria-hidden="true" />
+        </div>
+        {replies.map((m) => (
+          <ThreadMessageRow key={m.id} message={m} />
+        ))}
+      </div>
+
+      <MentionComposer mentionables={mentionables} onSend={onSend} placeholder="Reply…" />
+    </aside>
+  );
+}
+
+/**
+ * One message rendered inside the thread panel — a compact, self-contained
+ * row mirroring the flat timeline look (bold name, timestamp, glass body)
+ * so the panel reads consistently without re-subscribing the channel feed.
+ *
+ * @param message - The message to render
+ * @param isRoot - When true, this is the thread's root (slightly emphasized)
+ */
+function ThreadMessageRow({
+  message,
+  isRoot = false,
+}: {
+  message: Message;
+  isRoot?: boolean;
+}): JSX.Element {
+  const isAgent = message.author.role !== 'user';
+  const name = message.author.name ?? message.author.id;
+  const time = (() => {
+    try {
+      return new Date(message.createdAt).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  })();
   return (
     <div
-      role="note"
-      data-testid="thread-reply-banner"
-      className="mx-4 flex items-center justify-between gap-2 border-t border-border-dark px-4 py-1.5 text-xs text-text-secondary-dark"
+      className="flex flex-col"
+      data-testid={`thread-msg-${message.id}`}
+      data-author-role={message.author.role}
     >
-      <span>
-        Replying to thread{' '}
-        <code className="rounded bg-primary/10 px-1 text-primary">{threadRootId}</code>
-      </span>
-      <button
-        type="button"
-        onClick={onExit}
-        data-testid="thread-exit"
-        className="rounded px-2 py-0.5 text-text-secondary-dark transition hover:bg-white/5 hover:text-text-primary-dark"
+      <div className="flex items-baseline gap-2">
+        <span
+          className={`text-[13px] font-bold ${isAgent ? 'text-primary' : 'text-text-primary-dark'}`}
+        >
+          {name}
+        </span>
+        <time className="text-[10px] text-text-secondary-dark">{time}</time>
+      </div>
+      <div
+        className={`glass-panel mt-1 max-w-full whitespace-pre-wrap break-words rounded-xl rounded-tl-none px-4 py-2 text-sm leading-relaxed text-text-primary-dark ${
+          isAgent ? 'border-l-2 border-l-primary' : ''
+        } ${isRoot ? 'ring-1 ring-border-dark' : ''}`}
       >
-        Cancel
-      </button>
+        {message.content}
+      </div>
     </div>
   );
 }

--- a/packages/chat-ui/src/api/dto.test.ts
+++ b/packages/chat-ui/src/api/dto.test.ts
@@ -148,6 +148,43 @@ describe('messageFromDTO', () => {
     expect(messageFromDTO(dto).author.name).toBe('System');
   });
 
+  // Slack-style threading — reply count summary fields.
+  it('maps replyCount + lastReplyAt (ms → ISO) when present on a root', () => {
+    const dto: MessageDTO = {
+      id: 'root-1',
+      channelId: 'ch-1',
+      seq: 1,
+      senderType: 'user',
+      senderId: 'demo-user',
+      content: 'root',
+      contentType: 'markdown',
+      createdAt: 0,
+      attachments: [],
+      replyCount: 3,
+      lastReplyAt: 1729790000000,
+    };
+    const m = messageFromDTO(dto);
+    expect(m.replyCount).toBe(3);
+    expect(m.lastReplyAt).toBe(new Date(1729790000000).toISOString());
+  });
+
+  it('leaves replyCount/lastReplyAt undefined when the wire omits them', () => {
+    const dto: MessageDTO = {
+      id: 'plain',
+      channelId: 'ch-1',
+      seq: 1,
+      senderType: 'user',
+      senderId: 'demo-user',
+      content: 'plain',
+      contentType: 'markdown',
+      createdAt: 0,
+      attachments: [],
+    };
+    const m = messageFromDTO(dto);
+    expect(m.replyCount).toBeUndefined();
+    expect(m.lastReplyAt).toBeUndefined();
+  });
+
   // Phase B (SEALED §3.2) — mention array invariants.
   it('preserves a mentions array verbatim through translation', () => {
     const dto: MessageDTO = {

--- a/packages/chat-ui/src/api/dto.ts
+++ b/packages/chat-ui/src/api/dto.ts
@@ -89,6 +89,13 @@ export interface MessageDTO {
    * message is a reply within a thread; consumers group by `threadId`.
    */
   threadId?: string;
+  /**
+   * Slack-style threading — server-computed reply count, present only on
+   * root messages with at least one reply.
+   */
+  replyCount?: number;
+  /** Slack-style threading — ms-since-epoch of the most recent reply. */
+  lastReplyAt?: number;
 }
 
 /** Wire shape for attachments (Phase 1 image only). */
@@ -235,6 +242,10 @@ export function messageFromDTO(dto: MessageDTO): Message {
     // omits the field, so domain consumers can rely on `m.mentions`.
     mentions: Array.isArray(dto.mentions) ? dto.mentions : [],
     threadId: dto.threadId,
+    // Slack-style thread summary — only present on root messages with
+    // replies. `lastReplyAt` is ms on the wire; surface as ISO domain-side.
+    replyCount: typeof dto.replyCount === 'number' ? dto.replyCount : undefined,
+    lastReplyAt: msToIso(dto.lastReplyAt),
   };
 }
 

--- a/packages/chat-ui/src/components/MessageThread.test.tsx
+++ b/packages/chat-ui/src/components/MessageThread.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { ChatAPIProvider } from '../context/ChatAPIProvider';
 import { MockChatApiClient } from '../api/mock-client';
-import { MessageThread, avatarInitials, avatarColor } from './MessageThread';
+import { MessageThread, avatarInitials, avatarColor, relativeTime } from './MessageThread';
+import type { Channel, Message } from '../types/chat.types';
 
 describe('MessageThread', () => {
   beforeEach(() => {
@@ -156,5 +157,113 @@ describe('avatarInitials / avatarColor', () => {
     const b = avatarColor('Orchestrator');
     expect(a).toBe(b);
     expect(a.startsWith('bg-')).toBe(true);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Slack-style threading additions (additive — legacy callers omit the props).
+// ---------------------------------------------------------------------------
+
+describe('MessageThread threading', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = function () {
+      /* no-op */
+    };
+  });
+
+  const channel: Channel = {
+    id: 'c-thread',
+    agentSession: '',
+    name: '#general',
+    createdAt: '2026-04-25T00:00:00.000Z',
+    type: 'channel',
+    teamId: 't1',
+  };
+
+  const root: Message = {
+    id: 'root-1',
+    channelId: 'c-thread',
+    seq: 1,
+    author: { role: 'user', id: 'me', name: 'Me' },
+    content: 'root message',
+    createdAt: '2026-04-25T00:00:00.000Z',
+    mentions: [],
+    replyCount: 2,
+    lastReplyAt: new Date().toISOString(),
+  };
+  const reply: Message = {
+    id: 'reply-1',
+    channelId: 'c-thread',
+    seq: 2,
+    author: { role: 'agent', id: 'sam', name: 'Sam' },
+    content: 'a reply',
+    createdAt: '2026-04-25T00:01:00.000Z',
+    mentions: [],
+    threadId: 'root-1',
+  };
+
+  function renderWith(props: Record<string, unknown>) {
+    const client = new MockChatApiClient({
+      initialChannels: [channel],
+      initialMessages: { 'c-thread': [root, reply] },
+    });
+    return render(
+      <ChatAPIProvider client={client} mode="mock">
+        <MessageThread channelId="c-thread" layout="flat" {...props} />
+      </ChatAPIProvider>,
+    );
+  }
+
+  it('does not show reply affordances when onReplyInThread is omitted', async () => {
+    renderWith({});
+    await waitFor(() => expect(screen.getByText('root message')).toBeInTheDocument());
+    expect(screen.queryByTestId('msg-reply-action-root-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('msg-thread-summary-root-1')).not.toBeInTheDocument();
+  });
+
+  it('renders the hover reply action + the N replies summary chip when enabled', async () => {
+    const onReplyInThread = vi.fn();
+    renderWith({ onReplyInThread });
+    await waitFor(() => expect(screen.getByText('root message')).toBeInTheDocument());
+
+    const action = screen.getByTestId('msg-reply-action-root-1');
+    expect(action).toBeInTheDocument();
+    const summary = screen.getByTestId('msg-thread-summary-root-1');
+    expect(summary).toHaveTextContent('2 replies');
+
+    fireEvent.click(summary);
+    expect(onReplyInThread).toHaveBeenCalledWith(expect.objectContaining({ id: 'root-1' }));
+    fireEvent.click(action);
+    expect(onReplyInThread).toHaveBeenCalledTimes(2);
+  });
+
+  it('hideReplies=true removes thread-reply rows from the main timeline', async () => {
+    renderWith({ onReplyInThread: vi.fn(), hideReplies: true });
+    await waitFor(() => expect(screen.getByText('root message')).toBeInTheDocument());
+    expect(screen.queryByText('a reply')).not.toBeInTheDocument();
+  });
+
+  it('hideReplies=false (default) keeps thread-reply rows visible', async () => {
+    renderWith({ onReplyInThread: vi.fn() });
+    await waitFor(() => expect(screen.getByText('root message')).toBeInTheDocument());
+    expect(screen.getByText('a reply')).toBeInTheDocument();
+  });
+});
+
+describe('relativeTime', () => {
+  it('renders "now" for a just-now timestamp', () => {
+    expect(relativeTime(new Date().toISOString())).toBe('now');
+  });
+
+  it('renders minute / hour / day buckets', () => {
+    const now = Date.now();
+    expect(relativeTime(new Date(now - 5 * 60_000).toISOString())).toBe('5m');
+    expect(relativeTime(new Date(now - 3 * 3_600_000).toISOString())).toBe('3h');
+    expect(relativeTime(new Date(now - 2 * 86_400_000).toISOString())).toBe('2d');
+  });
+
+  it('returns empty string on an unparseable value', () => {
+    expect(relativeTime('not-a-date')).toBe('');
   });
 });

--- a/packages/chat-ui/src/components/MessageThread.tsx
+++ b/packages/chat-ui/src/components/MessageThread.tsx
@@ -31,7 +31,7 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { Bot } from 'lucide-react';
+import { Bot, MessageSquare } from 'lucide-react';
 import type { Message } from '../types/chat.types';
 import { useMessages } from '../hooks/useMessages';
 import { renderMinimalMarkdown } from './internal/minimal-markdown';
@@ -66,6 +66,23 @@ export interface MessageThreadProps {
    *   grouped under one header. Used by the consolidated team-chat surface.
    */
   layout?: 'bubble' | 'flat';
+  /**
+   * Slack-style threading (additive — omit on legacy callers).
+   *
+   * When provided (flat layout), each message row gets a hover
+   * "Reply in thread" action and root messages with `replyCount > 0`
+   * render a clickable "💬 N replies · <relative time>" summary chip.
+   * Both invoke this callback with the message to open as the thread root.
+   */
+  onReplyInThread?(message: Message): void;
+  /**
+   * Slack-style threading — when true, messages that are thread replies
+   * (have a `threadId`) are filtered out of this timeline. The main
+   * channel passes `true`; the thread panel passes `false` so it shows
+   * every message for that thread. Defaults to `false` (no filtering),
+   * preserving legacy behavior.
+   */
+  hideReplies?: boolean;
 }
 
 export function MessageThread({
@@ -76,8 +93,15 @@ export function MessageThread({
   unreadAfterSeq = null,
   unreadDividerLabel = 'New',
   layout = 'bubble',
+  onReplyInThread,
+  hideReplies = false,
 }: MessageThreadProps): JSX.Element {
-  const { messages, loading, error, hasMore, agentThinking, loadMore } = useMessages(channelId);
+  const { messages: allMessages, loading, error, hasMore, agentThinking, loadMore } =
+    useMessages(channelId);
+  // Slack-style: the main timeline hides thread replies (they live in the
+  // thread panel). `hideReplies=false` (default) keeps the full timeline,
+  // preserving legacy single-channel behavior.
+  const messages = hideReplies ? allMessages.filter((m) => !m.threadId) : allMessages;
   const bottomRef = useRef<HTMLDivElement | null>(null);
 
   // Auto-scroll to newest on every mutation — Phase 1 keeps it simple.
@@ -126,7 +150,7 @@ export function MessageThread({
         role="list"
         className={`flex flex-1 flex-col ${flat ? 'gap-4 px-6 py-4' : 'gap-3 px-4 py-4'}`}
       >
-        {renderTimeline({ messages, unreadAfterSeq, unreadDividerLabel, layout })}
+        {renderTimeline({ messages, unreadAfterSeq, unreadDividerLabel, layout, onReplyInThread })}
         {agentThinking && <AgentThinkingRow agentName={agentName} layout={layout} />}
         {loading && (
           <li
@@ -157,8 +181,9 @@ function renderTimeline(args: {
   unreadAfterSeq: number | null;
   unreadDividerLabel: string;
   layout: 'bubble' | 'flat';
+  onReplyInThread?(message: Message): void;
 }): React.ReactNode[] {
-  const { messages, unreadAfterSeq, unreadDividerLabel, layout } = args;
+  const { messages, unreadAfterSeq, unreadDividerLabel, layout, onReplyInThread } = args;
   const out: React.ReactNode[] = [];
 
   // In flat (Slack) mode, consecutive messages from the same author group
@@ -176,7 +201,15 @@ function renderTimeline(args: {
   let dividerInserted = false;
   for (const m of messages) {
     const groupStart = layout !== 'flat' || prevAuthor !== m.author.id;
-    out.push(<MessageRow key={m.id} message={m} layout={layout} groupStart={groupStart} />);
+    out.push(
+      <MessageRow
+        key={m.id}
+        message={m}
+        layout={layout}
+        groupStart={groupStart}
+        onReplyInThread={onReplyInThread}
+      />,
+    );
     prevAuthor = m.author.id;
     if (!dividerInserted && hasMatchingSeq && m.seq === unreadAfterSeq) {
       out.push(<UnreadDividerRow key="unread-divider" label={unreadDividerLabel} layout={layout} />);
@@ -235,13 +268,21 @@ function MessageRow({
   message,
   layout = 'bubble',
   groupStart = true,
+  onReplyInThread,
 }: {
   message: Message;
   layout?: 'bubble' | 'flat';
   groupStart?: boolean;
+  onReplyInThread?(message: Message): void;
 }): JSX.Element {
   if (layout === 'flat') {
-    return <FlatMessageRow message={message} groupStart={groupStart} />;
+    return (
+      <FlatMessageRow
+        message={message}
+        groupStart={groupStart}
+        onReplyInThread={onReplyInThread}
+      />
+    );
   }
   const isUser = message.author.role === 'user';
   const alignment = isUser ? 'items-end' : 'items-start';
@@ -292,9 +333,11 @@ function MessageRow({
 function FlatMessageRow({
   message,
   groupStart,
+  onReplyInThread,
 }: {
   message: Message;
   groupStart: boolean;
+  onReplyInThread?(message: Message): void;
 }): JSX.Element {
   const status = message.deliveryStatus;
   const name = message.author.name ?? message.author.id;
@@ -302,10 +345,17 @@ function FlatMessageRow({
   // Inactive/sleep deliveries read dimmed + dashed so they recede from view.
   const inactive = status === 'pending';
   const faded = inactive ? 'opacity-50' : '';
+  // Slack threading: the hover "Reply" action + the "N replies" summary chip
+  // only render when the host opts in via `onReplyInThread`. The chip is for
+  // roots with replies; the action is for any non-pending message.
+  const threadingOn = typeof onReplyInThread === 'function';
+  const replyCount = message.replyCount ?? 0;
+  const showSummary = threadingOn && replyCount > 0;
+  const showReplyAction = threadingOn && status !== 'pending' && status !== 'failed';
 
   return (
     <li
-      className={`group flex gap-3 ${groupStart ? 'mt-1' : ''}`}
+      className={`group relative flex gap-3 ${groupStart ? 'mt-1' : ''}`}
       data-author-role={message.author.role}
       data-delivery-status={status ?? 'sent'}
     >
@@ -361,7 +411,37 @@ function FlatMessageRow({
             Send failed — tap to retry
           </span>
         )}
+        {showSummary && (
+          <button
+            type="button"
+            data-testid={`msg-thread-summary-${message.id}`}
+            onClick={() => onReplyInThread?.(message)}
+            className="mt-1 inline-flex items-center gap-1.5 rounded-md border border-border-dark bg-surface-dark px-2 py-1 text-[11px] font-medium text-primary transition hover:bg-white/5"
+          >
+            <MessageSquare size={12} className="shrink-0" />
+            <span>
+              {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+            </span>
+            {message.lastReplyAt && (
+              <span className="font-normal text-text-secondary-dark">
+                · last reply {relativeTime(message.lastReplyAt)}
+              </span>
+            )}
+          </button>
+        )}
       </div>
+      {showReplyAction && (
+        <button
+          type="button"
+          data-testid={`msg-reply-action-${message.id}`}
+          onClick={() => onReplyInThread?.(message)}
+          aria-label="Reply in thread"
+          className="absolute right-2 top-0 hidden items-center gap-1 rounded-md border border-border-dark bg-surface-dark px-2 py-1 text-[11px] text-text-secondary-dark transition hover:text-text-primary-dark group-hover:flex"
+        >
+          <MessageSquare size={12} className="shrink-0" />
+          <span>Reply</span>
+        </button>
+      )}
     </li>
   );
 }
@@ -488,6 +568,32 @@ function AgentThinkingRow({
       </div>
     </li>
   );
+}
+
+/**
+ * Compact, locale-agnostic relative time for the thread-summary chip
+ * (e.g. "now", "5m", "3h", "2d", then an absolute short date past a week).
+ * Exported so the threading UI can be unit-tested without rendering.
+ *
+ * @param iso - ISO 8601 timestamp of the last reply
+ * @returns A short relative-time label; empty string on parse failure
+ */
+export function relativeTime(iso: string): string {
+  try {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return '';
+    const diff = Date.now() - then;
+    const m = Math.floor(diff / 60_000);
+    if (m < 1) return 'now';
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h`;
+    const d = Math.floor(h / 24);
+    if (d < 7) return `${d}d`;
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
 }
 
 function formatTimestamp(iso: string): string {

--- a/packages/chat-ui/src/hooks/useMessages.test.ts
+++ b/packages/chat-ui/src/hooks/useMessages.test.ts
@@ -3,7 +3,14 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { ChatAPIProvider } from '../context/ChatAPIProvider';
 import { MockChatApiClient } from '../api/mock-client';
-import { useMessages, reconcileMessage, deriveAgentThinking, toAscendingBySeq } from './useMessages';
+import {
+  useMessages,
+  reconcileMessage,
+  deriveAgentThinking,
+  toAscendingBySeq,
+  selectRootMessages,
+  selectThreadReplies,
+} from './useMessages';
 import type { Message } from '../types/chat.types';
 
 describe('useMessages', () => {
@@ -244,5 +251,38 @@ describe('toAscendingBySeq', () => {
     expect(asc.map((m) => m.seq)).toEqual([1, 2, 24, 25, 26]);
     // Does not mutate the input.
     expect(desc.map((m) => m.seq)).toEqual([26, 25, 24, 2, 1]);
+  });
+});
+
+
+describe('selectRootMessages / selectThreadReplies', () => {
+  const mk = (seq: number, threadId?: string): Message => ({
+    id: `m-${seq}`,
+    channelId: 'c1',
+    seq,
+    author: { role: 'user', id: 'me' },
+    content: `msg ${seq}`,
+    createdAt: '2026-04-25T01:00:00.000Z',
+    mentions: [],
+    threadId,
+  });
+
+  it('selectRootMessages keeps only messages without a threadId', () => {
+    const timeline = [mk(1), mk(2, 'm-1'), mk(3), mk(4, 'm-3'), mk(5, 'm-1')];
+    const roots = selectRootMessages(timeline);
+    expect(roots.map((m) => m.id)).toEqual(['m-1', 'm-3']);
+  });
+
+  it('selectThreadReplies returns replies for a root ascending by seq', () => {
+    // Intentionally out of seq order to prove the helper sorts.
+    const timeline = [mk(1), mk(5, 'm-1'), mk(3), mk(2, 'm-1'), mk(4, 'm-3')];
+    const replies = selectThreadReplies(timeline, 'm-1');
+    expect(replies.map((m) => m.seq)).toEqual([2, 5]);
+    expect(replies.every((m) => m.threadId === 'm-1')).toBe(true);
+  });
+
+  it('selectThreadReplies returns [] for a root with no replies', () => {
+    const timeline = [mk(1), mk(2, 'm-1')];
+    expect(selectThreadReplies(timeline, 'm-99')).toEqual([]);
   });
 });

--- a/packages/chat-ui/src/hooks/useMessages.ts
+++ b/packages/chat-ui/src/hooks/useMessages.ts
@@ -105,6 +105,37 @@ export function toAscendingBySeq(messages: Message[]): Message[] {
   return [...messages].sort((a, b) => a.seq - b.seq);
 }
 
+/**
+ * Select the root (top-level) messages from a timeline — those that are
+ * NOT thread replies (`threadId` unset). The main channel timeline renders
+ * only these; replies live inside the thread panel.
+ *
+ * Pure helper so the split is unit-testable without React.
+ *
+ * @param messages - The full channel timeline
+ * @returns Root messages in their original order
+ */
+export function selectRootMessages(messages: Message[]): Message[] {
+  return messages.filter((m) => !m.threadId);
+}
+
+/**
+ * Select the replies belonging to a given thread root, ascending by `seq`
+ * (oldest → newest, matching the timeline contract). A reply belongs to a
+ * thread when its `threadId` equals the root message id.
+ *
+ * Pure helper so the thread panel can derive its view live from `messages`
+ * (so a reply arriving via WS shows instantly) and so the split is
+ * unit-testable without React.
+ *
+ * @param messages - The full channel timeline
+ * @param rootId - The thread root message id
+ * @returns Reply messages for that thread, ascending by seq
+ */
+export function selectThreadReplies(messages: Message[], rootId: string): Message[] {
+  return messages.filter((m) => m.threadId === rootId).sort((a, b) => a.seq - b.seq);
+}
+
 export function deriveAgentThinking(messages: Message[]): boolean {
   if (messages.length === 0) return false;
   const last = messages[messages.length - 1];

--- a/packages/chat-ui/src/index.ts
+++ b/packages/chat-ui/src/index.ts
@@ -36,7 +36,7 @@ export type {
 // Hooks
 export { useChannels } from './hooks/useChannels';
 export type { UseChannelsResult } from './hooks/useChannels';
-export { useMessages } from './hooks/useMessages';
+export { useMessages, selectRootMessages, selectThreadReplies } from './hooks/useMessages';
 export type { UseMessagesResult } from './hooks/useMessages';
 export { useSendMessage } from './hooks/useSendMessage';
 export type { UseSendMessageResult } from './hooks/useSendMessage';

--- a/packages/chat-ui/src/types/chat.types.ts
+++ b/packages/chat-ui/src/types/chat.types.ts
@@ -204,6 +204,17 @@ export interface Message {
    * group by `threadId` to render the thread sub-pane.
    */
   threadId?: string;
+  /**
+   * Slack-style threading — number of replies in this message's thread.
+   * Server-computed and present only on root messages (those with no
+   * `threadId`) that have at least one reply. Undefined otherwise.
+   */
+  replyCount?: number;
+  /**
+   * Slack-style threading — ISO 8601 timestamp of the most recent reply
+   * in this message's thread. Paired with `replyCount`.
+   */
+  lastReplyAt?: string;
 }
 
 /** Body for `POST /api/chat/channels/:id/messages`. */


### PR DESCRIPTION
## What
Adds Slack-style threads to the OSS chat:
- **Hover any message → "Reply"** action; clicking it (or a root's reply-count chip) opens a **right-hand Thread panel** with the root message + its replies + a composer.
- Replies post with **`threadId = root id`** and are **hidden from the main channel timeline** (they live only in the thread).
- A root with replies shows a **"💬 N replies · &lt;last reply&gt;"** chip; clicking it reopens the thread.

## Backend
- `ChatMessageDTO` gains `replyCount` + `lastReplyAt`. `listMessages` attaches them via **one `GROUP BY thread_id` aggregate per page** (root rows only). Message-ordering contract unchanged.
- The `threadId` POST/validate/persist path already existed.

## chat-ui (additive, Portal-safe)
- `Message`/`MessageDTO` gain `replyCount`/`lastReplyAt` (mapped in `dto`).
- `useMessages` exports `selectRootMessages` + `selectThreadReplies`.
- `MessageThread` gains `onReplyInThread` + `hideReplies` props (+ `msg-reply-action-*` / `msg-thread-summary-*`). No new color tokens — existing dark palette + lucide icons.

## Host
`LiveTeamChatPage` replaces the primitive `thread-enter`/`ThreadReplyBanner` with a single `activeThreadRootId` + a `thread-panel` (with `thread-close`). The main timeline hides replies and opens the panel; live WS replies flow into the open panel.

## Verified end-to-end (Claude-in-Chrome)
Hover → Reply → panel opens (root + composer) → posted a reply → it appears in the panel ("1 reply"), is **absent from the main timeline**, and the root shows the **"💬 1 reply · last reply now"** chip.

## Tests
chat-ui 204 · frontend Chat-team 67 · new backend reply-count test green · build clean. (Two pre-existing, unrelated backend failures — `1:1 binding` + slack-delivery-window — are in untouched code paths.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)