### PR TITLE
fix(telegram): resilient message delivery — Markdown parse fallback + empty-response guard

### DIFF
--- a/backend/src/services/telegram/telegram-orchestrator-bridge.test.ts
+++ b/backend/src/services/telegram/telegram-orchestrator-bridge.test.ts
@@ -196,6 +196,35 @@ describe('TelegramOrchestratorBridge', () => {
 				55
 			);
 		});
+
+		it('should skip the reply when the orchestrator response is empty', async () => {
+			await bridge.initialize();
+
+			const testMessage = {
+				chatId: '12345',
+				messageId: 55,
+				userId: '42',
+				userName: 'Alice',
+				text: 'Hello',
+				timestamp: 1700000000,
+			};
+
+			mockTelegramService.emit('message', testMessage);
+			await new Promise(resolve => setTimeout(resolve, 10));
+
+			const enqueueCall = mockQueueService.enqueue.mock.calls[0]![0] as {
+				sourceMetadata: { telegramResolve: (response: string) => void };
+			};
+
+			// Simulate an empty/whitespace capture from the PTY-backed orchestrator.
+			enqueueCall.sourceMetadata.telegramResolve('   ');
+			await new Promise(resolve => setTimeout(resolve, 10));
+
+			// No blank message and no misleading "something went wrong" error are sent,
+			// and nothing is stored as a bot reply.
+			expect(mockTelegramService.sendMessage).not.toHaveBeenCalled();
+			expect(mockThreadStore.appendBotReply).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('destroy', () => {

--- a/backend/src/services/telegram/telegram-orchestrator-bridge.ts
+++ b/backend/src/services/telegram/telegram-orchestrator-bridge.ts
@@ -154,6 +154,18 @@ export class TelegramOrchestratorBridge {
 				),
 			]);
 
+			// Guard against empty captures: the orchestrator is a PTY-backed agent
+			// whose reply is occasionally captured empty/whitespace. Sending empty
+			// text to Telegram fails with HTTP 400 and is then reported to the user
+			// as the misleading "something went wrong" error below — even though the
+			// message was received and is being worked on. Skip the reply instead.
+			if (!response || !response.trim()) {
+				this.logger.warn('Empty orchestrator response — skipping Telegram reply', {
+					chatId: msg.chatId,
+				});
+				return;
+			}
+
 			// Store the bot reply
 			await this.threadStore.appendBotReply(msg.chatId, response);
 

--- a/backend/src/services/telegram/telegram.service.test.ts
+++ b/backend/src/services/telegram/telegram.service.test.ts
@@ -277,6 +277,50 @@ describe('TelegramService', () => {
 			expect(body.text.length).toBeLessThanOrEqual(4096);
 			expect(body.text).toContain('...(truncated)');
 		});
+
+		it('should retry as plain text when Markdown parsing fails', async () => {
+			// First attempt: Telegram rejects the message because the Markdown
+			// entities don't parse (e.g. **snake_case_name**).
+			mockFetch.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						ok: false,
+						error_code: 400,
+						description:
+							"Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 12",
+					}),
+					{ status: 400 }
+				)
+			);
+			// Retry without parse_mode succeeds.
+			mockFetch.mockResolvedValueOnce(
+				new Response(JSON.stringify({ ok: true, result: { message_id: 88 } }), { status: 200 })
+			);
+
+			const msgId = await service.sendMessage('12345', 'Build **antique_identifier** is ready');
+			expect(msgId).toBe(88);
+
+			const sendCalls = mockFetch.mock.calls.filter((c) => String(c[0]).includes('/sendMessage'));
+			expect(sendCalls).toHaveLength(2);
+			const firstBody = JSON.parse((sendCalls[0]![1] as RequestInit).body as string);
+			const retryBody = JSON.parse((sendCalls[1]![1] as RequestInit).body as string);
+			expect(firstBody.parse_mode).toBe('Markdown');
+			expect(retryBody.parse_mode).toBeUndefined();
+			expect(retryBody.text).toContain('antique_identifier');
+		});
+
+		it('should not retry on non-parse 400 errors', async () => {
+			mockFetch.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({ ok: false, error_code: 400, description: 'Bad Request: chat not found' }),
+					{ status: 400 }
+				)
+			);
+
+			await expect(service.sendMessage('12345', 'hi')).rejects.toThrow('send failed');
+			const sendCalls = mockFetch.mock.calls.filter((c) => String(c[0]).includes('/sendMessage'));
+			expect(sendCalls).toHaveLength(1); // no retry
+		});
 	});
 
 	describe('getStatus', () => {

--- a/backend/src/services/telegram/telegram.service.ts
+++ b/backend/src/services/telegram/telegram.service.ts
@@ -215,15 +215,36 @@ export class TelegramService extends EventEmitter {
 			body.reply_to_message_id = replyToMessageId;
 		}
 
-		const resp = await fetch(
-			`${TELEGRAM_CONSTANTS.API_BASE}${this.config.botToken}/sendMessage`,
-			{
+		const { botToken } = this.config;
+		const sendOnce = (payload: Record<string, unknown>): Promise<Response> =>
+			fetch(`${TELEGRAM_CONSTANTS.API_BASE}${botToken}/sendMessage`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
+				body: JSON.stringify(payload),
 				signal: AbortSignal.timeout(TELEGRAM_CONSTANTS.FETCH_TIMEOUT_MS),
+			});
+
+		let resp = await sendOnce(body);
+
+		// Telegram returns HTTP 400 "can't parse entities" when the text contains
+		// Markdown its legacy parser can't parse — extremely common with LLM/agent
+		// output (e.g. **snake_case_name**, an unbalanced `code` span, or a stray
+		// '_' / '*'). Without a fallback the message is silently dropped. Retry once
+		// as plain text (no parse_mode) so delivery always succeeds.
+		if (!resp.ok && resp.status === 400) {
+			const details = await resp.text();
+			if (/can't parse entities/i.test(details)) {
+				this.logger.warn('Telegram Markdown parse failed — retrying as plain text', {
+					chatId,
+					details: details.slice(0, 200),
+				});
+				const plainBody = { ...body };
+				delete plainBody.parse_mode;
+				resp = await sendOnce(plainBody);
+			} else {
+				throw new Error(`Telegram send failed (${resp.status}): ${details}`);
 			}
-		);
+		}
 
 		if (!resp.ok) {
 			const details = await resp.text();


### PR DESCRIPTION
## Summary

Two small, independent fixes to the Telegram subsystem that together stop the bot from **silently dropping or mis-reporting replies**. Both surfaced while driving an agent crew over Telegram, where LLM-formatted replies are the norm.

### 1. `fix(telegram): fall back to plain text when Markdown parsing fails`

`TelegramService.sendMessage` always sends `parse_mode: 'Markdown'`. LLM / agent output frequently contains Markdown that Telegram's legacy parser can't parse — e.g. `**antique_identifier**` (the `_` inside bold opens an italic entity that never closes), unbalanced `` `code` `` spans, or a stray `_` / `*`. Telegram then returns:

```
400 Bad Request: can't parse entities: Can't find end of the entity starting at byte offset N
```

…and the **entire message is dropped**. The user's message is acknowledged but the answer never arrives.

**Fix:** on a `400` whose body contains `can't parse entities`, retry the send **once** without `parse_mode` (plain text). Any other failure is rethrown unchanged; well-formed messages are unaffected (single request, Markdown preserved).

### 2. `fix(telegram): don't report empty orchestrator captures as errors`

In the orchestrator bridge, when the resolved response is empty / whitespace, `enqueueMessage` still called `sendMessage('')`. Telegram rejects empty text with a `400`, which falls into the `catch` block and sends the user *"Sorry, something went wrong processing your message"* — even though the message was received and is being processed. The PTY-backed orchestrator periodically yields an empty capture, so this false error fired on otherwise-healthy messages.

**Fix:** guard against empty / whitespace responses before sending — log a warning and skip the reply rather than pushing blank text (and the misleading error) to the chat.

## Tests

- `telegram.service.test.ts` — a parse-entities `400` retries as plain text and succeeds (asserts the retry drops `parse_mode`); a non-parse `400` (e.g. *"chat not found"*) still throws with no retry.
- `telegram-orchestrator-bridge.test.ts` — an empty resolve sends no message and stores no bot reply.

```
npx jest backend/src/services/telegram/telegram.service.test.ts \
         backend/src/services/telegram/telegram-orchestrator-bridge.test.ts
# Test Suites: 2 passed, 2 total
# Tests:       33 passed, 33 total
```

## Notes

- No behaviour change for healthy Markdown messages or non-`400` errors.
- The two fixes are independent (separate commits) — happy to split into two PRs if you'd prefer.