### PR TITLE
fix: GET /api/task-pool/items honors status/target filters (#679)

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -17,6 +17,7 @@ import {
   completeItem,
   addItem,
   cancelQueuedItem,
+  listAllItems,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
 // Express types used for mock helpers below
@@ -1019,6 +1020,78 @@ describe('TaskPoolController', () => {
       const addedWI = mockService.addToPool.mock.calls[0][0];
       expect(addedWI.status).toBe('blocked');
       expect(addedWI.dependsOn).toEqual(['wi-upstream-1', 'wi-upstream-2']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/task-pool/items — listAllItems (status/target filters, #679)
+  // -------------------------------------------------------------------------
+
+  describe('listAllItems (#679 status/target filters)', () => {
+    const items = [
+      { id: 'wi-run-a', status: 'running', target: 'agent-a' },
+      { id: 'wi-run-b', status: 'running', target: 'agent-b' },
+      { id: 'wi-queued-a', status: 'queued', target: 'agent-a' },
+      { id: 'wi-done-a', status: 'done', target: 'agent-a' },
+    ];
+
+    beforeEach(() => {
+      mockService.getAllItems.mockResolvedValue(items);
+    });
+
+    it('returns every item when no filters are given', async () => {
+      const req = mockReq();
+      const res = mockRes();
+      await listAllItems(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.count).toBe(4);
+      expect(body.data.map((w: any) => w.id)).toEqual(
+        ['wi-run-a', 'wi-run-b', 'wi-queued-a', 'wi-done-a'],
+      );
+    });
+
+    // The complete-task fallback query: ?status=running&target=<session>.
+    // It must resolve to ONLY that session's running WI — previously it
+    // received all items and [0] could be another agent's / a terminal WI.
+    it('filters by status AND target (the complete-task resolution path)', async () => {
+      const req = mockReq({ query: { status: 'running', target: 'agent-a' } });
+      const res = mockRes();
+      await listAllItems(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.count).toBe(1);
+      expect(body.data[0].id).toBe('wi-run-a');
+    });
+
+    it('supports a comma-separated status list', async () => {
+      const req = mockReq({ query: { status: 'running,queued' } });
+      const res = mockRes();
+      await listAllItems(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.data.map((w: any) => w.id).sort()).toEqual(
+        ['wi-queued-a', 'wi-run-a', 'wi-run-b'],
+      );
+    });
+
+    it('returns an empty list when the session has no matching item (no misdirection)', async () => {
+      const req = mockReq({ query: { status: 'running', target: 'agent-ghost' } });
+      const res = mockRes();
+      await listAllItems(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.count).toBe(0);
+      expect(body.data).toEqual([]);
+    });
+
+    it('filters by target alone', async () => {
+      const req = mockReq({ query: { target: 'agent-a' } });
+      const res = mockRes();
+      await listAllItems(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.data.map((w: any) => w.id)).toEqual(['wi-run-a', 'wi-queued-a', 'wi-done-a']);
     });
   });
 

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -895,7 +895,7 @@ export async function revokeAndRelease(req: Request, res: Response): Promise<voi
 // ---------------------------------------------------------------------------
 
 /**
- * Returns every WorkItem currently in the pool — including cancelled,
+ * Returns WorkItems currently in the pool — including cancelled,
  * done_by_worker, failed, etc. — so admin / cleanup tooling can audit the
  * full state without filtering by claimability.
  *
@@ -905,14 +905,42 @@ export async function revokeAndRelease(req: Request, res: Response): Promise<voi
  * downstream consumers, this endpoint adds the audit-shaped surface that
  * the bulk-DELETE script needs.
  *
+ * Optional query filters (#679): callers may narrow by `status` (a single
+ * value or comma-separated list) and/or `target` (exact session match).
+ * These were previously IGNORED — the endpoint always returned every item.
+ * The `complete-task` skill resolves the WorkItem to complete via
+ * `GET /api/task-pool/items?status=running&target=<session>` and takes the
+ * first result; with no server-side filtering it received an arbitrary item
+ * (another agent's WI, or an already-terminal one), so the worker's
+ * completion landed on the WRONG WorkItem and was rejected with 409 —
+ * leaving the worker unable to close its own task. Honoring the filters
+ * makes that resolution correct (and returns an empty list when the session
+ * has no matching item, instead of a misleading first-of-everything).
+ *
  * Response: `{ success: true, data: WorkItem[], count }`.
  *
- * @param req - Express request
+ * @param req - Express request (optional `?status=`, `?target=` query)
  * @param res - Express response
  */
 export async function listAllItems(req: Request, res: Response): Promise<void> {
   try {
-    const items = await getService().getAllItems();
+    let items = await getService().getAllItems();
+
+    const statusParam = typeof req.query.status === 'string' ? req.query.status.trim() : '';
+    if (statusParam) {
+      const allowed = new Set(
+        statusParam.split(',').map(s => s.trim()).filter(Boolean),
+      );
+      if (allowed.size > 0) {
+        items = items.filter(wi => allowed.has(wi.status));
+      }
+    }
+
+    const targetParam = typeof req.query.target === 'string' ? req.query.target.trim() : '';
+    if (targetParam) {
+      items = items.filter(wi => wi.target === targetParam);
+    }
+
     res.json({ success: true, data: items, count: items.length });
   } catch (error) {
     res.status(500).json({ success: false, error: (error as Error).message });


### PR DESCRIPTION
## Problem (#679 — complete-task taskId misdirection)

`listAllItems` (`GET /api/task-pool/items`) returned **every** WorkItem in the pool and **ignored** the `status` and `target` query params.

The `complete-task` skill resolves the WorkItem to complete via:

```
GET /api/task-pool/items?status=running&target=<session>
```

then takes the **first** result. With no server-side filtering, it received an arbitrary item — **another agent's** WI, or an already-terminal/verified one — so the worker's completion transition landed on the **wrong** WorkItem and was rejected with `409`. The worker could never close its own task, compounding the stuck-queue in #679.

## Fix

Honor the filters in `listAllItems`:
- `status` — single value or comma-separated list (e.g. `running`, `running,queued`).
- `target` — exact session match.

Unfiltered calls behave **exactly** as before (full audit list for the bulk-DELETE / cleanup tooling). When the session has no matching item, the endpoint returns an **empty list** instead of a misleading first-of-everything.

The `complete-task` skill needs **no change** — its query was already correct; the server was silently dropping the filters.

## Tests

- No filter → all items.
- `status=running&target=agent-a` → only that one matching WI (the complete-task path).
- Comma-separated status list.
- No match → empty list (no misdirection).
- Target-only filter.

All task-pool controller tests pass; backend typecheck clean.

Addresses #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)