### PR TITLE
feat(cron): cron fires enqueue a WorkItem into the task pool (fix #678 offline-drop)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,7 +55,6 @@ import { getSettingsService } from './services/settings/index.js';
 import { MemoryService } from './services/memory/memory.service.js';
 import { getImprovementStartupService } from './services/orchestrator/improvement-startup.service.js';
 import { initializeSlackIfConfigured, shutdownSlack } from './services/slack/index.js';
-import { resolveTeamByIdOrSlug, slugifyTeamName } from './services/workflow/team-identifier-resolver.js';
 import { initializeWhatsAppIfConfigured, shutdownWhatsApp } from './services/whatsapp/index.js';
 import { initializeGoogleChatIfConfigured } from './services/messaging/google-chat-initializer.js';
 import { initializeTelegramIfConfigured, shutdownTelegram } from './services/telegram/index.js';
@@ -1802,83 +1801,50 @@ void (async () => {
 				});
 			}
 
-			// #286: Start cron task service with agent status/start callbacks
+			// #286/#678: Cron fires ENQUEUE a WorkItem into the task pool instead
+			// of writing straight to the agent's terminal. The pool's wake-mesh
+			// (WorkItemDispatchSubscriber push + AgentAutoClaim pull + reconciler
+			// self-heal) then assigns + delivers it — so a cron firing for an
+			// OFFLINE agent becomes a durable queued item that gets woken, instead
+			// of being silently dropped (#678). No agent-status/auto-start callbacks
+			// are wired: the cron now ALWAYS enqueues regardless of liveness, and
+			// the pool owns online/offline delivery + recovery.
 			try {
 				const cronTaskService = CronTaskService.getInstance();
-				const storageRef = this.storageService;
-				const registrationRef = this.apiController.agentRegistrationService;
+				const { TaskPoolService } = await import('./services/task-pool/task-pool.service.js');
+				const { createWorkItem } = await import('./types/v2/work-item.types.js');
 
 				cronTaskService.setExecutionCallback(async (task) => {
-					this.logger.info('Executing cron task', { id: task.id, target: task.targetAgent });
-					await registrationRef.sendMessageToAgent(
-						task.targetAgent,
-						`[CRON_TASK:${task.id}] ${task.taskDescription}`,
-					);
-				});
-				// Issue #307: cron tasks created with `targetTeamId` set to a
-				// name slug (e.g. "stock-ops-team") instead of the UUID would
-				// silently 404 on every fire — `teams.find(t => t.id === teamId)`
-				// returned undefined and both callbacks returned `false` with
-				// no log surface. `resolveTeamByIdOrSlug` (imported statically
-				// at the top of the file) tries UUID first, then falls back
-				// to a slug match against `name`. Misses now surface a distinct
-				// warn-log with the available slugs so the cause is visible
-				// instead of hiding behind the generic "agent offline" warn
-				// from cron-task.service.
-				cronTaskService.setAgentStatusCallback(async (sessionName, teamId) => {
-					// Handle orchestrator separately — it's not in regular teams
-					if (sessionName === CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME || teamId === 'orchestrator') {
-						const orchStatus = await storageRef.getOrchestratorStatus();
-						return orchStatus?.agentStatus === 'active' || orchStatus?.agentStatus === 'started';
-					}
-					const teams = await storageRef.getTeams();
-					const team = resolveTeamByIdOrSlug(teams, teamId);
-					if (!team) {
-						this.logger.warn('CronTask: targetTeamId resolves to no team', {
-							sessionName,
-							targetTeamId: teamId,
-							availableSlugs: teams.slice(0, 10).map((t) => slugifyTeamName(t.name)),
-							hint: 'Set targetTeamId to either the team UUID or one of availableSlugs (lowercase, spaces→-)',
-						});
-						return false;
-					}
-					const member = team.members.find((m) => m.sessionName === sessionName);
-					if (!member) return false;
-					// #286 Root Cause C: treat both 'active' and 'started' as online
-					return member.agentStatus === 'active' || member.agentStatus === 'started';
-				});
-				cronTaskService.setAgentStartCallback(async (sessionName, teamId) => {
-					try {
-						const teams = await storageRef.getTeams();
-						const team = resolveTeamByIdOrSlug(teams, teamId);
-						if (!team) {
-							this.logger.warn('CronTask auto-start: targetTeamId resolves to no team', {
-								sessionName,
-								targetTeamId: teamId,
-								availableSlugs: teams.slice(0, 10).map((t) => slugifyTeamName(t.name)),
-								hint: 'Set targetTeamId to either the team UUID or one of availableSlugs (lowercase, spaces→-)',
-							});
-							return false;
-						}
-						const member = team.members.find((m) => m.sessionName === sessionName);
-						if (!member) return false;
-						await registrationRef.createAgentSession({
-							sessionName: member.sessionName,
-							role: member.role,
-							// Use the resolved team's UUID — not the user-supplied identifier
-							// — so downstream agent-registration always sees the canonical id.
-							teamId: team.id,
-							memberId: member.id,
-						});
-						return true;
-					} catch {
-						return false;
-					}
+					// Deterministic id per fire slot: re-evaluating the same due slot
+					// is a no-op (addToPool dedups by id), but each scheduled
+					// occurrence is a fresh WorkItem. `task.nextRunAt` is still the
+					// firing slot here — the service advances it AFTER this returns.
+					const slot = task.nextRunAt ?? new Date().toISOString();
+					const workItem = createWorkItem({
+						id: `cron-${task.id}-${slot}`,
+						type: 'cron_run',
+						owner: 'orchestrator',
+						target: task.targetAgent,
+						title: `Cron: ${task.taskDescription.slice(0, 80)}`,
+						description: task.taskDescription,
+						metadata: {
+							source: 'cron',
+							cronTaskId: task.id,
+							targetTeamId: task.targetTeamId,
+							firedSlot: slot,
+						},
+					});
+					await TaskPoolService.getInstance().addToPool(workItem);
+					this.logger.info('Cron task enqueued as WorkItem', {
+						id: task.id,
+						workItemId: workItem.id,
+						target: task.targetAgent,
+					});
 				});
 				// Self-heal stale nextRunAt values from pre-timezone-fix versions
 				await cronTaskService.recalculateAllNextRunTimes();
 				cronTaskService.start();
-				this.logger.info('CronTaskService started');
+				this.logger.info('CronTaskService started (cron fires → task pool WorkItems)');
 			} catch (cronErr) {
 				this.logger.warn('CronTaskService initialization failed (non-critical)', {
 					error: cronErr instanceof Error ? cronErr.message : String(cronErr),

--- a/backend/src/services/workflow/cron-task.service.test.ts
+++ b/backend/src/services/workflow/cron-task.service.test.ts
@@ -356,6 +356,34 @@ describe('CronTaskService', () => {
 			expect(executedTasks).toHaveLength(0);
 		});
 
+		// #678 gate: the composition root no longer wires agentStatusCallback /
+		// agentStartCallback — cron now ALWAYS executes (enqueues a WorkItem) and
+		// the task pool owns offline delivery + recovery. Guard that a due task
+		// fires regardless of agent liveness when no status callback is set.
+		it('executes a due task with NO agent-status callback (always enqueues — #678)', async () => {
+			const executedTasks: CronTask[] = [];
+			service.setExecutionCallback(async (task) => { executedTasks.push(task); });
+			// intentionally NO setAgentStatusCallback / setAgentStartCallback
+
+			setupTeamDirs(['team-a']);
+			const pastTime = new Date(Date.now() - 60000).toISOString();
+			mockReadFile.mockImplementation(async (path: any) => {
+				if (String(path).includes('team-a')) {
+					return JSON.stringify({ tasks: [{
+						id: 'cron-always-1', cronExpression: '0 9 * * *', timezone: 'UTC',
+						targetAgent: 'offline-agent', targetTeamId: 'team-a', taskDescription: 'Run',
+						enabled: true, lastRunAt: null, nextRunAt: pastTime,
+						createdBy: 'user', createdAt: '2026-01-01',
+					}] });
+				}
+				throw new Error('ENOENT');
+			});
+
+			await service.evaluateTasks();
+			expect(executedTasks).toHaveLength(1);
+			expect(executedTasks[0].id).toBe('cron-always-1');
+		});
+
 		// Issue #305 regression gate: an offline agent that auto-start
 		// successfully wakes up must be allowed to receive the cron task
 		// once it reports ready. Previously the executionCallback fired

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -443,6 +443,12 @@ describe('WorkItem Types', () => {
       const wi = createWorkItem(input);
       expect(wi.id).toMatch(/^[0-9a-f]{8}-/);
     });
+    it('should honor a supplied deterministic id (idempotent occurrences)', () => {
+      const wi = createWorkItem({ ...input, id: 'cron-task-7-2026-06-02T08:00:00.000Z' });
+      expect(wi.id).toBe('cron-task-7-2026-06-02T08:00:00.000Z');
+      const again = createWorkItem({ ...input, id: 'cron-task-7-2026-06-02T08:00:00.000Z' });
+      expect(again.id).toBe(wi.id);
+    });
     it('should default maxRetries to DEFAULT_MAX_RETRIES', () => {
       const wi = createWorkItem(input);
       expect(wi.maxRetries).toBe(DEFAULT_MAX_RETRIES);

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -255,6 +255,13 @@ export interface WorkItem {
  * Input for creating a new WorkItem.
  */
 export interface CreateWorkItemInput {
+  /**
+   * Optional deterministic id. When omitted a random uuid is generated. Supply
+   * a stable id when the WorkItem represents an idempotent occurrence (e.g. a
+   * cron fire keyed to its slot) so re-creating the same occurrence is a no-op
+   * via the pool's `(id)` dedup instead of a duplicate.
+   */
+  id?: string;
   requestId?: string;
   parentWorkItemId?: string;
   type: WorkItemType;
@@ -558,7 +565,7 @@ export function createWorkItem(input: CreateWorkItemInput): WorkItem {
       ? 'scheduled'
       : 'queued';
   return {
-    id: uuidv4(),
+    id: input.id ?? uuidv4(),
     requestId: input.requestId,
     parentWorkItemId: input.parentWorkItemId,
     type: input.type,


### PR DESCRIPTION
## What
Cron tasks no longer write straight to the agent's terminal. They now mint a **`cron_run` WorkItem** into the task pool, so the pool's wake-mesh assigns + delivers it:
- **PUSH** `WorkItemDispatchSubscriber` (on `workitem:queued`)
- **PULL** `AgentAutoClaimService`
- **SELF-HEAL** `ReconcilerService` (wakes inactive targets)

So a cron firing for an **offline** agent becomes a durable queued item that gets woken — instead of being silently **dropped** (the #678 amplifier). This is exactly what the v3 `TriggerEngine` already does (`createWorkItem → addToPool`); v1 cron was the lone holdout.

## How
- **`index.ts` cron wiring:** `executionCallback` → `createWorkItem({ type:'cron_run', owner:'orchestrator', target: task.targetAgent, description: task.taskDescription, id: \`cron-<taskId>-<slot>\` })` → `TaskPoolService.addToPool`. Removed the `agentStatusCallback`/`agentStartCallback` gating + offline auto-start path (the pool owns liveness/recovery now) and the now-unused team-resolver import. Relies on cron-task.service's existing "no status callback ⇒ always execute" path.
- **`createWorkItem`:** optional deterministic `id` so the per-slot id makes `addToPool` idempotent (re-evaluating the same due slot is a no-op; each occurrence is a fresh WorkItem). Dispatch keys on `target` (not type), so `cron_run` dispatches to the agent like `delegate`.

## Out of scope (separate follow-up)
The fire-time-drift residuals — `getNextRunTime` `:225` `now+24h` fallback, and the timezone-naive `UnifiedScheduler` — are independent of the offline-drop and left for later.

## Tests
- `work-item.types` +1 (honors supplied id), `cron-task.service` +1 (due task executes with no status callback — #678 guard). 128/128 across both suites, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)