### PR TITLE
fix(agent): don't confirm delivery from a stuck-text echo; substitute config placeholders

### DIFF
--- a/backend/src/services/agent/agent-registration.service.test.ts
+++ b/backend/src/services/agent/agent-registration.service.test.ts
@@ -914,6 +914,29 @@ describe('AgentRegistrationService', () => {
 			expect(mockSessionHelper.clearCurrentCommandLine).toHaveBeenCalled();
 		}, 120000);
 
+		it('DOES confirm delivery when output changes and the message text is NOT stuck', async () => {
+			// Positive counterpart to the false-positive test above: the output
+			// changed from the pre-send baseline AND our message text is not sitting
+			// at the prompt → a real response landed, so delivery is confirmed.
+			// Guards the reordered confirmation logic: stuck-echo ≠ delivered, but a
+			// genuine non-stuck change IS.
+			mockSessionHelper.sessionExists.mockReturnValue(true);
+			let capturePaneCount = 0;
+			mockSessionHelper.capturePane.mockImplementation(() => {
+				capturePaneCount++;
+				if (capturePaneCount === 1) return '❯ \n'; // pre-send: clean prompt
+				if (capturePaneCount === 2) return '❯ \n'; // beforeOutput baseline
+				// Changed output, no idle prompt, message text NOT present → real response.
+				return 'Working on your request…\n';
+			});
+
+			const resultPromise = service.sendMessageToAgent('test-session', 'Hello world');
+			await jest.advanceTimersByTimeAsync(300000);
+			const result = await resultPromise;
+
+			expect(result.success).toBe(true);
+		}, 120000);
+
 		it('should fall through to direct delivery when agent is not at prompt', async () => {
 			mockSessionHelper.sessionExists.mockReturnValue(true);
 			// capturePane shows non-prompt content (agent is busy/modal)

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -1196,7 +1196,20 @@ export class AgentRegistrationService {
 				this.promptCache.set(templatePath, content);
 			}
 
-			await writeFile(config.outputPath, content, { flag: 'wx' }).catch(() => {
+			// Substitute path placeholders before writing (#209). The cache holds
+			// the RAW template; resolve into a per-project copy so skill-script and
+			// project paths in the provisioned config file point at real locations
+			// (mirrors the placeholder substitution done for the registration prompt).
+			const agentSkillsPath = path.join(this.projectRoot, 'config', 'skills', 'agent');
+			const orchestratorSkillsPath = path.join(this.projectRoot, 'config', 'skills', 'orchestrator');
+			const marketplaceSkillsPath = path.join(os.homedir(), '.crewly', 'marketplace', 'skills');
+			const resolved = content
+				.replace(/\{\{PROJECT_PATH\}\}/g, projectPath)
+				.replace(/\{\{AGENT_SKILLS_PATH\}\}/g, agentSkillsPath)
+				.replace(/\{\{ORCHESTRATOR_SKILLS_PATH\}\}/g, orchestratorSkillsPath)
+				.replace(/\{\{MARKETPLACE_SKILLS_PATH\}\}/g, marketplaceSkillsPath);
+
+			await writeFile(config.outputPath, resolved, { flag: 'wx' }).catch(() => {
 				// File already exists — no action needed
 			});
 		} catch (err) {
@@ -4143,6 +4156,8 @@ Loop until done, blocked, or explicitly reassigned:
 							confirmAttempt++;
 
 							const loopOutput = sessionHelper.capturePane(sessionName);
+							const loopBottom = loopOutput.split('\n').slice(-10).join(' ').replace(/\s+/g, ' ');
+							const textStuck = loopBottom.includes(confirmSnippet);
 
 							// Spinner or working indicator → delivered
 							if (containsSpinnerOrWorkingIndicator(loopOutput)) {
@@ -4153,7 +4168,29 @@ Loop until done, blocked, or explicitly reassigned:
 								break;
 							}
 
-							// Fast-response detection: output changed since send → delivered
+							// Text still stuck → Enter was dropped, NOT delivered. Try
+							// Tab+Enter recovery and re-check next iteration. This is
+							// checked BEFORE the output-change shortcut below: when our
+							// own pasted message is echoed at the prompt the output DID
+							// change vs the pre-send baseline, but that change is the
+							// stuck echo, not a response — treating it as "delivered"
+							// is the false-positive that masked the orc 假死 (#686
+							// follow-up: a hung session looked "delivered" forever).
+							if (textStuck) {
+								this.logger.warn('Confirmation loop: text still stuck, pressing Tab+Enter', {
+									sessionName, attempt, confirmAttempt,
+								});
+								await sessionHelper.sendKey(sessionName, 'Tab');
+								await delay(200);
+								await sessionHelper.sendEnter(sessionName);
+								await delay(500);
+								await sessionHelper.sendEnter(sessionName); // backup
+								continue;
+							}
+
+							// Fast-response detection: output changed since send AND our
+							// message text is NOT stuck at the prompt → a real response
+							// landed and returned to prompt before we looked. Delivered.
 							if (loopOutput !== beforeOutput) {
 								this.logger.info('Confirmation loop: output changed from pre-send — fast response confirmed', {
 									sessionName, attempt, confirmAttempt,
@@ -4163,25 +4200,12 @@ Loop until done, blocked, or explicitly reassigned:
 							}
 
 							// Not at prompt and text not stuck → delivered
-							const loopBottom = loopOutput.split('\n').slice(-10).join(' ').replace(/\s+/g, ' ');
-							if (!this.isClaudeAtPrompt(loopOutput, runtimeType) && !loopBottom.includes(confirmSnippet)) {
+							if (!this.isClaudeAtPrompt(loopOutput, runtimeType)) {
 								this.logger.info('Confirmation loop: prompt gone, text cleared', {
 									sessionName, attempt, confirmAttempt,
 								});
 								claudeDelivered = true;
 								break;
-							}
-
-							// Text still stuck → Tab+Enter recovery
-							if (loopBottom.includes(confirmSnippet)) {
-								this.logger.warn('Confirmation loop: text still stuck, pressing Tab+Enter', {
-									sessionName, attempt, confirmAttempt,
-								});
-								await sessionHelper.sendKey(sessionName, 'Tab');
-								await delay(200);
-								await sessionHelper.sendEnter(sessionName);
-								await delay(500);
-								await sessionHelper.sendEnter(sessionName); // backup
 							}
 						}
 


### PR DESCRIPTION
## Why

Fixes the two long-red `agent-registration.service` tests — both surfaced by the **Irissair orchestrator 假死 incident**. The on-machine diagnosis found the orc's Claude Code TUI session was hung (claim→revoke loop, then silence), yet inbound messages were reported "delivery confirmed" and users saw only the auto-nudge placeholder. The reason the hang was **invisible** is bug #1 below.

## What

**1. Don't confirm delivery from a stuck-text echo (the invisibility root cause)**
In the extended confirmation loop, *"output changed vs the pre-send baseline → delivered"* fired even when the only change was our **own pasted message echoed at the prompt** (Enter dropped). So a hung session looked "delivered" forever and never actually ran an agent turn.

Now the **stuck-text check runs before** the output-change shortcut:
- message text still at the prompt → **not** delivery (attempt Tab+Enter recovery, re-check next iteration);
- output-change counts as a fast response **only when the text is not stuck**.

Fixes `should NOT declare success from raw output-change alone (pasted text false positive)` and adds a positive counterpart test (a genuine non-stuck change *is* confirmed).

**2. Substitute placeholders in provisioned runtime config (#209)**
`provisionRuntimeConfigFile` wrote the template (`.crewly/CLAUDE.md`, `GEMINI.md`, `AGENTS.md`) **verbatim**, leaving `{{AGENT_SKILLS_PATH}}` / `{{PROJECT_PATH}}` / etc. unsubstituted → broken skill-script paths in the provisioned file. Now substitutes them into a per-project copy (the template cache stays raw), mirroring the registration-prompt substitution. Fixes `should replace {{AGENT_SKILLS_PATH}} in template content (#209)`.

## Testing
- Full agent-registration suite green: **199/199** (was 197/199 — both pre-existing reds now pass, +1 new positive test).
- Backend typecheck clean.

## Note
This is the first of the engine-level fixes from the Irissair incident. A complementary `/health` enhancement (detect "orc up but stalled", not just `active===0`) and a hung-session auto-recovery watchdog are planned follow-ups so the system both *sees* and *self-heals* this class of session hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
