### PR TITLE
feat(orchestrator): auto-recover a hung session via the grace-revoke signal

### DIFF
--- a/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.test.ts
+++ b/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.test.ts
@@ -50,6 +50,26 @@ jest.mock('../agent/auditor-scheduler.service.js', () => ({
 	},
 }));
 
+// Hung-session signal (#713) + recovery gate. Default: not hung, recovery on —
+// so existing tests fall through to the normal heartbeat/idle logic unchanged.
+const mockGetHungAgents = jest.fn<string[], []>(() => []);
+const mockClearHungState = jest.fn();
+jest.mock('../task-pool/task-pool.service.js', () => ({
+	TaskPoolService: {
+		getInstance: () => ({
+			getHungAgents: mockGetHungAgents,
+			clearHungState: mockClearHungState,
+		}),
+	},
+}));
+
+const mockGetSettings = jest
+	.fn()
+	.mockResolvedValue({ general: { autoRecoverHungOrchestrator: true } });
+jest.mock('../settings/index.js', () => ({
+	getSettingsService: () => ({ getSettings: mockGetSettings }),
+}));
+
 import { OrchestratorHeartbeatMonitorService } from './orchestrator-heartbeat-monitor.service.js';
 import { OrchestratorRestartService } from './orchestrator-restart.service.js';
 import { PtyActivityTrackerService } from '../agent/pty-activity-tracker.service.js';
