### PR TITLE
feat(chat): move Slack threads from in-conversation bar to a sidebar section

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -507,7 +507,7 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     });
   });
 
-  it('surfaces Slack threads INSIDE the Orchestrator conversation, not the sidebar', async () => {
+  it('surfaces Slack threads as a sidebar section (collapsed), not a bar inside the conversation', async () => {
     const slackId = 'slack-D0AC7NF5N7L-1777760999-956969';
     const channels: Channel[] = [
       orcDm,
@@ -516,21 +516,16 @@ describe('LiveTeamChatPage — workspace rail IA', () => {
     const { client } = makeStubClient(channels);
     render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
 
-    // The orchestrator is the default conversation; Slack is NOT a sidebar group.
-    await waitFor(() => expect(screen.getByTestId('conv-row-orc-dm')).toBeInTheDocument());
-    expect(screen.queryByTestId('conv-group-slack')).not.toBeInTheDocument();
-    expect(screen.queryByTestId(`conv-row-${slackId}`)).not.toBeInTheDocument();
+    // Slack threads now live in the sidebar as their own group — NOT an
+    // in-conversation bar. The section renders (collapsed by default).
+    await waitFor(() => expect(screen.getByTestId('conv-group-slack')).toBeInTheDocument());
+    expect(screen.queryByTestId('slack-threads-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slack-threads-bar')).not.toBeInTheDocument();
 
-    // Instead, the orchestrator conversation hosts a collapsible Slack-threads bar.
-    const toggle = await screen.findByTestId('slack-threads-toggle');
-    expect(toggle).toHaveTextContent('Slack threads · 1');
-    fireEvent.click(toggle);
-    const thread = await screen.findByTestId(`slack-thread-${slackId}`);
-    expect(thread).toHaveTextContent(/Slack thread ·/);
-
-    // Opening the thread switches to it and offers a way back to the orchestrator.
-    fireEvent.click(thread);
-    expect(await screen.findByTestId('slack-back-to-orc')).toBeInTheDocument();
+    // Expanding the section reveals the thread row with its prettified title.
+    fireEvent.click(screen.getByTestId('conv-group-toggle-slack'));
+    const row = await screen.findByTestId(`conv-row-${slackId}`);
+    expect(row).toHaveTextContent(/Slack thread ·/);
   });
 
   it('calls onEnsureDm when a team member without a channel is opened', async () => {

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -33,9 +33,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Home,
-  ChevronDown,
-  ChevronRight,
-  MessageSquare,
   Search,
   Info,
   Plus,
@@ -471,6 +468,10 @@ function LiveTeamChatPageBody({
       if (pinnedRows.length > 0) out.push({ id: 'pinned', label: 'Pinned', rows: pinnedRows });
       if (dmRows.length > 0) out.push({ id: 'dms', label: 'Direct messages', rows: dmRows });
       if (allHuddleRows.length > 0) out.push({ id: 'huddles', label: 'Group chats', rows: allHuddleRows });
+      // Slack-bridged threads (all orc-owned) live in the sidebar as their own
+      // collapsed section (alongside DMs / group chats) rather than a bar
+      // inside the orchestrator conversation.
+      if (slackThreads.length > 0) out.push({ id: 'slack', label: 'Slack threads', rows: slackThreads });
       return out;
     }
 
@@ -517,6 +518,7 @@ function LiveTeamChatPageBody({
     channelTeamId,
     pinnedChats,
     directoryAgents,
+    slackThreads,
   ]);
 
   const totalRows = useMemo(
@@ -644,9 +646,6 @@ function LiveTeamChatPageBody({
       <LiveTeamChatRightPanel
         conversation={activeConversation}
         mentionables={mentionables}
-        slackThreads={slackThreads}
-        orcRow={orcRow}
-        onSelectConversation={handleSelectConversation}
       />
 
       {showCreateGroup && (
@@ -667,19 +666,11 @@ function LiveTeamChatPageBody({
 interface RightPanelProps {
   conversation: ConversationRow | undefined;
   mentionables: MentionTarget[];
-  /** Slack-bridged threads (all orc-owned), surfaced inside the orc conversation. */
-  slackThreads: ConversationRow[];
-  /** The orchestrator conversation row (for the "back to Orchestrator" action). */
-  orcRow: ConversationRow | undefined;
-  onSelectConversation: (row: ConversationRow) => void;
 }
 
 function LiveTeamChatRightPanel({
   conversation,
   mentionables,
-  slackThreads,
-  orcRow,
-  onSelectConversation,
 }: RightPanelProps): JSX.Element {
   // No conversation selected — happens on first render of an empty
   // workspace, or transiently after a workspace switch.
@@ -699,9 +690,6 @@ function LiveTeamChatRightPanel({
     <LiveTeamChatRightPanelInner
       conversation={conversation}
       mentionables={mentionables}
-      slackThreads={slackThreads}
-      orcRow={orcRow}
-      onSelectConversation={onSelectConversation}
     />
   );
 }
@@ -709,15 +697,9 @@ function LiveTeamChatRightPanel({
 function LiveTeamChatRightPanelInner({
   conversation,
   mentionables,
-  slackThreads,
-  orcRow,
-  onSelectConversation,
 }: {
   conversation: ConversationRow;
   mentionables: MentionTarget[];
-  slackThreads: ConversationRow[];
-  orcRow: ConversationRow | undefined;
-  onSelectConversation: (row: ConversationRow) => void;
 }): JSX.Element {
   const { messages } = useMessages(conversation.id);
   const { send, error: sendError, reset: resetSendError } = useSendMessage();
@@ -741,13 +723,6 @@ function LiveTeamChatRightPanelInner({
   const toast = useMemo(() => buildToastMessage(sendError), [sendError]);
 
   const recipientName = conversation.kind === 'dm' ? conversation.title : undefined;
-
-  // Slack threads all belong to the orchestrator, so they're navigated from
-  // INSIDE the orc conversation (here) rather than the sidebar.
-  const isSlackThread = conversation.id.startsWith(SLACK_ID_PREFIX);
-  const isOrc = conversation.agentSession === ORCHESTRATOR_SESSION && !isSlackThread;
-  const showSlackBar = (isOrc || isSlackThread) && slackThreads.length > 0;
-  const [slackOpen, setSlackOpen] = useState(false);
 
   // The root message of the open thread (found in the live timeline) + its
   // replies derived live so a WS-delivered reply shows in the panel instantly.
@@ -823,54 +798,6 @@ function LiveTeamChatRightPanelInner({
             </HeaderActionButton>
           </div>
         </header>
-
-        {showSlackBar && (
-          <div className="border-b border-border-dark" data-testid="slack-threads-bar">
-            <div className="flex items-center justify-between px-4 py-2">
-              <button
-                type="button"
-                onClick={() => setSlackOpen((o) => !o)}
-                aria-expanded={slackOpen}
-                data-testid="slack-threads-toggle"
-                className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-text-secondary-dark"
-              >
-                {slackOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                Slack threads · {slackThreads.length}
-              </button>
-              {isSlackThread && orcRow && (
-                <button
-                  type="button"
-                  onClick={() => onSelectConversation(orcRow)}
-                  data-testid="slack-back-to-orc"
-                  className="text-xs text-primary hover:underline"
-                >
-                  ← Orchestrator
-                </button>
-              )}
-            </div>
-            {slackOpen && (
-              <ul className="chat-scrollbar max-h-48 overflow-y-auto px-2 pb-2" role="list">
-                {slackThreads.map((t) => (
-                  <li key={t.id}>
-                    <button
-                      type="button"
-                      onClick={() => onSelectConversation(t)}
-                      data-testid={`slack-thread-${t.id}`}
-                      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
-                        t.id === conversation.id
-                          ? 'bg-primary/10 text-primary'
-                          : 'text-text-secondary-dark hover:bg-white/5 hover:text-text-primary-dark'
-                      }`}
-                    >
-                      <MessageSquare size={13} className="shrink-0 opacity-60" />
-                      <span className="truncate">{t.title}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
 
         {/* Main timeline: roots only (replies hidden — they live in the
             thread panel). Hover "Reply in thread" + the "N replies" chip


### PR DESCRIPTION
## Feedback
The orchestrator conversation had a "SLACK THREADS · N" bar at the **top of its message timeline**. You asked: why a separate bar inside the chat? Move them to the side panel so pinned / DMs / group chats / **slack threads** all live together (Slack-style), and keep the chat timeline clean.

## Change
- The Home conversation-list now includes a **"Slack threads"** group (built from the orc-owned slack rows), collapsed by default so it doesn't flood the list.
- Removed the in-conversation Slack bar entirely + its state and the now-unused right-panel props (`slackThreads`/`orcRow`/`onSelectConversation`) and dead lucide imports.
- Selecting a Slack thread from the sidebar opens it in the main panel as before (it's a real chat-v2 channel).

## Tests
LiveTeamChatPage 21/21 (flipped the slack test: sidebar `conv-group-slack` present + no `slack-threads-bar`; expand reveals the thread row), Chat-team suite 68/68, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)