### PR TITLE
feat(chat): fill Home conversation list with the Direct-messages roster

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -186,10 +186,12 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     expect(screen.queryAllByTestId(/^workspace-row-/).length).toBe(3);
   });
 
-  it('Home shows the orchestrator by default (top, pinned group)', async () => {
+  it('Home lists the orchestrator first in the Direct messages group', async () => {
     const { client } = makeStubClient([orcDm]);
     render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
-    await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
+    // Home now surfaces the full DM roster (orc first) rather than only a
+    // single pinned orc row, so the panel is populated, not an empty void.
+    await waitFor(() => expect(screen.getByTestId('conv-group-dms')).toBeInTheDocument());
     expect(screen.getByTestId('conv-row-orc-dm')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -427,20 +427,50 @@ function LiveTeamChatPageBody({
   const groups = useMemo<ConversationGroup[]>(() => {
     const sel = resolvedWorkspaceId;
 
-    // Home: orchestrator (default, top) + pinned agents + huddles. Slack threads
-    // are NOT listed here — they all belong to the orchestrator, so they're
-    // surfaced inside the Orchestrator conversation (see slackThreads below).
+    // Home: the personal landing — Pinned (if any) → Direct messages (the full
+    // agent roster, orc first, presence-sorted) → Group chats. Surfacing the
+    // whole DM directory keeps the panel populated and every agent one click
+    // away (it used to show only orc + a big empty void). Slack threads are NOT
+    // listed here — they belong to the orchestrator (see slackThreads below).
     if (sel === HOME_ID) {
-      const pinnedRows = allDmRows.filter(
-        (r) =>
-          r.agentSession !== ORCHESTRATOR_SESSION &&
-          !r.id.startsWith(SLACK_ID_PREFIX) &&
-          pinnedChats.isPinned(pinKeyOf(r)),
+      const roleBySession = new Map(
+        directoryAgents.map((a) => [a.agentSession, a.role] as const),
       );
-      const top = [...(orcRow ? [orcRow] : []), ...pinnedRows];
+      const withRole = (r: ConversationRow): ConversationRow => {
+        const role = r.agentSession ? roleBySession.get(r.agentSession) : undefined;
+        return role ? { ...r, subtitle: role } : r;
+      };
+      // Real DMs + synthetic directory rows; exclude Slack-thread channels.
+      const agentDmRows = allDmRows.filter((r) => r.agentSession && !r.id.startsWith(SLACK_ID_PREFIX));
+
+      const pinnedRows = agentDmRows
+        .filter((r) => r.agentSession !== ORCHESTRATOR_SESSION && pinnedChats.isPinned(pinKeyOf(r)))
+        .map(withRole);
+      const pinnedKeys = new Set(pinnedRows.map((r) => pinKeyOf(r)));
+
+      // Direct messages excludes pinned agents (shown above) to avoid dupes;
+      // the orchestrator always appears here, first.
+      // Orchestrator first; then online → busy → offline; then most-recent; then name.
+      const presenceRank = (p?: ChatPresenceStatus): number =>
+        p === 'online' ? 0 : p === 'busy' ? 1 : p === 'offline' ? 2 : 3;
+      const dmRows = [...agentDmRows]
+        .filter((r) => r.agentSession === ORCHESTRATOR_SESSION || !pinnedKeys.has(pinKeyOf(r)))
+        .sort((a, b) => {
+          if (a.agentSession === ORCHESTRATOR_SESSION) return -1;
+          if (b.agentSession === ORCHESTRATOR_SESSION) return 1;
+          const pr = presenceRank(a.presence) - presenceRank(b.presence);
+          if (pr !== 0) return pr;
+          const at = a.lastMessageAt ?? '';
+          const bt = b.lastMessageAt ?? '';
+          if (at !== bt) return bt.localeCompare(at);
+          return a.title.localeCompare(b.title);
+        })
+        .map(withRole);
+
       const out: ConversationGroup[] = [];
-      if (top.length > 0) out.push({ id: 'pinned', label: 'Pinned', rows: top });
-      if (allHuddleRows.length > 0) out.push({ id: 'huddles', label: 'Huddles', rows: allHuddleRows });
+      if (pinnedRows.length > 0) out.push({ id: 'pinned', label: 'Pinned', rows: pinnedRows });
+      if (dmRows.length > 0) out.push({ id: 'dms', label: 'Direct messages', rows: dmRows });
+      if (allHuddleRows.length > 0) out.push({ id: 'huddles', label: 'Group chats', rows: allHuddleRows });
       return out;
     }
 


### PR DESCRIPTION
## Feedback addressed
On **Home**, the conversation-list panel showed only the orchestrator (+ any pinned agents) over a **big empty void** — it looked broken. The full agent roster already exists in `allDmRows` (real DMs + synthetic directory rows w/ presence); Home just never surfaced it.

## Change (host-side composition only)
Home's `groups` now builds:
1. **Pinned** (only if non-empty) — user-pinned agents.
2. **Direct messages** — the full agent roster, **orchestrator first**, then `online → busy → offline`, then most-recent, then name; each agent's **role** as subtitle. Pinned agents are excluded here to avoid duplicates.
3. **Group chats** — huddles (renamed from "Huddles").

Every agent is one click away and the panel is always populated. No `ConversationListPanel` API change (Portal-safe); no palette change — per the UI-designer's cohesion verdict, the lighter `surface-dark` list panel stays as the nav-column cue.

## Tests
LiveTeamChatPage 21/21 (updated the Home test: orc now lands first in the `dms` group; the pin test still surfaces a pinned member once under Home), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)