### PR TITLE
feat(boot): welcome on first boot vs "back online" on restart

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -78,7 +78,7 @@ import { RequestStatusUpdateSubscriber } from './services/v3/request-status-upda
 import { RequestCascadeSubscriber } from './services/v3/request-cascade.subscriber.js';
 import { setRequestServiceEventBus, RequestService } from './services/v3/request.service.js';
 import { getSlackService } from './services/slack/slack.service.js';
-import { sendBootAnnouncement } from './services/boot/boot-announce.service.js';
+import { sendBootAnnouncement, isFirstBoot, markBooted } from './services/boot/boot-announce.service.js';
 import { SlackThreadStoreService, setSlackThreadStore, getSlackThreadStore } from './services/slack/slack-thread-store.service.js';
 import { GoogleChatThreadStoreService, setGchatThreadStore } from './services/messaging/gchat-thread-store.service.js';
 import { SlackImageService, setSlackImageService } from './services/slack/slack-image.service.js';
@@ -2603,9 +2603,14 @@ void (async () => {
 					} catch {
 						version = process.env.npm_package_version || 'unknown';
 					}
+					// First-ever boot → welcome; subsequent boots → "back online".
+					const bootMarker = path.join(this.config.crewlyHome, '.boot-announced');
+					const firstBoot = isFirstBoot(bootMarker);
+					if (firstBoot) markBooted(bootMarker);
 					await sendBootAnnouncement(
 						{
 							version,
+							firstBoot,
 							offlineDurationMs: this.lastOfflineReplay?.offlineDurationMs,
 							replayedCount: this.lastOfflineReplay?.replayedCount,
 						},

--- a/backend/src/services/boot/boot-announce.service.test.ts
+++ b/backend/src/services/boot/boot-announce.service.test.ts
@@ -3,9 +3,14 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
+import { existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
   composeBootAnnouncement,
   sendBootAnnouncement,
+  isFirstBoot,
+  markBooted,
   type BootAnnounceDeps,
 } from './boot-announce.service.js';
 
@@ -36,6 +41,45 @@ describe('composeBootAnnouncement', () => {
     const { message } = composeBootAnnouncement({ version: '1.0.0' });
     expect(message).not.toContain('离线');
     expect(message).not.toContain('已补处理');
+  });
+
+  it('shows a WELCOME (not restarted) on first boot, and omits offline/replayed', () => {
+    const { title, message } = composeBootAnnouncement({
+      version: '1.11.4',
+      firstBoot: true,
+      offlineDurationMs: 999_999, // should be ignored on first boot
+      replayedCount: 5, // should be ignored on first boot
+    });
+    expect(title).toContain('欢迎');
+    expect(title).not.toContain('重启');
+    expect(message).toContain('1.11.4');
+    expect(message).not.toContain('离线');
+    expect(message).not.toContain('已补处理');
+  });
+
+  it('shows the restarted message when firstBoot is false', () => {
+    const { title } = composeBootAnnouncement({ version: '1.11.4', firstBoot: false });
+    expect(title).toContain('重启');
+  });
+});
+
+describe('isFirstBoot / markBooted', () => {
+  it('is first boot when the marker is absent, not after markBooted', () => {
+    // Unique path per run (Date.now/random are unavailable here).
+    const marker = join(tmpdir(), `crewly-boot-marker-${process.pid}-${process.hrtime.bigint()}`);
+    try {
+      expect(isFirstBoot(marker)).toBe(true);
+      markBooted(marker);
+      expect(existsSync(marker)).toBe(true);
+      expect(isFirstBoot(marker)).toBe(false);
+    } finally {
+      rmSync(marker, { force: true });
+    }
+  });
+
+  it('markBooted swallows write errors (unwritable path) without throwing', () => {
+    const bad = join(tmpdir(), 'crewly-no-such-dir-xyz', 'marker');
+    expect(() => markBooted(bad)).not.toThrow();
   });
 });
 

