### PR TITLE
feat(boot): announce "back online" to the owner's channel after restart

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -78,6 +78,7 @@ import { RequestStatusUpdateSubscriber } from './services/v3/request-status-upda
 import { RequestCascadeSubscriber } from './services/v3/request-cascade.subscriber.js';
 import { setRequestServiceEventBus, RequestService } from './services/v3/request.service.js';
 import { getSlackService } from './services/slack/slack.service.js';
+import { sendBootAnnouncement } from './services/boot/boot-announce.service.js';
 import { SlackThreadStoreService, setSlackThreadStore, getSlackThreadStore } from './services/slack/slack-thread-store.service.js';
 import { GoogleChatThreadStoreService, setGchatThreadStore } from './services/messaging/gchat-thread-store.service.js';
 import { SlackImageService, setSlackImageService } from './services/slack/slack-image.service.js';
@@ -179,6 +180,8 @@ export class CrewlyServer {
 	private io: SocketIOServer;
 	private config: StartupConfig;
 	private logger = LoggerService.getInstance().createComponentLogger('CrewlyServer');
+	/** Offline-replay summary from this boot, surfaced in the boot announcement. */
+	private lastOfflineReplay?: { offlineDurationMs?: number; replayedCount?: number };
 
 	private storageService!: StorageService;
 	private tmuxService!: TmuxService;
@@ -1754,6 +1757,11 @@ void (async () => {
 					this.config.crewlyHome,
 				);
 				const replayResult = await replayService.replayPendingMessages();
+				// Stash for the boot announcement (surfaced after the orchestrator starts).
+				this.lastOfflineReplay = {
+					offlineDurationMs: replayResult.offlineDurationMs,
+					replayedCount: replayResult.replayedCount,
+				};
 				if (replayResult.replayedCount > 0) {
 					this.logger.info('Replayed pending messages from offline period (#247)', {
 						replayed: replayResult.replayedCount,
@@ -2582,6 +2590,47 @@ void (async () => {
 			}
 
 			this.logger.info('Orchestrator auto-started successfully');
+
+			// Announce "back online" to the owner's channel (best-effort, never
+			// blocks boot). Deterministic system message — reports startup + the
+			// running version, enriched with offline duration + replayed count.
+			try {
+				const settings = await getSettingsService().getSettings();
+				if (settings.general.announceOnBoot) {
+					let version = 'unknown';
+					try {
+						version = VersionCheckService.getInstance().getLocalVersion();
+					} catch {
+						version = process.env.npm_package_version || 'unknown';
+					}
+					await sendBootAnnouncement(
+						{
+							version,
+							offlineDurationMs: this.lastOfflineReplay?.offlineDurationMs,
+							replayedCount: this.lastOfflineReplay?.replayedCount,
+						},
+						{
+							isSlackConnected: () => getSlackService().isConnected(),
+							sendSlack: (msg) =>
+								getSlackService().sendNotification({
+									type: 'project_update',
+									title: msg.title,
+									message: msg.message,
+									urgency: 'normal',
+									timestamp: new Date().toISOString(),
+								}),
+							logger: {
+								info: (m, meta) => this.logger.info(m, meta),
+								warn: (m, meta) => this.logger.warn(m, meta),
+							},
+						},
+					);
+				}
+			} catch (announceErr) {
+				this.logger.warn('Boot announce skipped (non-critical)', {
+					error: announceErr instanceof Error ? announceErr.message : String(announceErr),
+				});
+			}
 		} catch (error) {
 			this.logger.error('Failed to auto-start orchestrator', {
 				error: error instanceof Error ? error.message : String(error),

--- a/backend/src/services/boot/boot-announce.service.test.ts
+++ b/backend/src/services/boot/boot-announce.service.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the Boot Announce Service.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  composeBootAnnouncement,
+  sendBootAnnouncement,
+  type BootAnnounceDeps,
+} from './boot-announce.service.js';
+
+describe('composeBootAnnouncement', () => {
+  it('always reports startup + version', () => {
+    const { title, message } = composeBootAnnouncement({ version: '1.11.3' });
+    expect(title).toContain('上线');
+    expect(message).toBe('• 版本: 1.11.3');
+  });
+
+  it('adds offline duration when present (minutes)', () => {
+    const { message } = composeBootAnnouncement({ version: '1.11.3', offlineDurationMs: 12 * 60_000 });
+    expect(message).toContain('• 版本: 1.11.3');
+    expect(message).toContain('• 离线: 12 分钟');
+  });
+
+  it('formats hours+minutes and sub-minute durations', () => {
+    expect(composeBootAnnouncement({ version: 'x', offlineDurationMs: 125 * 60_000 }).message).toContain('2 小时 5 分钟');
+    expect(composeBootAnnouncement({ version: 'x', offlineDurationMs: 30_000 }).message).toContain('<1 分钟');
+  });
+
+  it('adds replayed count when > 0, omits it when 0', () => {
+    expect(composeBootAnnouncement({ version: 'x', replayedCount: 3 }).message).toContain('已补处理: 3 条');
+    expect(composeBootAnnouncement({ version: 'x', replayedCount: 0 }).message).not.toContain('已补处理');
+  });
+
+  it('omits optional lines when absent', () => {
+    const { message } = composeBootAnnouncement({ version: '1.0.0' });
+    expect(message).not.toContain('离线');
+    expect(message).not.toContain('已补处理');
+  });
+});
+
+describe('sendBootAnnouncement', () => {
+  function makeDeps(connected: boolean): { deps: BootAnnounceDeps; sent: BootAnnounceDeps['sendSlack'] } {
+    const sent = jest.fn(async () => {});
+    const deps: BootAnnounceDeps = {
+      isSlackConnected: () => connected,
+      sendSlack: sent as unknown as BootAnnounceDeps['sendSlack'],
+      logger: { info: jest.fn(), warn: jest.fn() },
+    };
+    return { deps, sent };
+  }
+
+  it('sends when Slack is connected', async () => {
+    const { deps, sent } = makeDeps(true);
+    await sendBootAnnouncement({ version: '1.11.3' }, deps);
+    expect(sent).toHaveBeenCalledTimes(1);
+    const arg = (sent as jest.Mock).mock.calls[0][0] as { title: string; message: string };
+    expect(arg.message).toContain('1.11.3');
+  });
+
+  it('skips silently when Slack is not connected', async () => {
+    const { deps, sent } = makeDeps(false);
+    await sendBootAnnouncement({ version: '1.11.3' }, deps);
+    expect(sent).not.toHaveBeenCalled();
+  });
+
+  it('swallows a send error (never throws) and warns', async () => {
+    const warn = jest.fn();
+    const deps: BootAnnounceDeps = {
+      isSlackConnected: () => true,
+      sendSlack: (async () => {
+        throw new Error('slack down');
+      }) as unknown as BootAnnounceDeps['sendSlack'],
+      logger: { info: jest.fn(), warn },
+    };
+    await expect(sendBootAnnouncement({ version: '1.11.3' }, deps)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/boot/boot-announce.service.ts
+++ b/backend/src/services/boot/boot-announce.service.ts
@@ -1,0 +1,120 @@
+/**
+ * Boot Announce Service
+ *
+ * Posts a one-time "back online" message to the owner's channel after the
+ * backend restarts and the orchestrator is ready, so a restart is visible
+ * instead of silent. The message is deterministic (composed here, not by the
+ * orchestrator) and reports startup success + the running version, optionally
+ * enriched with how long the system was offline and how many queued messages
+ * were replayed.
+ *
+ * Design: the composer is PURE (unit-testable); sending takes injected
+ * dependencies (Slack connectivity + sender + logger) so the I/O is testable
+ * and the caller in index.ts stays thin. Sending is best-effort — any failure
+ * is swallowed and logged, never blocking boot.
+ *
+ * v1 targets Slack (the owner's primary channel). Posting to the web chat
+ * (chat-v2) can be layered on later via the same composer.
+ *
+ * @module services/boot/boot-announce.service
+ */
+
+/** Inputs describing the just-completed boot. */
+export interface BootAnnounceInfo {
+  /** The running Crewly version, e.g. "1.11.3". */
+  version: string;
+  /** How long the system was offline before this boot, in ms (optional). */
+  offlineDurationMs?: number;
+  /** How many queued offline messages were replayed on boot (optional). */
+  replayedCount?: number;
+}
+
+/** A composed announcement ready to send. */
+export interface BootAnnounceMessage {
+  /** Short title / headline. */
+  title: string;
+  /** Body text (one fact per line). */
+  message: string;
+}
+
+/**
+ * Formats a millisecond duration as a short human-readable Chinese string.
+ *
+ * @param ms - Duration in milliseconds.
+ * @returns e.g. "<1 分钟", "12 分钟", "2 小时 5 分钟".
+ */
+function formatDuration(ms: number): string {
+  const totalMin = Math.floor(ms / 60_000);
+  if (totalMin < 1) return '<1 分钟';
+  if (totalMin < 60) return `${totalMin} 分钟`;
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return m > 0 ? `${h} 小时 ${m} 分钟` : `${h} 小时`;
+}
+
+/**
+ * Composes the boot announcement text. Pure — no I/O.
+ *
+ * Always includes startup success + version. Adds an offline-duration line and
+ * a replayed-messages line only when those values are present and meaningful.
+ *
+ * @param info - The boot info (version required; offline/replayed optional).
+ * @returns The title + message to send.
+ *
+ * @example
+ * composeBootAnnouncement({ version: '1.11.3', offlineDurationMs: 720000, replayedCount: 3 })
+ * // → { title: '✅ Crewly 已重启上线', message: '• 版本: 1.11.3\n• 离线: 12 分钟\n• 已补处理: 3 条离线消息' }
+ */
+export function composeBootAnnouncement(info: BootAnnounceInfo): BootAnnounceMessage {
+  const lines: string[] = [`• 版本: ${info.version}`];
+  if (typeof info.offlineDurationMs === 'number' && info.offlineDurationMs > 0) {
+    lines.push(`• 离线: ${formatDuration(info.offlineDurationMs)}`);
+  }
+  if (typeof info.replayedCount === 'number' && info.replayedCount > 0) {
+    lines.push(`• 已补处理: ${info.replayedCount} 条离线消息`);
+  }
+  return {
+    title: '✅ Crewly 已重启上线',
+    message: lines.join('\n'),
+  };
+}
+
+/** Injected dependencies for sending the announcement (keeps I/O testable). */
+export interface BootAnnounceDeps {
+  /** Whether the Slack channel is currently connected. */
+  isSlackConnected: () => boolean;
+  /** Sends the composed announcement to Slack (e.g. via sendNotification). */
+  sendSlack: (msg: BootAnnounceMessage) => Promise<void>;
+  /** Minimal logger. */
+  logger: {
+    info: (message: string, meta?: Record<string, unknown>) => void;
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+/**
+ * Sends the boot announcement. Best-effort: skips silently when Slack is not
+ * connected, and swallows any send error (logged as a warning) so a failed
+ * announcement never affects startup.
+ *
+ * @param info - The boot info to announce.
+ * @param deps - Injected Slack connectivity + sender + logger.
+ */
+export async function sendBootAnnouncement(
+  info: BootAnnounceInfo,
+  deps: BootAnnounceDeps,
+): Promise<void> {
+  const composed = composeBootAnnouncement(info);
+  try {
+    if (!deps.isSlackConnected()) {
+      deps.logger.info('Boot announce: Slack not connected — skipping', { version: info.version });
+      return;
+    }
+    await deps.sendSlack(composed);
+    deps.logger.info('Boot announce sent', { version: info.version });
+  } catch (err) {
+    deps.logger.warn('Boot announce failed (non-critical)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/types/settings.types.test.ts
+++ b/backend/src/types/settings.types.test.ts
@@ -64,6 +64,7 @@ describe('Settings Types', () => {
         maxConcurrentAgents: 10,
         verboseLogging: false,
         autoResumeOnRestart: true,
+        announceOnBoot: true,
         runtimeCommands: {
           'claude-code': 'claude --dangerously-skip-permissions',
           'gemini-cli': 'gemini --yolo',
@@ -97,6 +98,7 @@ describe('Settings Types', () => {
         maxConcurrentAgents: 5,
         verboseLogging: true,
         autoResumeOnRestart: false,
+        announceOnBoot: true,
         runtimeCommands: {
           'claude-code': '/custom/path/to/claude --dangerously-skip-permissions',
           'gemini-cli': '/custom/gemini --custom-flag',
@@ -162,6 +164,7 @@ describe('Settings Types', () => {
           maxConcurrentAgents: 10,
           verboseLogging: false,
           autoResumeOnRestart: true,
+          announceOnBoot: true,
           runtimeCommands: {
             'claude-code': 'claude --dangerously-skip-permissions',
             'gemini-cli': 'gemini --yolo',

--- a/backend/src/types/settings.types.ts
+++ b/backend/src/types/settings.types.ts
@@ -46,6 +46,9 @@ export interface GeneralSettings {
   /** Whether to auto-resume agent sessions on restart */
   autoResumeOnRestart: boolean;
 
+  /** Whether to post a "back online" message to the owner's channel after a restart */
+  announceOnBoot: boolean;
+
   /** Per-runtime CLI init commands. Key = runtime type, value = CLI command string */
   runtimeCommands: Record<AIRuntime, string>;
 
@@ -332,6 +335,7 @@ export function getDefaultSettings(): CrewlySettings {
       maxConcurrentAgents: 10,
       verboseLogging: false,
       autoResumeOnRestart: true,
+      announceOnBoot: true,
       runtimeCommands: {
         'claude-code': 'claude --dangerously-skip-permissions',
         'gemini-cli': 'gemini --yolo',


### PR DESCRIPTION
## What

After a restart, the backend posts a one-time **"✅ Crewly 已重启上线"** message to the owner's Slack channel once the orchestrator is ready — so a restart is visible instead of silent. It reports **startup success + the running version**, enriched with **how long the system was offline** and **how many queued messages were replayed**.

Example:
```
✅ Crewly 已重启上线
• 版本: 1.11.3
• 离线: 12 分钟
• 已补处理: 3 条离线消息
```

## Design
- **Deterministic system message** (composed by the backend, NOT the orchestrator) for reliability — no extra LLM turn, always fires.
- **Best-effort**: skips silently if Slack isn't connected; swallows any send error → never blocks boot.
- **Pure composer + injected I/O** so the logic is fully unit-tested.
- Gated by a new setting **`announceOnBoot`** (`GeneralSettings`, default `true`).
- **v1 targets Slack** (the owner's primary channel). Web/chat-v2 can layer onto the same composer later (left out of v1 because the correct orchestrator chat-v2 channel resolution needs separate confirmation).

## Changes
- `services/boot/boot-announce.service.ts` — `composeBootAnnouncement` (pure) + `sendBootAnnouncement` (best-effort, injected deps).
- `index.ts` — stash the offline-replay summary on boot; after orchestrator auto-start succeeds, send the announcement via Slack `sendNotification` (uses `defaultChannelId`), gated by the setting.
- `settings.types.ts` — `announceOnBoot` field + default `true`.

## Tests
- `boot-announce.service.test.ts` — 8 cases: compose variants (version-only / offline / hours+minutes / replayed / omitted) + send connected/disconnected/throws.
- settings fixtures updated. **backend `tsc` 0 errors.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)