### PR TITLE
feat(publish): add `crewly publish --cloud` — submit via Crewly Cloud

### DIFF
--- a/cli/src/commands/publish.test.ts
+++ b/cli/src/commands/publish.test.ts
@@ -47,6 +47,12 @@ jest.mock('../utils/gh-submit.js', () => ({
   submitToGitHub: (...args: unknown[]) => mockSubmitToGitHub(...args),
 }));
 
+// Mock cloud-submit
+const mockSubmitToCloud = jest.fn();
+jest.mock('../utils/cloud-submit.js', () => ({
+  submitToCloud: (...args: unknown[]) => mockSubmitToCloud(...args),
+}));
+
 // Mock fs
 jest.mock('fs', () => {
   const actual = jest.requireActual('fs');
@@ -163,6 +169,40 @@ describe('publishCommand', () => {
     expect(mockConsole).toHaveBeenCalledWith(
       expect.stringContaining('Pull request created successfully'),
     );
+  });
+
+  it('should call submitToCloud (and NOT gh) when --cloud flag is set', async () => {
+    mockValidate.mockReturnValue({ valid: true, errors: [], warnings: [] });
+    mockCreateArchive.mockResolvedValue('/output/test-1.0.0.tar.gz');
+    mockGenerateChecksum.mockReturnValue('sha256:abc123');
+    mockGenerateRegistryEntry.mockReturnValue({ id: 'test', type: 'skill' });
+    mockSubmitToCloud.mockResolvedValue({
+      prUrl: 'https://github.com/stevehuang0115/crewly/pull/100',
+      branch: 'skill/test',
+      updated: false,
+    });
+
+    await publishCommand('/some/path', { cloud: true });
+
+    expect(mockSubmitToCloud).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: 'test' }),
+    );
+    expect(mockSubmitToGitHub).not.toHaveBeenCalled();
+    expect(mockConsole).toHaveBeenCalledWith(expect.stringContaining('Submission PR opened'));
+  });
+
+  it('should exit when --cloud submission fails (e.g. not logged in)', async () => {
+    mockValidate.mockReturnValue({ valid: true, errors: [], warnings: [] });
+    mockCreateArchive.mockResolvedValue('/output/test-1.0.0.tar.gz');
+    mockGenerateChecksum.mockReturnValue('sha256:abc123');
+    mockGenerateRegistryEntry.mockReturnValue({ id: 'test', type: 'skill' });
+    mockSubmitToCloud.mockRejectedValue(
+      new Error('Not logged in to Crewly Cloud. Run `crewly cloud login` first.'),
+    );
+
+    await expect(publishCommand('/some/path', { cloud: true })).rejects.toThrow('process.exit');
+    expect(mockConsole).toHaveBeenCalledWith(expect.stringContaining('Cloud submission failed'));
   });
 
   it('should show manual instructions when submit fails', async () => {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -17,6 +17,7 @@ import type { SkillManifest } from '../utils/package-validator.js';
 import { readFileSync } from 'fs';
 import { MARKETPLACE_CONSTANTS } from '../../../config/constants.js';
 import { submitToGitHub } from '../utils/gh-submit.js';
+import { submitToCloud } from '../utils/cloud-submit.js';
 
 /** Options for the publish command */
 interface PublishOptions {
@@ -24,8 +25,10 @@ interface PublishOptions {
   dryRun?: boolean;
   /** Output directory for the archive (defaults to cwd) */
   output?: string;
-  /** If true, submit the archive to the marketplace for review */
+  /** If true, submit the archive to the marketplace via the user's own gh CLI */
   submit?: boolean;
+  /** If true, submit via Crewly Cloud (cloud opens the PR using its bot token; requires `crewly cloud login`) */
+  cloud?: boolean;
   /** Backend URL for submission (defaults to localhost:3000) */
   url?: string;
 }
@@ -99,7 +102,25 @@ export async function publishCommand(skillPath?: string, options?: PublishOption
   console.log(chalk.blue('\nRegistry entry:'));
   console.log(JSON.stringify(entry, null, 2));
 
-  // Submit to marketplace if --submit flag is set
+  // Submit via Crewly Cloud if --cloud flag is set (cloud opens the PR with its
+  // bot token; the user only needs to be logged in — no local gh / GitHub account).
+  if (options?.cloud) {
+    try {
+      const result = await submitToCloud(absPath, manifest);
+      console.log(chalk.green(`\n${result.updated ? 'Updated existing submission PR!' : 'Submission PR opened!'}`));
+      console.log(chalk.blue(`  PR: ${result.prUrl}`));
+      console.log(chalk.gray(`  Branch: ${result.branch}`));
+      console.log(chalk.gray('  A maintainer will review and merge it. The registry index updates on merge.'));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(chalk.red(`\nCloud submission failed: ${msg}`));
+      process.exit(1);
+    }
+    console.log(chalk.green('\nDone!'));
+    return;
+  }
+
+  // Submit to marketplace via the user's own gh CLI if --submit flag is set
   if (options?.submit) {
     try {
       const result = await submitToGitHub(absPath, manifest);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -100,7 +100,8 @@ program
   .description('Validate and package a skill for the Crewly marketplace')
   .option('--dry-run', 'Validate only, do not create archive')
   .option('-o, --output <dir>', 'Output directory for the archive')
-  .option('--submit', 'Submit the skill to the marketplace for review')
+  .option('--submit', 'Submit via your own GitHub (gh CLI) — opens a PR from your account')
+  .option('--cloud', 'Submit via Crewly Cloud — the cloud opens the PR for you (requires `crewly cloud login`)')
   .option('--url <url>', 'Backend URL for submission (default: http://localhost:3000)')
   .action(publishCommand);
 

--- a/cli/src/utils/cloud-submit.test.ts
+++ b/cli/src/utils/cloud-submit.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for cli/utils/cloud-submit.
+ *
+ * `fs` and `axios` are mocked (matching the cloud.test.ts pattern) so we can
+ * drive loadCloudToken / collectSkillFiles / submitToCloud without real I/O.
+ */
+
+const mockExistsSync = jest.fn();
+const mockReadFileSync = jest.fn();
+const mockReaddirSync = jest.fn();
+const mockStatSync = jest.fn();
+jest.mock('fs', () => ({
+  existsSync: (...a: any[]) => mockExistsSync(...a),
+  readFileSync: (...a: any[]) => mockReadFileSync(...a),
+  readdirSync: (...a: any[]) => mockReaddirSync(...a),
+  statSync: (...a: any[]) => mockStatSync(...a),
+}));
+
+const mockAxiosPost = jest.fn();
+const mockIsAxiosError = jest.fn();
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: (...a: any[]) => mockAxiosPost(...a),
+    isAxiosError: (e: any) => mockIsAxiosError(e),
+  },
+}));
+
+import { loadCloudToken, collectSkillFiles, submitToCloud } from './cloud-submit.js';
+
+/** Build a Dirent-like entry. */
+function dirent(name: string, kind: 'file' | 'dir') {
+  return { name, isDirectory: () => kind === 'dir', isFile: () => kind === 'file' };
+}
+
+const manifest = {
+  id: 'my-skill',
+  name: 'My Skill',
+  description: 'd',
+  version: '1.0.0',
+  category: 'productivity',
+  assignableRoles: ['agent'],
+  tags: ['x'],
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsAxiosError.mockReturnValue(false);
+});
+
+describe('loadCloudToken', () => {
+  it('returns null when the config file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(loadCloudToken()).toBeNull();
+  });
+
+  it('returns the token and cloudUrl when present', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ token: 'jwt', cloudUrl: 'https://c' }));
+    expect(loadCloudToken()).toEqual({ token: 'jwt', cloudUrl: 'https://c' });
+  });
+
+  it('returns null when the file has no token', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify({ cloudUrl: 'https://c' }));
+    expect(loadCloudToken()).toBeNull();
+  });
+});
+
+describe('collectSkillFiles', () => {
+  it('walks the dir, base64-encodes files, and marks .sh executable', () => {
+    mockReaddirSync.mockImplementation((dir: unknown) => {
+      if ((dir as string).endsWith('my-skill')) {
+        return [dirent('skill.json', 'file'), dirent('execute.sh', 'file'), dirent('sub', 'dir')];
+      }
+      return [dirent('nested.md', 'file')];
+    });
+    mockReadFileSync.mockImplementation((p: unknown) => Buffer.from(`data:${p}`));
+    mockStatSync.mockReturnValue({ mode: 0o644 });
+
+    const files = collectSkillFiles('/abs/my-skill');
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toEqual(['execute.sh', 'skill.json', 'sub/nested.md']);
+
+    const sh = files.find((f) => f.path === 'execute.sh')!;
+    expect(sh.executable).toBe(true); // .sh → executable even with 0o644 mode
+    expect(Buffer.from(sh.contentBase64, 'base64').toString()).toContain('data:');
+
+    const json = files.find((f) => f.path === 'skill.json')!;
+    expect(json.executable).toBe(false);
+  });
+
+  it('throws when the total size exceeds the cap', () => {
+    mockReaddirSync.mockReturnValue([dirent('big.bin', 'file')]);
+    mockReadFileSync.mockReturnValue(Buffer.alloc(3 * 1024 * 1024));
+    mockStatSync.mockReturnValue({ mode: 0o644 });
+    expect(() => collectSkillFiles('/abs/my-skill')).toThrow(/size limit/);
+  });
+});
+
+describe('submitToCloud', () => {
+  function loggedIn() {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation((p: unknown) => {
+      if (String(p).endsWith('config.json')) return JSON.stringify({ token: 'jwt', cloudUrl: 'https://c' });
+      return Buffer.from('file');
+    });
+    mockReaddirSync.mockReturnValue([dirent('skill.json', 'file')]);
+    mockStatSync.mockReturnValue({ mode: 0o644 });
+  }
+
+  it('throws a login hint when not logged in', async () => {
+    mockExistsSync.mockReturnValue(false);
+    await expect(submitToCloud('/abs/my-skill', manifest)).rejects.toThrow(/crewly cloud login/);
+  });
+
+  it('posts to the cloud and returns the PR result', async () => {
+    loggedIn();
+    mockAxiosPost.mockResolvedValue({
+      data: { prUrl: 'https://github.com/x/y/pull/1', branch: 'skill/my-skill', updated: false },
+    });
+    const res = await submitToCloud('/abs/my-skill', manifest);
+    expect(res.prUrl).toBe('https://github.com/x/y/pull/1');
+
+    const [url, payload, config] = mockAxiosPost.mock.calls[0] as [string, { manifest: { id: string }; files: unknown[] }, { headers: Record<string, string> }];
+    expect(url).toBe('https://c/api/registry/submit');
+    expect(payload.manifest.id).toBe('my-skill');
+    expect(payload.files.length).toBe(1);
+    expect(config.headers.Authorization).toBe('Bearer jwt');
+  });
+
+  it('maps a 401 to a re-login message', async () => {
+    loggedIn();
+    mockIsAxiosError.mockReturnValue(true);
+    mockAxiosPost.mockRejectedValue({ response: { status: 401, data: { error: 'no' }, headers: {} } });
+    await expect(submitToCloud('/abs/my-skill', manifest)).rejects.toThrow(/login\W+again/i);
+  });
+
+  it('maps a 429 to a rate-limit message with retry hint', async () => {
+    loggedIn();
+    mockIsAxiosError.mockReturnValue(true);
+    mockAxiosPost.mockRejectedValue({
+      response: { status: 429, data: { error: 'slow down' }, headers: { 'retry-after': '120' } },
+    });
+    await expect(submitToCloud('/abs/my-skill', manifest)).rejects.toThrow(/retry after 120s/);
+  });
+});