--- a/backend/src/services/boot/boot-announce.service.ts
+++ b/backend/src/services/boot/boot-announce.service.ts
@@ -19,10 +19,14 @@
  * @module services/boot/boot-announce.service
  */
 
+import { existsSync, writeFileSync } from 'fs';
+
 /** Inputs describing the just-completed boot. */
 export interface BootAnnounceInfo {
   /** The running Crewly version, e.g. "1.11.3". */
   version: string;
+  /** True on the first-ever boot (welcome) vs a restart (back-online). */
+  firstBoot?: boolean;
   /** How long the system was offline before this boot, in ms (optional). */
   offlineDurationMs?: number;
   /** How many queued offline messages were replayed on boot (optional). */
@@ -66,6 +70,15 @@ function formatDuration(ms: number): string {
  * // → { title: '✅ Crewly 已重启上线', message: '• 版本: 1.11.3\n• 离线: 12 分钟\n• 已补处理: 3 条离线消息' }
  */
 export function composeBootAnnouncement(info: BootAnnounceInfo): BootAnnounceMessage {
+  // First-ever boot: a welcome, not a "restarted" message — and offline /
+  // replayed lines are meaningless (there was no prior run).
+  if (info.firstBoot) {
+    return {
+      title: '🎉 欢迎使用 Crewly！',
+      message: `Crewly 已启动并就绪。\n• 版本: ${info.version}`,
+    };
+  }
+
   const lines: string[] = [`• 版本: ${info.version}`];
   if (typeof info.offlineDurationMs === 'number' && info.offlineDurationMs > 0) {
     lines.push(`• 离线: ${formatDuration(info.offlineDurationMs)}`);
@@ -116,5 +129,29 @@ export async function sendBootAnnouncement(
     deps.logger.warn('Boot announce failed (non-critical)', {
       error: err instanceof Error ? err.message : String(err),
     });
+  }
+}
+
+/**
+ * Returns true if no boot marker exists yet — i.e. this is the first-ever boot.
+ *
+ * @param markerPath - Absolute path to the boot marker file.
+ * @returns True when the marker is absent.
+ */
+export function isFirstBoot(markerPath: string): boolean {
+  return !existsSync(markerPath);
+}
+
+/**
+ * Persists the boot marker so subsequent boots are recognized as restarts.
+ * Best-effort: if the write fails, a future boot may re-show the welcome — harmless.
+ *
+ * @param markerPath - Absolute path to the boot marker file.
+ */
+export function markBooted(markerPath: string): void {
+  try {
+    writeFileSync(markerPath, new Date().toISOString());
+  } catch {
+    // Ignore — persistence is best-effort.
   }
 }


### PR DESCRIPTION
## What

Follow-up to the boot announcement (#705). On the **first-ever boot**, the "✅ 已重启上线 / back online" wording is inaccurate (nothing restarted). This shows a **welcome** instead, and distinguishes first-boot from restart via a persisted marker.

- **First boot** → `🎉 欢迎使用 Crewly！` + version (offline/replayed lines omitted — meaningless with no prior run).
- **Restart** → unchanged `✅ Crewly 已重启上线` + version / offline / replayed.

## How
- `composeBootAnnouncement` branches on a new `firstBoot` flag (composer stays pure).
- `isFirstBoot(markerPath)` / `markBooted(markerPath)` — marker at `~/.crewly/.boot-announced`; absent → first boot (write it), present → restart. `markBooted` is best-effort (swallows write errors → at worst a future boot re-shows the welcome, harmless).
- `index.ts` computes `firstBoot` before announcing and passes it through.

## Tests
+4 cases: welcome omits offline/replayed & isn't "restarted"; restart wording; marker absent→true then false after `markBooted`; unwritable path doesn't throw. **12/12, backend `tsc` 0 errors.**

Stacks on #705 — both land together in the next publish (1.11.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)