### PR TITLE
fix(session): reap orphaned runtime processes at startup (#715)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -34,6 +34,7 @@ import {
 	destroySessionBackend,
 	PtySessionBackend,
 } from './services/session/index.js';
+import { RuntimePidRegistry } from './services/session/runtime-pid-registry.service.js';
 import { ApiController } from './controllers/api.controller.js';
 import { createApiRoutes } from './routes/api.routes.js';
 import { TerminalGateway, setTerminalGateway } from './websocket/terminal.gateway.js';
@@ -2289,6 +2290,23 @@ void (async () => {
 
 			// Start health monitoring
 			this.startHealthMonitoring();
+
+			// Reap orphaned runtime processes left by a previous, non-graceful
+			// backend death (crash / OOM / force-exit) BEFORE we spawn any new
+			// sessions below — otherwise stray `gemini --yolo` / `claude` runtimes
+			// accumulate across restarts and inflate the process table (#715).
+			// Identity-verified: only kills recorded PIDs whose live cmdline still
+			// matches, so it never touches an unrelated reused PID.
+			try {
+				const reaped = RuntimePidRegistry.getInstance().reapOrphans();
+				if (reaped > 0) {
+					this.logger.warn('Reaped orphaned runtime processes at startup', { reaped });
+				}
+			} catch (err) {
+				this.logger.warn('Orphan runtime reap failed (non-fatal)', {
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
 
 			// Auto-start orchestrator if enabled in settings
 			await this.autoStartOrchestratorIfEnabled();

--- a/backend/src/services/session/pty/pty-session-backend.ts
+++ b/backend/src/services/session/pty/pty-session-backend.ts
@@ -17,6 +17,7 @@ import { PtyTerminalBuffer } from './pty-terminal-buffer.js';
 import { LoggerService, ComponentLogger } from '../../core/logger.service.js';
 import { PTY_CONSTANTS, CREWLY_CONSTANTS } from '../../../constants.js';
 import { PtyActivityTrackerService } from '../../agent/pty-activity-tracker.service.js';
+import { RuntimePidRegistry } from '../runtime-pid-registry.service.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -178,6 +179,15 @@ export class PtySessionBackend implements ISessionBackend {
 		this.sessions.set(name, session);
 		this.terminalBuffers.set(name, terminalBuffer);
 
+		// Record the spawned PID so a non-graceful backend death can be cleaned
+		// up at the next boot (issue #715). Removed again on clean teardown.
+		RuntimePidRegistry.getInstance().record(
+			session.pid,
+			name,
+			options.command,
+			options.args ?? [],
+		);
+
 		this.logger.info('PTY session created', {
 			name,
 			pid: session.pid,
@@ -231,6 +241,9 @@ export class PtySessionBackend implements ISessionBackend {
 			terminalBuffer.dispose();
 			this.terminalBuffers.delete(name);
 		}
+
+		// We reaped this process ourselves — drop it from the orphan registry.
+		RuntimePidRegistry.getInstance().remove(name);
 
 		this.cumulativeOutputBytes.delete(name);
 		this.closeSessionLogStream(name);
@@ -498,6 +511,10 @@ export class PtySessionBackend implements ISessionBackend {
 		this.sessions.clear();
 		this.terminalBuffers.clear();
 		this.cumulativeOutputBytes.clear();
+
+		// We just reaped every tracked process + group — clear the orphan
+		// registry so the next boot doesn't try to re-reap these PIDs.
+		RuntimePidRegistry.getInstance().clear();
 
 		this.logger.info('Force-destroyed all PTY sessions');
 	}

--- a/backend/src/services/session/runtime-pid-registry.service.test.ts
+++ b/backend/src/services/session/runtime-pid-registry.service.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for RuntimePidRegistry — the orphan runtime-process reaper (#715).
+ *
+ * Reap tests spy on `process.kill` so a "verified orphan" is never actually
+ * signalled to a real process, and inject a stub cmdline reader so identity
+ * verification is deterministic and platform-independent.
+ *
+ * @module services/session/runtime-pid-registry.service.test
+ */
+
+jest.mock('../core/logger.service.js', () => ({
+  LoggerService: {
+    getInstance: () => ({
+      createComponentLogger: () => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }),
+    }),
+  },
+}));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  RuntimePidRegistry,
+  RUNTIME_PID_FILE,
+  isPidAlive,
+  readProcessCmdline,
+} from './runtime-pid-registry.service.js';
+
+/** A process.kill mock: signal 0 = liveness probe over `alive`, others = no-op record. */
+function mockProcessKill(alive: Set<number>): jest.SpyInstance {
+  return jest.spyOn(process, 'kill').mockImplementation(((pid: number, signal?: string | number) => {
+    if (signal === 0) {
+      if (alive.has(Math.abs(Number(pid)))) return true;
+      const err = new Error('ESRCH') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    }
+    return true; // SIGKILL etc — recorded by the spy, no real signal sent
+  }) as typeof process.kill);
+}
+
+describe('RuntimePidRegistry', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pidreg-'));
+    file = path.join(dir, RUNTIME_PID_FILE);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  describe('record / remove / clear', () => {
+    it('records spawns with a normalised signature and persists them', () => {
+      const reg = RuntimePidRegistry.resetForTesting({ filePath: file });
+      reg.record(1234, 's1', 'gemini', ['--yolo']);
+      reg.record(5678, 's2', 'claude', ['--dangerously-skip-permissions']);
+
+      const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+      expect(data).toHaveLength(2);
+      expect(data[0]).toMatchObject({ pid: 1234, sessionName: 's1', signature: 'gemini --yolo' });
+    });
+
+    it('replaces a prior record for the same session', () => {
+      const reg = RuntimePidRegistry.resetForTesting({ filePath: file });
+      reg.record(1234, 's1', 'gemini', ['--yolo']);
+      reg.record(9999, 's1', 'gemini', ['--yolo']); // session restarted, new pid
+
+      const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+      expect(data).toHaveLength(1);
+      expect(data[0].pid).toBe(9999);
+    });
+
+    it('remove() drops a session record', () => {
+      const reg = RuntimePidRegistry.resetForTesting({ filePath: file });
+      reg.record(1234, 's1', 'gemini', ['--yolo']);
+      reg.record(5678, 's2', 'claude', []);
+      reg.remove('s1');
+
+      const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+      expect(data).toHaveLength(1);
+      expect(data[0].sessionName).toBe('s2');
+    });
+
+    it('ignores invalid pids (<=1)', () => {
+      const reg = RuntimePidRegistry.resetForTesting({ filePath: file });
+      reg.record(1, 's1', 'init', []);
+      expect(fs.existsSync(file)).toBe(false);
+    });
+  });
+
+  describe('reapOrphans', () => {
+    it('returns 0 on an empty registry', () => {
+      const reg = RuntimePidRegistry.resetForTesting({ filePath: file });
+      expect(reg.reapOrphans()).toBe(0);
+    });
+
+    it('reaps a live PID whose cmdline still matches, and clears the file', () => {
+      const reg = RuntimePidRegistry.resetForTesting({
+        filePath: file,
+        cmdlineReader: (pid) => (pid === 4242 ? 'gemini --yolo' : null),
+      });
+      reg.record(4242, 'orc', 'gemini', ['--yolo']);
+      const killSpy = mockProcessKill(new Set([4242]));
+
+      const reaped = reg.reapOrphans();
+
+      expect(reaped).toBe(1);
+      expect(killSpy).toHaveBeenCalledWith(4242, 'SIGKILL');
+      expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGKILL'); // process group
+      expect(fs.readFileSync(file, 'utf8').trim()).toBe('[]');
+    });
+
+    it('does NOT reap when the live cmdline no longer matches (PID reuse)', () => {
+      const reg = RuntimePidRegistry.resetForTesting({
+        filePath: file,
+        cmdlineReader: () => 'nginx: master process', // PID reused by something else
+      });
+      reg.record(4242, 'orc', 'gemini', ['--yolo']);
+      const killSpy = mockProcessKill(new Set([4242]));
+
+      const reaped = reg.reapOrphans();
+
+      expect(reaped).toBe(0);
+      expect(killSpy).not.toHaveBeenCalledWith(4242, 'SIGKILL');
+    });
+
+    it('skips dead PIDs', () => {
+      const reg = RuntimePidRegistry.resetForTesting({
+        filePath: file,
+        cmdlineReader: () => 'gemini --yolo',
+      });
+      reg.record(4242, 'orc', 'gemini', ['--yolo']);
+      const killSpy = mockProcessKill(new Set()); // nothing alive
+
+      expect(reg.reapOrphans()).toBe(0);
+      expect(killSpy).not.toHaveBeenCalledWith(4242, 'SIGKILL');
+    });
+
+    it('reaps only the matching subset across mixed records', () => {
+      const reg = RuntimePidRegistry.resetForTesting({
+        filePath: file,
+        cmdlineReader: (pid) => {
+          if (pid === 100) return 'gemini --yolo'; // match → reap
+          if (pid === 200) return 'unrelated daemon'; // reused → skip
+          return null; // 300 dead/gone → skip
+        },
+      });
+      reg.record(100, 'a', 'gemini', ['--yolo']);
+      reg.record(200, 'b', 'gemini', ['--yolo']);
+      reg.record(300, 'c', 'gemini', ['--yolo']);
+      const killSpy = mockProcessKill(new Set([100, 200])); // 300 dead
+
+      expect(reg.reapOrphans()).toBe(1);
+      expect(killSpy).toHaveBeenCalledWith(100, 'SIGKILL');
+      expect(killSpy).not.toHaveBeenCalledWith(200, 'SIGKILL');
+    });
+  });
+
+  describe('helpers (real OS, no killing)', () => {
+    it('isPidAlive is true for the current process, false for a clearly-dead pid', () => {
+      expect(isPidAlive(process.pid)).toBe(true);
+      expect(isPidAlive(2_000_000_000)).toBe(false);
+      expect(isPidAlive(1)).toBe(false); // guarded
+    });
+
+    it('readProcessCmdline returns a cmdline for the current process and null for a dead pid', () => {
+      expect(readProcessCmdline(process.pid)).toBeTruthy();
+      expect(readProcessCmdline(2_000_000_000)).toBeNull();
+    });
+  });
+});

--- a/backend/src/services/session/runtime-pid-registry.service.ts
+++ b/backend/src/services/session/runtime-pid-registry.service.ts
@@ -1,0 +1,243 @@
+/**
+ * Runtime PID Registry
+ *
+ * Tracks the OS process ids of spawned agent-runtime PTY sessions so orphaned
+ * runtime processes can be reaped after a NON-graceful backend death (crash,
+ * OOM-kill, external `kill -9`, or the shutdown force-exit `SIGKILL`-self firing
+ * mid-cleanup). Normal teardown (`killSession`/`forceDestroyAll`) already reaps
+ * children; the gap this closes is the cross-restart one — a fresh backend has
+ * no record of the previous run's children, so they live on indefinitely
+ * (issue #715: ~7 stray `gemini --yolo` on Irissair since Feb).
+ *
+ * Safety is the whole point. The startup reaper:
+ *   1. only ever touches PIDs THIS backend recorded (never a broad `pkill`),
+ *   2. re-reads each live PID's command line and kills it ONLY if it still
+ *      matches the recorded spawn signature — so a PID reused by an unrelated
+ *      process after a crash is left untouched.
+ *
+ * @module services/session/runtime-pid-registry.service
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
+
+/** One recorded runtime process. */
+interface RuntimePidRecord {
+  /** OS process id of the PTY child. */
+  pid: number;
+  /** Owning session name. */
+  sessionName: string;
+  /** Normalised spawn command line (executable + args), used to verify identity. */
+  signature: string;
+  /** ISO timestamp when recorded. */
+  spawnedAt: string;
+}
+
+/** Registry file name under the Crewly home. */
+export const RUNTIME_PID_FILE = 'runtime-pids.json';
+
+/** Collapse whitespace + trim so signatures compare stably across `/proc` and `ps`. */
+function normalizeCmdline(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Read the live command line for a pid, cross-platform, or null if the process
+ * does not exist / is unreadable.
+ *
+ * - Linux: `/proc/<pid>/cmdline` (NUL-separated argv).
+ * - Other (macOS/BSD): `ps -o command= -p <pid>`.
+ *
+ * @param pid - Process id to inspect.
+ * @returns The normalised command line, or null.
+ */
+export function readProcessCmdline(pid: number): string | null {
+  // Linux fast path — read argv directly from /proc.
+  const procPath = `/proc/${pid}/cmdline`;
+  if (existsSync(procPath)) {
+    try {
+      const raw = readFileSync(procPath);
+      // argv is NUL-separated, trailing NUL.
+      const cmd = raw.toString('utf8').replace(/\0/g, ' ');
+      return normalizeCmdline(cmd) || null;
+    } catch {
+      return null;
+    }
+  }
+  // Portable fallback (macOS): ask `ps`.
+  try {
+    const out = execFileSync('ps', ['-o', 'command=', '-p', String(pid)], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const cmd = normalizeCmdline(out);
+    return cmd || null;
+  } catch {
+    // Non-zero exit = no such process.
+    return null;
+  }
+}
+
+/** Whether a pid is currently alive (signal 0 probe). */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return false; // never touch pid 0/1
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM = exists but not ours to signal → treat as alive (don't reap).
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Persistent, identity-verified registry of spawned runtime PIDs.
+ *
+ * Records are written on session spawn and removed on clean teardown; whatever
+ * remains at the next boot is a candidate orphan from a non-graceful death.
+ */
+export interface RuntimePidRegistryOptions {
+  /** Override the registry file location (tests). */
+  filePath?: string;
+  /** Override how a pid's live command line is read (tests). */
+  cmdlineReader?: (pid: number) => string | null;
+}
+
+export class RuntimePidRegistry {
+  private static instance: RuntimePidRegistry | null = null;
+  private readonly filePath: string;
+  private readonly cmdlineReader: (pid: number) => string | null;
+  private readonly logger: ComponentLogger;
+
+  private constructor(options: RuntimePidRegistryOptions = {}) {
+    this.filePath = options.filePath ?? path.join(getCrewlyHomePath(), RUNTIME_PID_FILE);
+    this.cmdlineReader = options.cmdlineReader ?? readProcessCmdline;
+    this.logger = LoggerService.getInstance().createComponentLogger('RuntimePidRegistry');
+  }
+
+  static getInstance(): RuntimePidRegistry {
+    if (!this.instance) this.instance = new RuntimePidRegistry();
+    return this.instance;
+  }
+
+  /** Reset for tests (optionally pointing at a temp file + stub cmdline reader). */
+  static resetForTesting(options: RuntimePidRegistryOptions = {}): RuntimePidRegistry {
+    this.instance = new RuntimePidRegistry(options);
+    return this.instance;
+  }
+
+  private read(): RuntimePidRecord[] {
+    if (!existsSync(this.filePath)) return [];
+    try {
+      const parsed = JSON.parse(readFileSync(this.filePath, 'utf8')) as unknown;
+      return Array.isArray(parsed) ? (parsed as RuntimePidRecord[]) : [];
+    } catch {
+      // Corrupt file — treat as empty (and it gets rewritten on next mutation).
+      return [];
+    }
+  }
+
+  private write(records: RuntimePidRecord[]): void {
+    try {
+      mkdirSync(path.dirname(this.filePath), { recursive: true });
+      writeFileSync(this.filePath, JSON.stringify(records, null, 2), 'utf8');
+    } catch (err) {
+      this.logger.warn('Failed to persist runtime PID registry (non-fatal)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Record a freshly spawned runtime process.
+   *
+   * @param pid - PTY child pid.
+   * @param sessionName - Owning session.
+   * @param command - Spawn executable.
+   * @param args - Spawn args.
+   */
+  record(pid: number, sessionName: string, command: string, args: string[] = []): void {
+    if (!Number.isInteger(pid) || pid <= 1) return;
+    const signature = normalizeCmdline([command, ...args].join(' '));
+    const records = this.read().filter((r) => r.sessionName !== sessionName && r.pid !== pid);
+    records.push({ pid, sessionName, signature, spawnedAt: new Date().toISOString() });
+    this.write(records);
+  }
+
+  /**
+   * Drop the record for a session we have torn down ourselves (so it is not a
+   * reap candidate next boot).
+   *
+   * @param sessionName - Session whose record to remove.
+   */
+  remove(sessionName: string): void {
+    const records = this.read();
+    const next = records.filter((r) => r.sessionName !== sessionName);
+    if (next.length !== records.length) this.write(next);
+  }
+
+  /** Clear all records (graceful shutdown reaped everything itself). */
+  clear(): void {
+    this.write([]);
+  }
+
+  /**
+   * Reap orphaned runtime processes left by a previous, non-graceful backend
+   * exit. Call ONCE at boot, before sessions are restored. Kills a recorded pid
+   * only if it is still alive AND its live command line still matches the
+   * recorded signature (guards against PID reuse). Clears the registry after.
+   *
+   * @returns The number of orphan processes reaped.
+   */
+  reapOrphans(): number {
+    const records = this.read();
+    if (records.length === 0) return 0;
+
+    let reaped = 0;
+    for (const rec of records) {
+      if (!isPidAlive(rec.pid)) continue;
+
+      const liveCmdline = this.cmdlineReader(rec.pid);
+      if (!liveCmdline || !liveCmdline.includes(rec.signature)) {
+        // Either unreadable, or the PID was reused by an unrelated process —
+        // do NOT kill. Log so a surprising mismatch is observable.
+        this.logger.warn('Skipping recorded PID — not a matching runtime (reused or changed)', {
+          pid: rec.pid,
+          sessionName: rec.sessionName,
+          expected: rec.signature,
+          live: liveCmdline ?? '(gone)',
+        });
+        continue;
+      }
+
+      // Verified orphan — SIGKILL the process and its group.
+      this.logger.error('Reaping orphaned runtime process from a previous backend run', {
+        pid: rec.pid,
+        sessionName: rec.sessionName,
+        signature: rec.signature,
+        spawnedAt: rec.spawnedAt,
+      });
+      try {
+        process.kill(rec.pid, 'SIGKILL');
+      } catch {
+        /* already gone between the probe and now */
+      }
+      try {
+        process.kill(-rec.pid, 'SIGKILL'); // process group
+      } catch {
+        /* no group / already gone */
+      }
+      reaped++;
+    }
+
+    // Whatever was recorded belongs to a prior run — this run records fresh.
+    this.clear();
+    if (reaped > 0) {
+      this.logger.warn('Orphan runtime reaper finished', { reaped, scanned: records.length });
+    }
+    return reaped;
+  }
+}


### PR DESCRIPTION
Closes #715.

## Why

Orphaned agent-runtime processes (`gemini --yolo`, `claude`, …) accumulate across **non-graceful** backend deaths — crash / OOM-kill / external `kill -9`, or the shutdown force-exit `SIGKILL`-self firing while `forceDestroyAll` is still mid SIGTERM→SIGKILL escalation. Normal teardown (`killSession` / `forceDestroyAll`) already reaps children; the gap is **cross-restart**: a fresh backend has no record of the previous run's PTY children (session-state persistence doesn't store PIDs), so they live for months. Irissair had ~7 stray `gemini --yolo` since Feb, a contributing factor to the 2026-06-02 `posix_spawnp` exhaustion.

## What

New `RuntimePidRegistry`:
- `record()` the PTY child PID + a normalised spawn signature on session create (`PtySessionBackend`), `remove()` on clean `killSession`, `clear()` on `forceDestroyAll`.
- `reapOrphans()` runs **once at boot, before any sessions are spawned/restored**.

## Safety (the whole point — never a broad `pkill`)

- Only ever touches PIDs **this backend recorded**.
- Re-reads each live PID's command line — Linux `/proc/<pid>/cmdline`, macOS `ps -o command=` — and SIGKILLs (pid **+ process group**) **only if it still matches the recorded signature**. A PID reused by an unrelated process after a crash is left untouched (and logged).

## Testing

- 11/11 registry tests: record / remove / replace-same-session / reap-on-match (+ clears file) / skip-on-cmdline-mismatch (PID reuse) / skip-dead / mixed-subset / real-OS helper probes. `process.kill` is spied in reap tests so **no real signal is ever sent**.
- Backend typecheck clean. Session suite otherwise green (the one unrelated `session-handoff` CHAT_RESUME failure is pre-existing — fails identically on `main`).

## Context

Final item from the Irissair orchestrator-hang investigation, after #712 (false delivery-confirm), #713 (hang detection + /health), #714 (auto-recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
