### PR TITLE
fix(chat-v2): let the web user READ bridged Slack channels (so they merge into the orc timeline)

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -888,6 +888,41 @@ describe('ChatV2Service', () => {
         service.listMessages({ channelId: ch.id, principal: otherUser }),
       ).toThrow(ChatError);
     });
+
+    it('lets any caller READ a shared bridged Slack channel they do not own', () => {
+      // Slack bridge persists under the synthetic 'system' owner; the bound
+      // agent records the turn. The team-chat surface merges these into the
+      // Orchestrator timeline, so a non-owner web user must be able to read them.
+      const ch = service.ensureChannelForLegacyConversation({
+        conversationId: 'slack-D0-read',
+        agentSession: 'crewly-orc',
+      });
+      const orcAgent: ChatPrincipal = {
+        userId: 'orc-agent',
+        agentSession: 'crewly-orc',
+        source: 'oss',
+      };
+      service.sendMessage({ channelId: ch.id, principal: orcAgent, content: 'from slack' });
+      // `owner` does NOT own this channel ('system' does) yet can read it.
+      const page = service.listMessages({ channelId: ch.id, principal: owner });
+      expect(page.messages.map((m) => m.content)).toEqual(['from slack']);
+    });
+
+    it('still forbids a non-owner from POSTING into a shared Slack channel', () => {
+      const ch = service.ensureChannelForLegacyConversation({
+        conversationId: 'slack-D0-write',
+        agentSession: 'crewly-orc',
+      });
+      // The read gate now allows shared Slack channels, but resolveSender keeps
+      // writes locked to the owner / bound agent → forbidden for a plain user.
+      try {
+        service.sendMessage({ channelId: ch.id, principal: owner, content: 'nope' });
+        fail('expected ChatError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ChatError);
+        expect((err as ChatError).code).toBe('forbidden');
+      }
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -1520,7 +1520,18 @@ export class ChatV2Service extends EventEmitter {
   }
 
   /**
-   * Fetch the channel and allow if the caller is the owner OR the bound agent.
+   * Fetch the channel and allow if the caller is the owner OR the bound agent
+   * OR the channel is a shared bridged Slack conversation.
+   *
+   * Slack-bridged channels (`slack-…`, persisted under the synthetic `'system'`
+   * owner by the inbound bridge) belong to no single Crewly user — exactly like
+   * {@link ChannelStore.listBridged} surfaces them in the consolidated list
+   * regardless of owner, this lets the web user READ them (e.g. the team-chat
+   * surface merges them inline into the Orchestrator timeline). Writes are still
+   * gated downstream by {@link resolveSender}, which throws `forbidden` unless
+   * the caller is the owner or bound agent — so this read allowance does not let
+   * a user post into a bridged channel.
+   *
    * Used for read + send; agents must always be acting from their own session.
    */
   private requireReadableChannel(channelId: string, principal: ChatPrincipal): ChatChannelRow {
@@ -1531,7 +1542,8 @@ export class ChatV2Service extends EventEmitter {
     const isOwner = row.owner_user_id === principal.userId;
     const isBoundAgent =
       !!principal.agentSession && principal.agentSession === row.agent_session;
-    if (!isOwner && !isBoundAgent) {
+    const isSharedBridged = row.id.startsWith('slack-');
+    if (!isOwner && !isBoundAgent && !isSharedBridged) {
       throw new ChatError(CHAT_ERROR_CODES.CHANNEL_NOT_FOUND, 404, 'Channel not found');
     }
     if (row.archived_at) {


### PR DESCRIPTION
## Problem
`GET /api/chat/channels/slack-…/messages` returned **404 `channel_not_found`** for the logged-in web user, so the team-chat Orchestrator timeline (which merges all `slack-*` channels inline, per #668) silently showed **no** Slack messages — each `listMessages()` 404'd and the client swallowed it. Verified live: the channel list returns 33 Slack channels, but their messages endpoint 404'd while the orc DM returned 200.

## Root cause
`requireReadableChannel` allowed only the channel **owner** or the **bound agent**. Slack-bridged channels are persisted under the synthetic `'system'` owner, so the web user (`dev-user-001`) was neither → 404.

## Fix
The channel **list** already surfaces these as shared bridged channels (`ChannelStore.listBridged`, owner-agnostic). The **read** path now matches: a `slack-*` channel is readable by any authenticated caller. Writes stay locked — `resolveSender` still throws `forbidden` for a non-owner/non-agent, so this does **not** allow posting into a bridged channel.

## Tests
- `chat-v2.service` +2: non-owner can READ a shared Slack channel; non-owner POST still `forbidden`.
- Pre-existing unrelated failures (`1:1-binding`, `findMessagesWithPendingSlackDelivery`) are untouched (confirmed they fail identically without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)