### PR TITLE
fix: reconciler starts orchestrator via /orchestrator/setup, not member-start (#679)

### DIFF
--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -154,6 +154,7 @@ import { WorkItemDispatchSubscriber } from '../v3/workitem-dispatch.subscriber.j
 import type { WorkItem } from '../../types/v2/work-item.types.js';
 import type { TaskClaim } from '../../types/v2/claim.types.js';
 import type { WakeAction } from '../../types/v2/reconcile.types.js';
+import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 
 // Access mock instances via type assertions
 const mockPool = (TaskPoolService as any)._mockInstance;
@@ -937,6 +938,40 @@ describe('LiveReconcilerDataProvider', () => {
       );
       const bodyArg = (globalThis.fetch as jest.Mock).mock.calls[0][1].body as string;
       expect(JSON.parse(bodyArg)).toMatchObject({ sessionName: 'agent-idle', workItemId: 'wi-1' });
+
+      globalThis.fetch = originalFetch;
+    });
+
+    // #679 / #686: the orchestrator is a virtual member with undefined
+    // teamId/memberId. The old fallback URL `/api/teams/members/start`
+    // misrouted to `startTeam` → 404 "Team not found" (retried every ~10s),
+    // and the orchestrator could never be (re)started by the reconciler — so
+    // after a backend restart it stayed inactive and inbound work sat queued.
+    // It must be routed to the dedicated, idempotent /api/orchestrator/setup.
+    it('starts the orchestrator via /api/orchestrator/setup, not the member-start path (#679, #686)', async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true }),
+      });
+
+      const action: WakeAction = {
+        workItemId: 'wi-orc-1',
+        agentSessionName: ORCHESTRATOR_SESSION_NAME, // 'crewly-orc'
+        strategy: 'start',
+        // teamId/memberId intentionally absent — orc is a virtual member.
+        score: 90,
+        scoreBreakdown: { skillMatch: 40, urgency: 40, contextFamiliarity: 10, loadPenalty: 0 },
+        triggeredAt: new Date().toISOString(),
+      };
+
+      const result = await provider.executeWakeAction(action);
+
+      expect(result).toBe(true);
+      const calledUrl = (globalThis.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('/api/orchestrator/setup');
+      // Must NOT hit the misrouting member-start fallback.
+      expect(calledUrl).not.toContain('/api/teams/members/start');
 
       globalThis.fetch = originalFetch;
     });

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -31,7 +31,7 @@ import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
 import { TokenUsageService } from '../monitoring/token-usage.service.js';
 import { isUnderMemoryPressure, getMemoryStats } from '../core/system-health.util.js';
 import type { EventBusService } from '../event-bus/event-bus.service.js';
