### PR TITLE
fix(orchestrator): stop verify-of-verify cascade, harden agent kickoff, repair embeddings

### DIFF
--- a/backend/src/constants.ts
+++ b/backend/src/constants.ts
@@ -1089,9 +1089,9 @@ export const SLACK_FILE_DOWNLOAD_CONSTANTS = {
  */
 export const EMBEDDING_CONSTANTS = {
 	/** Gemini embedding model identifier */
-	GEMINI_MODEL: 'text-embedding-004',
+	GEMINI_MODEL: 'gemini-embedding-001',
 	/** Base endpoint for Gemini generative language API */
-	GEMINI_ENDPOINT: 'https://generativelanguage.googleapis.com/v1/models',
+	GEMINI_ENDPOINT: 'https://generativelanguage.googleapis.com/v1beta/models',
 	/** Timeout for embedding API calls (ms) */
 	TIMEOUT_MS: 10000,
 	/** Maximum documents to embed in a single batch */

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -5154,12 +5154,12 @@ Loop until done, blocked, or explicitly reassigned:
 				await sessionHelper.sendMessage(sessionName, messageToSend);
 
 				// Claude Code: rapid-check verification.
-				// Check every 1s for up to 8s whether Claude started processing.
+				// Check every 1s for up to 24s (Claude v2 first-token can be slow: MCP/skill load) whether Claude started processing.
 				// If Claude leaves the prompt at any point, the message was received.
 				// This avoids the old length-comparison approach which was unreliable
 				// (Claude's TUI redraws change output length unpredictably).
 				if (isClaudeCode) {
-					for (let i = 0; i < 8; i++) {
+					for (let i = 0; i < 24; i++) {
 						await delay(1000);
 						if (abortSignal?.aborted) return false;
 
@@ -5185,9 +5185,21 @@ Loop until done, blocked, or explicitly reassigned:
 					// Claude still at prompt after 8s — message likely not received.
 					// For Claude Code with --append-system-prompt-file, don't retry
 					// (would cause duplicate). Log warning and return false.
-					this.logger.warn('Kickoff delivery unconfirmed — Claude still at prompt after 8s (not retrying)', {
-						sessionName, runtimeType,
-					});
+					// Still at prompt — the kickoff was likely typed but not submitted (PTY submit
+					// can be dropped). A missing agent costs far more than a duplicate kickoff
+					// (idempotent: it just re-reads the prompt file), so resend ONCE and re-poll.
+					this.logger.warn('Kickoff unconfirmed after 24s — resending once', { sessionName, runtimeType });
+					await sessionHelper.sendMessage(sessionName, messageToSend);
+					for (let j = 0; j < 12; j++) {
+						await delay(1000);
+						if (abortSignal?.aborted) return false;
+						const out2 = sessionHelper.capturePane(sessionName);
+						if (containsSpinnerOrWorkingIndicator(out2) || !this.isClaudeAtPrompt(out2, RUNTIME_TYPES.CLAUDE_CODE)) {
+							this.logger.debug('Kickoff delivered on resend', { sessionName, checkIndex: j });
+							return true;
+						}
+					}
+					this.logger.warn('Kickoff delivery unconfirmed after resend — giving up', { sessionName, runtimeType });
 					return false;
 				}
 

--- a/backend/src/services/event-bus/event-to-workitem-bridge.service.test.ts
+++ b/backend/src/services/event-bus/event-to-workitem-bridge.service.test.ts
@@ -298,6 +298,55 @@ describe('EventToWorkItemBridge', () => {
       expect(taskPool.addCalls).toHaveLength(0);
       bridge.stop();
     });
+
+    // -----------------------------------------------------------------------
+    // #698 — verify-of-verify cascade guard. A verification WI is itself a
+    // task; when the team lead completes it, it re-emits task:done_by_worker.
+    // Without the guard, each verify spawns another verify (verify-of-verify),
+    // an unbounded cascade that floods the pool and starves real work. These
+    // three tests pin each of the guard's recognised "source is a verification"
+    // signals → NO new verification WI is created.
+    // -----------------------------------------------------------------------
+    it('does NOT create a verify-of-verify when the source WI is a review (type=review)', async () => {
+      const sourceWI = buildWorkItem({ type: 'review' as WorkItemType });
+      const taskPool = buildFakeTaskPool([sourceWI]);
+      const { bridge, bus } = buildBridge({ taskPool });
+      bridge.start();
+
+      bus.publish(buildEvent({ type: 'task:done_by_worker' }));
+      await bridge.flushPending();
+
+      expect(taskPool.addCalls).toHaveLength(0);
+      bridge.stop();
+    });
+
+    it('does NOT create a verify-of-verify when the source id contains ":verify:" (cascade breaker)', async () => {
+      const verifyWI = buildWorkItem({ id: 'wi-x:verify:wi-x' });
+      const taskPool = buildFakeTaskPool([verifyWI]);
+      const { bridge, bus } = buildBridge({ taskPool });
+      bridge.start();
+
+      bus.publish(buildEvent({ type: 'task:done_by_worker', workItemId: 'wi-x:verify:wi-x' }));
+      await bridge.flushPending();
+
+      expect(taskPool.addCalls).toHaveLength(0);
+      bridge.stop();
+    });
+
+    it('does NOT create a verify-of-verify when the source WI carries metadata.verifyOf', async () => {
+      const sourceWI = buildWorkItem({
+        metadata: { teamId: 'team-product', triggerSource: 'event', verifyOf: 'wi-source-1' },
+      });
+      const taskPool = buildFakeTaskPool([sourceWI]);
+      const { bridge, bus } = buildBridge({ taskPool });
+      bridge.start();
+
+      bus.publish(buildEvent({ type: 'task:done_by_worker' }));
+      await bridge.flushPending();
+
+      expect(taskPool.addCalls).toHaveLength(0);
+      bridge.stop();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/backend/src/services/event-bus/event-to-workitem-bridge.service.ts
+++ b/backend/src/services/event-bus/event-to-workitem-bridge.service.ts
@@ -376,6 +376,23 @@ export class EventToWorkItemBridge {
       return;
     }
 
+    // Do NOT create a verification WI for a WI that is itself a verification/review.
+    // A verify WI is a task; when the team lead completes it, it re-emits
+    // task:done_by_worker — without this guard each verify spawns another verify
+    // (verify-of-verify), an infinite cascade that floods the orchestrator and
+    // starves real work (members such as the Builder never get spawned).
+    if (
+      sourceWI.type === 'review' ||
+      sourceWI.metadata?.['verifyOf'] ||
+      String(sourceWI.id).includes(':verify:')
+    ) {
+      this.logger.debug('Skipping verification WI for a verification/review source (no verify-of-verify)', {
+        sourceWorkItemId: sourceWI.id,
+        type: sourceWI.type,
+      });
+      return;
+    }
+
     const target = await this.resolveTeamLeadSession(sourceWI);
     const verifyId = `${sourceWI.id}:verify:${sourceWI.id}`;
 

--- a/backend/src/services/knowledge/embedding-provider.ts
+++ b/backend/src/services/knowledge/embedding-provider.ts
@@ -63,6 +63,7 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
 					body: JSON.stringify({
 						model: `models/${EMBEDDING_CONSTANTS.GEMINI_MODEL}`,
 						content: { parts: [{ text }] },
+						outputDimensionality: EMBEDDING_CONSTANTS.EMBEDDING_DIMENSIONS,
 					}),
 					signal: controller.signal,
 				});

--- a/backend/src/services/knowledge/knowledge-search.service.ts
+++ b/backend/src/services/knowledge/knowledge-search.service.ts
@@ -320,6 +320,7 @@ export class GeminiEmbeddingStrategy implements KnowledgeSearchStrategy {
           body: JSON.stringify({
             model: `models/${EMBEDDING_CONSTANTS.GEMINI_MODEL}`,
             content: { parts: [{ text }] },
+            outputDimensionality: EMBEDDING_CONSTANTS.EMBEDDING_DIMENSIONS,
           }),
           signal: controller.signal,
         });
@@ -453,6 +454,7 @@ export class LocalVectorSearchStrategy implements KnowledgeSearchStrategy {
           body: JSON.stringify({
             model: `models/${EMBEDDING_CONSTANTS.GEMINI_MODEL}`,
             content: { parts: [{ text }] },
+            outputDimensionality: EMBEDDING_CONSTANTS.EMBEDDING_DIMENSIONS,
           }),
           signal: controller.signal,
         });

--- a/backend/src/services/memory/embedding-provider.ts
+++ b/backend/src/services/memory/embedding-provider.ts
@@ -63,6 +63,7 @@ export class GeminiEmbeddingProvider implements EmbeddingProvider {
 					body: JSON.stringify({
 						model: `models/${EMBEDDING_CONSTANTS.GEMINI_MODEL}`,
 						content: { parts: [{ text }] },
+						outputDimensionality: EMBEDDING_CONSTANTS.EMBEDDING_DIMENSIONS,
 					}),
 					signal: controller.signal,
 				});


### PR DESCRIPTION
## Summary

Three fixes for failures that left a team with **no working crew** (orchestrator healthy, but members like the Builder never spawned and projects sat at 0%). Diagnosed live on a 6-member team running Claude Code agents.

### 1. Stop the verify-of-verify WorkItem cascade (`event-to-workitem-bridge`)
`handleTaskDoneByWorker` creates a `review`-type verification WI for every completed task. But a verify WI **is itself a task** — when the team lead completes it, it re-emits `task:done_by_worker`, which creates a verify-of-the-verify, and so on. The idempotency key (`${id}:verify:${id}`) only dedupes per source, not the recursion. The result is an unbounded verification cascade that floods the task pool (observed: 140+ WIs, ~19 min avg wait), monopolises the orchestrator, and starves real work so members never get spawned.

**Fix:** skip verification when the source WI is itself a review/verification (`type === 'review'`, has `metadata.verifyOf`, or id contains `:verify:`).

### 2. Harden Claude Code agent kickoff (`agent-registration`)
The kickoff polled only **8s** for the TUI to start processing and then gave up with **no retry**. Claude Code v2's first token can lag behind MCP/skill loading, so kickoff frequently logged *"unconfirmed — not retrying"* and the agent never registered.

**Fix:** widen the window to 24s; if still unconfirmed, **resend the kickoff once** and re-poll before giving up (a missing agent is worse than an idempotent duplicate kickoff — it just re-reads the prompt file).

### 3. Repair embeddings (`constants` + knowledge/memory providers)
`text-embedding-004` on the `/v1` endpoint returns **404** (the model is served on `/v1beta` and is being retired), so semantic search silently fell back to keyword search.

**Fix:** use `gemini-embedding-001` on `/v1beta` and request `outputDimensionality: 768` so vectors keep the expected dimensionality.

## Testing
- Applied to a live 1.11.x install; backend restarts **healthy**, the constant embedding-404 error stream stops, and the edits are localized (no behavioural change to the happy path).
- Changes are small and self-contained per file.
