### PR TITLE
fix(wiki-migrate): detect docs-only projects so the migrate banner surfaces

### DIFF
--- a/backend/src/services/wiki/wiki-migrate.service.test.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.test.ts
@@ -7,7 +7,6 @@
  * @module services/wiki/wiki-migrate.service.test
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -156,6 +155,24 @@ describe('WikiMigrateService.scan', () => {
     expect(md?.targetRelativePath).toMatch(
       /^llm-curated\/decisions\/2026-05-04-runbook\.md$/,
     );
+  });
+
+  it('flags legacyDetected + proposes pages for a docs-only project (retired Knowledge feature)', async () => {
+    // A project whose ONLY legacy store is `.crewly/docs/` (the retired
+    // Company-Knowledge feature) must still surface the migrate banner —
+    // otherwise that data strands silently after the feature is removed.
+    await write(
+      '.crewly/docs/business-model.md',
+      '# Business Model\n\nPricing, GTM, and the cloud-first plan in detail.\n',
+    );
+    const out = await svc.scan({ projectRoot, homeDir });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.legacyDetected).toBe(true);
+    const doc = out.proposedPages.find(
+      (p) => p.sourceFile === '.crewly/docs/business-model.md',
+    );
+    expect(doc?.targetRelativePath).toMatch(/^llm-curated\/docs\//);
   });
 
   it('proposes agent memory.json roleKnowledge as memory-entry pages', async () => {

--- a/backend/src/services/wiki/wiki-migrate.service.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.ts
@@ -640,13 +640,17 @@ export class WikiMigrateService {
     // 114 such docs (blog drafts, case studies, business-model, cloud-mvp
     // plan, competitive scans). Without this they're invisible to
     // wiki-query and stuck in the deprecated `query-knowledge` path.
-    await this.proposeProjectDocs(
-      projectRoot,
-      vaultPath,
-      proposedPages,
-      migratedIds,
-      migratedHashes,
-    );
+    if (
+      await this.proposeProjectDocs(
+        projectRoot,
+        vaultPath,
+        proposedPages,
+        migratedIds,
+        migratedHashes,
+      )
+    ) {
+      legacyDetected = true;
+    }
 
     if (includeMemory) {
       const agentsDir = path.join(homeDir, '.crewly', 'agents');
@@ -1206,16 +1210,17 @@ export class WikiMigrateService {
     out: WikiMigrateProposedPage[],
     migratedIds: Set<string>,
     migratedHashes: Set<string>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const docsDir = path.join(projectRoot, '.crewly', 'docs');
-    if (!existsSync(docsDir)) return;
+    if (!existsSync(docsDir)) return false;
     let entries: import('fs').Dirent[];
     try {
       entries = await fs.readdir(docsDir, { withFileTypes: true });
     } catch {
-      return;
+      return false;
     }
     let count = 0;
+    let anyNew = false;
     for (const entry of entries) {
       if (count >= WIKI_MIGRATE_MAX_LOOSE_MD) break;
       if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
@@ -1240,6 +1245,7 @@ export class WikiMigrateService {
       const hash = sha256(body);
       const skipReason =
         migratedIds.has(sourceId) || migratedHashes.has(hash) ? 'already migrated' : undefined;
+      if (!skipReason) anyNew = true;
       out.push({
         sourceType: 'loose-md',
         sourceFile: path.join('.crewly/docs', entry.name),
@@ -1253,6 +1259,10 @@ export class WikiMigrateService {
       });
       runbookRenderCache.set(sourceId, body);
     }
+    // Signal legacy data so the migrate banner surfaces for projects whose only
+    // legacy store is `.crewly/docs/` (the retired Company-Knowledge feature) —
+    // without this they would never see the prompt and the data would strand.
+    return anyNew;
   }
 
   private async proposeFromAgentMemory(


### PR DESCRIPTION
## Why

Follow-up to #708 (retiring the standalone Company-Knowledge feature). That PR removed the Knowledge UI/API and noted existing `.crewly/docs/` data folds into the wiki via `WikiMigrateService.proposeProjectDocs`. But there was a gap: the migrate **banner** in the Wiki page only renders when `scan.legacyDetected === true` (`Wiki.tsx:1513`), and `proposeProjectDocs` added pages **without** flipping `legacyDetected` (only `.crewly/knowledge/` and agent memory did).

Result: an OSS user whose *only* legacy store is `.crewly/docs/` (i.e. they used the Knowledge feature) would have the UI removed **and never be prompted to migrate** — the data strands silently. This is exactly the "I can't run other users' migration" problem: the migration must surface itself for them.

## What

- `proposeProjectDocs` now returns whether it found any not-yet-migrated docs; `run()` sets `legacyDetected = true` accordingly — mirroring the agent-memory path (`if (found) legacyDetected = true`).
- Idempotent: once migrated, the pages carry `skipReason` and no longer re-trigger the banner (so it doesn't nag after a successful apply).
- Migration stays explicit (dry-run scan → user clicks apply); this only fixes **detection**, it does not auto-write.

## Testing

- Unstrands `wiki-migrate.service.test.ts` (dropped a stray `vitest` import so it runs under jest — it was previously failing to load).
- Adds a docs-only regression test (project with only `.crewly/docs/*.md` → `legacyDetected === true` + a page targeting `llm-curated/docs/`).
- 24/24 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
