### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
Minor release (1.9.0 → 1.10.0). Highlights: team-chat consolidation + Slack-into-orc merge; cron→WorkItem pool (#680) + fire-time hardening (#681); presence/IME/refresh-401/reply-skill fixes; retire UnifiedScheduler. 🤖 Generated with [Claude Code](https://claude.com/claude-code)