### PR TITLE
skill: add xhs-downloader (小红书 note downloader)

### DIFF
--- a/config/skills/agent/marketplace/xhs-downloader/.crewlyignore
+++ b/config/skills/agent/marketplace/xhs-downloader/.crewlyignore
@@ -1,0 +1,4 @@
+static/
+source/
+locale/
+Volume/

--- a/config/skills/agent/marketplace/xhs-downloader/download.py
+++ b/config/skills/agent/marketplace/xhs-downloader/download.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+XHS-Downloader helper script.
+Usage: python3 download.py <url> <output_dir>
+Outputs JSON: {"success": true/false, "files": [...], "type": "image|video", "error": "..."}
+
+All XHS library logging goes to stderr; only the final JSON result goes to stdout.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Add skill source directory to path
+SKILL_DIR = Path(__file__).parent
+sys.path.insert(0, str(SKILL_DIR))
+
+# ── Redirect stdout → stderr while XHS library initialises/runs ──────────────
+# XHS uses rich.print() which writes to stdout. We swap stdout to stderr for
+# the duration of the download and restore it just before writing our JSON.
+_real_stdout = sys.stdout
+sys.stdout = sys.stderr  # XHS logging now goes to stderr
+
+from source import XHS
+
+sys.stdout = _real_stdout  # Restore for our JSON output
+
+
+async def download_xhs(url: str, output_dir: str) -> dict:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Snapshot files before download
+    before_files = set(output_path.rglob("*"))
+
+    # XHS is a singleton — reset it between calls by clearing __INSTANCE
+    XHS._XHS__INSTANCE = None
+
+    # Redirect stdout again during the async download
+    sys.stdout = sys.stderr
+    try:
+        async with XHS(
+            work_path=str(output_path),
+            folder_name=".",           # Save directly in output_dir (no subfolder)
+            name_format="作品标题 作者昵称",
+            cookie="",                 # No cookie needed
+            proxy=None,
+            timeout=30,
+            max_retry=3,
+            record_data=False,
+            image_format="JPEG",       # Full quality JPEG for images
+            image_download=True,
+            video_download=True,
+            live_download=False,
+            download_record=False,     # Don't write ID records
+            folder_mode=False,         # Flat layout, not per-post subfolders
+            author_archive=False,
+            write_mtime=False,
+            language="zh_CN",
+        ) as xhs:
+            results = await xhs.extract(url, download=True)
+    finally:
+        sys.stdout = _real_stdout
+
+    # Snapshot after download
+    after_files = set(output_path.rglob("*"))
+    new_files = sorted(
+        str(f) for f in (after_files - before_files)
+        if f.is_file() and not f.name.endswith(".db")
+    )
+
+    # Determine content type from results
+    content_type = "unknown"
+    if results:
+        first = results[0]
+        type_val = first.get("作品类型", "")
+        if "视频" in type_val:
+            content_type = "video"
+        elif "图" in type_val:
+            content_type = "image"
+
+    return {
+        "success": len(new_files) > 0,
+        "files": new_files,
+        "type": content_type,
+        "metadata": [
+            {
+                "title": r.get("作品标题", ""),
+                "author": r.get("作者昵称", ""),
+                "type": r.get("作品类型", ""),
+                "desc": r.get("作品描述", "")[:200] if r.get("作品描述") else "",
+            }
+            for r in results
+        ] if results else [],
+    }
+
+
+def main():
+    if len(sys.argv) < 3:
+        _real_stdout.write(json.dumps(
+            {"success": False, "error": "Usage: download.py <url> <output_dir>"}
+        ) + "\n")
+        sys.exit(1)
+
+    url = sys.argv[1]
+    output_dir = sys.argv[2]
+
+    try:
+        result = asyncio.run(download_xhs(url, output_dir))
+        _real_stdout.write(json.dumps(result, ensure_ascii=False) + "\n")
+    except Exception as e:
+        _real_stdout.write(json.dumps({
+            "success": False,
+            "files": [],
+            "error": str(e),
+        }, ensure_ascii=False) + "\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/config/skills/agent/marketplace/xhs-downloader/execute.sh
+++ b/config/skills/agent/marketplace/xhs-downloader/execute.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# xhs-downloader skill — download images/videos from 小红书 (XHS) share links
+# Usage: bash execute.sh '{"url":"https://..."}'
+#        echo '{"url":"..."}' | bash execute.sh
+# Input JSON:
+#   url       (required) XHS share URL (full URL or xhslink.com short link)
+#   outputDir (optional) Download directory
+#             (default: ~/projects/personal-assistant/reports/rednote/downloads/)
+# Output JSON:
+#   success   bool
+#   files     array of absolute file paths downloaded
+#   type      "image" | "video" | "unknown"
+#   metadata  array of {title, author, type, desc}
+#   error     string (only present on failure)
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PYTHON="${SKILL_DIR}/../xhs-downloader-venv/bin/python"
+DOWNLOAD_SCRIPT="${SKILL_DIR}/download.py"
+DEFAULT_OUTPUT_DIR="${HOME}/projects/personal-assistant/reports/rednote/downloads"
+
+# ── Read input ────────────────────────────────────────────────────────────────
+if [ -n "${1:-}" ]; then
+    INPUT="$1"
+else
+    INPUT="$(cat)"
+fi
+
+# ── Parse JSON fields via Python stdin pipe ───────────────────────────────────
+PARSED=$(printf '%s' "$INPUT" | python3 -c "
+import sys, json
+
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print('')
+    sys.exit(0)
+
+url = d.get('url', '')
+output_dir = d.get('outputDir', '')
+print(url)
+print(output_dir)
+")
+
+URL=$(printf '%s' "$PARSED" | head -n1)
+OUTPUT_DIR=$(printf '%s' "$PARSED" | tail -n1)
+
+if [ -z "$OUTPUT_DIR" ] || [ "$OUTPUT_DIR" = "$URL" ]; then
+    OUTPUT_DIR="$DEFAULT_OUTPUT_DIR"
+fi
+
+# ── Validate ──────────────────────────────────────────────────────────────────
+if [ -z "$URL" ]; then
+    printf '{"success":false,"error":"Missing required field: url"}\n'
+    exit 0
+fi
+
+# ── Ensure venv exists ────────────────────────────────────────────────────────
+if [ ! -f "$VENV_PYTHON" ]; then
+    printf '{"success":false,"error":"XHS-Downloader venv not found. Please reinstall the skill."}\n'
+    exit 1
+fi
+
+# ── Ensure output directory exists ────────────────────────────────────────────
+mkdir -p "$OUTPUT_DIR"
+
+# ── Run downloader (XHS logs go to stderr, JSON result to stdout) ─────────────
+cd "$SKILL_DIR"
+RESULT=$("$VENV_PYTHON" "$DOWNLOAD_SCRIPT" "$URL" "$OUTPUT_DIR" 2>/dev/null) || true
+
+if [ -z "$RESULT" ]; then
+    printf '{"success":false,"error":"Downloader produced no output. The URL may be invalid or network unreachable."}\n'
+    exit 0
+fi
+
+printf '%s\n' "$RESULT"

--- a/config/skills/agent/marketplace/xhs-downloader/instructions.md
+++ b/config/skills/agent/marketplace/xhs-downloader/instructions.md
@@ -1,0 +1,51 @@
+# XHS (小红书) Note Downloader
+
+Download images and videos from 小红书 (RedNote) share links without needing an account login.
+
+## Prerequisites
+
+- XHS-Downloader Python venv must be present at `~/.crewly/marketplace/skills/xhs-downloader-venv/`
+- Network access to reach XHS CDN
+
+## Usage
+
+```bash
+bash execute.sh '{"url":"https://xhslink.com/o/..."}'
+bash execute.sh '{"url":"https://www.xiaohongshu.com/explore/...", "outputDir":"/tmp/downloads"}'
+```
+
+## Input
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | XHS share URL (full URL or xhslink.com short link) |
+| `outputDir` | No | Download directory (default: `~/projects/personal-assistant/reports/rednote/downloads/`) |
+
+## Output
+
+```json
+{
+  "success": true,
+  "files": ["/path/to/image1.jpg", "/path/to/image2.jpg"],
+  "type": "image",
+  "metadata": [{"title": "...", "author": "...", "type": "image", "desc": "..."}]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `success` | Whether the download succeeded |
+| `files` | Array of absolute paths to downloaded files |
+| `type` | `"image"`, `"video"`, or `"unknown"` |
+| `metadata` | Post metadata: title, author, type, description |
+| `error` | Error message (only present on failure) |
+
+## Examples
+
+```bash
+# Download from a short link
+bash execute.sh '{"url":"http://xhslink.com/o/7457ZK51oun"}'
+
+# Download to a specific directory
+bash execute.sh '{"url":"https://www.xiaohongshu.com/explore/abc123","outputDir":"/Users/irisran/Desktop"}'
+```

--- a/config/skills/agent/marketplace/xhs-downloader/skill.json
+++ b/config/skills/agent/marketplace/xhs-downloader/skill.json
@@ -1,0 +1,22 @@
+{
+  "id": "xhs-downloader",
+  "name": "XHS (小红书) Note Downloader",
+  "description": "Download images and videos from 小红书 (RedNote/XHS) share links. Pass a URL or xhslink.com short link; returns downloaded file paths + metadata (title, author, type). Uses XHS-Downloader Python library — no account login required.",
+  "category": "automation",
+  "skillType": "claude-skill",
+  "promptFile": "instructions.md",
+  "execution": {
+    "type": "script",
+    "script": {
+      "file": "execute.sh",
+      "interpreter": "bash",
+      "timeoutMs": 60000
+    }
+  },
+  "triggers": ["download xhs", "download rednote", "下载小红书", "xhs download", "save rednote note", "保存小红书笔记"],
+  "tags": ["automation", "rednote", "xiaohongshu", "download", "media", "images", "video"],
+  "assignableRoles": ["generalist", "researcher"],
+  "version": "1.0.0",
+  "createdAt": "2026-06-05T00:00:00.000Z",
+  "updatedAt": "2026-06-05T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

Adds the `xhs-downloader` skill to the Crewly marketplace.

- **Skill ID:** `xhs-downloader`
- **Category:** automation
- **Version:** 1.0.0

### What it does
Downloads images and videos from 小红书 (RedNote/XHS) share links (full URLs or `xhslink.com` short links). Returns downloaded file paths and post metadata (title, author, type, description).

### Usage
```bash
bash execute.sh '{"url":"http://xhslink.com/o/..."}'
bash execute.sh '{"url":"https://www.xiaohongshu.com/explore/abc123","outputDir":"/tmp/downloads"}'
```

### Dependencies
Requires the `xhs-downloader-venv` Python virtual environment (installed separately via `crewly install xhs-downloader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)