### PR TITLE
fix(chat): pinned conversations (incl. orchestrator) go under the Pinned section

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -181,11 +181,14 @@ describe('LiveTeamChatPage — consolidated conversation list', () => {
     expect(channelRow).toHaveTextContent('Crewly Product');
   });
 
-  it('lists the orchestrator first in the Direct messages group', async () => {
+  it('surfaces the orchestrator (pinned by default) in the Pinned group', async () => {
     const { client } = makeStubClient([orcDm]);
     render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
-    await waitFor(() => expect(screen.getByTestId('conv-group-dms')).toBeInTheDocument());
-    expect(screen.getByTestId('conv-row-orc-dm')).toBeInTheDocument();
+    // The orchestrator is pinned by default, so it lands in Pinned (not DMs).
+    await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
+    expect(
+      within(screen.getByTestId('conv-group-pinned')).getByTestId('conv-row-orc-dm'),
+    ).toBeInTheDocument();
   });
 
   it('tags a team lead with a "Lead" badge in the DM list', async () => {
@@ -484,6 +487,25 @@ describe('LiveTeamChatPage — consolidated conversation list', () => {
     fireEvent.click(screen.getByTestId('conv-pin-dm-ella'));
     await waitFor(() => expect(screen.getByTestId('conv-group-pinned')).toBeInTheDocument());
     expect(within(screen.getByTestId('conv-group-pinned')).getByTestId('conv-row-dm-ella')).toBeInTheDocument();
+  });
+
+  it('unpinning the orchestrator moves it out of Pinned into Direct messages', async () => {
+    window.localStorage.clear();
+    const channels: Channel[] = [
+      orcDm,
+      { id: 'dm-ella', agentSession: 'sess-ella', name: 'Ella', createdAt: ISO, type: 'dm', presence: 'online' },
+    ];
+    const { client } = makeStubClient(channels);
+    render(<LiveTeamChatPage client={client} mentionables={MENTIONABLES} teams={[]} />);
+    // Pinned by default → orc starts in the Pinned group.
+    await waitFor(() =>
+      expect(within(screen.getByTestId('conv-group-pinned')).getByTestId('conv-row-orc-dm')).toBeInTheDocument(),
+    );
+    // Unpin it → it drops into Direct messages.
+    fireEvent.click(screen.getByTestId('conv-pin-orc-dm'));
+    await waitFor(() =>
+      expect(within(screen.getByTestId('conv-group-dms')).getByTestId('conv-row-orc-dm')).toBeInTheDocument(),
+    );
   });
 });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -350,27 +350,32 @@ function LiveTeamChatPageBody({
       (r) => r.agentSession && !r.id.startsWith(SLACK_ID_PREFIX),
     );
 
-    const pinnedRows = agentDmRows
-      .filter((r) => r.agentSession !== ORCHESTRATOR_SESSION && pinnedChats.isPinned(pinKeyOf(r)))
+    // Orchestrator first; then online → busy → offline; then most-recent; name.
+    const presenceRank = (p?: ChatPresenceStatus): number =>
+      p === 'online' ? 0 : p === 'busy' ? 1 : p === 'offline' ? 2 : 3;
+    const byDmOrder = (a: ConversationRow, b: ConversationRow): number => {
+      if (a.agentSession === ORCHESTRATOR_SESSION) return -1;
+      if (b.agentSession === ORCHESTRATOR_SESSION) return 1;
+      const pr = presenceRank(a.presence) - presenceRank(b.presence);
+      if (pr !== 0) return pr;
+      const at = a.lastMessageAt ?? '';
+      const bt = b.lastMessageAt ?? '';
+      if (at !== bt) return bt.localeCompare(at);
+      return a.title.localeCompare(b.title);
+    };
+
+    // Pinned: ANY pinned conversation (the orchestrator included) — pinning is
+    // an explicit user choice, so it wins over the orc's default DM placement.
+    const pinnedRows = [...agentDmRows]
+      .filter((r) => pinnedChats.isPinned(pinKeyOf(r)))
+      .sort(byDmOrder)
       .map(withMeta);
     const pinnedKeys = new Set(pinnedRows.map((r) => pinKeyOf(r)));
 
-    // Direct messages: orchestrator first; then online → busy → offline; then
-    // most-recent; then name. Pinned agents are lifted into the Pinned group.
-    const presenceRank = (p?: ChatPresenceStatus): number =>
-      p === 'online' ? 0 : p === 'busy' ? 1 : p === 'offline' ? 2 : 3;
+    // Direct messages: everything not lifted into Pinned.
     const dmRows = [...agentDmRows]
-      .filter((r) => r.agentSession === ORCHESTRATOR_SESSION || !pinnedKeys.has(pinKeyOf(r)))
-      .sort((a, b) => {
-        if (a.agentSession === ORCHESTRATOR_SESSION) return -1;
-        if (b.agentSession === ORCHESTRATOR_SESSION) return 1;
-        const pr = presenceRank(a.presence) - presenceRank(b.presence);
-        if (pr !== 0) return pr;
-        const at = a.lastMessageAt ?? '';
-        const bt = b.lastMessageAt ?? '';
-        if (at !== bt) return bt.localeCompare(at);
-        return a.title.localeCompare(b.title);
-      })
+      .filter((r) => !pinnedKeys.has(pinKeyOf(r)))
+      .sort(byDmOrder)
       .map(withMeta);
 
     const out: ConversationGroup[] = [];


### PR DESCRIPTION
## Problem
The orchestrator is pinned by default (`usePinnedChats` `DEFAULT_PINS`), and its pin icon shows filled — but it stayed in **Direct messages** and never appeared in a **Pinned** section. The consolidated groups builder explicitly excluded the orchestrator from Pinned (`agentSession !== ORCHESTRATOR_SESSION`) and force-kept it in DMs.

## Fix
Any pinned conversation — orchestrator included — now lands in the **Pinned** group; unpinning drops it back into **Direct messages**. Pinned + DM rows share one orc-first / presence comparator (`byDmOrder`).

## Tests
- `LiveTeamChatPage` 21/21 (added: orc pinned-by-default appears in Pinned; unpinning moves it to DMs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)