### PR TITLE
style(chat): distinct list-panel shade + collapse left nav on chat page

### DIFF
--- a/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.test.tsx
@@ -6,6 +6,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { SidebarProvider, useSidebar } from '../../contexts/SidebarContext';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Team } from '../../types';
 import { ORCHESTRATOR_SESSION } from '../../utils/team-chat.utils';
@@ -63,7 +64,9 @@ function makeMember(id: string, name: string, sessionName: string) {
 function renderAt(path: string): void {
   render(
     <MemoryRouter initialEntries={[path]}>
-      <TeamChatRoute />
+      <SidebarProvider>
+        <TeamChatRoute />
+      </SidebarProvider>
     </MemoryRouter>,
   );
 }
@@ -182,5 +185,23 @@ describe('TeamChatRoute', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     const props = liveProps.mock.calls[0][0] as { backendURL?: string };
     expect(props.backendURL).toBeUndefined();
+  });
+
+  it('collapses the left app nav while on the chat page', async () => {
+    function Probe(): JSX.Element {
+      const { isCollapsed } = useSidebar();
+      return <div data-testid="sidebar-collapsed">{String(isCollapsed)}</div>;
+    }
+    render(
+      <MemoryRouter initialEntries={['/team-chat']}>
+        <SidebarProvider>
+          <Probe />
+          <TeamChatRoute />
+        </SidebarProvider>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-collapsed').textContent).toBe('true'),
+    );
   });
 });

--- a/frontend/src/components/Chat-team/TeamChatRoute.tsx
+++ b/frontend/src/components/Chat-team/TeamChatRoute.tsx
@@ -36,6 +36,7 @@ import {
   type ChatTeam,
 } from './LiveTeamChatPage';
 import { useTeams } from '../../hooks/useTeams';
+import { useSidebar } from '../../contexts/SidebarContext';
 import { resolveBackendURL, resolveChatMode } from '../../utils/chat-backend';
 import {
   buildTeamLabels,
@@ -71,6 +72,19 @@ async function ensureChannel(url: string, body: Record<string, unknown>): Promis
 export function TeamChatRoute(): JSX.Element {
   const [searchParams] = useSearchParams();
   const { teams } = useTeams();
+  const { isCollapsed, collapseSidebar, expandSidebar } = useSidebar();
+
+  // The chat is already a dense 3-panel surface; collapse the app's left nav
+  // while on this page to give it room, then restore the user's prior state
+  // when they leave. Mount/unmount only — capture the pre-chat state once.
+  useEffect(() => {
+    const wasExpanded = !isCollapsed;
+    collapseSidebar();
+    return () => {
+      if (wasExpanded) expandSidebar();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const mode = resolveChatMode();
   const backendURL = mode === 'real' ? resolveBackendURL() : undefined;

--- a/packages/chat-ui/src/components/ConversationListPanel.tsx
+++ b/packages/chat-ui/src/components/ConversationListPanel.tsx
@@ -143,7 +143,7 @@ export function ConversationListPanel({
 
   return (
     <aside
-      className={`flex h-full w-[240px] flex-col border-r border-border-dark bg-surface-dark ${className}`}
+      className={`flex h-full w-[240px] flex-col border-r border-border-dark bg-[#232d3b] ${className}`}
       aria-label={workspaceName ? `${workspaceName} conversations` : 'Conversations'}
       data-testid="conversation-list-panel"
     >


### PR DESCRIPTION
## Two tweaks
1. **List-panel background** — it was `bg-surface-dark` (#1a222c), the **same color as the app's left nav**, so the left region read as one flat block. Now an elevated `#232d3b` (the existing Crewly `bg-tertiary`/`surface-hover`), making it the lightest, clearly-distinct nav column over the darker rail/main.
2. **Collapse the left nav on the chat page** — the chat is already a dense 3-panel surface, so `/team-chat` now auto-collapses the app's left nav (via `useSidebar` in `TeamChatRoute`, collapse on mount) and **restores the user's prior state on leave** (only re-expands if it was expanded before).

## Tests
TeamChatRoute 8/8 (added a collapse-on-chat test + `SidebarProvider` wrapper), Chat-team suite 68/68, ConversationListPanel 18/18, build clean. Confirmed `#232d3b` emits into the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)