### PR TITLE
fix: honor explicit workItemId in POST /api/task-pool/claim (#679)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -40,6 +40,7 @@ jest.mock('../../services/task-pool/task-pool.service.js', () => {
 const mockService = {
   getAvailableItems: jest.fn(),
   claimFromPool: jest.fn(),
+  claimSpecificItem: jest.fn(),
   releaseBack: jest.fn(),
   getPoolStatus: jest.fn(),
   heartbeat: jest.fn(),
@@ -191,6 +192,49 @@ describe('TaskPoolController', () => {
       await claimItem(req, res);
 
       expect(mockService.claimFromPool).toHaveBeenCalledWith('agent-leo', filters);
+    });
+
+    // #679 (sub): an explicit workItemId targets a specific queued item
+    // instead of taking next-available — needed to drain a specific stuck WI.
+    it('claims a specific WorkItem when workItemId is provided (targeted claim)', async () => {
+      const claimResult = {
+        workItem: { id: 'wi-stuck', status: 'running' },
+        claim: { id: 'cl-9', agentId: 'agent-leo' },
+      };
+      mockService.claimSpecificItem.mockResolvedValue(claimResult);
+
+      const req = mockReq({ body: { agentId: 'agent-leo', workItemId: 'wi-stuck' } });
+      const res = mockRes();
+      await claimItem(req, res);
+
+      expect(mockService.claimSpecificItem).toHaveBeenCalledWith('agent-leo', 'wi-stuck');
+      // Must NOT fall back to FIFO next-available.
+      expect(mockService.claimFromPool).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith({ success: true, data: claimResult });
+    });
+
+    it('returns 404 with a targeted message when the specific WorkItem is not claimable', async () => {
+      mockService.claimSpecificItem.mockResolvedValue(null);
+
+      const req = mockReq({ body: { agentId: 'agent-leo', workItemId: 'wi-stuck' } });
+      const res = mockRes();
+      await claimItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      const body = res.json.mock.calls[0][0];
+      expect(body.error).toMatch(/wi-stuck/);
+      expect(mockService.claimFromPool).not.toHaveBeenCalled();
+    });
+
+    it('falls back to FIFO when workItemId is blank/whitespace', async () => {
+      mockService.claimFromPool.mockResolvedValue(null);
+
+      const req = mockReq({ body: { agentId: 'agent-leo', workItemId: '   ' } });
+      const res = mockRes();
+      await claimItem(req, res);
+
+      expect(mockService.claimSpecificItem).not.toHaveBeenCalled();
+      expect(mockService.claimFromPool).toHaveBeenCalledWith('agent-leo', undefined);
     });
   });
 

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -321,23 +321,36 @@ export async function listAvailable(req: Request, res: Response): Promise<void> 
 // ---------------------------------------------------------------------------
 
 /**
- * Agent claims the next available WorkItem from the pool.
+ * Agent claims a WorkItem from the pool.
+ *
+ * Two modes:
+ * - **Next-available (FIFO)** — omit `workItemId`. Claims the next queued
+ *   item matching `filters` for the agent.
+ * - **Targeted** — pass `workItemId`. Claims that specific queued item
+ *   (#679: previously impossible — the endpoint only ever handed out the
+ *   next-available item, so a specific stuck `queued` WI could not be
+ *   targeted for claim, forcing operators to repeatedly claim-and-release
+ *   to drain it). The service-layer `claimSpecificItem` still enforces the
+ *   agent-liveness and target-respect gates, so a targeted claim of a WI
+ *   owned by a different agent (or for a dead session) is refused.
  *
  * Request body:
  * ```json
  * {
  *   "agentId": "crewly-product-leo-member-n",
- *   "filters": { "types": ["delegate"], "owner": "agent" }
+ *   "workItemId": "wi-123",                       // optional — targeted claim
+ *   "filters": { "types": ["delegate"], "owner": "agent" }  // ignored if workItemId set
  * }
  * ```
  *
- * @param req - Express request with agentId in body
+ * @param req - Express request with agentId (and optional workItemId) in body
  * @param res - Express response with claimed item and claim, or 404
  */
 export async function claimItem(req: Request, res: Response): Promise<void> {
   try {
-    const { agentId, filters } = req.body as {
+    const { agentId, workItemId, filters } = req.body as {
       agentId?: string;
+      workItemId?: string;
       filters?: PoolFilters;
     };
 
@@ -346,12 +359,17 @@ export async function claimItem(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    const result = await getService().claimFromPool(agentId.trim(), filters);
+    const hasTarget = typeof workItemId === 'string' && workItemId.trim().length > 0;
+    const result = hasTarget
+      ? await getService().claimSpecificItem(agentId.trim(), workItemId.trim())
+      : await getService().claimFromPool(agentId.trim(), filters);
 
     if (!result) {
       res.status(404).json({
         success: false,
-        error: 'No available WorkItem matching filters',
+        error: hasTarget
+          ? `WorkItem ${workItemId} is not claimable by ${agentId.trim()} (not queued, already claimed, target mismatch, or agent not active)`
+          : 'No available WorkItem matching filters',
       });
       return;
     }


### PR DESCRIPTION
## Problem (#679 — targeted-claim sub-item)

`POST /api/task-pool/claim` only ever called `claimFromPool()` — next-available (FIFO) selection. A specific stuck `queued` WorkItem could **not** be targeted for claim, so draining a stuck queue meant repeatedly claim-and-release until the right item happened to come up. (Noted directly in #679's "Related observations".)

## Fix

The service already has `claimSpecificItem(agentId, workItemId)` — with the **same** agent-liveness and target-respect gates as `claimFromPool` — it just wasn't exposed over HTTP. Wire it:

- Body carries a non-empty `workItemId` → claim that specific item (`claimSpecificItem`).
- Otherwise → unchanged FIFO path (`claimFromPool`).
- Targeted miss → `404` naming the WI and the likely reasons (not queued / already claimed / target mismatch / agent not active).
- Blank/whitespace `workItemId` → falls back to FIFO.

`filters` is ignored when `workItemId` is set (a specific item is being targeted).

## Tests

- Targeted claim calls `claimSpecificItem` and **not** `claimFromPool`.
- Targeted miss → 404 whose message names the WI.
- Blank `workItemId` → FIFO fallback.
- All 58 task-pool controller tests pass; backend typecheck clean.

## Note

This is the **targeted-claim** sub-item of #679. The primary root cause (orchestrator start → 404 "Team not found") shipped in [#687](https://github.com/stevehuang0115/crewly/pull/687). The remaining #679 sub-item — `complete-task`/`report-status` taskId misdirection — is being addressed separately.

Addresses #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)