### PR TITLE
fix(chat): DM presence dots reflect real running agents (was always offline)

### DIFF
--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -55,6 +55,7 @@ import { createOssTeamMembershipValidator } from '../services/chat-v2/chat-v2.te
 import {
   createOssAgentDirectoryProvider,
   createOssAgentPresenceProvider,
+  createOssSyncPresence,
 } from '../services/chat-v2/chat-v2.providers.js';
 
 /**
@@ -214,17 +215,23 @@ export function createApiRoutes(apiController: ApiController): Router {
   // endpoints can resolve real team data and live agent status. Providers
   // live in `chat-v2.providers.ts` so this wire-up doesn't bloat the
   // route table or pull controller code into the routes module.
+  const chatV2Service = getChatV2Service({
+    validateTeamMembership: createOssTeamMembershipValidator(),
+  });
+  // Wire the SYNC presence used by the channel-list DTOs (the DM presence
+  // dots). Via a setter — not the constructor — because the singleton may
+  // already have been built (with DEFAULT_PRESENCE='offline') by an earlier
+  // no-arg caller (ws gateway / slack bridge / replay), in which case
+  // constructor overrides are ignored. Without this every DM dot reads offline
+  // even while agents are running. The async provider below still backs the
+  // richer /presence endpoint.
+  chatV2Service.setPresenceProvider(createOssSyncPresence());
   router.use(
     '/chat',
-    createChatV2Router(
-      getChatV2Service({
-        validateTeamMembership: createOssTeamMembershipValidator(),
-      }),
-      {
-        directory: createOssAgentDirectoryProvider(apiController.storageService),
-        presence: createOssAgentPresenceProvider(apiController.storageService),
-      },
-    ),
+    createChatV2Router(chatV2Service, {
+      directory: createOssAgentDirectoryProvider(apiController.storageService),
+      presence: createOssAgentPresenceProvider(apiController.storageService),
+    }),
   );
 
   // Keep legacy modular routes for handlers not yet migrated (for backward compatibility)

--- a/backend/src/services/chat-v2/chat-v2.providers.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.providers.test.ts
@@ -7,6 +7,7 @@
 import {
   createOssAgentDirectoryProvider,
   createOssAgentPresenceProvider,
+  createOssSyncPresence,
   resolvePresenceStatus,
   type IStorageServiceLike,
 } from './chat-v2.providers.js';
@@ -240,5 +241,29 @@ describe('createOssAgentPresenceProvider', () => {
     const result = await provider.getPresence('crewly-orc');
     expect(result.status).toBe('offline');
     expect(result.lastSeenAt).toBeNull();
+  });
+});
+
+describe('createOssSyncPresence', () => {
+  it('returns online + a lastSeenAt when the agent is alive', () => {
+    const getPresence = createOssSyncPresence({
+      isAliveSync: (s) => s === 'crewly-orc',
+      now: () => 4242,
+    });
+    expect(getPresence('crewly-orc')).toEqual({ status: 'online', lastSeenAt: 4242 });
+  });
+
+  it('returns offline + null when the agent is not alive', () => {
+    const getPresence = createOssSyncPresence({ isAliveSync: () => false });
+    expect(getPresence('sleepy-agent')).toEqual({ status: 'offline', lastSeenAt: null });
+  });
+
+  it('treats a thrown liveness probe as offline (DTO mapper must never throw)', () => {
+    const getPresence = createOssSyncPresence({
+      isAliveSync: () => {
+        throw new Error('boom');
+      },
+    });
+    expect(getPresence('x')).toEqual({ status: 'offline', lastSeenAt: null });
   });
 });

--- a/backend/src/services/chat-v2/chat-v2.providers.ts
+++ b/backend/src/services/chat-v2/chat-v2.providers.ts
@@ -25,6 +25,7 @@ import type {
   IAgentPresenceProvider,
   ChatAgentPresenceDTO,
 } from '../../controllers/chat-v2/chat-v2.controller.js';
+import { getSessionBackendSync } from '../session/index.js';
 
 /**
  * Minimal storage surface the providers need. Decoupled from the full
@@ -247,5 +248,58 @@ export function createOssAgentPresenceProvider(
         lastSeenAt: active ? now() : null,
       };
     },
+  };
+}
+
+/**
+ * SYNCHRONOUS presence for the channel-LIST path.
+ *
+ * `ChatV2Service.toChannelDTO` is synchronous and `listChannels` builds many
+ * DTOs at once, so the channel rows (which drive the DM presence dots) need a
+ * sync `getPresence`. The async {@link createOssAgentPresenceProvider} backs
+ * the richer `/presence/:id` endpoint, but it was never wired into the service
+ * — so every DM dot fell back to `DEFAULT_PRESENCE` ('offline') regardless of
+ * whether the agent was actually running.
+ *
+ * This factory returns a sync presence keyed on runtime liveness — the SAME
+ * "is the agent's child process alive" signal behind the Dashboard's
+ * "Running Agents" count (`isAgentActive` → `getSessionBackendSync`) — so a DM
+ * dot turns green exactly when the agent is running. Busy/idle refinement needs
+ * the async team-status read and stays in the `/presence` provider; here online
+ * vs offline is what the dot needs.
+ *
+ * @param opts.isAliveSync - Liveness override (tests pass a stub).
+ * @param opts.now - Clock override (tests freeze `lastSeenAt`).
+ * @returns A sync `(agentSession) => { status, lastSeenAt }` for `getPresence`.
+ */
+export function createOssSyncPresence(opts: {
+  isAliveSync?: (agentSession: string) => boolean;
+  now?: () => number;
+} = {}): (agentSession: string) => { status: ChatAgentPresenceDTO['status']; lastSeenAt: number | null } {
+  const now = opts.now ?? Date.now;
+  const isLive =
+    opts.isAliveSync ??
+    ((agentSession: string): boolean => {
+      try {
+        const backend = getSessionBackendSync();
+        return (
+          !!backend &&
+          backend.sessionExists(agentSession) &&
+          !!backend.isChildProcessAlive?.(agentSession)
+        );
+      } catch {
+        return false;
+      }
+    });
+  return (agentSession: string) => {
+    let live = false;
+    try {
+      live = isLive(agentSession);
+    } catch {
+      // toChannelDTO must never throw on presence (it'd blank the whole
+      // channel list) — degrade to offline.
+      live = false;
+    }
+    return { status: live ? 'online' : 'offline', lastSeenAt: live ? now() : null };
   };
 }

