### PR TITLE
fix: idempotent CronTaskService.create() (#613, #621)

### DIFF
--- a/backend/src/services/workflow/cron-task.service.test.ts
+++ b/backend/src/services/workflow/cron-task.service.test.ts
@@ -211,6 +211,100 @@ describe('CronTaskService', () => {
 				'utf-8',
 			);
 		});
+
+		// Idempotency (#613, #621): create() must not append a duplicate when an
+		// identical task already exists, otherwise the evaluation loop fires
+		// every copy → N× reports per trigger, and agents that self-schedule on
+		// each restart accumulate duplicates.
+		it('returns the existing task without writing when an identical task already exists', async () => {
+			const existing: Partial<CronTask> = {
+				id: 'cron-existing',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Daily report',
+				createdBy: 'orchestrator',
+				createdAt: '2026-01-01',
+				enabled: true,
+				lastRunAt: null,
+			};
+			setupTeamStore('team-alpha', [existing]);
+
+			const task = await service.create({
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Daily report',
+			});
+
+			// Same task returned, no new id minted
+			expect(task.id).toBe('cron-existing');
+			// Crucially, nothing was written back (no duplicate appended)
+			expect(mockWriteFile).not.toHaveBeenCalled();
+		});
+
+		it('creates a distinct task when the schedule differs from existing ones', async () => {
+			const existing: Partial<CronTask> = {
+				id: 'cron-existing',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Daily report',
+				createdBy: 'orchestrator',
+				createdAt: '2026-01-01',
+				enabled: true,
+				lastRunAt: null,
+			};
+			setupTeamStore('team-alpha', [existing]);
+
+			// Different cron expression → must NOT be deduped
+			const task = await service.create({
+				cronExpression: '0 15 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Daily report',
+			});
+
+			expect(task.id).not.toBe('cron-existing');
+			expect(task.id).toMatch(/^cron-/);
+			// A write happened (new task persisted)
+			expect(mockWriteFile).toHaveBeenCalledWith(
+				'/tmp/test-crewly/teams/team-alpha/cron-tasks.json',
+				expect.any(String),
+				'utf-8',
+			);
+		});
+
+		it('creates a distinct task when the description differs (same schedule)', async () => {
+			const existing: Partial<CronTask> = {
+				id: 'cron-existing',
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Daily report',
+				createdBy: 'orchestrator',
+				createdAt: '2026-01-01',
+				enabled: true,
+				lastRunAt: null,
+			};
+			setupTeamStore('team-alpha', [existing]);
+
+			const task = await service.create({
+				cronExpression: '0 9 * * *',
+				timezone: 'UTC',
+				targetAgent: 'agent-1',
+				targetTeamId: 'team-alpha',
+				taskDescription: 'Pre-market prep', // different description
+			});
+
+			expect(task.id).not.toBe('cron-existing');
+			expect(mockWriteFile).toHaveBeenCalled();
+		});
 	});
 
 	describe('list (aggregated across teams)', () => {

--- a/backend/src/services/workflow/cron-task.service.ts
+++ b/backend/src/services/workflow/cron-task.service.ts
@@ -576,6 +576,43 @@ export class CronTaskService {
 	 */
 	async create(request: CreateCronTaskRequest): Promise<CronTask> {
 		const timezone = request.timezone || 'UTC';
+		const isOrchestratorTask = request.targetTeamId === ORCHESTRATOR_TEAM_ID;
+
+		// Load the destination store up front so we can both dedup against it
+		// and append to it (orchestrator tasks live in the global store,
+		// team tasks in their per-team store).
+		const store = isOrchestratorTask
+			? await this.loadGlobalStore()
+			: await this.loadTeamStore(request.targetTeamId);
+
+		// Idempotency guard (#613, #621). A cron is logically identified by its
+		// target agent + team + schedule + timezone + description. If an
+		// identical task already exists, return it instead of pushing a
+		// duplicate. Without this, repeated create-cron calls — an agent
+		// self-scheduling on every restart (#621), or the orchestrator
+		// re-running a startup routine — accumulate duplicate entries in the
+		// store file, and `evaluateTasks` fires EVERY copy, delivering N
+		// identical reports per trigger (#613). create() generates a fresh
+		// random id per call, so id-based dedup cannot catch this; we match on
+		// the logical key. Genuinely distinct schedules (different time,
+		// timezone, or description) are never collapsed.
+		const existing = store.tasks.find(t =>
+			t.targetAgent === request.targetAgent &&
+			t.targetTeamId === request.targetTeamId &&
+			t.cronExpression === request.cronExpression &&
+			(t.timezone || 'UTC') === timezone &&
+			t.taskDescription === request.taskDescription,
+		);
+		if (existing) {
+			this.logger.info('Cron task create deduplicated — identical task already exists', {
+				id: existing.id,
+				cron: existing.cronExpression,
+				target: existing.targetAgent,
+				teamId: existing.targetTeamId,
+			});
+			return existing;
+		}
+
 		const nextRunAt = getNextRunTime(request.cronExpression, timezone);
 
 		const task: CronTask = {
@@ -593,13 +630,10 @@ export class CronTaskService {
 		};
 
 		// Orchestrator tasks go to global store; team tasks go to per-team store
-		if (task.targetTeamId === ORCHESTRATOR_TEAM_ID) {
-			const store = await this.loadGlobalStore();
-			store.tasks.push(task);
+		store.tasks.push(task);
+		if (isOrchestratorTask) {
 			await this.saveGlobalStore(store);
 		} else {
-			const store = await this.loadTeamStore(task.targetTeamId);
-			store.tasks.push(task);
 			await this.saveTeamStore(task.targetTeamId, store);
 		}
 


### PR DESCRIPTION
## Problem

`CronTaskService.create()` minted a fresh random id and unconditionally `store.tasks.push(task)` on every call — no dedup. Two failure paths exploit this:

- **#621**: an agent (e.g. Eve) self-schedules the same cron on every session restart → a new duplicate entry each time.
- **orchestrator** re-running a startup routine that re-creates its crons.

Because the evaluation loop polls the store file each tick and fires **every** matching entry, a cron duplicated N times delivers **N identical reports/PDFs per trigger** — exactly the user-visible symptom in **#613** (file observed growing to 119 entries; `cron-ella-morning-brief` had 7 copies).

> Note on #613: the original *live-registry* duplication mechanism is already gone (the service is now a single file-polling evaluator). But the **symptom** is still reachable via non-idempotent `create()` accumulating duplicate file entries, so #613 is fixed here rather than closed as stale.

## Fix

Add a logical-key idempotency guard in `create()`. A cron is identified by `(targetAgent, targetTeamId, cronExpression, timezone, taskDescription)`. If an identical task already exists in the destination store, return it instead of appending a duplicate. id-based dedup can't help because `create()` generates a new id per call. Genuinely distinct schedules (different time, timezone, or description) are never collapsed.

## Tests

- identical task → returns existing task, writes nothing (no duplicate appended)
- differing cron expression → creates a distinct task + persists
- differing description (same schedule) → creates a distinct task

All 48 tests in `cron-task.service.test.ts` pass; backend build clean.

Fixes #613
Fixes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)