### PR TITLE
feat(health): surface orchestrator-liveness on /health (#686)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -69,6 +69,7 @@ import { MilestoneNotificationSubscriber } from './services/notification/milesto
 import {
 	RequestSlaSubscriber,
 	setRequestSlaSubscriber,
+	getRequestSlaSubscriber,
 } from './services/v3/request-sla.subscriber.js';
 import {
 	RequestDecomposeSubscriber,
@@ -1069,6 +1070,24 @@ void (async () => {
 				  }
 				: { status: 'warming', last_sweep_age_ms: -1, shadowMode: null };
 
+			// Orchestrator-liveness signal (issue #686). The silent 假死 symptom is
+			// "inbound user messages queue but nobody answers": no active agent AND
+			// outstanding `respond_to_user` SLA trackers. Surface it as a body block
+			// — we deliberately keep top-level status:"healthy" / HTTP 200 so a load
+			// balancer doesn't drop the node on this (the LB keys on the status code;
+			// this signal is for dashboards/monitoring to read from the body).
+			const slaSub = getRequestSlaSubscriber();
+			const pendingUserRequests = slaSub ? slaSub.getPendingUserRequestCount() : 0;
+			const orchestratorStalled = agentCount === 0 && pendingUserRequests > 0;
+			const orchestratorBlock = {
+				status: orchestratorStalled ? 'degraded' : 'ok',
+				activeAgents: agentCount,
+				pendingUserRequests,
+				reason: orchestratorStalled
+					? `no active agent with ${pendingUserRequests} pending user request(s) — orchestrator may be down`
+					: null,
+			};
+
 			res.json({
 				status: 'healthy',
 				timestamp: new Date().toISOString(),
@@ -1082,6 +1101,7 @@ void (async () => {
 					total: agentCount,
 				},
 				team_health: teamHealthBlock,
+				orchestrator: orchestratorBlock,
 			});
 		});
 

--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -523,6 +523,32 @@ describe('RequestSlaSubscriber', () => {
   });
 
   // -------------------------------------------------------------------------
+  // getPendingUserRequestCount — powers the /health orchestrator signal (#686)
+  // -------------------------------------------------------------------------
+
+  describe('getPendingUserRequestCount', () => {
+    it('starts at 0 with no tracked requests', () => {
+      expect(sub.getPendingUserRequestCount()).toBe(0);
+    });
+
+    it('counts an inbound-tagged request awaiting a response', async () => {
+      const r = buildRequest({ tags: ['slack'] });
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+      expect(sub.getPendingUserRequestCount()).toBe(1);
+    });
+
+    it('does not count a request with no inbound tag', async () => {
+      const r = buildRequest({ tags: ['cli'] });
+      svc.registry.set(r.id, r);
+      bus.publish(buildEvent(r.id));
+      await sub.flushPending();
+      expect(sub.getPendingUserRequestCount()).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Inbound tag filter
   // -------------------------------------------------------------------------
 

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -602,6 +602,19 @@ export class RequestSlaSubscriber {
   }
 
   /**
+   * Number of inbound user Requests still awaiting an orchestrator response —
+   * i.e. live `respond_to_user` SLA trackers that have neither been answered
+   * nor breached-and-cleared. Powers the `/health` orchestrator-liveness signal
+   * (issue #686): `agents.active === 0` while this is `> 0` means inbound user
+   * messages are queued with no one to answer them (the silent 假死 symptom).
+   *
+   * @returns Count of pending tracked `respond_to_user` work items.
+   */
+  getPendingUserRequestCount(): number {
+    return this.trackedByRequest.size;
+  }
+
+  /**
    * Wait for in-flight async dispatches to settle. Test affordance.
    */
   async flushPending(): Promise<void> {


### PR DESCRIPTION
## Why

Closes the remaining observability gap from #686. The silent 假死 symptom is *"inbound user messages queue but nobody answers"* — no active agent while `respond_to_user` SLA trackers are still outstanding. `/health` previously reported `status:"healthy"` regardless, so this failure mode was invisible to monitoring.

(The core bug — `crewly-agent-in-process` sentinel shelled out → exit-127 — was already fixed by #693 sentinel interception + settings self-heal, with #687/#688 fixing recovery + boot retry. This PR is just the monitoring signal the issue asked for.)

## What

- **`RequestSlaSubscriber.getPendingUserRequestCount()`** — exposes the number of inbound user Requests still awaiting an orchestrator response (live `respond_to_user` trackers in `trackedByRequest`).
- **`/health` gains an `orchestrator` block:**
  ```json
  "orchestrator": { "status": "degraded", "activeAgents": 0, "pendingUserRequests": 3,
                    "reason": "no active agent with 3 pending user request(s) — orchestrator may be down" }
  ```
  `status:"ok"` otherwise.

## Design note (the issue's open question)

The issue asked whether degraded should change the HTTP status code. It **deliberately does not** — top-level `status:"healthy"` / **HTTP 200 is preserved** so a load balancer (which keys on the status code) won't drop the node on this signal. It's a **body-level indicator** for dashboards/monitoring to read. Also resolves the "`respond_to_user` isn't a WorkItem type" blocker: the signal keys on the SLA tracker count, not a WorkItem type.

## Testing

- 3 new tests for `getPendingUserRequestCount` (0 when idle; +1 on an inbound-tagged request; unaffected by non-inbound requests). 100/100 in the SLA subscriber suite.
- Backend typecheck clean.

## Follow-up (not in this PR)

Issue item #2 (a structured alert event on boot-retry exhaustion) remains a small optional follow-up — #688 already loud-`ERROR` logs on exhaustion, so the silent-failure case is covered; a formal alert sink can come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