--- a/backend/src/services/chat-v2/chat-v2.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.test.ts
@@ -372,6 +372,16 @@ describe('ChatV2Service', () => {
       expect(service.listChannels({ principal: otherUser })).toHaveLength(1);
     });
 
+    it('setPresenceProvider swaps the presence used by channel DTOs (DM dots)', () => {
+      const ch = createSam();
+      // Default beforeEach presence is 'online'; the setter replaces it,
+      // proving the composition root can wire live presence post-construction.
+      service.setPresenceProvider(() => ({ status: 'busy', lastSeenAt: 777 }));
+      const dto = service.getChannel(ch.id, owner);
+      expect(dto.agentPresence.status).toBe('busy');
+      expect(dto.agentPresence.lastSeenAt).toBe(777);
+    });
+
     it('surfaces bridged Slack channels the caller does not own', () => {
       // Slack bridge persists under the synthetic 'system' owner.
       service.ensureChannelForLegacyConversation({

--- a/backend/src/services/chat-v2/chat-v2.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.service.ts
@@ -291,7 +291,7 @@ export class ChatV2Service extends EventEmitter {
   private readonly db: ChatDatabase;
   private readonly channels: ChannelStore;
   private readonly messages: MessageStore;
-  private readonly presence: ChatV2ServiceOptions['getPresence'];
+  private presence: ChatV2ServiceOptions['getPresence'];
   private readonly validateTeamMembership: ChatV2ServiceOptions['validateTeamMembership'];
   private readonly now: () => number;
 
@@ -304,6 +304,20 @@ export class ChatV2Service extends EventEmitter {
     this.presence = options.getPresence ?? DEFAULT_PRESENCE;
     this.validateTeamMembership = options.validateTeamMembership;
     this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Wire (or replace) the synchronous presence provider used by the channel
+   * DTO mapper — i.e. what drives the DM presence dots in the conversation
+   * list. Settable POST-construction because the singleton is first-constructed
+   * by whichever caller wins the race (slack bridge, ws gateway, replay, …),
+   * usually with no presence wired; the composition root then calls this once
+   * so the dots reflect real agent liveness regardless of construction order.
+   *
+   * @param getPresence - Sync presence lookup (e.g. `createOssSyncPresence()`)
+   */
+  setPresenceProvider(getPresence: ChatV2ServiceOptions['getPresence']): void {
+    this.presence = getPresence;
   }
 
   /** Release the DB handle. Safe to call during graceful shutdown / in tests. */


### PR DESCRIPTION
## Symptom
Dashboard shows agents running ("Running Agents: 2", teams **Active**) but **every chat DM presence dot is gray**.

## Root cause
The channel-list DTO presence (`ChatV2Service.toChannelDTO`, which drives the DM dots) uses the **sync** `getPresence` option — and it was **never wired**. The composition root passes the async `createOssAgentPresenceProvider` to the **router** (for `/presence/:id`), but `getChatV2Service({…})` received no `getPresence`, so the service fell back to `DEFAULT_PRESENCE = 'offline'`. Compounding it: the singleton is first-constructed by whichever no-arg caller wins the startup race (ws gateway / slack bridge / replay), so even constructor wiring would be unreliable.

## Fix
- **`createOssSyncPresence()`** — sync presence keyed on runtime liveness (`getSessionBackendSync` → child-process-alive, the same signal behind the Dashboard's "Running Agents"). `online` when alive, else `offline`; never throws (the DTO mapper must not blank the list).
- **`ChatV2Service.setPresenceProvider()`** — wire/replace presence **post-construction**, independent of singleton construction order.
- `api.routes` calls `chatV2Service.setPresenceProvider(createOssSyncPresence())`.

The async provider still backs the richer `/presence/:id` endpoint (busy/idle nuance via team status).

## Verified live
- DM list renders exactly **2 green (Orchestrator + Ella)**, 29 gray — matches "Running Agents: 2".
- `/api/chat/channels`: **35 online / 17 offline** (was 52 offline).

## Tests
- `chat-v2.providers` +3 (online/offline/never-throws), `chat-v2.service` +1 (setter swaps channel-DTO presence). Pre-existing unrelated failures (1:1-binding, pending-slack-delivery) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)