### PR TITLE
feat: list-my-crons agent skill — agents can see their own crons (#621)

### DIFF
--- a/config/skills/agent/core/list-my-crons/SKILL.md
+++ b/config/skills/agent/core/list-my-crons/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: list-my-crons
+description: List the recurring cron tasks the orchestrator has scheduled FOR you — call before self-scheduling so you don't create duplicates that fire N× reports.
+version: 1.0.0
+category: followup
+skillType: claude-skill
+tags:
+  - cron
+  - schedule
+  - audit
+execution:
+  type: script
+  script:
+    file: execute.sh
+    interpreter: bash
+    timeoutMs: 15000
+---
+
+# list-my-crons
+
+List the recurring **cron tasks** that target you — i.e. schedules the
+orchestrator (or you) registered with you as the `targetAgent`. Call this
+**before** creating a cron or a `schedule-followup`, so you can confirm whether
+you are already scheduled instead of stacking a duplicate.
+
+## Why this exists
+
+Cron tasks and follow-up triggers live in **two different stores**:
+
+| What | Store | List it with |
+|------|-------|--------------|
+| Recurring cron the orchestrator set for you | cron-tasks (per-team file) | **`list-my-crons`** (this skill) |
+| Follow-up timers you created | triggers (TriggerEngine) | `list-my-followups` |
+
+`list-my-followups` will **not** show the orchestrator's crons — they are in a
+separate store. If you only check followups, you can wrongly conclude "I have
+no schedule" and self-create a duplicate cron. That duplicate then fires every
+trigger N× (N identical reports/PDFs). Always check **both** before scheduling.
+
+> Note: "cron API shows 0" is **not** a reliable "no schedule exists" signal on
+> its own — historically agents misread it and self-duplicated (#621). Check
+> the actual list here, and if unsure, ask the orchestrator rather than
+> re-creating.
+
+## Examples
+
+```bash
+# All crons targeting you
+bash execute.sh
+
+# Only enabled ones
+bash execute.sh --enabled true
+```
+
+## Options
+
+| Flag | Meaning |
+|------|---------|
+| `--enabled <true\|false>` | Filter by enabled state (optional) |
+| `--target <session>` | Query a different agent's crons (default: yourself) |
+| `--json`, `-j` | Raw JSON payload (legacy) |
+
+## Output
+
+```
+{ "success": true, "count": <n>, "data": [ CronTask, ... ] }
+```

--- a/config/skills/agent/core/list-my-crons/execute.sh
+++ b/config/skills/agent/core/list-my-crons/execute.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# List the recurring cron tasks that target YOU (or another agent via --target).
+#
+# Cron tasks and follow-up triggers live in two different stores. This skill
+# reads the cron-tasks store (what the orchestrator schedules FOR an agent),
+# which `list-my-followups` does NOT cover. Call this before self-scheduling so
+# you don't stack a duplicate cron that fires N× reports per trigger (#621).
+#
+# Supports CLI flags (preferred) or legacy JSON.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../_common/lib.sh"
+
+print_usage() {
+  cat <<'EOF_USAGE'
+Usage:
+  bash execute.sh                      # All crons targeting you
+  bash execute.sh --enabled true       # Only enabled crons targeting you
+  bash execute.sh --target <session>   # Crons targeting another agent
+
+Options:
+  --enabled   One of: true | false (optional)
+  --target    Agent session to query (default: yourself, $CREWLY_SESSION_NAME)
+  --json -j   Raw JSON payload (legacy)
+  --help -h   Show this help
+
+Output: JSON object { success, count, data: [CronTask, ...] }
+EOF_USAGE
+}
+
+INPUT_JSON=""
+ENABLED_FILTER=""
+TARGET=""
+
+if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
+  INPUT_JSON="$1"
+  shift || true
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --enabled)   ENABLED_FILTER="$2"; shift 2 ;;
+    --target)    TARGET="$2"; shift 2 ;;
+    --json|-j)   INPUT_JSON="$2"; shift 2 ;;
+    --help|-h)   print_usage; exit 0 ;;
+    --)          shift; break ;;
+    *)
+      if [[ -z "$INPUT_JSON" && ${1:0:1} == '{' ]]; then
+        INPUT_JSON="$1"; shift
+      else
+        echo '{"error":"Unknown argument: '"$1"'"}' >&2
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [ -n "$INPUT_JSON" ]; then
+  ENABLED_FILTER=$(printf '%s' "$INPUT_JSON" | jq -r '.enabled // empty')
+  TARGET=$(printf '%s' "$INPUT_JSON" | jq -r '.target // empty')
+fi
+
+# Default target = self
+[ -z "$TARGET" ] && TARGET="${CREWLY_SESSION_NAME:-}"
+[ -z "$TARGET" ] && { echo '{"error":"No --target and CREWLY_SESSION_NAME is unset"}' >&2; exit 1; }
+
+# Build query string: filter by targetAgent (Option A from #621 — the API
+# returns crons where targetAgent == session, regardless of who created them).
+QUERY="?targetAgent=${TARGET}"
+[ -n "$ENABLED_FILTER" ] && QUERY="${QUERY}&enabled=${ENABLED_FILTER}"
+
+LIST_RESP=$(api_call GET "/cron-tasks${QUERY}" "")
+
+# Normalise to { success, count, data } so callers get a stable shape.
+DATA=$(printf '%s' "$LIST_RESP" | jq '(.data // [])')
+COUNT=$(printf '%s' "$DATA" | jq 'length')
+printf '%s' "$DATA" | jq --arg c "$COUNT" '{success:true, count:($c|tonumber), data:.}'

