### PR TITLE
feat(health): detect hung orchestrator sessions (claim-but-never-heartbeat)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1078,14 +1078,34 @@ void (async () => {
 			// this signal is for dashboards/monitoring to read from the body).
 			const slaSub = getRequestSlaSubscriber();
 			const pendingUserRequests = slaSub ? slaSub.getPendingUserRequestCount() : 0;
-			const orchestratorStalled = agentCount === 0 && pendingUserRequests > 0;
+
+			// "Down" — no active agent while user work is queued (issue #686).
+			const orchestratorDown = agentCount === 0 && pendingUserRequests > 0;
+
+			// "Up but hung" — the orchestrator process is alive yet its session keeps
+			// claiming work and never heartbeats (claims get grace-revoked in a loop).
+			// agentCount>0 hides this from the "down" check, so detect it explicitly
+			// via the claim-service hung signal (the Irissair 假死).
+			let orchestratorHung = false;
+			try {
+				orchestratorHung = TaskPoolService.getInstance()
+					.getHungAgents()
+					.includes(ORCHESTRATOR_SESSION_NAME);
+			} catch {
+				// Task pool not ready yet — treat as not-hung.
+			}
+
+			const orchestratorStalled = orchestratorDown || orchestratorHung;
 			const orchestratorBlock = {
 				status: orchestratorStalled ? 'degraded' : 'ok',
 				activeAgents: agentCount,
 				pendingUserRequests,
-				reason: orchestratorStalled
-					? `no active agent with ${pendingUserRequests} pending user request(s) — orchestrator may be down`
-					: null,
+				hung: orchestratorHung,
+				reason: orchestratorHung
+					? 'orchestrator session is hung — claiming work but not heartbeating (repeated grace-revokes)'
+					: orchestratorDown
+						? `no active agent with ${pendingUserRequests} pending user request(s) — orchestrator may be down`
+						: null,
 			};
 
 			res.json({

--- a/backend/src/services/task-pool/claim.service.test.ts
+++ b/backend/src/services/task-pool/claim.service.test.ts
@@ -7,7 +7,7 @@
  * @module services/task-pool/claim.service.test
  */
 
-import { ClaimService } from './claim.service.js';
+import { ClaimService, HUNG_SESSION_GRACE_REVOKE_THRESHOLD } from './claim.service.js';
 import { PoolStorage } from './pool-storage.js';
 import {
   DEFAULT_LEASE_DURATION_MS,
@@ -348,6 +348,47 @@ describe('ClaimService', () => {
 
     it('should throw for non-existent claim', async () => {
       await expect(service.revoke('nonexistent', 'expired')).rejects.toThrow(/not found/);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // hung-session detection (grace-revoke tracking) — Irissair 假死
+  // -----------------------------------------------------------------------
+
+  describe('hung-session detection', () => {
+    // Mirrors the reconciler's revoke reason (reconcile-rules.ts).
+    const GRACE_REASON = 'Grace period exceeded for claim c-x on WorkItem wi-x';
+
+    it('counts consecutive grace-revokes per agent and flags hung at the threshold', async () => {
+      for (let i = 0; i < HUNG_SESSION_GRACE_REVOKE_THRESHOLD; i++) {
+        const claim = await service.createClaim({ workItemId: `wi-${i}`, agentId: 'agent-hung' });
+        await service.revoke(claim.id, GRACE_REASON);
+      }
+      expect(service.getConsecutiveGraceRevokes('agent-hung')).toBe(
+        HUNG_SESSION_GRACE_REVOKE_THRESHOLD,
+      );
+      expect(service.getHungAgents()).toContain('agent-hung');
+    });
+
+    it('resets the count on a successful heartbeat (proof of life)', async () => {
+      const c1 = await service.createClaim({ workItemId: 'wi-a', agentId: 'agent-x' });
+      await service.revoke(c1.id, GRACE_REASON);
+      const c2 = await service.createClaim({ workItemId: 'wi-b', agentId: 'agent-x' });
+      await service.revoke(c2.id, GRACE_REASON);
+      expect(service.getConsecutiveGraceRevokes('agent-x')).toBe(2);
+
+      const c3 = await service.createClaim({ workItemId: 'wi-c', agentId: 'agent-x' });
+      await service.heartbeat(c3.id, 'agent-x');
+
+      expect(service.getConsecutiveGraceRevokes('agent-x')).toBe(0);
+      expect(service.getHungAgents()).not.toContain('agent-x');
+    });
+
+    it('ignores non-grace revoke reasons', async () => {
+      const claim = await service.createClaim({ workItemId: 'wi-1', agentId: 'agent-y' });
+      await service.revoke(claim.id, 'released by user');
+      expect(service.getConsecutiveGraceRevokes('agent-y')).toBe(0);
+      expect(service.getHungAgents()).not.toContain('agent-y');
     });
   });
 

--- a/backend/src/services/task-pool/claim.service.ts
+++ b/backend/src/services/task-pool/claim.service.ts
@@ -30,6 +30,18 @@ import {
   DEFAULT_MAX_EXTENSIONS,
 } from '../../types/v2/claim.types.js';
 
+/**
+ * Consecutive grace-period revocations (with NO intervening heartbeat) after
+ * which an agent's session is considered HUNG — it keeps claiming work but
+ * never proves liveness. This is the Irissair orchestrator 假死 signature:
+ * claimed hourly, never heartbeated, revoked ~13 min later, repeat. Surfaced
+ * via {@link ClaimService.getHungAgents}.
+ */
+export const HUNG_SESSION_GRACE_REVOKE_THRESHOLD = 3;
+
+/** Prefix of the reconciler's revoke reason for grace-period revocations. */
+const GRACE_REVOKE_REASON_PREFIX = 'Grace period exceeded';
+
 // ---------------------------------------------------------------------------
 // Result Types
 // ---------------------------------------------------------------------------
@@ -103,6 +115,14 @@ export interface ExpiredClaimsSummary {
 export class ClaimService {
   private readonly storage: PoolStorage;
   private readonly logger: ComponentLogger;
+
+  /**
+   * Per-agent count of consecutive grace-period revocations with NO intervening
+   * heartbeat. Incremented on each grace revoke, reset to 0 on any successful
+   * heartbeat (proof the session is alive). Powers hung-session detection
+   * ({@link getHungAgents}).
+   */
+  private readonly consecutiveGraceRevokes = new Map<string, number>();
 
   constructor(storage: PoolStorage) {
     this.storage = storage;
@@ -210,6 +230,10 @@ export class ClaimService {
 
     const updatedClaim = claims.find((c) => c.id === claimId)!;
     this.logger.debug?.('Heartbeat received', { claimId, agentId });
+
+    // Liveness proof — clear any accumulated grace-revoke count for this agent
+    // so hung-session detection only fires on agents that NEVER heartbeat.
+    this.consecutiveGraceRevokes.delete(agentId);
 
     return { success: true, claim: updatedClaim };
   }
@@ -341,6 +365,52 @@ export class ClaimService {
     });
 
     this.logger.info('Claim revoked', { claimId, reason, agentId: claim.agentId });
+
+    // Hung-session detection: a grace-period revoke means the agent held a lease
+    // but never heartbeated. Track consecutive occurrences per agent (reset on
+    // the next heartbeat). Repeated grace revokes with no heartbeat = a session
+    // that keeps claiming work but never executes it (the Irissair 假死).
+    if (reason.startsWith(GRACE_REVOKE_REASON_PREFIX)) {
+      const next = (this.consecutiveGraceRevokes.get(claim.agentId) ?? 0) + 1;
+      this.consecutiveGraceRevokes.set(claim.agentId, next);
+      if (next >= HUNG_SESSION_GRACE_REVOKE_THRESHOLD) {
+        this.logger.error(
+          'Agent session looks HUNG — repeated grace-period revokes with no heartbeat',
+          {
+            agentId: claim.agentId,
+            consecutiveGraceRevokes: next,
+            threshold: HUNG_SESSION_GRACE_REVOKE_THRESHOLD,
+          },
+        );
+      }
+    }
+  }
+
+  /**
+   * Consecutive grace-period revocations (with no intervening heartbeat) for an
+   * agent. Resets to 0 on the agent's next successful heartbeat.
+   *
+   * @param agentId - The agent/session id.
+   * @returns The current consecutive grace-revoke count (0 if none).
+   */
+  getConsecutiveGraceRevokes(agentId: string): number {
+    return this.consecutiveGraceRevokes.get(agentId) ?? 0;
+  }
+
+  /**
+   * Agents whose consecutive grace-revoke count is at or above `threshold` —
+   * their sessions keep claiming work but never heartbeat, i.e. they look HUNG.
+   *
+   * @param threshold - Minimum consecutive grace-revokes (default
+   *   {@link HUNG_SESSION_GRACE_REVOKE_THRESHOLD}).
+   * @returns Agent ids that currently look hung.
+   */
+  getHungAgents(threshold: number = HUNG_SESSION_GRACE_REVOKE_THRESHOLD): string[] {
+    const hung: string[] = [];
+    for (const [agentId, count] of this.consecutiveGraceRevokes) {
+      if (count >= threshold) hung.push(agentId);
+    }
+    return hung;
   }
 
   // -----------------------------------------------------------------------

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1462,6 +1462,18 @@ export class TaskPoolService {
   }
 
   /**
+   * Agents that look HUNG — they keep claiming work but never heartbeat, so
+   * their claims are repeatedly grace-revoked. Powers the `/health`
+   * orchestrator-liveness signal ("up but stalled") and hung-session recovery.
+   *
+   * @param threshold - Minimum consecutive grace-revokes to count as hung.
+   * @returns Agent ids that currently look hung.
+   */
+  getHungAgents(threshold?: number): string[] {
+    return this.claimService.getHungAgents(threshold);
+  }
+
+  /**
    * Revokes a claim and releases the work item back to the pool.
    * Used by the Reconciler when a claim's grace period is exceeded.
    *


### PR DESCRIPTION
## Why

The Irissair incident was a **new failure mode**, not #686. The orchestrator process was alive (`agents.active=1`) but its Claude Code session was **hung**: it auto-claimed work hourly, **never heartbeated**, got grace-revoked ~13 min later, and repeated for ~11h with zero output — users saw only the auto-nudge placeholder.

The `/health` signal from #711 keys on `agents.active===0`, so for a hung-but-alive orchestrator it reported **"ok"** and missed this completely. This closes that blind spot.

## What

Detection at the claim layer (it owns heartbeat + revoke — the natural place to know "claimed but never proved liveness"):

- **`ClaimService`** tracks **consecutive grace-period revocations per agent**, reset to `0` on any successful heartbeat. Repeated grace revokes with no intervening heartbeat = a session that keeps claiming work but never executes it. Crossing `HUNG_SESSION_GRACE_REVOKE_THRESHOLD` (3) logs a loud `ERROR`.
- New `getConsecutiveGraceRevokes(agentId)` / `getHungAgents(threshold)`; `TaskPoolService.getHungAgents()` delegates.
- **`/health`** orchestrator block now reports `status:"degraded"`, `hung:true`, and a reason when the orchestrator session is hung — in addition to the existing "down" (active=0 + pending) case. Top-level `status:"healthy"` / HTTP 200 stays (LB-safe; body-only signal).

## Scope

This is the **detection + visibility** foundation — the capability that was actually missing (Irissair was invisible for 11h). **Auto-recovery** (restart the hung session on this signal, with threshold + cooldown) is the planned immediate follow-up; it needs orc-vs-worker restart-context plumbing (the reconciler uses `/orchestrator/setup` for the orc per #687) and is higher-stakes, so it ships separately on top of this proven signal rather than half-baked here.

## Testing
- `ClaimService` grace-revoke tracking: increment on grace revoke, reset on heartbeat, non-grace reasons ignored — 39/39.
- task-pool + reconciler suites: 430/430. Backend typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
