### PR TITLE
fix: reject WorkItems dispatched to non-existent target sessions (#615)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -19,6 +19,7 @@ import {
   cancelQueuedItem,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
+import { StorageService } from '../../services/core/storage.service.js';
 // Express types used for mock helpers below
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,12 @@ jest.mock('../../services/task-pool/task-pool.service.js', () => {
     TaskPoolService: { getInstance: jest.fn() },
   };
 });
+
+// #615: addItem now validates the target session via StorageService. Mock it
+// so target resolution is controllable per-test.
+jest.mock('../../services/core/storage.service.js', () => ({
+  StorageService: { getInstance: jest.fn() },
+}));
 
 const mockService = {
   getAvailableItems: jest.fn(),
@@ -56,6 +63,12 @@ const mockService = {
 };
 
 (TaskPoolService.getInstance as any) = jest.fn().mockReturnValue(mockService);
+
+// #615: StorageService.findMemberBySessionName backs addItem's target check.
+const mockStorage = {
+  findMemberBySessionName: jest.fn(),
+};
+(StorageService.getInstance as any) = jest.fn().mockReturnValue(mockStorage);
 
 function mockReq(overrides: Record<string, any> = {}): any {
   return {
@@ -852,6 +865,12 @@ describe('TaskPoolController', () => {
     beforeEach(() => {
       mockService.addToPool.mockResolvedValue(undefined);
       mockService.getAllItems.mockResolvedValue([]);
+      // Default: any targeted session resolves to a real member, so the
+      // #615 target guard passes. Individual tests override to return null.
+      mockStorage.findMemberBySessionName.mockResolvedValue({
+        team: { id: 'team-1' },
+        member: { id: 'm-1', sessionName: 'crewly-product-leo' },
+      });
     });
 
     it('accepts a minimal CreateWorkItemInput body and generates id + status + createdAt', async () => {
@@ -1019,6 +1038,75 @@ describe('TaskPoolController', () => {
       const addedWI = mockService.addToPool.mock.calls[0][0];
       expect(addedWI.status).toBe('blocked');
       expect(addedWI.dependsOn).toEqual(['wi-upstream-1', 'wi-upstream-2']);
+    });
+
+    // #615: an agent (Don) invented teammates "Leo"/"Noah" with plausible
+    // session names and dispatched WorkItems that orphaned forever. The target
+    // must resolve to a real member or known virtual agent, else reject.
+    it('rejects a WorkItem whose target session does not resolve to any member (#615)', async () => {
+      mockStorage.findMemberBySessionName.mockResolvedValue(null); // fabricated target
+
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          target: 'stock-ops-team-noah-cbe74bbd', // looks real, does not exist
+          title: 'Distribute report',
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      const body = res.json.mock.calls[0][0];
+      expect(body.success).toBe(false);
+      expect(body.code).toBe('unknown_target_session');
+      expect(body.error).toMatch(/does not exist/);
+      // Crucially, the orphan WI must NOT enter the pool.
+      expect(mockService.addToPool).not.toHaveBeenCalled();
+    });
+
+    it('allows a known virtual agent target (orchestrator) even without a member record (#615)', async () => {
+      // findMemberBySessionName returns null for virtual sessions, but the
+      // orchestrator is an allowed dispatch target via the virtual allowlist.
+      mockStorage.findMemberBySessionName.mockResolvedValue(null);
+
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          target: 'crewly-orc',
+          title: 'Escalate to orchestrator',
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockService.addToPool).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows an unassigned WorkItem (no target) — hybrid-wake picks it up (#615)', async () => {
+      mockStorage.findMemberBySessionName.mockResolvedValue(null);
+
+      const req = mockReq({
+        body: {
+          type: 'delegate',
+          owner: 'orchestrator',
+          title: 'Unassigned work',
+          // no target
+        },
+      });
+      const res = mockRes();
+
+      await addItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(mockService.addToPool).toHaveBeenCalledTimes(1);
+      // The target validator must not even consult storage for an absent target.
+      expect(mockStorage.findMemberBySessionName).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -30,8 +30,56 @@ import {
 } from '../../types/v2/work-item.types.js';
 import { formatError } from '../../utils/format-error.js';
 import { LoggerService } from '../../services/core/logger.service.js';
+import { ORCHESTRATOR_SESSION_NAME } from '../../constants.js';
 
 const logger = LoggerService.getInstance().createComponentLogger('TaskPoolController');
+
+/**
+ * Known virtual agent sessions that are NOT stored as team members in
+ * teams.json but are legitimate dispatch targets. These mirror the virtual
+ * members surfaced by `buildOrchestratorTeam` in the team controller.
+ */
+const VIRTUAL_AGENT_SESSIONS: ReadonlySet<string> = new Set([
+  ORCHESTRATOR_SESSION_NAME, // 'crewly-orc'
+  'crewly-orc-assistant',    // in-process shadow orchestrator (AI SDK runtime)
+  'crewly-auditor',          // auditor agent
+]);
+
+/**
+ * Validate that a WorkItem's `target` (when set) resolves to a real agent —
+ * either a stored team member's session, or a known virtual agent
+ * (orchestrator / its assistant / auditor).
+ *
+ * #615: an agent (Don) hallucinated non-existent teammates ("Leo"/"Noah")
+ * and dispatched real WorkItems to fabricated session names that followed
+ * the real `<team>-<name>-<uuid>` convention. Because the dispatch path
+ * never validated the target, those WorkItems passed through silently and
+ * orphaned in the pool forever — no session existed to claim them. This is
+ * the system-side structural guard: a fabricated target is rejected at
+ * enqueue time instead of polluting the pool.
+ *
+ * An ABSENT target is legitimate (an unassigned WorkItem that hybrid-wake
+ * picks up), so it passes.
+ *
+ * @param target - The WorkItem target session name (may be undefined)
+ * @returns null if the target is valid or absent, otherwise an error message
+ */
+async function validateTargetSession(target: string | undefined): Promise<string | null> {
+  if (!target || typeof target !== 'string' || target.trim() === '') {
+    return null; // unassigned WorkItem — allowed
+  }
+  if (VIRTUAL_AGENT_SESSIONS.has(target)) {
+    return null;
+  }
+  const found = await StorageService.getInstance().findMemberBySessionName(target);
+  if (found) {
+    return null;
+  }
+  return (
+    `target session "${target}" does not exist — no team member or known agent has this session. ` +
+    `Dispatch only to sessions listed in your team context; do not invent session names.`
+  );
+}
 
 /**
  * Maps service-layer errors to appropriate HTTP status codes and sends a JSON error response.
@@ -255,6 +303,20 @@ export async function addItem(req: Request, res: Response): Promise<void> {
         res.status(400).json({ success: false, errors: postBuildErrors });
         return;
       }
+    }
+
+    // #615: reject WorkItems addressed to a fabricated/non-existent target
+    // session before they enqueue and orphan in the pool. Runs for both body
+    // shapes (the workItem is fully built by this point).
+    const targetError = await validateTargetSession(workItem.target);
+    if (targetError) {
+      logger.warn('Rejected WorkItem with non-existent target session (#615)', {
+        target: workItem.target,
+        workItemId: workItem.id,
+        type: workItem.type,
+      });
+      res.status(400).json({ success: false, error: targetError, code: 'unknown_target_session' });
+      return;
     }
 
     // ServiceContract gate — only runs when the body carries cross-team


### PR DESCRIPTION
## Problem (#615)

Agent **Don** hallucinated two non-existent teammates — **Leo** (`stock-ops-team-leo-8b07e536`) and **Noah** (`stock-ops-team-noah-cbe74bbd`) — and dispatched real WorkItems to those fabricated session names (which followed the real `<team>-<name>-<uuid>` convention). The dispatch path never validated the target, so the WorkItems passed through silently and **orphaned in the pool forever** — no session existed to claim them. Result: 4 stuck WorkItems, pool pollution, no error surfaced.

## Fix

System-side structural guard in `POST /api/task-pool/add`. When a WorkItem carries a `target`, it must resolve to either:
- a stored team member (`StorageService.findMemberBySessionName`), or
- a known virtual agent (`crewly-orc` / `crewly-orc-assistant` / `crewly-auditor`).

Otherwise it's rejected with `400 unknown_target_session` **before enqueue**. An **absent** target stays valid (an unassigned WorkItem that hybrid-wake picks up), and the validator doesn't consult storage in that case.

- Runs for **both** add-body shapes (minimal `CreateWorkItemInput` and legacy full `WorkItem`).
- **Internal trusted callers** (cron `executionCallback`, bridges) use `createWorkItem` + `addToPool` directly and are unaffected — the guard only constrains the agent-driven HTTP dispatch surface, which is exactly where fabrication happens. So no false-positive risk to internal flows.

## Tests

- Rejects a fabricated target (no member) → 400 + `addToPool` never called.
- Allows a virtual-agent target (`crewly-orc`) even with no member record (via the allowlist).
- Allows an unassigned WI without consulting storage.
- All 58 task-pool controller tests pass; backend typecheck clean.

## Note

This is the **system-side** half of #615's expected behavior. The **agent-side** half ("only dispatch to sessions listed in your prompt") is LLM-behavioral and not addressed here — but the structural guard makes the failure mode non-silent and non-persistent regardless of model behavior.

Fixes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)