### PR TITLE
docs(orchestrator): add "verify before you alarm" operational discipline rule

### DIFF
--- a/config/roles/orchestrator/prompt.md
+++ b/config/roles/orchestrator/prompt.md
@@ -788,6 +788,39 @@ If a WI's brief begins with `# Wiki Queue Drain`, `# Wiki Legacy Migration`,
 or similar `# Wiki <action>` heading **AND** carries `metadata.autoCreated
 === true`, it's a bridge WI. Process it via the named skill; don't delete.
 
+## Verify before you alarm — operational actions (restart / upgrade / cleanup / bulk ops) — MANDATORY
+
+Before you WARN about (or perform) any operational action with perceived risk
+— a restart, a version upgrade, a bulk delete, a cleanup — do the cheap
+READ-ONLY verification of the ACTUAL state FIRST, then report what you found.
+Do NOT lead with a memory- or pattern-matched alarm and a menu of options.
+
+The 2026-06-02 pattern this prevents: asked to upgrade + restart, the orc
+warned "cron may be lost or duplicated on restart (Issue #613)" and offered
+A/B/C options — *before* ever reading the cron files. A 30-second read showed
+all 23 crons were safely persisted in the team stores; nothing was at risk.
+The instinct to be careful was right; leading with the alarm instead of the
+check was the mistake.
+
+- **Restart / cron example:** before claiming "cron may be lost or duplicated
+  on restart," actually read the stores and report real counts:
+  `~/.crewly/cron-tasks.json`, each team's `teams/<id>/cron-tasks.json`, and
+  `~/.crewly/triggers/triggers.json`. Persisted crons survive restart
+  (`create()` writes to disk) and load-time dedup prevents doubling — a normal
+  restart neither loses nor duplicates them. An empty GLOBAL cron file is
+  **normal** when crons are team-scoped; check the team files before
+  concluding "lost."
+- **Don't assume your INSTALLED version's bugs apply to the version you're
+  upgrading TO.** A known issue may already be fixed in the target version —
+  verify the target's behavior (or changelog) before citing it as a risk.
+- **Cite an issue number only after confirming it exists AND that its
+  mechanism still applies** to the version in play. (e.g. #613 was a real,
+  open issue, but its registry-duplication mechanism was refactored away; the
+  symptom now arises only from a separate path — so quoting it as a blocking
+  restart risk was wrong.)
+- Caution before a risky op is GOOD. The rule is **verify-first, report the
+  facts, then flag any real residual risk** — never alarm-first.
+
 ## Your Capabilities
 
 > **Note:** You achieve these capabilities by **delegating to agents**. Do not perform these tasks yourself — assign them to the right team member.


### PR DESCRIPTION
## Why

The orchestrator's behavior comes from its **always-loaded system prompt** (plus recalled memories). So the durable place to correct a recurring misbehavior is the prompt — not a per-session memory that may not be recalled at the decisive moment, and certainly not anything outside the orc.

## The incident (2026-06-02)

Asked to upgrade + restart, the orc warned **"cron may be lost or duplicated on restart (Issue #613)"** and presented A/B/C options — **before reading a single cron file**. A 30-second read-only check then showed all 23 crons were safely persisted in the team stores; nothing was at risk. The caution was right; **leading with a pattern-matched alarm instead of a cheap verification was the mistake.**

(Notably the orc also assumed its installed v1.8.9 bugs applied to the v1.10.0 it was upgrading *to*, and quoted #613 — which is real and open, but whose registry-duplication mechanism was refactored away, so it no longer applies as a restart risk.)

## The rule

A new MANDATORY section, mirroring the existing incident-driven precedent `## Bridge-auto WorkItems — DO NOT bulk-delete (2026-05-27)`:

> Before you WARN about (or perform) a restart / upgrade / cleanup / bulk op, do the cheap READ-ONLY verification of actual state FIRST, then report what you found. Don't lead with a memory/pattern-matched alarm + a menu of options.

With concrete guidance: read the real cron stores before claiming loss/dup (an empty GLOBAL file is normal when crons are team-scoped); don't assume the installed version's bugs apply to the upgrade target; cite an issue # only after confirming it exists AND its mechanism still applies; caution is good but the form is *verify-first, report facts, then flag a real residual risk*.

Ships to every orc on update (built-in role prompt at `config/roles/orchestrator/prompt.md`).

## Relation to the code fixes

This is the **behavioral** half. The **structural** half — the actual cron-restart safety the orc was (wrongly) worried about — is enforced by the code fixes in this batch: #684 (idempotent create, no dup accumulation), #685 (agents can see their own crons). So even if an orc ignores this rule, the system no longer loses or duplicates persisted crons on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)