-import { WEB_CONSTANTS, AGENT_SUSPEND_CONSTANTS } from '../../constants.js';
+import { WEB_CONSTANTS, AGENT_SUSPEND_CONSTANTS, ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -1205,7 +1205,7 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         return await suspendService.rehydrateAgent(agentSessionName);
       } else if (strategy === 'start') {
         // For inactive agents, we need to start them via the registration service.
-        // The agent session creation is complex — use the team-member-start API endpoint.
+        // The agent session creation is complex — use the HTTP API endpoint.
         const { teamId, memberId } = action;
 
         // Follow-up #10 from PR #543 review: replace the hardcoded
@@ -1213,21 +1213,42 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         // still wins when set so deployments overriding the default keep
         // working unchanged.
         const port = process.env.PORT || WEB_CONSTANTS.PORTS.BACKEND;
-        let url = `http://localhost:${port}/api/teams/members/start`;
-        if (teamId && memberId) {
-          url = `http://localhost:${port}/api/teams/${teamId}/members/${memberId}/start`;
+
+        // The main orchestrator (crewly-orc) is a VIRTUAL team member: its
+        // teamId/memberId are intentionally undefined in the health map, and
+        // it is "managed at system level". It CANNOT be started via the
+        // team-member-start path — that handler rejects the orchestrator
+        // member with 400, and the undefined-teamId fallback URL
+        // `/api/teams/members/start` misroutes to `startTeam` (route
+        // `/:id/start`, id="members") → 404 "Team not found", which the
+        // reconciler then retried every ~10s (#679). It must be (re)started
+        // via the dedicated, idempotent orchestrator setup endpoint — which
+        // skips if already healthy and is also the path that recovers the
+        // orchestrator after a backend restart (#686).
+        let url: string;
+        let body: Record<string, unknown>;
+        if (agentSessionName === ORCHESTRATOR_SESSION_NAME) {
+          url = `http://localhost:${port}/api/orchestrator/setup`;
+          // setupOrchestrator takes no body; it is idempotent and self-gating.
+          body = {};
+        } else {
+          url = `http://localhost:${port}/api/teams/members/start`;
+          if (teamId && memberId) {
+            url = `http://localhost:${port}/api/teams/${teamId}/members/${memberId}/start`;
+          }
+          // Pass `workItemId` so the team-controller wake-gate can verify
+          // that this wake is pool-driven (path 1 of the gate). Reconciler
+          // hybrid-wake has already decided which WI triggered the wake;
+          // the gate trusts that decision rather than re-scanning the pool.
+          // Without this, the gate would still pass via path 2 (pool scan)
+          // — but explicit is better when we already have the evidence.
+          body = { sessionName: agentSessionName, workItemId: action.workItemId };
         }
 
-        // Pass `workItemId` so the team-controller wake-gate can verify
-        // that this wake is pool-driven (path 1 of the gate). Reconciler
-        // hybrid-wake has already decided which WI triggered the wake;
-        // the gate trusts that decision rather than re-scanning the pool.
-        // Without this, the gate would still pass via path 2 (pool scan)
-        // — but explicit is better when we already have the evidence.
         const response = await fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sessionName: agentSessionName, workItemId: action.workItemId }),
+          body: JSON.stringify(body),
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Problem (#679)

`ReconcilerDataProvider.executeWakeAction` built the start URL as `/api/teams/{teamId}/members/{memberId}/start`, falling back to `/api/teams/members/start` when `teamId`/`memberId` were undefined.

The main orchestrator (`crewly-orc`) is a **virtual** team member — its `teamId`/`memberId` are intentionally undefined in the health map. So it always took the fallback URL, which has only two path segments and **misroutes** to `startTeam` (route `/:id/start` with `id="members"`) → `404 "Team not found"`. The reconciler retried this **every ~10s** while inbound work sat `queued`, producing the perpetual `已完成 0/1, 排队 1` status, and meaning the orchestrator was **never recoverable by the reconciler after a backend restart** (the #686 silent-假死).

Worse, the team-member-start path *can't* start the orchestrator even when routed correctly — that handler rejects the orchestrator member with `400` ("managed at system level. Use /api/orchestrator/setup").

## Fix

In `executeWakeAction`'s `start` branch, route `agentSessionName === ORCHESTRATOR_SESSION_NAME` to the dedicated, idempotent **`POST /api/orchestrator/setup`** (empty body). That endpoint skips when the orc is already healthy and (re)creates the session when it isn't. All other agents keep the member-start path + `workItemId` wake-gate body unchanged.

## Test

- New: starting the orchestrator hits `/api/orchestrator/setup` and **never** the `/api/teams/members/start` fallback.
- All 85 `reconciler-data-provider` tests pass; backend build clean.

## Scope

Fixes #679's **primary root cause** (the recurring orchestrator 404 / stuck-queue loop) and is the **precondition for #686's self-heal** (the reconciler can now actually restart the orc after a backend restart). The other #679 sub-items — `claim` honoring an explicit `workItemId`, a `DELETE` pool-item endpoint, and the `complete-task` taskId misdirection — are separate and not addressed here.

Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)