### PR TITLE
fix(chat): IME-safe composer + correct reply-skill name in dispatch prompt

### DIFF
--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.test.ts
@@ -72,8 +72,8 @@ describe('ChatV2DispatcherService', () => {
       expect(prompt).toContain('<steve@Chat with Sam>');
       // trim() stripped the leading/trailing whitespace
       expect(prompt).toContain('\nhi, sam\n');
-      expect(prompt).toContain('`reply-channel`');
-      expect(prompt).toContain('channelId="chan-1"');
+      expect(prompt).toContain('`reply-chat`');
+      expect(prompt).toContain('conversationId="chan-1"');
     });
 
     it('appends [cmid:...] when clientMessageId is present', () => {
@@ -628,7 +628,7 @@ describe('ChatV2DispatcherService', () => {
         // Prompt body for sess-b uses the "required" reply hint;
         // sess-a/c use the "optional" hint.
         const calledForB = calls.find((c) => c.sessionName === 'sess-b')!;
-        expect(calledForB.message).toContain('reply-channel');
+        expect(calledForB.message).toContain('reply-chat');
         expect(calledForB.message).not.toMatch(/否则不回复也可以/);
 
         const calledForA = calls.find((c) => c.sessionName === 'sess-a')!;

--- a/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
+++ b/backend/src/services/chat-v2/chat-v2.dispatcher.service.ts
@@ -8,14 +8,14 @@
  *     → controller broadcasts WS message frame (user bubble)
  *     → controller calls ChatV2Dispatcher.dispatchToAgent(channel, messageDTO)
  *     → sendMessageToAgent(agent_session, "[CHAT:<id>] <content>\n<hint>")
- *     → agent processes + calls `reply-channel` skill
+ *     → agent processes + calls `reply-chat` skill
  *     → skill POSTs back to /api/chat/channels/:id/messages as the agent
  *     → same controller path → WS message frame (agent bubble)
  *
  * This service is intentionally thin — a couple of dozen lines of glue
  * around the AgentRegistrationService's `sendMessageToAgent` primitive.
  * The dispatch prompt is extracted so tests can assert the format, which
- * is the contract the `reply-channel` skill relies on.
+ * is the contract the `reply-chat` skill relies on.
  *
  * @module services/chat-v2/chat-v2.dispatcher.service
  */
@@ -123,7 +123,7 @@ export interface ChatV2DispatcherOptions {
   agentSink: AgentMessageSink;
   /**
    * Override the prompt formatter for tests / future customization. The
-   * default matches the `reply-channel` skill's parser exactly.
+   * default matches the `reply-chat` skill's parser exactly.
    */
   formatPrompt?: (args: FormatPromptArgs) => string;
   /**
@@ -183,7 +183,7 @@ export interface FormatPromptArgs {
  * Default prompt formatter the agent sees when a user sends in their
  * chat channel.
  *
- * Format is intentionally stable and tag-prefixed so the `reply-channel`
+ * Format is intentionally stable and tag-prefixed so the `reply-chat`
  * skill (and future tooling) can reliably extract the channelId without
  * regex ambiguity. The `回复:` hint line gives the agent a one-step
  * instruction on how to reply.
@@ -197,8 +197,8 @@ export function defaultFormatPrompt(args: FormatPromptArgs): string {
   // to "optional" for non-@'d members.
   const mode = responseMode ?? 'required';
   const replyHint = mode === 'optional'
-    ? `回复本频道: 你在此 huddle 中收到此消息但未被 @ — 如有必要可用 \`reply-channel\` skill (channelId="${channelId}") 回复，否则不回复也可以。`
-    : `回复本频道: 用 \`reply-channel\` skill, 参数 channelId="${channelId}"、content="<your reply>"。`;
+    ? `回复本频道: 你在此 huddle 中收到此消息但未被 @ — 如有必要可用 \`reply-chat\` skill (conversationId="${channelId}") 回复，否则不回复也可以。`
+    : `回复本频道: 用 \`reply-chat\` skill, 参数 conversationId="${channelId}"、content="<your reply>"。`;
   return [
     `[CHAT:${channelId}]${idHint} <${senderId}@${channelName}>`,
     ``,

--- a/packages/chat-ui/src/components/MentionComposer.test.tsx
+++ b/packages/chat-ui/src/components/MentionComposer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { MentionTarget } from '../types/team-chat.types';
 import { MentionComposer } from './MentionComposer';
@@ -139,6 +139,33 @@ describe('MentionComposer', () => {
     await userEvent.type(screen.getByTestId('mention-textarea'), 'hello{Enter}');
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onSend.mock.calls[0][0].content).toBe('hello');
+  });
+
+  it('does NOT send on Enter while an IME composition is active (Chinese/JP/KR input)', async () => {
+    const onSend = vi.fn();
+    render(<MentionComposer mentionables={mentionables} onSend={onSend} />);
+    const ta = screen.getByTestId('mention-textarea');
+    await userEvent.type(ta, 'ni hao');
+    // Mid-composition: Enter commits the IME candidate, it must NOT send.
+    fireEvent.compositionStart(ta);
+    fireEvent.keyDown(ta, { key: 'Enter' });
+    expect(onSend).not.toHaveBeenCalled();
+    // After the composition ends, Enter sends as normal.
+    fireEvent.compositionEnd(ta);
+    fireEvent.keyDown(ta, { key: 'Enter' });
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend.mock.calls[0][0].content).toBe('ni hao');
+  });
+
+  it('does NOT send on Enter when nativeEvent.isComposing is set', async () => {
+    const onSend = vi.fn();
+    render(<MentionComposer mentionables={mentionables} onSend={onSend} />);
+    const ta = screen.getByTestId('mention-textarea');
+    await userEvent.type(ta, 'hello');
+    // Some browsers don't fire compositionStart but flag the committing
+    // keystroke via isComposing — guard on that too.
+    fireEvent.keyDown(ta, { key: 'Enter', isComposing: true });
+    expect(onSend).not.toHaveBeenCalled();
   });
 
   it('does NOT send on Shift+Enter (newline behavior)', async () => {

--- a/packages/chat-ui/src/components/MentionComposer.tsx
+++ b/packages/chat-ui/src/components/MentionComposer.tsx
@@ -78,6 +78,12 @@ export function MentionComposer({
   /** Filter text inside the suggestion popover — what comes after the `@`. */
   const [filter, setFilter] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // True while an IME composition is active (e.g. typing Chinese/Japanese/
+  // Korean). Pressing Enter to COMMIT a composition must NOT send — otherwise a
+  // half-composed message fires early. Tracked via composition events because
+  // `KeyboardEvent.isComposing` alone is unreliable across browsers/IMEs for
+  // the committing keystroke.
+  const isComposingRef = useRef(false);
 
   const grouped = useMemo(() => groupMentionables(mentionables, filter), [mentionables, filter]);
   const totalSuggestions = grouped.teams.length + grouped.agents.length;
@@ -145,12 +151,23 @@ export function MentionComposer({
         return;
       }
       if (e.key === 'Enter' && !e.shiftKey) {
+        // Don't send mid-IME-composition — Enter is committing the candidate,
+        // not submitting the message. `isComposingRef` (composition events) +
+        // the native `isComposing` flag together cover all browsers/IMEs.
+        if (isComposingRef.current || e.nativeEvent.isComposing) return;
         e.preventDefault();
         handleSend();
       }
     },
     [handleSend, popoverOpen],
   );
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+  const handleCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+  }, []);
 
   // The @ toolbar button inserts an `@` at the caret and opens the popover so
   // the mention flow is reachable without the keyboard.
@@ -197,6 +214,8 @@ export function MentionComposer({
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
           disabled={disabled}
           placeholder={placeholder}
           rows={1}


### PR DESCRIPTION
Two independent chat fixes the user hit.

## 1. Composer sends mid-IME-composition
Typing Chinese (and JP/KR) and pressing Enter to **commit the IME candidate** fired a half-composed message — because `MentionComposer`'s Enter handler had no composition guard. Now it bails out of send when an IME composition is active, tracked via `compositionstart`/`compositionend` (`isComposingRef`) **and** `e.nativeEvent.isComposing` (the committing keystroke is unreliable across browsers/IMEs, so both are checked).

## 2. Dispatch prompt names a non-existent skill
The `[CHAT:…]` prompt told agents: *"用 `reply-channel` skill, 参数 channelId=…"*. But there is no `reply-channel` skill — the real one is **`reply-chat`** taking **`conversationId`** (the channel id == the conversationId). The terminal showed the orchestrator fumbling: tried `reply-channel`, failed, searched, then found `reply-chat` and replied. Fixed `defaultFormatPrompt` (both the required and optional/huddle variants) + the doc comments to name `reply-chat`/`conversationId`, so agents reply in one step.

> Note: OSS **does** have the reply skill (`config/skills/orchestrator/reply-chat`); only the prompt was misnaming it.

## Tests
- `MentionComposer` +2 (Enter suppressed during composition; suppressed when `nativeEvent.isComposing`) — 19/19
- `chat-v2.dispatcher` prompt assertions updated to `reply-chat` / `conversationId` — 30/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)