### PR TITLE
fix: resilient orchestrator boot auto-start with retry+backoff (#686)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -40,6 +40,7 @@ import { TerminalGateway, setTerminalGateway } from './websocket/terminal.gatewa
 import { initializeChatGateway } from './websocket/chat.gateway.js';
 import { StartupConfig } from './types/index.js';
 import { LoggerService } from './services/core/logger.service.js';
+import { retryWithBackoff } from './services/core/retry.util.js';
 import {
 	CREWLY_CONSTANTS,
 	ORCHESTRATOR_SESSION_NAME,
@@ -2508,19 +2509,55 @@ void (async () => {
 				}
 			}
 
-			// Create orchestrator agent session
-			const result = await this.apiController.agentRegistrationService.createAgentSession({
-				sessionName: ORCHESTRATOR_SESSION_NAME,
-				role: ORCHESTRATOR_ROLE,
-				projectPath: this.config.crewlyHome,
-				windowName: ORCHESTRATOR_WINDOW_NAME,
-				runtimeType,
-				forceRecreate: true,
-			});
+			// Create orchestrator agent session, with bounded retry + backoff.
+			//
+			// #686: a single `createAgentSession` failure here used to be a
+			// one-shot WARN + return — the orchestrator then stayed inactive
+			// with NO retry and NO health signal, leaving the system in a
+			// silent "假死" state (inbound messages queue forever, /health still
+			// reports healthy). Transient failures are common at boot (e.g. a
+			// momentary PTY spawn-slot exhaustion like #611, or a downstream
+			// dependency still warming up after a process restart), so we retry
+			// with a linear backoff before giving up. The reconciler's
+			// hybrid-wake is the longer-term self-heal (it now restarts the orc
+			// via /orchestrator/setup, #679), but boot-time retry avoids leaving
+			// the orc dead until the next inbound message arrives.
+			const MAX_AUTOSTART_ATTEMPTS = 5;
+			const AUTOSTART_BACKOFF_MS = 3_000;
+
+			const result = await retryWithBackoff(
+				() => this.apiController.agentRegistrationService.createAgentSession({
+					sessionName: ORCHESTRATOR_SESSION_NAME,
+					role: ORCHESTRATOR_ROLE,
+					projectPath: this.config.crewlyHome,
+					windowName: ORCHESTRATOR_WINDOW_NAME,
+					runtimeType,
+					forceRecreate: true,
+				}),
+				{
+					maxAttempts: MAX_AUTOSTART_ATTEMPTS,
+					backoffMs: AUTOSTART_BACKOFF_MS,
+					isSuccess: r => r.success,
+					onRetry: ({ attempt, maxAttempts, retryInMs, result: r }) => {
+						this.logger.warn('Auto-start orchestrator failed to create session — retrying', {
+							error: r.error,
+							attempt,
+							maxAttempts,
+							retryInMs,
+						});
+					},
+				},
+			);
 
 			if (!result.success) {
-				this.logger.warn('Auto-start orchestrator failed to create session', {
+				// Exhausted all retries. Log loudly at ERROR (not WARN) so the
+				// failure is greppable in pm2/console output and not mistaken for
+				// a benign skip. The orchestrator stays inactive; recovery now
+				// falls to the reconciler's hybrid-wake on the next queued
+				// inbound WorkItem (#679 routing fix).
+				this.logger.error('Auto-start orchestrator FAILED after all retries — orchestrator is INACTIVE', {
 					error: result.error,
+					attempts: MAX_AUTOSTART_ATTEMPTS,
 				});
 				return;
 			}

--- a/backend/src/services/core/retry.util.test.ts
+++ b/backend/src/services/core/retry.util.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for retryWithBackoff.
+ *
+ * @module services/core/retry.util.test
+ */
+
+import { retryWithBackoff } from './retry.util.js';
+
+interface Result {
+	success: boolean;
+	error?: string;
+}
+
+describe('retryWithBackoff', () => {
+	// A no-op sleep so tests don't actually wait. Records the requested delays
+	// so we can assert the linear backoff schedule.
+	function makeSleepSpy(): { sleep: (ms: number) => Promise<void>; delays: number[] } {
+		const delays: number[] = [];
+		return {
+			delays,
+			sleep: async (ms: number) => {
+				delays.push(ms);
+			},
+		};
+	}
+
+	it('returns immediately on first success without sleeping', async () => {
+		const { sleep, delays } = makeSleepSpy();
+		const op = jest.fn(async () => ({ success: true }) as Result);
+
+		const result = await retryWithBackoff(op, {
+			maxAttempts: 5,
+			backoffMs: 1000,
+			isSuccess: r => r.success,
+			sleep,
+		});
+
+		expect(result.success).toBe(true);
+		expect(op).toHaveBeenCalledTimes(1);
+		expect(delays).toEqual([]); // never slept
+	});
+
+	it('retries on failure and succeeds on a later attempt', async () => {
+		const { sleep, delays } = makeSleepSpy();
+		let calls = 0;
+		const op = jest.fn(async () => {
+			calls++;
+			return { success: calls === 3 } as Result; // fail, fail, succeed
+		});
+
+		const result = await retryWithBackoff(op, {
+			maxAttempts: 5,
+			backoffMs: 1000,
+			isSuccess: r => r.success,
+			sleep,
+		});
+
+		expect(result.success).toBe(true);
+		expect(op).toHaveBeenCalledTimes(3);
+		// Linear backoff before attempt 2 (1000) and attempt 3 (2000); no sleep
+		// after the successful 3rd attempt.
+		expect(delays).toEqual([1000, 2000]);
+	});
+
+	it('exhausts all attempts and returns the last (failed) result', async () => {
+		const { sleep, delays } = makeSleepSpy();
+		const op = jest.fn(async (attempt: number) => ({ success: false, error: `fail-${attempt}` }) as Result);
+
+		const result = await retryWithBackoff(op, {
+			maxAttempts: 3,
+			backoffMs: 500,
+			isSuccess: r => r.success,
+			sleep,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error).toBe('fail-3'); // last result surfaced
+		expect(op).toHaveBeenCalledTimes(3);
+		// Sleeps only BETWEEN attempts (after 1 and 2), not after the final one.
+		expect(delays).toEqual([500, 1000]);
+	});
+
+	it('invokes onRetry before each backoff with attempt metadata', async () => {
+		const { sleep } = makeSleepSpy();
+		const onRetry = jest.fn();
+		const op = jest.fn(async () => ({ success: false }) as Result);
+
+		await retryWithBackoff(op, {
+			maxAttempts: 3,
+			backoffMs: 1000,
+			isSuccess: r => r.success,
+			onRetry,
+			sleep,
+		});
+
+		expect(onRetry).toHaveBeenCalledTimes(2); // before attempt 2 and 3
+		expect(onRetry).toHaveBeenNthCalledWith(1, expect.objectContaining({ attempt: 1, maxAttempts: 3, retryInMs: 1000 }));
+		expect(onRetry).toHaveBeenNthCalledWith(2, expect.objectContaining({ attempt: 2, maxAttempts: 3, retryInMs: 2000 }));
+	});
+
+	it('passes the 1-based attempt number to the operation', async () => {
+		const { sleep } = makeSleepSpy();
+		const seen: number[] = [];
+		const op = jest.fn(async (attempt: number) => {
+			seen.push(attempt);
+			return { success: false } as Result;
+		});
+
+		await retryWithBackoff(op, { maxAttempts: 3, backoffMs: 1, isSuccess: r => r.success, sleep });
+
+		expect(seen).toEqual([1, 2, 3]);
+	});
+
+	it('throws RangeError when maxAttempts < 1', async () => {
+		await expect(
+			retryWithBackoff(async () => ({ success: true }) as Result, {
+				maxAttempts: 0,
+				backoffMs: 100,
+				isSuccess: r => r.success,
+			}),
+		).rejects.toThrow(RangeError);
+	});
+
+	it('supports a custom isSuccess predicate', async () => {
+		const { sleep } = makeSleepSpy();
+		let calls = 0;
+		// "Success" here means a non-empty data string, not a `success` flag.
+		const op = jest.fn(async () => {
+			calls++;
+			return { data: calls >= 2 ? 'ready' : '' };
+		});
+
+		const result = await retryWithBackoff(op, {
+			maxAttempts: 4,
+			backoffMs: 10,
+			isSuccess: r => r.data.length > 0,
+			sleep,
+		});
+
+		expect(result.data).toBe('ready');
+		expect(op).toHaveBeenCalledTimes(2);
+	});
+});

--- a/backend/src/services/core/retry.util.ts
+++ b/backend/src/services/core/retry.util.ts
@@ -1,0 +1,91 @@
+/**
+ * Generic retry-with-backoff helper.
+ *
+ * Crewly services routinely return a success-flagged result object
+ * (`{ success: boolean, error?: string, ... }`) rather than throwing. This
+ * helper retries such an operation until it reports success or the attempt
+ * budget is exhausted, applying a linear backoff between tries.
+ *
+ * Extracted so retry policy is unit-testable in isolation (the original
+ * caller — the orchestrator auto-start in the server bootstrap, #686 — cannot
+ * be unit-tested without standing up the entire CrewlyServer).
+ *
+ * @module services/core/retry.util
+ */
+
+/**
+ * Options controlling {@link retryWithBackoff}.
+ */
+export interface RetryWithBackoffOptions<T> {
+	/** Maximum number of attempts (must be >= 1). The first try counts as attempt 1. */
+	maxAttempts: number;
+	/**
+	 * Base backoff in milliseconds. The wait before retry N is
+	 * `backoffMs * N` (linear backoff): after attempt 1 fails we wait
+	 * `backoffMs`, after attempt 2 we wait `2 * backoffMs`, etc. No wait is
+	 * applied after the final attempt.
+	 */
+	backoffMs: number;
+	/** Predicate deciding whether a result counts as success (stops retrying). */
+	isSuccess: (result: T) => boolean;
+	/** Optional hook invoked before each backoff sleep (for logging). */
+	onRetry?: (info: { attempt: number; maxAttempts: number; retryInMs: number; result: T }) => void;
+	/**
+	 * Sleep implementation, injectable for tests. Defaults to a real
+	 * `setTimeout`-based delay.
+	 */
+	sleep?: (ms: number) => Promise<void>;
+}
+
+/** Default real-time sleep. */
+function defaultSleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `operation` up to `maxAttempts` times until `isSuccess` returns true,
+ * waiting `backoffMs * attempt` between tries (linear backoff).
+ *
+ * Always returns the LAST result — successful or not — so the caller can
+ * inspect it (e.g. read `result.error`). The operation receives the 1-based
+ * attempt number.
+ *
+ * @param operation - Async operation to run; receives the 1-based attempt number
+ * @param options - Retry policy {@link RetryWithBackoffOptions}
+ * @returns The last result produced by `operation`
+ * @throws RangeError if `maxAttempts` < 1
+ *
+ * @example
+ * ```typescript
+ * const result = await retryWithBackoff(
+ *   () => service.createAgentSession({ ... }),
+ *   { maxAttempts: 5, backoffMs: 3000, isSuccess: r => r.success,
+ *     onRetry: ({ attempt, retryInMs }) => logger.warn('retrying', { attempt, retryInMs }) },
+ * );
+ * if (!result.success) logger.error('gave up', { error: result.error });
+ * ```
+ */
+export async function retryWithBackoff<T>(
+	operation: (attempt: number) => Promise<T>,
+	options: RetryWithBackoffOptions<T>,
+): Promise<T> {
+	const { maxAttempts, backoffMs, isSuccess, onRetry } = options;
+	if (maxAttempts < 1) {
+		throw new RangeError(`maxAttempts must be >= 1, got ${maxAttempts}`);
+	}
+	const sleep = options.sleep ?? defaultSleep;
+
+	let result!: T;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		result = await operation(attempt);
+		if (isSuccess(result)) {
+			return result;
+		}
+		if (attempt < maxAttempts) {
+			const retryInMs = backoffMs * attempt;
+			onRetry?.({ attempt, maxAttempts, retryInMs, result });
+			await sleep(retryInMs);
+		}
+	}
+	return result;
+}


### PR DESCRIPTION
## Problem (#686)

On `createAgentSession` failure, `autoStartOrchestratorIfEnabled` did a one-shot WARN + return — no retry, no backoff, no escalation:

```ts
if (!result.success) {
  this.logger.warn('Auto-start orchestrator failed to create session', { error: result.error });
  return; // <-- gives up permanently
}
```

A single **transient** failure at boot (momentary PTY spawn-slot exhaustion like #611, or a dependency still warming up after a process restart) left the orchestrator permanently `inactive` in a silent **"假死"** state: inbound messages enqueue a `respond_to_user` WorkItem that no live orchestrator ever claims, `/health` still reports `healthy`, and the only signal is one WARN line in pm2 logs. Hit live on **ESTestNode** during the `1.8.8 → 1.10.0` upgrade.

## Fix

- **`retryWithBackoff`** (`services/core/retry.util.ts`): a small, generic, unit-tested helper that retries a success-flagged async op with linear backoff until success or the attempt budget is exhausted, returning the last result (so the caller can read `.error`). Injectable `sleep` for tests.
- Orchestrator auto-start now uses it: **5 attempts, 3s linear backoff**, WARN per retry. On exhaustion it logs a **loud ERROR** (not WARN) so the failure is greppable and not mistaken for a benign skip.

Recovery is now layered: boot retry handles transient boot failures; the reconciler hybrid-wake ([#687](https://github.com/stevehuang0115/crewly/pull/687), #679 routing fix) restarts the orc on the next queued inbound WorkItem if boot still gives up.

## Tests

7 cases for `retryWithBackoff`: first-success-no-sleep, retry-then-succeed, exhaustion-returns-last-result, `onRetry` metadata, 1-based attempt numbers, `RangeError` guard, custom `isSuccess` predicate. Backend typecheck clean.

## Out of scope (separate #686 follow-ups)

- Making `/health` orchestrator-aware (report degraded when `agents.active == 0` AND queued inbound `respond_to_user` exists).
- Emitting a degraded-state alert event on exhaustion.
- Confirming `autoStartOrchestrator` default for headless/`crewly-agent` deployments.

Part of #686 (depends on #679 fix in #687 for the self-heal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)