--- a/cli/src/utils/cloud-submit.ts
+++ b/cli/src/utils/cloud-submit.ts
@@ -1,0 +1,188 @@
+/**
+ * Cloud Submit Utility
+ *
+ * Submits a skill to Crewly Cloud, which opens a PR to the marketplace repo on
+ * the user's behalf using a server-side bot token. Unlike `submitToGitHub`
+ * (which requires the user's own `gh` CLI + GitHub account), this path only
+ * needs the user to be logged in to Crewly Cloud (`crewly cloud login`).
+ *
+ * The skill's files are read from disk, base64-encoded, and POSTed to the cloud
+ * `POST /api/registry/submit` endpoint with the user's cloud JWT. The server
+ * authenticates, rate-limits, validates, and opens/updates the PR.
+ *
+ * @module cli/utils/cloud-submit
+ */
+
+import path from 'path';
+import { homedir } from 'os';
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import axios from 'axios';
+import type { SkillManifest } from './package-validator.js';
+
+/** Path to the cloud credentials written by `crewly cloud login`. */
+const CLOUD_CONFIG_FILE = path.join(homedir(), '.crewly', 'cloud', 'config.json');
+
+/** Cloud submission endpoint (relative to the cloud base URL). */
+const SUBMIT_ENDPOINT = '/api/registry/submit';
+
+/** Default cloud base URL when the saved config lacks one. */
+const DEFAULT_CLOUD_URL = process.env['CREWLY_CLOUD_URL'] || 'https://api.crewlyai.com';
+
+/** Client-side guard mirroring the server's 2 MiB total-size cap. */
+const MAX_TOTAL_BYTES = 2 * 1024 * 1024;
+
+/** Directories never included in a submission. */
+const SKIP_DIRS = new Set(['.git', 'node_modules', '.DS_Store']);
+
+/** Result returned by the cloud submit endpoint. */
+export interface CloudSubmitResult {
+  /** URL of the opened/updated pull request. */
+  prUrl: string;
+  /** Branch used (`skill/<id>`). */
+  branch: string;
+  /** True when an existing PR was updated rather than newly opened. */
+  updated: boolean;
+}
+
+/** A single file payload entry sent to the cloud. */
+export interface CloudSubmitFile {
+  /** Path relative to the skill directory, forward-slashed. */
+  path: string;
+  /** File contents, base64-encoded. */
+  contentBase64: string;
+  /** Whether the file carries the executable bit. */
+  executable: boolean;
+}
+
+/** Loaded cloud credentials. */
+interface CloudToken {
+  token: string;
+  cloudUrl: string;
+}
+
+/**
+ * Load the cloud token saved by `crewly cloud login`.
+ *
+ * @returns The token and cloud base URL, or null if not logged in.
+ */
+export function loadCloudToken(): CloudToken | null {
+  if (!existsSync(CLOUD_CONFIG_FILE)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(CLOUD_CONFIG_FILE, 'utf-8')) as {
+      token?: string;
+      cloudUrl?: string;
+    };
+    if (!raw.token) return null;
+    return { token: raw.token, cloudUrl: raw.cloudUrl || DEFAULT_CLOUD_URL };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recursively collect a skill directory's files as base64 payload entries.
+ *
+ * Skips VCS/dependency dirs. The executable bit is set for files with a Unix
+ * exec mode or a `.sh` extension. Enforces the total-size cap client-side so a
+ * too-large submission fails fast before hitting the network.
+ *
+ * @param skillDir - Absolute path to the skill directory.
+ * @returns The collected files (paths relative to `skillDir`, forward-slashed).
+ * @throws Error if the collected files exceed the size cap.
+ */
+export function collectSkillFiles(skillDir: string): CloudSubmitFile[] {
+  const out: CloudSubmitFile[] = [];
+  let total = 0;
+
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      const data = readFileSync(abs);
+      total += data.length;
+      if (total > MAX_TOTAL_BYTES) {
+        throw new Error(`Skill exceeds the ${MAX_TOTAL_BYTES}-byte size limit`);
+      }
+      const rel = path.relative(skillDir, abs).split(path.sep).join('/');
+      const mode = statSync(abs).mode;
+      out.push({
+        path: rel,
+        contentBase64: data.toString('base64'),
+        executable: (mode & 0o111) !== 0 || rel.endsWith('.sh'),
+      });
+    }
+  };
+
+  walk(skillDir);
+  return out;
+}
+
+/**
+ * Submit a skill to Crewly Cloud, which opens/updates the marketplace PR.
+ *
+ * @param skillDir - Absolute path to the validated skill directory.
+ * @param manifest - Parsed skill.json.
+ * @returns The PR result from the cloud.
+ * @throws Error with a user-actionable message on auth failure (not logged in /
+ *   expired), rate limiting (429), server misconfiguration (503), or network errors.
+ */
+export async function submitToCloud(
+  skillDir: string,
+  manifest: SkillManifest,
+): Promise<CloudSubmitResult> {
+  const creds = loadCloudToken();
+  if (!creds) {
+    throw new Error('Not logged in to Crewly Cloud. Run `crewly cloud login` first.');
+  }
+
+  const files = collectSkillFiles(skillDir);
+
+  try {
+    const res = await axios.post(
+      `${creds.cloudUrl}${SUBMIT_ENDPOINT}`,
+      {
+        manifest: {
+          id: manifest.id,
+          name: manifest.name,
+          version: manifest.version,
+          category: manifest.category,
+          description: manifest.description,
+          author: manifest.author,
+        },
+        files,
+      },
+      {
+        headers: { Authorization: `Bearer ${creds.token}` },
+        timeout: 30_000,
+      },
+    );
+    return res.data as CloudSubmitResult;
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response) {
+      const { status, data } = err.response;
+      const serverMsg = (data as { error?: string })?.error || err.message;
+      if (status === 401) {
+        throw new Error('Cloud session expired or invalid. Run `crewly cloud login` again.');
+      }
+      if (status === 429) {
+        const retry = err.response.headers?.['retry-after'];
+        throw new Error(
+          `Rate limited: ${serverMsg}${retry ? ` (retry after ${retry}s)` : ''}`,
+        );
+      }
+      if (status === 503) {
+        throw new Error(`Cloud submission unavailable: ${serverMsg}`);
+      }
+      throw new Error(`Cloud submission failed (${status}): ${serverMsg}`);
+    }
+    throw new Error(
+      `Could not reach Crewly Cloud: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds `crewly publish <skill> --cloud`: publish a skill to the marketplace **without your own GitHub account or `gh` CLI**. The cloud opens the PR on your behalf using a server-side bot token. You only need to be logged in (`crewly cloud login`).

This complements the existing `--submit` (which opens a PR from *your* GitHub via local `gh`).

## Flow

```
crewly publish <skill> --cloud
  → reads ~/.crewly/cloud/config.json (the `crewly cloud login` token)
  → collects skill files (base64), POST <cloud>/api/registry/submit  (Bearer JWT)
  → cloud authenticates, rate-limits, validates, opens/updates the PR
  → prints the PR URL; a maintainer reviews + merges
```

## Files
- `cli/utils/cloud-submit.ts` — `loadCloudToken`, `collectSkillFiles` (≤2 MiB client guard, `.sh` → executable), `submitToCloud` (maps 401→re-login, 429→rate-limited+retry, 503→unavailable).
- `cli/commands/publish.ts` — new `--cloud` path; not logged in → clear error pointing at `crewly cloud login`.
- `cli/index.ts` — register `--cloud`.
- Tests: cloud-submit (9) + publish `--cloud` success/failure (2). All green.

## Depends on
The cloud endpoint `POST /api/registry/submit` — **crewly-web PR https://github.com/stevehuang0115/crewly-web/pull/22**. Merge/deploy that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)