--- a/config/skills/agent/core/schedule-followup/SKILL.md
+++ b/config/skills/agent/core/schedule-followup/SKILL.md
@@ -34,6 +34,19 @@ that went quiet.
 | "Whenever Rex goes idle, check progress" | `watch-for-event` (event-based, not this skill) |
 | Simple self-reminder with no team scope | `schedule-check` (older skill) |
 
+## Before you schedule — check you aren't already scheduled
+
+Schedules live in **two stores**: follow-up triggers (this skill) and cron
+tasks the orchestrator sets for you. Check **both** before creating, or you
+will stack a duplicate that fires N× reports:
+
+- `list-my-followups` — your follow-up triggers
+- `list-my-crons` — recurring crons targeting you (the orchestrator's)
+
+Do **not** treat "cron list shows 0" alone as "no schedule exists" — verify
+with both skills, and if still unsure, ask the orchestrator instead of
+re-creating (#621).
+
 ## Key invariants
 
 - Every followup is **team-scoped**. It shows up under `list-my-followups` and


### PR DESCRIPTION
## Problem (#621, Option A)

Agents had **no way to see crons targeting them**:
- `list-cron` is orchestrator-only.
- `list-my-followups` covers only the **TriggerEngine** store, not the separate **cron-tasks** store.

So an agent (e.g. Eve) that checked only followups concluded "no schedule exists" and self-created a duplicate cron on every restart — firing N× duplicate reports/PDFs per trigger.

The issue's root-cause guess ("API filters by session ownership") is actually **not** the case: `CronTaskService.list({ targetAgent })` already filters by `targetAgent` across all teams with no ownership filter — i.e. the issue's **preferred Option A** is already satisfied at the API. The only missing piece was an agent-side read path.

## Fix

- **`list-my-crons`** (new read-only agent skill): queries `GET /api/cron-tasks?targetAgent={session}` (defaults to self), normalises to `{ success, count, data }`. Documents the two-store split so agents know followups ≠ crons.
- **`schedule-followup`** SKILL.md: instructs agents to check **both** `list-my-crons` and `list-my-followups` before scheduling, and not to treat "cron list shows 0" alone as "no schedule exists" (ask the orchestrator if unsure).

## Relation to #684

[#684](https://github.com/stevehuang0115/crewly/pull/684) makes `create()` idempotent — the backstop that collapses a duplicate even if an agent still self-creates. This PR removes the *reason* agents self-create (blindness). Together they close #621 at both layers.

Part of #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)