### PR TITLE
chore(release): 1.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
Version bump 1.11.3 → 1.11.4 to publish this session's batch (wiki BM25 memory recall + embedding/Knowledge retirement, Irissair orchestrator-hang fixes #712/#713/#714/#716, skill docs #313/#710). Full build verified green (backend + frontend + cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)