### PR TITLE
style(chat): clearer active state for the workspace rail (incl. Home)

### DIFF
--- a/packages/chat-ui/src/components/WorkspaceRail.test.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.test.tsx
@@ -67,6 +67,22 @@ describe('WorkspaceRail', () => {
     expect(row).toHaveAttribute('aria-current', 'page');
   });
 
+  it('gives the active tile a strong accent in caption mode — including Home', () => {
+    // Home active used to keep its neutral chip (isHome branch won over
+    // isActive), so the selected state was barely visible. Active must win.
+    render(
+      <WorkspaceRail
+        workspaces={[{ id: 'home', name: 'Home', kind: 'home' }, { id: 't1', name: 'Team One' }]}
+        showLabels
+        activeWorkspaceId="home"
+      />,
+    );
+    const home = screen.getByTestId('workspace-row-home');
+    // Active glyph gets the brand glow + a primary border (vs the neutral chip).
+    expect(home.querySelector('.active-glow')).not.toBeNull();
+    expect(home.innerHTML).toContain('border-primary');
+  });
+
   it('invokes onSelectWorkspace with the full workspace on click', async () => {
     const onSelect = vi.fn();
     render(<WorkspaceRail workspaces={fixture} onSelectWorkspace={onSelect} />);

--- a/packages/chat-ui/src/components/WorkspaceRail.tsx
+++ b/packages/chat-ui/src/components/WorkspaceRail.tsx
@@ -300,18 +300,21 @@ function CaptionTile({
   const hasUnread = (workspace.unreadCount ?? 0) > 0;
   const showChevron = isParent && !!onToggleCollapse;
 
-  // Circle treatment: Home + active/parent use the brand accent; plain
-  // teams use the neutral surface chip.
-  const circleClass = isHome
-    ? 'bg-white/5 border border-border-dark text-text-secondary-dark'
-    : isParent || isActive
+  // Circle treatment. ACTIVE wins over everything (incl. Home) with the
+  // strongest accent + glow so the selected tile is unmistakable; then
+  // parent, then Home, then plain teams (neutral chip).
+  const circleClass = isActive
+    ? 'bg-primary/20 text-primary border-2 border-primary active-glow'
+    : isParent
       ? 'bg-primary/10 text-primary border border-primary/30'
-      : 'bg-white/5 text-text-secondary-dark border border-border-dark hover:border-primary';
+      : isHome
+        ? 'bg-white/5 border border-border-dark text-text-secondary-dark hover:border-primary'
+        : 'bg-white/5 text-text-secondary-dark border border-border-dark hover:border-primary';
 
-  const captionClass = isParent
-    ? 'text-[10px] font-medium text-primary'
-    : isActive
-      ? 'text-[10px] text-center leading-tight max-w-[60px] text-text-primary-dark'
+  const captionClass = isActive
+    ? 'text-[10px] text-center leading-tight max-w-[60px] font-semibold text-primary'
+    : isParent
+      ? 'text-[10px] font-medium text-primary'
       : 'text-[10px] text-center leading-tight max-w-[60px] text-text-secondary-dark group-hover:text-text-primary-dark';
 
   // Indicator dot — mention > unread > presence (§8.2).


### PR DESCRIPTION
## Fix
The **Home** tile's active state was nearly invisible: `CaptionTile`'s `isHome` branch won over `isActive`, so a selected Home kept its neutral `bg-white/5` chip with no accent.

Reordered so **active wins** for every tile — the active glyph now uses `bg-primary/20 + border-2 border-primary + active-glow` and the caption is `font-semibold text-primary`. Parent / Home / plain treatments fall through below active.

## Tests
WorkspaceRail 19/19 (added a caption-mode active-accent test covering Home), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)