### PR TITLE
chore(release): 1.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [


### PR DESCRIPTION
Version bump 1.11.4 → 1.11.5 to publish the transcribe-audio (Whisper) skill (#718).

🤖 Generated with [Claude Code](https://claude.com/claude-code)