### PR TITLE
style(chat): flatten message rows (one cohesive surface, not isolated cards)

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -1029,11 +1029,7 @@ function ThreadMessageRow({
         </span>
         <time className="text-[10px] text-text-secondary-dark">{time}</time>
       </div>
-      <div
-        className={`glass-panel mt-1 max-w-full whitespace-pre-wrap break-words rounded-xl rounded-tl-none px-4 py-2 text-sm leading-relaxed text-text-primary-dark ${
-          isAgent ? 'border-l-2 border-l-primary' : ''
-        } ${isRoot ? 'ring-1 ring-border-dark' : ''}`}
-      >
+      <div className="mt-0.5 max-w-full whitespace-pre-wrap break-words text-sm leading-relaxed text-text-primary-dark">
         {message.content}
       </div>
     </div>

--- a/packages/chat-ui/src/components/MessageThread.test.tsx
+++ b/packages/chat-ui/src/components/MessageThread.test.tsx
@@ -131,6 +131,10 @@ describe('MessageThread', () => {
     expect(container.querySelector('.rounded-2xl')).toBeNull();
     // The own-message bubble fill (brand primary) must not appear in flat mode.
     expect(container.querySelector('.bg-primary')).toBeNull();
+    // Flat messages are plain rows (cohesive surface) — no per-message
+    // boxed/frosted body. The `glass-panel` treatment was removed so the
+    // timeline reads as one whole, not a stack of isolated cards.
+    expect(container.querySelector('.glass-panel')).toBeNull();
   });
 });
 

--- a/packages/chat-ui/src/components/MessageThread.tsx
+++ b/packages/chat-ui/src/components/MessageThread.tsx
@@ -355,7 +355,7 @@ function FlatMessageRow({
 
   return (
     <li
-      className={`group relative flex gap-3 ${groupStart ? 'mt-1' : ''}`}
+      className={`group relative flex gap-3 rounded-md px-2 py-0.5 transition hover:bg-white/[0.03] ${groupStart ? 'mt-2' : ''}`}
       data-author-role={message.author.role}
       data-delivery-status={status ?? 'sent'}
     >
@@ -387,9 +387,7 @@ function FlatMessageRow({
           </div>
         )}
         <div
-          className={`glass-panel mt-1 max-w-2xl rounded-xl rounded-tl-none px-4 py-2 text-sm leading-relaxed text-text-primary-dark ${
-            isAgent ? 'border-l-2 border-l-primary' : ''
-          } ${inactive ? 'border-dashed' : ''} ${faded}`}
+          className={`mt-0.5 max-w-prose text-sm leading-relaxed text-text-primary-dark ${faded}`}
         >
           {renderMinimalMarkdown(message.content)}
           {message.attachments?.map((a) =>
@@ -547,7 +545,7 @@ function AgentThinkingRow({
       <div
         className={
           flat
-            ? 'glass-panel rounded-xl rounded-tl-none px-4 py-2 text-sm text-text-secondary-dark'
+            ? 'px-2 py-1 text-sm text-text-secondary-dark'
             : 'rounded-2xl bg-surface-dark px-3 py-2 text-sm text-text-secondary-dark shadow-sm'
         }
       >


### PR DESCRIPTION
## Feedback addressed
The layout was good but it read as **many isolated blocks** rather than one whole — because every message was wrapped in its own bordered/frosted `glass-panel` box (rounded card + agent left-accent rule).

## Change
Render messages as **plain Slack-style rows**: avatar + bold name + timestamp, then plain text (no box/border/fill), with a subtle whole-row hover highlight. Applied to:
- the main flat timeline (`MessageThread` `FlatMessageRow`),
- the thread-panel rows (`ThreadMessageRow`),
- the flat "thinking" indicator.

Author is still distinguished by the blue name + `AGENT` tag; the reply action / "N replies" chip / AGENT tag keep their small affordance styling. No color tokens or logic changed.

## Tests
chat-ui MessageThread 19/19 (added a guard: flat mode has no `.glass-panel` body), frontend Chat-team 67/67, build clean.

> Note: couldn't grab a final screenshot — the browser screenshot tool hit a transient param error mid-verification — but the change is pure CSS and tests/build pass. Hard-refresh `/team-chat` to see the cohesive flat timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)