### PR TITLE
fix(skills): keep Title Case skill names; drop stale params (follow-up to #313)

### DIFF
--- a/config/skills/agent/core/accept-task/SKILL.md
+++ b/config/skills/agent/core/accept-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: accept-task
+name: Accept Task
 description: "Accept and take the next available task from the task queue. Use when an agent is idle and ready to pick up the highest-priority unassigned task. For assigning tasks to specific agents, use assign-task instead."
 version: 1.0.0
 category: task-management
@@ -41,14 +41,13 @@ Accept and take the next available task from the task queue. The backend selects
 
 ## When to Use
 
-Run this skill when the agent is idle and ready to pick up new work. The backend automatically selects the highest-priority unassigned task. Without a `teamMemberId`, assignment is based on the session alone.
+Run this skill when the agent is idle and ready to pick up new work. The backend automatically selects the highest-priority unassigned task; assignment is keyed by the agent's session.
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `sessionName` | Yes | The agent's session name (e.g., `dev-1`) |
-| `teamMemberId` | No | Team member ID for targeted assignment |
 | `projectPath` | No | Project path to scope task selection |
 | `taskGroup` | No | Task group to filter available tasks |
 
@@ -58,12 +57,6 @@ Run this skill when the agent is idle and ready to pick up new work. The backend
 
 ```bash
 bash config/skills/agent/core/accept-task/execute.sh '{"sessionName":"dev-1"}'
-```
-
-### Accept with team member targeting
-
-```bash
-bash config/skills/agent/core/accept-task/execute.sh '{"sessionName":"dev-1","teamMemberId":"tm-abc123"}'
 ```
 
 ### Accept within a specific project and task group

--- a/config/skills/agent/core/register-self/SKILL.md
+++ b/config/skills/agent/core/register-self/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: register-self
+name: Register Self
 description: "Register the agent as active with the Crewly backend on startup. Use when an agent first launches and needs to join the team and become visible to the orchestrator. For confirming responsiveness after registration, use heartbeat instead."
 version: 1.0.0
 category: system

--- a/config/skills/agent/marketplace/code-review/SKILL.md
+++ b/config/skills/agent/marketplace/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: code-review
+name: Code Review
 description: "Analyze git changes and produce a structured code review with automated checks for missing tests, debug statements, potential secrets, large changes, and dependency modifications. Use when reviewing staged changes, unstaged diffs, recent commits, or branch comparisons before submitting a pull request. For task-level quality gates, use check-quality-gates instead."
 version: 1.0.0
 category: development

--- a/config/skills/orchestrator/assign-task/SKILL.md
+++ b/config/skills/orchestrator/assign-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: assign-task
+name: Assign Task
 description: "Assign a task to a specific agent via the task management system. Use when the orchestrator needs to target a particular agent with a known task ID. For agents self-assigning the next available task, use accept-task instead."
 version: 1.0.0
 category: management
@@ -38,6 +38,7 @@ The skill passes the full JSON input to the assignment endpoint. Common fields:
 |-----------|----------|-------------|
 | `taskId` | Yes | The ID of the task to assign |
 | `assignee` | Yes | Target agent session name (e.g., `agent-joe`) |
+| `reason` | No | Why the task is being assigned (recorded with the assignment) |
 
 ## Examples
 
@@ -47,10 +48,10 @@ The skill passes the full JSON input to the assignment endpoint. Common fields:
 bash config/skills/orchestrator/assign-task/execute.sh '{"taskId":"task-123","assignee":"agent-joe"}'
 ```
 
-### Assign with additional priority context
+### Assign with a reason for the assignment
 
 ```bash
-bash config/skills/orchestrator/assign-task/execute.sh '{"taskId":"task-456","assignee":"agent-sam","priority":"high"}'
+bash config/skills/orchestrator/assign-task/execute.sh '{"taskId":"task-456","assignee":"agent-sam","reason":"owns the auth module"}'
 ```
 
 ## Output

--- a/config/skills/orchestrator/broadcast/SKILL.md
+++ b/config/skills/orchestrator/broadcast/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: broadcast
+name: Broadcast
 description: "Send a message to all active agent sessions, excluding the orchestrator. Use when the orchestrator needs to announce information or coordinate the entire team at once. For messaging a single agent, use send-message instead."
 version: 1.0.0
 category: communication


### PR DESCRIPTION
## Why

Follow-up to #313 (thanks @rohan-tessl 🙏). That PR landed excellent SKILL.md documentation improvements, but to satisfy the external `tessl skill review` judge it also changed five `name:` frontmatter fields to kebab-case. That requirement is Tessl's, not Crewly's:

- **Crewly uses `name` as a human-readable display + match string.** `SkillService` matches skills via `input.includes(name.toLowerCase())`, so a hyphenated `accept-task` actually **fails** to match natural input like "accept task", whereas "Accept Task" matches.
- **Title Case is the convention** across ~138 of the 159 skills; changing these 5 to kebab-case introduces inconsistency.

## What

- Revert the five `name:` fields to Title Case (`accept-task` → `Accept Task`, etc.).
- Drop two now-stale parameter references the docs carried:
  - **accept-task** `teamMemberId` — V3 keys claims by `agentId`; `execute.sh` notes it is "no longer needed". Removed the param row + its example.
  - **assign-task** `priority` — a key the script never reads. Swapped that example for a real `reason` param and documented `reason` in the table.

All other improvements from #313 (fixed example paths, parameter tables, worked examples, error handling, related-skills sections) are kept exactly as-is.

## Testing

- All five SKILL.md frontmatter blocks parse cleanly.
- Skill loader tests pass (the 2 failing `skill-catalog` cases are pre-existing — they use temp fixtures and fail identically on `main`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