@@ -83,6 +103,11 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 
 	beforeEach(() => {
 		jest.useFakeTimers();
+
+		// Reset hung-session mocks to the default (not hung, recovery enabled).
+		mockGetHungAgents.mockReturnValue([]);
+		mockClearHungState.mockReset();
+		mockGetSettings.mockResolvedValue({ general: { autoRecoverHungOrchestrator: true } });
 
 		OrchestratorHeartbeatMonitorService.resetInstance();
 		OrchestratorRestartService.resetInstance();
@@ -770,6 +795,54 @@ describe('OrchestratorHeartbeatMonitorService', () => {
 				expect.stringContaining('[SYSTEM] Orchestrator heartbeat timeout'),
 				expect.any(Object),
 			);
+
+			restartSpy.mockRestore();
+		});
+	});
+
+	describe('hung-session auto-restart (#713 signal)', () => {
+		it('restarts when the orchestrator session is hung and recovery is enabled', async () => {
+			mockGetHungAgents.mockReturnValue([ORCHESTRATOR_SESSION_NAME]);
+			const restartSpy = jest
+				.spyOn(OrchestratorRestartService.getInstance(), 'attemptRestart')
+				.mockResolvedValue(true);
+
+			await performCheckAndFlush(service);
+
+			expect(restartSpy).toHaveBeenCalled();
+			// Hung state cleared so the fresh session isn't immediately re-flagged.
+			expect(mockClearHungState).toHaveBeenCalledWith(ORCHESTRATOR_SESSION_NAME);
+
+			restartSpy.mockRestore();
+		});
+
+		it('does NOT restart when autoRecoverHungOrchestrator is disabled', async () => {
+			mockGetHungAgents.mockReturnValue([ORCHESTRATOR_SESSION_NAME]);
+			mockGetSettings.mockResolvedValue({
+				general: { autoRecoverHungOrchestrator: false },
+			});
+			const restartSpy = jest
+				.spyOn(OrchestratorRestartService.getInstance(), 'attemptRestart')
+				.mockResolvedValue(true);
+
+			await performCheckAndFlush(service);
+
+			expect(restartSpy).not.toHaveBeenCalled();
+			expect(mockClearHungState).not.toHaveBeenCalled();
+
+			restartSpy.mockRestore();
+		});
+
+		it('does not trigger the hung path when no agent is hung', async () => {
+			// Default mock returns [] — the hung branch must not fire, and the
+			// check must not clear hung state.
+			const restartSpy = jest
+				.spyOn(OrchestratorRestartService.getInstance(), 'attemptRestart')
+				.mockResolvedValue(true);
+
+			await performCheckAndFlush(service);
+
+			expect(mockClearHungState).not.toHaveBeenCalled();
 
 			restartSpy.mockRestore();
 		});

--- a/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.ts
+++ b/backend/src/services/orchestrator/orchestrator-heartbeat-monitor.service.ts
@@ -30,6 +30,8 @@ import { delay } from '../../utils/async.utils.js';
 import { PtyActivityTrackerService } from '../agent/pty-activity-tracker.service.js';
 import { OrchestratorRestartService } from './orchestrator-restart.service.js';
 import { isAgentActive } from './orchestrator-status.service.js';
+import { TaskPoolService } from '../task-pool/task-pool.service.js';
+import { getSettingsService } from '../settings/index.js';
 import type { ISessionBackend } from '../session/session-backend.interface.js';
 
 /**
@@ -378,6 +380,39 @@ export class OrchestratorHeartbeatMonitorService {
 				await this.triggerAutoRestart();
 				return;
 			}
+		}
+
+		// Hung-session trigger (Irissair 假死). The orchestrator can keep its
+		// PTY/API-activity heartbeat fresh by auto-claiming work every hour even
+		// when its session is actually stuck — those claims never heartbeat and
+		// get grace-revoked in a loop. The idle-time checks below are fooled by
+		// that periodic activity, so detect the stuck state DIRECTLY via the
+		// claim-service hung signal (#713) and reuse the same restart path.
+		try {
+			const hung = TaskPoolService.getInstance().getHungAgents();
+			if (hung.includes(ORCHESTRATOR_SESSION_NAME)) {
+				const settings = await getSettingsService().getSettings();
+				if (settings.general.autoRecoverHungOrchestrator) {
+					this.logger.error(
+						'Orchestrator session is HUNG (claims work but never heartbeats) — triggering auto-restart',
+						{ sessionName: ORCHESTRATOR_SESSION_NAME },
+					);
+					// Clear the hung state so a restart cooldown / slow restart does
+					// not immediately re-trigger before the fresh session heartbeats.
+					TaskPoolService.getInstance().clearHungState(ORCHESTRATOR_SESSION_NAME);
+					this.heartbeatRequestSentAt = null;
+					await this.triggerAutoRestart();
+					return;
+				}
+				this.logger.warn(
+					'Orchestrator session looks hung but autoRecoverHungOrchestrator is disabled',
+					{ sessionName: ORCHESTRATOR_SESSION_NAME },
+				);
+			}
+		} catch (err) {
+			this.logger.warn('Hung-session check failed (non-fatal)', {
+				error: err instanceof Error ? err.message : String(err),
+			});
 		}
 
 		const activityTracker = PtyActivityTrackerService.getInstance();

--- a/backend/src/services/task-pool/claim.service.ts
+++ b/backend/src/services/task-pool/claim.service.ts
@@ -413,6 +413,18 @@ export class ClaimService {
     return hung;
   }
 
+  /**
+   * Clear an agent's consecutive grace-revoke count. Called by the hung-session
+   * watchdog after it triggers a recovery (session restart) so the freshly
+   * restarted session is not immediately re-flagged as hung before it has had a
+   * chance to heartbeat.
+   *
+   * @param agentId - The agent/session id to clear.
+   */
+  clearGraceRevokes(agentId: string): void {
+    this.consecutiveGraceRevokes.delete(agentId);
+  }
+
   // -----------------------------------------------------------------------
   // Expiry Detection (used by Reconciler)
   // -----------------------------------------------------------------------

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1474,6 +1474,16 @@ export class TaskPoolService {
   }
 
   /**
+   * Clear an agent's hung state after a recovery (session restart), so the
+   * restarted session is not immediately re-flagged before it can heartbeat.
+   *
+   * @param agentId - The agent/session id to clear.
+   */
+  clearHungState(agentId: string): void {
+    this.claimService.clearGraceRevokes(agentId);
+  }
+
+  /**
    * Revokes a claim and releases the work item back to the pool.
    * Used by the Reconciler when a claim's grace period is exceeded.
    *

--- a/backend/src/types/settings.types.test.ts
+++ b/backend/src/types/settings.types.test.ts
@@ -60,6 +60,7 @@ describe('Settings Types', () => {
       const settings: GeneralSettings = {
         defaultRuntime: 'claude-code',
         autoStartOrchestrator: false,
+        autoRecoverHungOrchestrator: true,
         checkInIntervalMinutes: 5,
         maxConcurrentAgents: 10,
         verboseLogging: false,
@@ -94,6 +95,7 @@ describe('Settings Types', () => {
       const settings: GeneralSettings = {
         defaultRuntime: 'claude-code',
         autoStartOrchestrator: true,
+        autoRecoverHungOrchestrator: true,
         checkInIntervalMinutes: 10,
         maxConcurrentAgents: 5,
         verboseLogging: true,
@@ -160,6 +162,7 @@ describe('Settings Types', () => {
         general: {
           defaultRuntime: 'claude-code',
           autoStartOrchestrator: false,
+          autoRecoverHungOrchestrator: true,
           checkInIntervalMinutes: 5,
           maxConcurrentAgents: 10,
           verboseLogging: false,

--- a/backend/src/types/settings.types.ts
+++ b/backend/src/types/settings.types.ts
@@ -34,6 +34,13 @@ export interface GeneralSettings {
   /** Whether to auto-start the orchestrator on application launch */
   autoStartOrchestrator: boolean;
 
+  /**
+   * Whether the hung-session watchdog auto-restarts the orchestrator when its
+   * session is hung (alive but claiming work without ever heartbeating). When
+   * false, the hang is still detected + surfaced on `/health` but not recovered.
+   */
+  autoRecoverHungOrchestrator: boolean;
+
   /** Agent check-in interval in minutes */
   checkInIntervalMinutes: number;
 
@@ -331,6 +338,7 @@ export function getDefaultSettings(): CrewlySettings {
     general: {
       defaultRuntime: 'claude-code',
       autoStartOrchestrator: true,
+      autoRecoverHungOrchestrator: true,
       checkInIntervalMinutes: 5,
       maxConcurrentAgents: 10,
       verboseLogging: false,


### PR DESCRIPTION
## Why

Closes the loop on the Irissair 假死. #713 made an "alive but hung" orchestrator **visible**; this restarts it **automatically**.

**Why the existing monitor missed it:** `OrchestratorHeartbeatMonitorService` keys on PTY/API activity — any API call refreshes the heartbeat. The hung orchestrator auto-claimed work **every hour**, and those claim API-calls kept its activity heartbeat fresh, so the idle-based restart never fired. Meanwhile the claims themselves never heartbeated and were grace-revoked in a loop for ~11h. The claim-layer "hung" signal (#713) catches exactly that gap.

## What

Feed the hung signal into the **existing** restart path (no parallel watchdog):
- `ClaimService.clearGraceRevokes()` + `TaskPoolService.clearHungState()` — clear the hung state after recovery so a fresh session isn't immediately re-flagged before it heartbeats.
- `OrchestratorHeartbeatMonitor.performCheck()` now also restarts when the orchestrator is in `getHungAgents()`, reusing `triggerAutoRestart()` → `OrchestratorRestartService` (so the existing cooldown / concurrent-restart guards / resume logic all apply). Gated by the new `autoRecoverHungOrchestrator` setting (default **true**); when disabled, the hang is still detected + surfaced on `/health`, just not auto-recovered.
- New `autoRecoverHungOrchestrator` `GeneralSettings` flag.

## Scope

Orchestrator only. A hung **worker** is recoverable by the orchestrator re-delegating, and restarting an arbitrary worker needs role/project/runtime context that isn't safely reconstructable here — hung workers stay visible via `/health` + the loud `ClaimService` log (a possible later extension).

## Testing
- Monitor hung-restart: enabled → restart + clear hung state; disabled → no restart; not-hung → no-op. 47/47.
- orchestrator + task-pool + settings suites: 773/773. Backend typecheck clean.

## The Irissair recovery chain is now complete
1. **#712** — stop confirming delivery from a stuck-text echo (the hang was *invisible* because messages looked "delivered").
2. **#713** — detect the hang (claim-but-never-heartbeat) + surface it on `/health`.
3. **this** — auto-restart the hung orchestrator on that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
