### PR TITLE
fix(chat): badge every team-leader as "Lead" (role-based, not just leaderSessions)

### DIFF
--- a/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.test.tsx
@@ -191,11 +191,14 @@ describe('LiveTeamChatPage — consolidated conversation list', () => {
     ).toBeInTheDocument();
   });
 
-  it('tags a team lead with a "Lead" badge in the DM list', async () => {
+  it('tags leads with a "Lead" badge — by leaderSessions AND by team-leader role', async () => {
     const channels: Channel[] = [
       orcDm,
       { id: 'dm-maya', agentSession: 'sess-maya', name: 'Maya', createdAt: ISO, type: 'dm', presence: 'online' },
       { id: 'dm-alex', agentSession: 'sess-alex', name: 'Alex', createdAt: ISO, type: 'dm', presence: 'online' },
+      // Victor is a team-leader by ROLE but is NOT in any team's leaderSessions
+      // (the gap that previously left him unbadged).
+      { id: 'dm-victor', agentSession: 'sess-victor', name: 'Victor', createdAt: ISO, type: 'dm', presence: 'online' },
     ];
     const { client } = makeStubClient(channels);
     render(
@@ -210,11 +213,18 @@ describe('LiveTeamChatPage — consolidated conversation list', () => {
             memberSessions: ['sess-maya', 'sess-alex'],
           },
         ]}
+        directoryAgents={[
+          { agentSession: 'sess-maya', name: 'Maya', role: 'product-manager' },
+          { agentSession: 'sess-alex', name: 'Alex', role: 'designer' },
+          { agentSession: 'sess-victor', name: 'Victor', role: 'team-leader' },
+        ]}
       />,
     );
     await waitFor(() => expect(screen.getByTestId('conv-group-dms')).toBeInTheDocument());
-    // The lead carries a "Lead" badge; a non-lead does not.
+    // Maya: lead via leaderSessions. Victor: lead via team-leader role.
     expect(screen.getByTestId('conv-badge-dm-maya')).toHaveTextContent('Lead');
+    expect(screen.getByTestId('conv-badge-dm-victor')).toHaveTextContent('Lead');
+    // Alex is neither → no badge.
     expect(screen.queryByTestId('conv-badge-dm-alex')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
+++ b/frontend/src/components/Chat-team/LiveTeamChatPage.tsx
@@ -323,11 +323,16 @@ function LiveTeamChatPageBody({
       directoryAgents.map((a) => [a.agentSession, a.role] as const),
     );
     // Agents that lead ANY team — the per-team rosters are gone, so we surface
-    // the lead signal as a badge in the flat DM list instead.
+    // the lead signal as a badge in the flat DM list instead. A lead is anyone
+    // configured as a team's leader OR whose role is `team-leader` (so every
+    // team-leader is badged even when a team's `leaderSessions` is incomplete —
+    // which is why previously only one Lead showed).
     const leadSessions = new Set(teams.flatMap((t) => t.leaderSessions));
+    const isLeadRole = (role?: string): boolean => role === 'team-leader';
     const withMeta = (r: ConversationRow): ConversationRow => {
       const role = r.agentSession ? roleBySession.get(r.agentSession) : undefined;
-      const isLead = !!r.agentSession && leadSessions.has(r.agentSession);
+      const isLead =
+        (!!r.agentSession && leadSessions.has(r.agentSession)) || isLeadRole(role);
       let row = r;
       if (role) row = { ...row, subtitle: role };
       if (isLead) row = { ...row, badge: 'Lead' };


### PR DESCRIPTION
## Problem
Only Atlas showed the **Lead** badge, even though Sam, Victor, etc. also have the `team-leader` role. The badge was driven only by `teams[].leaderSessions`, which is frequently incomplete (only one team's leader populated) → most team-leaders went unbadged.

## Fix
An agent is now badged **Lead** if they're in any team's `leaderSessions` **or** their role is `team-leader`. Catches every team-leader regardless of team-config gaps.

## Tests
- `LiveTeamChatPage` 21/21 — the lead test now also covers a role-based lead (Victor: `team-leader` role, *not* in `leaderSessions`) getting the badge, while a non-lead does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)