### PR TITLE
fix(crewly-agent): stop shelling out in-process sentinel → exit-127 (#693)

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -152,6 +152,30 @@ export const RUNTIME_TYPES = {
 	CREWLY_AGENT: 'crewly-agent',
 } as const;
 
+/**
+ * The canonical managed binary name for the Crewly Agent runtime.
+ *
+ * After PR #599 (Plan A) the agent reasoning loop lives in the standalone
+ * `crewly-agent` npm package; OSS spawns it as a subprocess. This is the
+ * default value of `settings.general.runtimeCommands['crewly-agent']` and the
+ * command `resolveRuntimeCommand()` returns (no shell) when no genuine custom
+ * shell command is configured.
+ */
+export const CREWLY_AGENT_MANAGED_COMMAND = 'crewly-agent' as const;
+
+/**
+ * Legacy / sentinel values for `runtimeCommands['crewly-agent']` that must NOT
+ * be treated as real shell commands.
+ *
+ * `'crewly-agent-in-process'` was the factory default before PR #599 switched
+ * the runtime to an external binary. It is not a real executable — when shelled
+ * out via `sh -lc` it fails with exit-127 (issue #693). Any value listed here is
+ * recognized as "use the managed default binary" and is rewritten to
+ * `CREWLY_AGENT_MANAGED_COMMAND` on settings load (migration) and at command
+ * resolution time (defensive guard).
+ */
+export const LEGACY_CREWLY_AGENT_SENTINELS = ['crewly-agent-in-process'] as const;
+
 /** Error patterns indicating non-recoverable failures (e.g. missing CLI binary) that should not be retried. */
 export const NON_RECOVERABLE_ERROR_PATTERNS = ['command not found', 'not installed', 'No such file'] as const;
 

--- a/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.test.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.test.ts
@@ -14,7 +14,15 @@
  * @module services/agent/crewly-agent/crewly-agent-external-runtime.service.test
  */
 
+// Controllable settings mock — resolveRuntimeCommand() reads
+// settings.general.runtimeCommands['crewly-agent'] via getSettingsService().
+const mockGetSettings = jest.fn();
+jest.mock('../../settings/settings.service.js', () => ({
+  getSettingsService: jest.fn(() => ({ getSettings: mockGetSettings })),
+}));
+
 import { CrewlyAgentExternalRuntimeService } from './crewly-agent-external-runtime.service.js';
+import { CREWLY_AGENT_MANAGED_COMMAND } from '../../../constants.js';
 
 // Pull the private allow-list regex via a typed escape hatch so we
 // can pin its behavior. Keeping it private on the class is the right
@@ -23,6 +31,32 @@ import { CrewlyAgentExternalRuntimeService } from './crewly-agent-external-runti
 const ALLOW_LIST_RE: RegExp = (CrewlyAgentExternalRuntimeService as unknown as {
   SAFE_SHELL_COMMAND_RE: RegExp;
 }).SAFE_SHELL_COMMAND_RE;
+
+/**
+ * Build a minimal CrewlySettings-shaped object exposing only the field
+ * resolveRuntimeCommand() reads. `undefined` omits the command entirely.
+ */
+function settingsWithCrewlyAgentCommand(command?: string): unknown {
+  return {
+    general: {
+      runtimeCommands:
+        command === undefined ? {} : { 'crewly-agent': command },
+    },
+  };
+}
+
+/**
+ * Construct an instance against minimal stubs and invoke the private
+ * resolveRuntimeCommand() via a typed escape hatch.
+ */
+async function resolve(): Promise<{ command: string; useShell: boolean }> {
+  const svc = new CrewlyAgentExternalRuntimeService({} as never, '/tmp/project');
+  return (
+    svc as unknown as {
+      resolveRuntimeCommand: () => Promise<{ command: string; useShell: boolean }>;
+    }
+  ).resolveRuntimeCommand();
+}
 
 describe('CrewlyAgentExternalRuntimeService.SAFE_SHELL_COMMAND_RE — shell-injection guard', () => {
   describe('accepts safe shapes', () => {
@@ -89,6 +123,71 @@ describe('CrewlyAgentExternalRuntimeService.SAFE_SHELL_COMMAND_RE — shell-inje
 
   it('rejects backslash escapes (could smuggle metacharacters past a naive split)', () => {
     expect(ALLOW_LIST_RE.test('crewly-agent \\; rm')).toBe(false);
+  });
+});
+
+describe('CrewlyAgentExternalRuntimeService.resolveRuntimeCommand — sentinel routing (issue #693)', () => {
+  beforeEach(() => {
+    mockGetSettings.mockReset();
+  });
+
+  it('routes the legacy sentinel "crewly-agent-in-process" to the managed binary WITHOUT a shell (regression #693)', async () => {
+    // This is the exact value that shipped as the factory default before
+    // PR #599 and is still persisted on existing nodes. Before the fix it
+    // passed the shell allow-list and was run via `sh -lc` → exit-127.
+    mockGetSettings.mockResolvedValue(
+      settingsWithCrewlyAgentCommand('crewly-agent-in-process'),
+    );
+    const result = await resolve();
+    expect(result).toEqual({ command: CREWLY_AGENT_MANAGED_COMMAND, useShell: false });
+    // The whole point: a sentinel must NEVER reach the shell branch.
+    expect(result.useShell).toBe(false);
+  });
+
+  it('routes the managed command name itself to no-shell (explicit default never shells out)', async () => {
+    mockGetSettings.mockResolvedValue(
+      settingsWithCrewlyAgentCommand(CREWLY_AGENT_MANAGED_COMMAND),
+    );
+    expect(await resolve()).toEqual({
+      command: CREWLY_AGENT_MANAGED_COMMAND,
+      useShell: false,
+    });
+  });
+
+  it('honors a genuine custom shell command (useShell=true)', async () => {
+    mockGetSettings.mockResolvedValue(
+      settingsWithCrewlyAgentCommand('node /opt/crewly/bin/crewly-agent --verbose'),
+    );
+    expect(await resolve()).toEqual({
+      command: 'node /opt/crewly/bin/crewly-agent --verbose',
+      useShell: true,
+    });
+  });
+
+  it('falls back to the managed binary (no shell) for commands with shell metacharacters', async () => {
+    mockGetSettings.mockResolvedValue(
+      settingsWithCrewlyAgentCommand('crewly-agent; rm -rf ~'),
+    );
+    expect(await resolve()).toEqual({
+      command: CREWLY_AGENT_MANAGED_COMMAND,
+      useShell: false,
+    });
+  });
+
+  it('falls back to the managed binary (no shell) when no command is configured', async () => {
+    mockGetSettings.mockResolvedValue(settingsWithCrewlyAgentCommand(undefined));
+    expect(await resolve()).toEqual({
+      command: CREWLY_AGENT_MANAGED_COMMAND,
+      useShell: false,
+    });
+  });
+
+  it('falls back to the managed binary (no shell) when settings load throws', async () => {
+    mockGetSettings.mockRejectedValue(new Error('settings unreadable'));
+    expect(await resolve()).toEqual({
+      command: CREWLY_AGENT_MANAGED_COMMAND,
+      useShell: false,
+    });
   });
 });
 

--- a/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
@@ -27,7 +27,9 @@ import { LoggerService } from '../../core/logger.service.js';
 import {
   ADDON_CONSTANTS,
   CREWLY_CONSTANTS,
+  CREWLY_AGENT_MANAGED_COMMAND,
   ENV_CONSTANTS,
+  LEGACY_CREWLY_AGENT_SENTINELS,
   RUNTIME_TYPES,
   type RuntimeType,
 } from '../../../constants.js';
@@ -316,6 +318,24 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
       const configured = settings.general.runtimeCommands?.['crewly-agent'];
       if (configured && configured.trim()) {
         const trimmed = configured.trim();
+
+        // Managed sentinels are NOT real shell commands — route them to the
+        // managed binary (no shell). This is the root-cause guard for issue
+        // #693: the legacy default `'crewly-agent-in-process'` passes the
+        // shell allow-list below (no metacharacters), so without this branch
+        // it would be shelled out via `sh -lc` to a non-existent command and
+        // exit-127. We also treat the managed command name itself as a
+        // sentinel so the explicit default never accidentally shells out.
+        // Routing through `useShell: false` re-enables the pre-flight
+        // `lookupOnPath` check in spawnAgentProcess(), turning a cryptic
+        // exit-127 into a clear "binary not found on PATH" error.
+        if (
+          trimmed === CREWLY_AGENT_MANAGED_COMMAND ||
+          (LEGACY_CREWLY_AGENT_SENTINELS as readonly string[]).includes(trimmed)
+        ) {
+          return { command: CREWLY_AGENT_MANAGED_COMMAND, useShell: false };
+        }
+
         if (CrewlyAgentExternalRuntimeService.SAFE_SHELL_COMMAND_RE.test(trimmed)) {
           return { command: trimmed, useShell: true };
         }
@@ -330,7 +350,7 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
     } catch {
       // Fall through to default command.
     }
-    return { command: 'crewly-agent', useShell: false };
+    return { command: CREWLY_AGENT_MANAGED_COMMAND, useShell: false };
   }
 
   /**

--- a/backend/src/services/settings/settings.service.test.ts
+++ b/backend/src/services/settings/settings.service.test.ts
@@ -215,6 +215,58 @@ describe('SettingsService', () => {
       expect(settings.general.runtimeCommands['codex-cli']).toBe('codex -a never -s danger-full-access');
     });
 
+    it('should self-heal the stale crewly-agent-in-process sentinel to the managed binary (issue #693)', async () => {
+      // Nodes that persisted settings before PR #599 carry the sentinel
+      // 'crewly-agent-in-process', which is not a real executable and exits
+      // 127 when shelled out. Loading settings must rewrite it so existing
+      // nodes recover on restart without a manual settings.json edit.
+      const settingsWithStaleSentinel = {
+        general: {
+          runtimeCommands: {
+            'claude-code': 'claude --dangerously-skip-permissions',
+            'gemini-cli': 'gemini --yolo',
+            'codex-cli': 'codex -a never -s danger-full-access',
+            'crewly-agent': 'crewly-agent-in-process',
+          },
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(settingsWithStaleSentinel, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.runtimeCommands['crewly-agent']).toBe('crewly-agent');
+    });
+
+    it('should NOT rewrite a genuine custom crewly-agent command during migration', async () => {
+      const settingsWithCustomCommand = {
+        general: {
+          runtimeCommands: {
+            'claude-code': 'claude --dangerously-skip-permissions',
+            'gemini-cli': 'gemini --yolo',
+            'codex-cli': 'codex -a never -s danger-full-access',
+            'crewly-agent': 'node /opt/crewly/bin/crewly-agent --verbose',
+          },
+        },
+      };
+
+      await fs.writeFile(
+        path.join(testDir, 'settings.json'),
+        JSON.stringify(settingsWithCustomCommand, null, 2)
+      );
+
+      service.clearCache();
+      const settings = await service.getSettings();
+
+      expect(settings.general.runtimeCommands['crewly-agent']).toBe(
+        'node /opt/crewly/bin/crewly-agent --verbose'
+      );
+    });
+
     // ----------------------------------------------------------------------
     // enableProactiveCompact one-time flip migration
     // Per spec 2026-05-05-compact-fix-AB-followup §A.1

--- a/backend/src/services/settings/settings.service.ts
+++ b/backend/src/services/settings/settings.service.ts
@@ -22,6 +22,10 @@ import {
   resolveApiKey,
 } from '../../types/settings.types.js';
 import { atomicWriteJson, safeReadJson } from '../../utils/file-io.utils.js';
+import {
+  CREWLY_AGENT_MANAGED_COMMAND,
+  LEGACY_CREWLY_AGENT_SENTINELS,
+} from '../../constants.js';
 
 // ============================================================================
 // Custom Error Classes
@@ -311,6 +315,24 @@ export class SettingsService {
     const runtimeCommands = general['runtimeCommands'] as Record<string, unknown> | undefined;
     if (runtimeCommands?.['codex-cli'] === 'codex --full-auto') {
       runtimeCommands['codex-cli'] = 'codex -a never -s danger-full-access';
+    }
+
+    // Self-heal the stale crewly-agent sentinel (issue #693). Nodes that
+    // persisted settings before PR #599 carry
+    // `runtimeCommands['crewly-agent'] = 'crewly-agent-in-process'`, a value
+    // that is not a real executable: it passes the shell-command allow-list
+    // (no metacharacters) and gets shelled out via `sh -lc`, failing with
+    // exit-127 so the orchestrator never starts. Rewrite any known legacy
+    // sentinel to the managed binary so existing nodes recover on restart
+    // without a manual settings.json edit. Idempotent — fresh installs already
+    // default to the managed command.
+    if (
+      runtimeCommands &&
+      LEGACY_CREWLY_AGENT_SENTINELS.includes(
+        runtimeCommands['crewly-agent'] as (typeof LEGACY_CREWLY_AGENT_SENTINELS)[number],
+      )
+    ) {
+      runtimeCommands['crewly-agent'] = CREWLY_AGENT_MANAGED_COMMAND;
     }
 
     // One-time flip: existing users with proactive compact enabled get switched

--- a/backend/src/types/settings.types.test.ts
+++ b/backend/src/types/settings.types.test.ts
@@ -311,6 +311,16 @@ describe('Settings Types', () => {
       expect(defaults.general.runtimeCommands['codex-cli']).toBe('codex -a never -s danger-full-access');
     });
 
+    it('defaults crewly-agent to the managed binary, NOT the stale in-process sentinel (issue #693)', () => {
+      // The old default 'crewly-agent-in-process' is not a real executable;
+      // it shelled out via `sh -lc` and exited 127, so orchestrators using
+      // the crewly-agent runtime never started. PR #599 made crewly-agent an
+      // external binary — the default must be the real command name.
+      const defaults = getDefaultSettings();
+      expect(defaults.general.runtimeCommands['crewly-agent']).toBe('crewly-agent');
+      expect(defaults.general.runtimeCommands['crewly-agent']).not.toBe('crewly-agent-in-process');
+    });
+
     it('should include non-empty runtime commands for all runtimes', () => {
       const defaults = getDefaultSettings();
 
@@ -571,8 +581,9 @@ describe('Settings Types', () => {
 
       const merged = mergeSettings(existing, {});
 
-      // crewly-agent should be backfilled from defaults
-      expect(merged.general.runtimeCommands['crewly-agent']).toBe('crewly-agent-in-process');
+      // crewly-agent should be backfilled from defaults (the managed binary,
+      // not the stale 'crewly-agent-in-process' sentinel — issue #693).
+      expect(merged.general.runtimeCommands['crewly-agent']).toBe('crewly-agent');
       // Existing entries should be preserved
       expect(merged.general.runtimeCommands['claude-code']).toBe('claude --dangerously-skip-permissions');
     });

--- a/backend/src/types/settings.types.ts
+++ b/backend/src/types/settings.types.ts
@@ -7,6 +7,8 @@
  * @module types/settings.types
  */
 
+import { CREWLY_AGENT_MANAGED_COMMAND } from '../constants.js';
+
 /**
  * Available AI runtime options
  */
@@ -334,7 +336,10 @@ export function getDefaultSettings(): CrewlySettings {
         'claude-code': 'claude --dangerously-skip-permissions',
         'gemini-cli': 'gemini --yolo',
         'codex-cli': 'codex -a never -s danger-full-access',
-        'crewly-agent': 'crewly-agent-in-process',
+        // The managed external binary (PR #599). NOT 'crewly-agent-in-process'
+        // — that stale sentinel shelled out to a non-existent command and
+        // exited 127 (issue #693).
+        'crewly-agent': CREWLY_AGENT_MANAGED_COMMAND,
       },
       agentIdleTimeoutMinutes: 30,
       enableProactiveCompact: false,


### PR DESCRIPTION
## Summary
Fixes **#693** — the `crewly-agent` runtime never started on DeepSeek/crewly-agent nodes (e.g. the **ESTestNode orchestrator**): the spawned process exited **127** and the agent went silently dead (`agents.active=0`, inbound messages queued, no handler). owner Steve selected **path A** (fix the code, keep DeepSeek).

## Root cause
PR #599 (Plan A) switched `crewly-agent` to an external npm binary, but the **factory default** `runtimeCommands['crewly-agent']` was left as the pre-#599 sentinel `'crewly-agent-in-process'`.

- That value has no shell metacharacters → it **passes `SAFE_SHELL_COMMAND_RE`** in `resolveRuntimeCommand()` → returned with `useShell:true`.
- `spawnAgentProcess()` then runs `sh -lc crewly-agent-in-process` → *command not found* → **exit 127**.
- The pre-flight `lookupOnPath` guard only runs on the **no-shell** path, so the sentinel bypassed it.
- Existing nodes also **persisted** the stale value in `settings.json`, so changing only the default would not heal them.

## Fix
1. **`settings.types.ts`** — default `runtimeCommands['crewly-agent']` → `CREWLY_AGENT_MANAGED_COMMAND` (`'crewly-agent'`, the real binary). _(file:line: settings.types.ts:337-341)_
2. **`crewly-agent-external-runtime.service.ts` `resolveRuntimeCommand()`** — recognize the managed command name + legacy sentinel(s) as *"use the managed binary, no shell"* **before** the shell allow-list, so a sentinel can never reach `sh -lc`; the no-shell path re-enables the `lookupOnPath` pre-flight (cryptic exit-127 → clear *"binary not found on PATH"*). _(resolveRuntimeCommand ~:313-350)_
3. **`settings.service.ts` `migrateSettings()`** — self-heal persisted `'crewly-agent-in-process'` → `'crewly-agent'` on load, so existing nodes recover on **restart** without a manual `settings.json` edit. Genuine custom commands untouched. _(~:316)_
4. **`constants.ts`** — add `CREWLY_AGENT_MANAGED_COMMAND` + `LEGACY_CREWLY_AGENT_SENTINELS` (single source of truth, no hardcoded literals across the 3 callsites).

## Eval criteria
- ✅ **#1** Sentinel intercepted, never shells out; guard added (unrecognized/sentinel commands never reach `sh -lc`).
- ✅ **#2** Unit-verified the exit-127 trigger is gone (sentinel → `useShell:false`).
- ⏳ **#4** Deploy to ESTestNode then `curl http://137.184.113.118:8787/health` → `agents.active>=1`, orchestrator `agentStatus=active`, DeepSeek. **Deployment coordinated with Sora** (engine runs under crewly-pro; `crewly-agent` binary present in `crewly-pro/node_modules/.bin`). ⚠️ Deploy note: ensure `crewly-agent` is resolvable on the **engine PATH**, or point `runtimeCommands['crewly-agent']` at the absolute path of the bin.
- 🔗 **#5** Refs #686 (resilience symptom) / #687 (routing PR — does not cover this spawn bug; no change needed here).

## Tests — 179 pass across the 3 affected suites
- `resolveRuntimeCommand` sentinel routing (sentinel/managed → no-shell; genuine custom → shell; metacharacters/unset/throw → safe default)
- settings default = managed binary; backfill uses managed binary
- migration self-heals the sentinel; preserves custom commands

Typecheck clean for all changed files; build green; lint-neutral (the 6 errors in touched files pre-exist on `main` — unused `ModelConfig` import, security-regex escapes, test unused imports — left untouched to keep this PR scoped).

> Reviewer note: review with `git show origin/fix/crewly-agent-inprocess-sentinel-693` (per repo gotcha — don't read `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)