### PR TITLE
fix(in-process-runtime): dispatch 404-loop + /api/teams orc status (#693 follow-up bugs a & b)

### DIFF
--- a/backend/src/controllers/monitoring/terminal.controller.test.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.test.ts
@@ -122,6 +122,16 @@ jest.mock('../../services/agent/crewly-agent/in-process-log-buffer.js', () => ({
 	},
 }));
 
+// Mock the in-process runtime registry. writeToSession() consults it so a
+// /write to an in-process Crewly Agent runtime (no PTY session) is delivered
+// via handleMessage() instead of 404ing (issue #693 follow-up bug (a)).
+const mockGetInProcessRuntime = jest.fn<(s: string) => unknown>();
+const mockIsInProcessRuntimeActive = jest.fn<(s: string) => boolean>();
+jest.mock('../../services/agent/crewly-agent/in-process-runtime-registry.js', () => ({
+	getInProcessRuntime: (...args: [string]) => mockGetInProcessRuntime(...args),
+	isInProcessRuntimeActive: (...args: [string]) => mockIsInProcessRuntimeActive(...args),
+}));
+
 // Mock AdaptiveHeartbeatService defaults
 jest.mock('../../services/agent/adaptive-heartbeat.service.js', () => ({
 	ADAPTIVE_HEARTBEAT_DEFAULTS: {
@@ -159,6 +169,11 @@ describe('TerminalController', () => {
 		mockInProcessLogBuffer.getSessionNames.mockReturnValue([]);
 		mockInProcessLogBuffer.hasSession.mockReturnValue(false);
 		mockInProcessLogBuffer.capture.mockReturnValue('');
+
+		// Default: no in-process runtime registered (so the existing PTY-based
+		// tests, incl. the plain 404 path, behave exactly as before).
+		mockGetInProcessRuntime.mockReturnValue(undefined);
+		mockIsInProcessRuntimeActive.mockReturnValue(false);
 
 		// Create mock response with proper typing
 		const jsonMock = jest.fn().mockReturnThis();
@@ -453,6 +468,85 @@ describe('TerminalController', () => {
 				success: false,
 				error: "Session 'nonexistent' not found",
 			});
+		});
+
+		// Issue #693 follow-up bug (a): in-process Crewly Agent runtimes have no
+		// PTY session, so the dispatch subscriber's POST /write 404-looped against
+		// a live in-process orchestrator. writeToSession() now routes to the
+		// in-process runtime's handleMessage() when there is no PTY session.
+		it('should deliver to an active in-process runtime instead of 404 (no PTY session)', async () => {
+			const handleMessage = jest.fn<(m: string) => Promise<unknown>>().mockResolvedValue({
+				text: 'ok', steps: 1, toolCalls: [], usage: { input: 0, output: 0 },
+			});
+			mockBackend.getSession.mockReturnValue(null);
+			mockGetInProcessRuntime.mockReturnValue({ handleMessage });
+			mockIsInProcessRuntimeActive.mockReturnValue(true);
+			mockReq = {
+				params: { sessionName: 'crewly-orc' } as any,
+				body: { data: 'hello-orc' },
+			};
+
+			await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+			expect(handleMessage).toHaveBeenCalledWith('hello-orc');
+			expect(mockRes.status).not.toHaveBeenCalledWith(404);
+			expect(mockRes.json).toHaveBeenCalledWith({
+				success: true,
+				message: 'Data delivered to in-process runtime',
+			});
+		});
+
+		it('should still 404 when there is no PTY session AND no in-process runtime', async () => {
+			mockBackend.getSession.mockReturnValue(null);
+			mockGetInProcessRuntime.mockReturnValue(undefined);
+			mockIsInProcessRuntimeActive.mockReturnValue(false);
+			mockReq = {
+				params: { sessionName: 'gone' } as any,
+				body: { data: 'hello' },
+			};
+
+			await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+			expect(mockRes.status).toHaveBeenCalledWith(404);
+		});
+
+		it('should 404 when an in-process runtime is registered but not ready', async () => {
+			const handleMessage = jest.fn<(m: string) => Promise<unknown>>();
+			mockBackend.getSession.mockReturnValue(null);
+			mockGetInProcessRuntime.mockReturnValue({ handleMessage });
+			mockIsInProcessRuntimeActive.mockReturnValue(false); // not ready
+			mockReq = {
+				params: { sessionName: 'crewly-orc' } as any,
+				body: { data: 'hello' },
+			};
+
+			await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+			expect(handleMessage).not.toHaveBeenCalled();
+			expect(mockRes.status).toHaveBeenCalledWith(404);
+		});
+
+		it('should fire-and-forget in-process delivery — a handleMessage rejection is not surfaced', async () => {
+			const handleMessage = jest.fn<(m: string) => Promise<unknown>>().mockRejectedValue(
+				new Error('agent boom'),
+			);
+			mockBackend.getSession.mockReturnValue(null);
+			mockGetInProcessRuntime.mockReturnValue({ handleMessage });
+			mockIsInProcessRuntimeActive.mockReturnValue(true);
+			mockReq = {
+				params: { sessionName: 'crewly-orc' } as any,
+				body: { data: 'hello' },
+			};
+
+			await terminalController.writeToSession(mockReq as Request, mockRes as Response);
+
+			// Response is success immediately; the rejection is swallowed + logged
+			// so the /write contract stays non-blocking.
+			expect(mockRes.json).toHaveBeenCalledWith({
+				success: true,
+				message: 'Data delivered to in-process runtime',
+			});
+			expect(mockRes.status).not.toHaveBeenCalledWith(500);
 		});
 
 		it('should allow empty string data', async () => {

--- a/backend/src/controllers/monitoring/terminal.controller.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.ts
@@ -25,6 +25,10 @@ import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { PtySessionBackend } from '../../services/session/pty/pty-session-backend.js';
 import { InProcessLogBuffer } from '../../services/agent/crewly-agent/in-process-log-buffer.js';
+import {
+	getInProcessRuntime,
+	isInProcessRuntimeActive,
+} from '../../services/agent/crewly-agent/in-process-runtime-registry.js';
 import type { PendingWorkSummary, HeartbeatState } from '../../services/agent/adaptive-heartbeat.service.js';
 import { ADAPTIVE_HEARTBEAT_DEFAULTS } from '../../services/agent/adaptive-heartbeat.service.js';
 import { getAgentBehaviorLogService } from '../../services/observability/agent-behavior-log.singleton.js';
@@ -364,6 +368,43 @@ export async function writeToSession(req: Request, res: Response): Promise<void>
 
 		const session = backend.getSession(sessionName);
 		if (!session) {
+			// No PTY session. Before returning 404, check for an in-process Crewly
+			// Agent runtime (e.g. an in-process orchestrator): crewly-agent runs
+			// in-process with NO PTY session, so backend.getSession() is always
+			// null for it. The WorkItem dispatch subscriber and Hybrid-Wake
+			// redeliver both POST to this endpoint; without this branch they
+			// 404-loop against a live in-process target and the WI is never
+			// delivered (issue #693 follow-up bug (a)). The module-scoped
+			// in-process-runtime-registry is populated in this (API-server)
+			// process by AgentRegistrationService.registerAgent(), so the lookup
+			// is reliable here without an AgentRegistrationService reference.
+			const inProcessRuntime = getInProcessRuntime(sessionName);
+			if (inProcessRuntime && isInProcessRuntimeActive(sessionName)) {
+				// Fire-and-forget to preserve the /write contract's non-blocking
+				// semantics: a PTY session.write() returns immediately, whereas
+				// handleMessage() resolves only when the full agent run completes.
+				// Awaiting it here would stall the caller (the subscriber uses a
+				// 5s timeout) for the duration of a full agent turn. Delivery
+				// errors are logged, not surfaced — the caller's retry path (the
+				// subscriber leaves the WI undispatched on failure) handles
+				// redelivery. Bracketed-paste / two-step write is a PTY/TUI
+				// concern and is intentionally skipped for the in-process path.
+				void inProcessRuntime.handleMessage(dataStr).catch((err) => {
+					logger.warn('In-process runtime message delivery failed', {
+						sessionName,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				});
+				logger.debug('Data delivered to in-process runtime', {
+					sessionName,
+					dataLength: dataStr.length,
+				});
+				res.json({
+					success: true,
+					message: 'Data delivered to in-process runtime',
+				} as ApiResponse);
+				return;
+			}
 			res.status(404).json({
 				success: false,
 				error: `Session '${sessionName}' not found`,

--- a/backend/src/controllers/team/team.controller.test.ts
+++ b/backend/src/controllers/team/team.controller.test.ts
@@ -8,6 +8,10 @@ import { ActiveProjectsService } from '../../services/index.js';
 import { PromptTemplateService } from '../../services/index.js';
 import { Team, TeamMember } from '../../types/index.js';
 import { CREWLY_CONSTANTS } from '../../constants.js';
+// Mocked below via jest.mock('../../services/session/index.js') (jest hoists
+// the mock above imports) so tests can set its return value without an inline
+// require() — avoids @typescript-eslint/no-var-requires.
+import { getSessionBackendSync } from '../../services/session/index.js';
 
 // Mock dependencies
 jest.mock('../../services/index.js');
@@ -494,6 +498,57 @@ describe('Teams Handlers', () => {
       expect(assistant.agentStatus).toBe('inactive');
     });
 
+    // Issue #693 follow-up bug (b): the orchestrator itself can run as an
+    // in-process crewly-agent (no PTY). It was misreported INACTIVE because the
+    // orc status was resolved from PTY sessionExists only — which then drove
+    // SlackBridge to the offline path and silently dropped messages to the live
+    // orc. The orc's own status must now consult the in-process registry.
+    it('should show the orchestrator member as active when its in-process runtime is active (no PTY)', async () => {
+      mockStorageService.getTeams.mockResolvedValue([]);
+      mockStorageService.getOrchestratorStatus.mockResolvedValue(null);
+
+      // No PTY session for the orc, but its in-process runtime is active.
+      (getSessionBackendSync as unknown as jest.Mock).mockReturnValue({
+        sessionExists: jest.fn<any>().mockReturnValue(false),
+      });
+      (mockApiContext.agentRegistrationService as any).isInProcessRuntimeActive
+        .mockImplementation((name: string) => name === 'crewly-orc');
+
+      await teamsHandlers.getTeams.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      const responseData = responseMock.json.mock.calls[0][0] as any;
+      const orchestratorTeam = responseData.data[0];
+      const orcMember = orchestratorTeam.members.find((m: any) => m.sessionName === 'crewly-orc');
+      expect(orcMember.agentStatus).toBe('active');
+      // The top-level orchestrator status block must agree with the member.
+      expect(responseData.orchestrator.agentStatus).toBe('active');
+    });
+
+    it('should show the orchestrator member as inactive when there is no PTY and no in-process runtime', async () => {
+      mockStorageService.getTeams.mockResolvedValue([]);
+      mockStorageService.getOrchestratorStatus.mockResolvedValue(null);
+
+      (getSessionBackendSync as unknown as jest.Mock).mockReturnValue({
+        sessionExists: jest.fn<any>().mockReturnValue(false),
+      });
+      (mockApiContext.agentRegistrationService as any).isInProcessRuntimeActive.mockReturnValue(false);
+
+      await teamsHandlers.getTeams.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      const responseData = responseMock.json.mock.calls[0][0] as any;
+      const orchestratorTeam = responseData.data[0];
+      const orcMember = orchestratorTeam.members.find((m: any) => m.sessionName === 'crewly-orc');
+      expect(orcMember.agentStatus).toBe('inactive');
+    });
+
     it('should resolve team member status correctly with in-process runtime', async () => {
       const mockTeams = [{
         id: 'team-1',
@@ -764,6 +819,29 @@ describe('Teams Handlers', () => {
       const responseData = responseMock.json.mock.calls[0][0] as any;
       expect(responseData.data.lastActivity).toBeDefined();
       expect(typeof responseData.data.lastActivity).toBe('string');
+    });
+
+    // Issue #693 follow-up bug (b), GET /api/teams/orchestrator path: same fix
+    // as getTeams — the in-process orc must not be misreported INACTIVE.
+    it('should show the orchestrator member as active when its in-process runtime is active (no PTY)', async () => {
+      mockRequest.params = { id: 'orchestrator' };
+      mockStorageService.getOrchestratorStatus.mockResolvedValue(null);
+
+      (getSessionBackendSync as unknown as jest.Mock).mockReturnValue({
+        sessionExists: jest.fn<any>().mockReturnValue(false),
+      });
+      (mockApiContext.agentRegistrationService as any).isInProcessRuntimeActive
+        .mockImplementation((name: string) => name === 'crewly-orc');
+
+      await teamsHandlers.getTeam.call(
+        mockApiContext,
+        mockRequest as Request,
+        mockResponse as Response
+      );
+
+      const responseData = responseMock.json.mock.calls[0][0] as any;
+      const orcMember = responseData.data.members.find((m: any) => m.sessionName === 'crewly-orc');
+      expect(orcMember.agentStatus).toBe('active');
     });
   });
 

--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -1111,9 +1111,19 @@ export async function getTeams(this: ApiContext, req: Request, res: Response): P
     const backend = getSessionBackendSync();
     const orchestratorSessionExists = backend?.sessionExists(CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME) || false;
 
+    // The orchestrator can run as an in-process Crewly Agent runtime (no PTY,
+    // so sessionExists is always false for it). Consult the in-process runtime
+    // registry so its status is not misreported INACTIVE — a wrong status here
+    // makes SlackBridge route messages to the OFFLINE path and silently drop
+    // them to a live orc (issue #693 follow-up bug (b)).
+    const orchestratorInProcessActive = this.agentRegistrationService.isInProcessRuntimeActive(
+      CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME
+    );
+
     const actualOrchestratorStatus = resolveAgentStatus(
       orchestratorStatus?.agentStatus as TeamMember['agentStatus'],
-      orchestratorSessionExists
+      orchestratorSessionExists,
+      orchestratorInProcessActive
     );
 
     // Check in-process runtime status for virtual team members (Assistant, Auditor)
@@ -1176,9 +1186,17 @@ export async function getTeam(this: ApiContext, req: Request, res: Response): Pr
       const backend = getSessionBackendSync();
       const orchestratorSessionExists = backend?.sessionExists(CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME) || false;
 
+      // In-process orchestrator has no PTY — consult the runtime registry so
+      // it isn't misreported INACTIVE (issue #693 follow-up bug (b)). See the
+      // getTeams() handler for the full rationale.
+      const orchestratorInProcessActive = this.agentRegistrationService.isInProcessRuntimeActive(
+        CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME
+      );
+
       const actualOrchestratorStatus = resolveAgentStatus(
         orchestratorStatus?.agentStatus as TeamMember['agentStatus'],
-        orchestratorSessionExists
+        orchestratorSessionExists,
+        orchestratorInProcessActive
       );
 
       const inProcessStatus = getInProcessRuntimeStatusMap(this.agentRegistrationService);


### PR DESCRIPTION
## Summary
Two pre-existing in-process-runtime engine bugs surfaced once the ESTestNode orchestrator started running as an **in-process** `crewly-agent` (post-#693). Both live in the agent-runtime/dispatch subsystem; one PR, two commits.

## Bug (a) — P1: WI dispatch/redeliver 404-loops for in-process targets
**Root cause (confirmed):** `WorkItemDispatchSubscriber.dispatchTo()`/`redispatch()` POST to `/api/terminal/{target}/write`, a PTY-only path. An in-process crewly-agent has **no PTY session**, so `writeToSession()` 404s → WI never marked dispatched → tight redeliver loop (e.g. stale WI `de4a0701` re-fires every ~10s on ESTestNode).

**Fix (transport layer — the centralized choice):** in `terminal.controller.writeToSession`, when there is no PTY session but an **active** in-process runtime is registered for the target, route to `runtime.handleMessage()` instead of 404. Fire-and-forget to preserve `/write`'s non-blocking contract (`handleMessage` resolves only on full agent-run completion; awaiting would stall the subscriber's 5s timeout). PTY targets unaffected. The module-scoped `in-process-runtime-registry` is populated in the API-server process by `AgentRegistrationService`, so the lookup is reliable without an `AgentRegistrationService` reference.

**Tests:** in-process delivery (no PTY) → 200; still-404 when neither PTY nor in-process; 404 when runtime registered-but-not-ready; fire-and-forget error swallowing.

## Bug (b) — P1 (routing-correctness): /api/teams reports in-process orc INACTIVE
**Root cause (confirmed):** `getTeams`/`getTeam` resolved the orchestrator's status from PTY `sessionExists` **only** — `actualOrchestratorStatus = resolveAgentStatus(stored, sessionExists)` — never consulting the in-process runtime registry. An in-process orc (no PTY) → reported INACTIVE. Per the registry's own contract, a wrong status here drives **SlackBridge to the OFFLINE path and silently drops/misroutes messages to the live orc** (same "orc looks dead" class as #693).

`resolveAgentStatus()` already accepts an `isInProcessActive` 3rd arg (used in the member loop); the orc's own computation just wasn't passing it.

**Fix:** pass `agentRegistrationService.isInProcessRuntimeActive('crewly-orc')` as the 3rd arg at both orc status sites (getTeams + getTeam).

**Tests:** orc member + top-level orchestrator status = ACTIVE when in-process active with no PTY (getTeams + getTeam); INACTIVE when neither present.

## Verification
- `npm run build` ✅  `tsc -p backend` ✅ (exit 0)  lint: **no new errors vs main baseline**
- Affected suites: terminal.controller (incl. 4 new) + team.controller (incl. 3 new) + in-process-runtime-registry + workitem-dispatch.subscriber — **all green**

## Post-merge / post-deploy (needs orc coordination — ESTestNode prod red line)
- Stale WI `de4a0701` is **not** in the local pool; the 404-loop lives on ESTestNode (in-process orc). After this deploys there: clean up `de4a0701` and confirm the 404 loop stops.
- Bug (b) verify: confirm `/api/teams` reports the in-process orc ACTIVE consistent with `teamAgentStatus.json`, and SlackBridge routes to the **online** path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
