### PR TITLE
fix(orchestrator): exempt owner-configured cron/trigger wakes from the commitment gate

### DIFF
--- a/backend/src/controllers/team/team.controller.ts
+++ b/backend/src/controllers/team/team.controller.ts
@@ -46,6 +46,7 @@ import { getChatV2Service } from '../../services/chat-v2/chat-v2.singleton.js';
 import {
   evaluateColdLaunch,
   isDormantTeam,
+  isPreAuthorizedSchedule,
   COMMITMENT_APPROVAL_LOOKBACK_MS,
 } from '../../services/orchestrator/commitment-approval-guard.js';
 
@@ -205,6 +206,43 @@ async function checkWakeGate(
       `with target set explicitly to this member, or pass workItemId in the ` +
       `request body to indicate which orphan WI you intend this wake to fulfil.`,
   };
+}
+
+/**
+ * Determines whether a wake is pre-authorized by a real owner-configured
+ * schedule (cron or trigger), and therefore exempt from the commitment gate.
+ *
+ * A cron/trigger the owner set up IS the approval to run on that cadence —
+ * blocking it would break scheduled autonomy (e.g. a 3am cron with the owner
+ * asleep). SECURITY: the WorkItem's self-declared origin is NOT trusted; the
+ * claimed cron-task / trigger id must resolve in the real scheduler registry
+ * (which the orchestrator cannot fabricate), else the wake falls through to the
+ * gate. Fail-SAFE: any lookup error returns false (apply the gate), unlike the
+ * chat read which fails open.
+ *
+ * @param workItemId - The `workItemId` from the start request body, if any.
+ * @returns True when the wake should bypass the commitment-approval gate.
+ */
+async function isScheduledWakePreAuthorized(workItemId: string | null): Promise<boolean> {
+  if (!workItemId) return false;
+  try {
+    const { TaskPoolService } = await import('../../services/task-pool/task-pool.service.js');
+    const wi = await TaskPoolService.getInstance().findWorkItem(workItemId);
+    if (!wi) return false;
+    // Pre-import both scheduler registries so the lookups can run.
+    const { CronTaskService } = await import('../../services/workflow/cron-task.service.js');
+    const { TriggerEngine } = await import('../../services/v3/trigger-engine.service.js');
+    return await isPreAuthorizedSchedule(wi, {
+      cronTaskExists: async (id: string) => (await CronTaskService.getInstance().get(id)) != null,
+      triggerExists: (id: string) => TriggerEngine.getInstance().get(id) != null,
+    });
+  } catch (err) {
+    logger.warn('Commitment gate: schedule-exemption check failed — not exempting', {
+      workItemId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
 }
 
 /**
@@ -1858,7 +1896,24 @@ export async function startTeamMember(this: ApiContext, req: Request, res: Respo
     // the orc cannot fabricate. Continuation (an already-active team) and crash
     // recovery are unaffected (isDormantTeam → false). Fail-OPEN on read error
     // so a chat hiccup never blocks legitimate starts.
-    if (!memberAlreadyActive && isDormantTeam(team)) {
+    //
+    // EXEMPTION: a wake driven by a cron job or trigger the OWNER configured is
+    // already pre-authorized (the schedule IS the approval) — without this, all
+    // scheduled autonomy on a dormant team would be blocked (e.g. a 3am cron
+    // with the owner asleep). The exemption is verified against the real
+    // scheduler registry, so the orc cannot forge a `source:'cron'` claim.
+    const wakeWorkItemId =
+      typeof req.body?.workItemId === 'string' ? (req.body.workItemId as string) : null;
+    const scheduledPreAuthorized = await isScheduledWakePreAuthorized(wakeWorkItemId);
+    if (scheduledPreAuthorized) {
+      logger.info('Commitment gate: exempting pre-authorized scheduled wake (cron/trigger)', {
+        teamId,
+        memberId,
+        sessionName: member.sessionName,
+        workItemId: wakeWorkItemId,
+      });
+    }
+    if (!memberAlreadyActive && isDormantTeam(team) && !scheduledPreAuthorized) {
       let ownerMessages: string[] = [];
       let readOk = true;
       try {

--- a/backend/src/services/orchestrator/commitment-approval-guard.test.ts
+++ b/backend/src/services/orchestrator/commitment-approval-guard.test.ts
@@ -7,7 +7,10 @@ import {
   isDormantTeam,
   containsApprovalToken,
   evaluateColdLaunch,
+  extractScheduleClaim,
+  isPreAuthorizedSchedule,
   type GuardTeam,
+  type GuardWorkItem,
 } from './commitment-approval-guard.js';
 
 const dormant: GuardTeam = {
@@ -95,5 +98,69 @@ describe('evaluateColdLaunch', () => {
   it('ALLOWS continuation/recovery of an already-active team without any approval', () => {
     const d = evaluateColdLaunch({ team: active, recentOwnerMessages: [] });
     expect(d.allowed).toBe(true);
+  });
+});
+
+describe('extractScheduleClaim', () => {
+  it('extracts a cron claim from a cron_run WorkItem carrying cronTaskId', () => {
+    const wi: GuardWorkItem = { type: 'cron_run', metadata: { source: 'cron', cronTaskId: 'cron-abc123' } };
+    expect(extractScheduleClaim(wi)).toEqual({ kind: 'cron', refId: 'cron-abc123' });
+  });
+
+  it('extracts a cron claim from metadata.source=cron even if type differs', () => {
+    const wi: GuardWorkItem = { type: 'delegate', metadata: { source: 'cron', cronTaskId: 'cron-x' } };
+    expect(extractScheduleClaim(wi)).toEqual({ kind: 'cron', refId: 'cron-x' });
+  });
+
+  it('extracts a trigger claim from triggerId', () => {
+    const wi: GuardWorkItem = { type: 'delegate', triggerId: 'trg-77' };
+    expect(extractScheduleClaim(wi)).toEqual({ kind: 'trigger', refId: 'trg-77' });
+  });
+
+  it('returns null for a cron_run with NO cronTaskId (nothing to verify)', () => {
+    expect(extractScheduleClaim({ type: 'cron_run', metadata: { source: 'cron' } })).toBeNull();
+    expect(extractScheduleClaim({ type: 'cron_run' })).toBeNull();
+  });
+
+  it('returns null for an ordinary delegate WorkItem', () => {
+    expect(extractScheduleClaim({ type: 'delegate', metadata: { source: 'orchestrator' } })).toBeNull();
+    expect(extractScheduleClaim({ type: 'delegate' })).toBeNull();
+  });
+});
+
+describe('isPreAuthorizedSchedule', () => {
+  // Registry where only these ids are real (owner-configured).
+  const registry = {
+    cronTaskExists: async (id: string) => id === 'cron-real',
+    triggerExists: (id: string) => id === 'trg-real',
+  };
+
+  it('EXEMPTS a cron run whose cronTaskId resolves in the registry', async () => {
+    const wi: GuardWorkItem = { type: 'cron_run', metadata: { source: 'cron', cronTaskId: 'cron-real' } };
+    expect(await isPreAuthorizedSchedule(wi, registry)).toBe(true);
+  });
+
+  it('does NOT exempt a FORGED cron claim whose id is not registered (security)', async () => {
+    // The orchestrator can write source:'cron' onto a fabricated WorkItem — but
+    // it cannot fabricate a real cron task, so the id does not resolve.
+    const wi: GuardWorkItem = { type: 'cron_run', metadata: { source: 'cron', cronTaskId: 'cron-FORGED' } };
+    expect(await isPreAuthorizedSchedule(wi, registry)).toBe(false);
+  });
+
+  it('EXEMPTS a trigger wake whose triggerId resolves in the registry', async () => {
+    expect(await isPreAuthorizedSchedule({ triggerId: 'trg-real' }, registry)).toBe(true);
+  });
+
+  it('does NOT exempt a forged/unknown triggerId', async () => {
+    expect(await isPreAuthorizedSchedule({ triggerId: 'trg-FORGED' }, registry)).toBe(false);
+  });
+
+  it('does NOT exempt a WorkItem with no scheduled-origin claim', async () => {
+    expect(await isPreAuthorizedSchedule({ type: 'delegate' }, registry)).toBe(false);
+  });
+
+  it('does NOT exempt a null/missing WorkItem', async () => {
+    expect(await isPreAuthorizedSchedule(null, registry)).toBe(false);
+    expect(await isPreAuthorizedSchedule(undefined, registry)).toBe(false);
   });
 });

--- a/backend/src/services/orchestrator/commitment-approval-guard.ts
+++ b/backend/src/services/orchestrator/commitment-approval-guard.ts
@@ -179,3 +179,97 @@ export function evaluateColdLaunch(args: {
       'NOT count.',
   };
 }
+
+// ---------------------------------------------------------------------------
+// Pre-authorized schedule exemption (cron / trigger)
+// ---------------------------------------------------------------------------
+//
+// WHY: a wake driven by a CRON job or a TRIGGER the owner configured is already
+// authorized — the owner set up the schedule, which is a durable, explicit
+// "run this on this cadence" approval. The commitment gate (which demands a
+// fresh "启动/go" in chat) would otherwise block ALL scheduled autonomy on a
+// dormant team: a 3am cron with the owner asleep would sit blocked forever.
+// That defeats the purpose of scheduling. So scheduled-origin wakes are exempt.
+//
+// SECURITY: the orchestrator can fabricate WorkItem fields, so we must NOT
+// trust a WI that merely *claims* `source: 'cron'`. The exemption is honored
+// ONLY when the claimed cron task / trigger id resolves to a REAL entry in the
+// scheduler registry — which the orc cannot fabricate (same principle as the
+// gate keying off the owner's real chat history). A forged claim whose id does
+// not resolve is NOT exempt and falls through to the normal gate.
+
+/** A minimal view of a WorkItem — only the fields the exemption needs. */
+export interface GuardWorkItem {
+  /** WorkItem type, e.g. 'cron_run' for scheduled runs. */
+  type?: string;
+  /** Trigger id, set when an event/time trigger created/woke the WorkItem. */
+  triggerId?: string;
+  /** Extensible metadata; cron runs carry `source:'cron'` + `cronTaskId`. */
+  metadata?: Record<string, unknown> | null;
+}
+
+/** A WorkItem's self-declared scheduled origin, pending registry verification. */
+export interface ScheduleClaim {
+  /** Which scheduler the WorkItem claims to originate from. */
+  kind: 'cron' | 'trigger';
+  /** The id to verify against the real scheduler registry (unfakeable check). */
+  refId: string;
+}
+
+/**
+ * Extracts a WorkItem's claimed scheduled origin, if any.
+ *
+ * Returns the backing cron-task / trigger id that the CALLER must then verify
+ * against the real scheduler registry. Returns null when the WorkItem makes no
+ * verifiable scheduled-origin claim (e.g. a `cron_run` with no `cronTaskId`, or
+ * an ordinary delegate WorkItem) — such items get no exemption.
+ *
+ * @param wi - The WorkItem that triggered the wake.
+ * @returns The schedule claim to verify, or null if none.
+ */
+export function extractScheduleClaim(wi: GuardWorkItem): ScheduleClaim | null {
+  const md = wi.metadata ?? undefined;
+  const source = md && typeof md.source === 'string' ? (md.source as string) : undefined;
+
+  // Cron-origin: a cron_run WorkItem (or one tagged source:'cron') must carry
+  // the backing cron task id so it can be verified. No id → not verifiable → no claim.
+  if (wi.type === 'cron_run' || source === 'cron') {
+    const cronTaskId = md && typeof md.cronTaskId === 'string' ? (md.cronTaskId as string) : '';
+    if (cronTaskId) return { kind: 'cron', refId: cronTaskId };
+  }
+
+  // Trigger-origin: a WorkItem woken by an event/time trigger carries triggerId.
+  if (typeof wi.triggerId === 'string' && wi.triggerId) {
+    return { kind: 'trigger', refId: wi.triggerId };
+  }
+
+  return null;
+}
+
+/**
+ * Decides whether a wake is pre-authorized by a real owner-configured schedule.
+ *
+ * The decision is the whole exemption logic, made unit-testable by injecting the
+ * registry lookups: a claim is honored ONLY when its id resolves in the real
+ * scheduler, so a forged `source:'cron'` claim with a non-existent id is
+ * rejected and falls through to the commitment gate.
+ *
+ * @param wi - The WorkItem that triggered the wake (may be null).
+ * @param registry - Lookups against the REAL scheduler registry.
+ * @param registry.cronTaskExists - Resolves true iff the cron task id is registered.
+ * @param registry.triggerExists - True iff the trigger id is registered.
+ * @returns True when the wake should bypass the commitment gate.
+ */
+export async function isPreAuthorizedSchedule(
+  wi: GuardWorkItem | null | undefined,
+  registry: {
+    cronTaskExists: (id: string) => Promise<boolean>;
+    triggerExists: (id: string) => boolean;
+  },
+): Promise<boolean> {
+  if (!wi) return false;
+  const claim = extractScheduleClaim(wi);
+  if (!claim) return false;
+  if (claim.kind === 'cron') return registry.cronTaskExists(claim.refId);
+  return registry.triggerExists(claim.refId);
+}


### PR DESCRIPTION
## Problem

The commitment-approval gate (#696) blocks cold-launching a **dormant** team unless the owner says "启动/go" in chat. That also blocked **scheduled** work: a cron firing at 3am (owner asleep, no recent approval) creates a `cron_run` WorkItem → reconciler wakes the agent via `startTeamMember` → gate returns 403 `commitment_requires_owner_approval` → **the scheduled task never runs**. Scheduled autonomy on dormant teams was effectively dead.

(Found via Steve's question: "cron job 创建的 WorkItem 是不是也需要我说启动才能跑?" — yes, confirmed it was.)

## Fix

A cron/trigger the owner configured **is** the approval — the schedule is a durable "run this on this cadence" directive. Scheduled-origin wakes are now exempt from the gate.

**Security (the important part):** the orchestrator can fabricate WorkItem fields, so a WI merely *claiming* `source:'cron'` is NOT trusted. The exemption is honored **only when the claimed cron-task / trigger id resolves in the REAL scheduler registry** (`CronTaskService.get` / `TriggerEngine.get`) — which the orc cannot fabricate (same principle as the gate keying off the owner's real chat history). A forged claim whose id doesn't resolve falls through to the gate. Fail-**safe** on lookup error (apply the gate), unlike the chat read which fails open.

## Changes
- `commitment-approval-guard.ts` — pure, fully unit-testable:
  - `extractScheduleClaim(wi)` — parses the WI's claimed origin (`cron_run`/`source:'cron'`+`cronTaskId`, or `triggerId`).
  - `isPreAuthorizedSchedule(wi, registry)` — decision with **injected** registry lookups, so the forge-rejection is unit-tested.
- `team.controller.ts` — `isScheduledWakePreAuthorized(workItemId)` verifies against the real `CronTaskService`/`TriggerEngine`; gate condition becomes `isDormantTeam && !scheduledPreAuthorized`; logs every exemption.

## What stays blocked (unchanged)
- Orc-fabricated cold launches with no owner approval and no real backing schedule → still 403.
- A forged `source:'cron'` WI whose `cronTaskId` isn't registered → still 403.
- Dormant-team launches the owner didn't approve and didn't schedule → still 403.

## Tests
- guard `+11` cases (cron/trigger exempt when registered; **forged source:'cron' with unregistered id NOT exempt**; trigger forged → not exempt; no-claim/null → not exempt). Guard **21/21**.
- `team.controller.test.ts` regression: **112 passed**, 0 failed. backend `tsc` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)