### PR TITLE
feat(browser): thread agentGoal through the takeover command path

### DIFF
--- a/backend/src/controllers/browser/browser.controller.test.ts
+++ b/backend/src/controllers/browser/browser.controller.test.ts
@@ -700,9 +700,34 @@ describe('Browser Controller — per-tab dispatch (M2)', () => {
 				'navigate',
 				expect.objectContaining({ url: 'https://example.com' }),
 				undefined,
-				expect.any(String)
+				expect.any(String),
+				undefined // agentGoal — none supplied on this request
 			);
 			expect(bridge.sendCommand).not.toHaveBeenCalled();
+		});
+
+		it('forwards the X-Agent-Goal header through to sendCommandForAgent', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const spy = jest
+				.spyOn(bridge, 'sendCommandForAgent')
+				.mockResolvedValue(okResponse);
+			jest.spyOn(bridge, 'sendCommand').mockResolvedValue(okResponse);
+
+			await request(app)
+				.post('/api/browser/navigate')
+				.set('X-Agent-Session', 'agent-A')
+				.set('X-Agent-Goal', 'Verify crewlyai.com DMARC setup')
+				.send({ url: 'https://example.com' });
+
+			expect(spy).toHaveBeenCalledWith(
+				'agent-A',
+				'navigate',
+				expect.objectContaining({ url: 'https://example.com' }),
+				undefined,
+				expect.any(String),
+				'Verify crewlyai.com DMARC setup' // agentGoal threaded from the header
+			);
 		});
 
 		it('falls back to sendCommand (legacy active-tab) when no agentSession is set', async () => {

--- a/backend/src/controllers/browser/browser.controller.test.ts
+++ b/backend/src/controllers/browser/browser.controller.test.ts
@@ -15,6 +15,19 @@ import {
 	BrowserBridgeService,
 	type BrowserCommandResponse,
 } from '../../services/browser/browser-bridge.service.js';
+import { TaskPoolService } from '../../services/task-pool/task-pool.service.js';
+
+// Mock the task pool so agentGoal auto-derive is deterministic: by default no
+// active claim → no derived goal (keeps tests that don't care unaffected).
+// Individual tests override getInstance to simulate a claimed work item.
+jest.mock('../../services/task-pool/task-pool.service.js', () => ({
+	TaskPoolService: {
+		getInstance: jest.fn(() => ({
+			getClaimService: () => ({ getActiveClaimByAgent: jest.fn().mockResolvedValue(undefined) }),
+			findWorkItem: jest.fn().mockResolvedValue(null),
+		})),
+	},
+}));
 
 // Mock logger
 jest.mock('../../services/core/logger.service.js', () => ({
@@ -727,6 +740,37 @@ describe('Browser Controller — per-tab dispatch (M2)', () => {
 				undefined,
 				expect.any(String),
 				'Verify crewlyai.com DMARC setup' // agentGoal threaded from the header
+			);
+		});
+
+		it('auto-derives agentGoal from the agent\'s active work item when no header is set', async () => {
+			const bridge = BrowserBridgeService.getInstance();
+			markBridgeConnected(bridge);
+			const spy = jest
+				.spyOn(bridge, 'sendCommandForAgent')
+				.mockResolvedValue(okResponse);
+			jest.spyOn(bridge, 'sendCommand').mockResolvedValue(okResponse);
+
+			// Agent 'agent-A' has an active claim on a work item titled "Fix the login bug".
+			(TaskPoolService.getInstance as jest.Mock).mockReturnValueOnce({
+				getClaimService: () => ({
+					getActiveClaimByAgent: jest.fn().mockResolvedValue({ workItemId: 'wi-9' }),
+				}),
+				findWorkItem: jest.fn().mockResolvedValue({ title: 'Fix the login bug' }),
+			});
+
+			await request(app)
+				.post('/api/browser/navigate')
+				.set('X-Agent-Session', 'agent-A')
+				.send({ url: 'https://example.com' }); // note: NO X-Agent-Goal header
+
+			expect(spy).toHaveBeenCalledWith(
+				'agent-A',
+				'navigate',
+				expect.objectContaining({ url: 'https://example.com' }),
+				undefined,
+				expect.any(String),
+				'Fix the login bug' // auto-derived from the work item title
 			);
 		});
 

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -187,6 +187,26 @@ function extractAgentSession(req: Request): string | undefined {
 }
 
 /**
+ * Extract the agent's goal/objective from request headers or body.
+ *
+ * Shown as a secondary line in the extension takeover banner so the user
+ * knows *what* the agent is trying to accomplish, not just which tool ran.
+ * The caller (the agent's browser tool / drive source) is responsible for
+ * the goal's value — typically the agent's current work-item description,
+ * or an explicit per-action override. The controller only forwards it.
+ *
+ * @param req - Express request
+ * @returns Goal string or undefined when not supplied
+ */
+function extractAgentGoal(req: Request): string | undefined {
+	const fromHeader = req.headers['x-agent-goal'];
+	if (typeof fromHeader === 'string' && fromHeader.length > 0) return fromHeader;
+	const fromBody = (req.body as { agentGoal?: unknown } | undefined)?.agentGoal;
+	if (typeof fromBody === 'string' && fromBody.length > 0) return fromBody;
+	return undefined;
+}
+
+/**
  * Cross-agent ownership guard for the explicit `tabId` override path.
  *
  * Per spec §13.5: if a request supplies an explicit `tabId` that is bound
@@ -263,6 +283,7 @@ async function sendToolCommand(
 	const instance = resolveInstanceParam(req);
 	const agentName = extractAgentName(req);
 	const agentSession = extractAgentSession(req);
+	const agentGoal = extractAgentGoal(req);
 
 	// Per-tab ownership: explicit `tabId` in body must belong to this agent.
 	// When the check passes and a tabId was present, fold it into params so
@@ -280,7 +301,7 @@ async function sendToolCommand(
 	// Path 1: If a specific instance is requested AND proxy is available, use proxy
 	if (instance && proxy.isAvailable()) {
 		try {
-			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession);
+			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession, agentGoal);
 			res.json(result);
 			return;
 		} catch (err) {
@@ -294,8 +315,8 @@ async function sendToolCommand(
 	if (bridge.isConnected()) {
 		try {
 			const result = agentSession
-				? await bridge.sendCommandForAgent(agentSession, tool, params, timeoutMs, agentName)
-				: await bridge.sendCommand(tool, params, timeoutMs, agentName);
+				? await bridge.sendCommandForAgent(agentSession, tool, params, timeoutMs, agentName, agentGoal)
+				: await bridge.sendCommand(tool, params, timeoutMs, agentName, agentGoal);
 			res.json(result);
 			return;
 		} catch (err) {
@@ -307,7 +328,7 @@ async function sendToolCommand(
 	// Path 3: Proxy relay (relay_to addressed messaging)
 	if (proxy.isAvailable()) {
 		try {
-			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession);
+			const result = await proxy.sendCommand(tool, params, instance, timeoutMs, agentName, agentSession, agentGoal);
 			res.json(result);
 			return;
 		} catch (err) {

--- a/backend/src/controllers/browser/browser.controller.ts
+++ b/backend/src/controllers/browser/browser.controller.ts
@@ -12,6 +12,7 @@ import type { Request, Response } from 'express';
 import { BrowserBridgeService } from '../../services/browser/browser-bridge.service.js';
 import { BrowserProxyService } from '../../services/browser/browser-proxy.service.js';
 import { CloudClientService } from '../../services/cloud/cloud-client.service.js';
+import { TaskPoolService } from '../../services/task-pool/task-pool.service.js';
 import { BROWSER_BRIDGE_CONSTANTS } from '../../constants.js';
 
 /**
@@ -191,19 +192,38 @@ function extractAgentSession(req: Request): string | undefined {
  *
  * Shown as a secondary line in the extension takeover banner so the user
  * knows *what* the agent is trying to accomplish, not just which tool ran.
- * The caller (the agent's browser tool / drive source) is responsible for
- * the goal's value — typically the agent's current work-item description,
- * or an explicit per-action override. The controller only forwards it.
+ *
+ * Resolution order ("both" model):
+ *   1. Explicit override — `X-Agent-Goal` header or `agentGoal` body field
+ *      (the remote-browser skill's `--goal`). Always wins; most accurate.
+ *   2. Auto — the title of the agent's currently-claimed work item, looked
+ *      up by `agentSession`. Lets the banner show intent with zero agent
+ *      effort. Best-effort: any miss/error yields `undefined` (banner falls
+ *      back to a generic title).
  *
  * @param req - Express request
- * @returns Goal string or undefined when not supplied
+ * @returns Goal string or undefined when none can be determined
  */
-function extractAgentGoal(req: Request): string | undefined {
+async function extractAgentGoal(req: Request): Promise<string | undefined> {
 	const fromHeader = req.headers['x-agent-goal'];
 	if (typeof fromHeader === 'string' && fromHeader.length > 0) return fromHeader;
 	const fromBody = (req.body as { agentGoal?: unknown } | undefined)?.agentGoal;
 	if (typeof fromBody === 'string' && fromBody.length > 0) return fromBody;
-	return undefined;
+
+	// Auto-derive from the agent's active work item (no override supplied).
+	const agentSession = extractAgentSession(req);
+	if (!agentSession) return undefined;
+	try {
+		const pool = TaskPoolService.getInstance();
+		const claim = await pool.getClaimService().getActiveClaimByAgent(agentSession);
+		if (!claim) return undefined;
+		const workItem = await pool.findWorkItem(claim.workItemId);
+		const title = workItem?.title?.trim();
+		return title ? title : undefined;
+	} catch {
+		// Task pool unavailable / lookup failed — banner just omits the goal.
+		return undefined;
+	}
 }
 
 /**
@@ -283,7 +303,7 @@ async function sendToolCommand(
 	const instance = resolveInstanceParam(req);
 	const agentName = extractAgentName(req);
 	const agentSession = extractAgentSession(req);
-	const agentGoal = extractAgentGoal(req);
+	const agentGoal = await extractAgentGoal(req);
 
 	// Per-tab ownership: explicit `tabId` in body must belong to this agent.
 	// When the check passes and a tabId was present, fold it into params so

--- a/backend/src/services/browser/browser-bridge.service.ts
+++ b/backend/src/services/browser/browser-bridge.service.ts
@@ -61,6 +61,8 @@ export interface BrowserCommand {
 	params?: Record<string, unknown>;
 	/** Name of the agent sending this command (displayed in extension banner) */
 	agentName?: string;
+	/** What the agent is trying to accomplish (displayed in extension banner) */
+	agentGoal?: string;
 }
 
 /** Response from Chrome Extension */
@@ -369,6 +371,7 @@ export class BrowserBridgeService {
 	 * @param params - Tool parameters
 	 * @param timeoutMs - Command timeout in milliseconds
 	 * @param agentName - Optional agent name to display in the extension banner
+	 * @param agentGoal - Optional agent goal/objective to display in the banner
 	 * @returns Response from the Chrome Extension
 	 * @throws Error if no client is connected or command times out
 	 */
@@ -376,7 +379,8 @@ export class BrowserBridgeService {
 		tool: string,
 		params?: Record<string, unknown>,
 		timeoutMs: number = BROWSER_BRIDGE_CONSTANTS.COMMAND_TIMEOUT_MS,
-		agentName?: string
+		agentName?: string,
+		agentGoal?: string
 	): Promise<BrowserCommandResponse> {
 		const client = this.getActiveClient();
 
@@ -400,13 +404,13 @@ export class BrowserBridgeService {
 			const proxy = BrowserProxyService.getInstance();
 			if (proxy.isAvailable()) {
 				this.logger.info('No direct WS client, routing via BrowserProxy', { tool });
-				return proxy.sendCommand(tool, params, undefined, timeoutMs, agentName);
+				return proxy.sendCommand(tool, params, undefined, timeoutMs, agentName, undefined, agentGoal);
 			}
 			const { BrowserRelayAdapter } = await import('./browser-relay-adapter.service.js');
 			const relayAdapter = BrowserRelayAdapter.getInstance();
 			if (relayAdapter.isAvailable()) {
 				this.logger.info('No direct WS client and no proxy, routing via legacy adapter', { tool });
-				return relayAdapter.sendViaRelay(tool, params, timeoutMs, agentName);
+				return relayAdapter.sendViaRelay(tool, params, timeoutMs, agentName, agentGoal);
 			}
 			throw new Error('No Chrome Extension connected (direct WS, BrowserProxy, or Cloud relay)');
 		}
@@ -415,6 +419,9 @@ export class BrowserBridgeService {
 		const command: BrowserCommand = { id, tool, params };
 		if (agentName) {
 			command.agentName = agentName;
+		}
+		if (agentGoal) {
+			command.agentGoal = agentGoal;
 		}
 
 		return new Promise<BrowserCommandResponse>((resolve, reject) => {
@@ -599,13 +606,15 @@ export class BrowserBridgeService {
 	 * @param params Tool params; if it contains `tabId` we treat as explicit override.
 	 * @param timeoutMs Optional command timeout.
 	 * @param agentName Optional agent name for the Extension banner.
+	 * @param agentGoal Optional agent goal/objective for the Extension banner.
 	 */
 	async sendCommandForAgent(
 		agentSession: string | undefined,
 		tool: string,
 		params?: Record<string, unknown>,
 		timeoutMs?: number,
-		agentName?: string
+		agentName?: string,
+		agentGoal?: string
 	): Promise<BrowserCommandResponse> {
 		// Path 1: explicit tabId override — pass through, log so it's auditable.
 		if (params && typeof (params as { tabId?: unknown }).tabId === 'number') {
@@ -614,12 +623,12 @@ export class BrowserBridgeService {
 				tabId: (params as { tabId?: number }).tabId,
 				tool,
 			});
-			return this.sendCommand(tool, params, timeoutMs, agentName);
+			return this.sendCommand(tool, params, timeoutMs, agentName, agentGoal);
 		}
 
 		// Path 4: no agent session — legacy active-tab path.
 		if (!agentSession) {
-			return this.sendCommand(tool, params, timeoutMs, agentName);
+			return this.sendCommand(tool, params, timeoutMs, agentName, agentGoal);
 		}
 
 		// Path 2 / 3: resolve binding, auto-bind on miss.
@@ -631,7 +640,7 @@ export class BrowserBridgeService {
 		binding.lastActivityAt = new Date();
 
 		const merged: Record<string, unknown> = { ...(params ?? {}), tabId: binding.tabId };
-		return this.sendCommand(tool, merged, timeoutMs, agentName);
+		return this.sendCommand(tool, merged, timeoutMs, agentName, agentGoal);
 	}
 
 	/**

--- a/backend/src/services/browser/browser-proxy.service.test.ts
+++ b/backend/src/services/browser/browser-proxy.service.test.ts
@@ -322,6 +322,36 @@ describe('BrowserProxyService', () => {
       expect(result.id).toBe(cmdId);
     });
 
+    it('includes agentName + agentGoal in the relay_to payload for the takeover banner', async () => {
+      connectAndRegister();
+      const proxy = BrowserProxyService.getInstance();
+
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({
+          type: 'browser_list',
+          instances: [{ instanceId: 'id-1', instanceName: 'Chrome', sessionId: 'bs-1' }],
+        }),
+      );
+
+      // tool, params, instance, timeoutMs, agentName, agentSession, agentGoal.
+      // agentSession omitted on purpose: supplying it triggers an async tabId-
+      // binding import that defers the send past our synchronous lastCall read.
+      const cmdPromise = proxy.sendCommand('navigate', { url: 'https://x.com' }, undefined, 5000, 'researcher-1', undefined, 'Verify DMARC setup');
+
+      const sentMsg = JSON.parse(latestMockWs!.send.mock.lastCall![0] as string);
+      const payload = JSON.parse(sentMsg.payload as string);
+      expect(payload.agentName).toBe('researcher-1');
+      expect(payload.agentGoal).toBe('Verify DMARC setup');
+
+      // Resolve the pending command so no timer/promise dangles into the next test.
+      latestMockWs!._trigger(
+        'message',
+        JSON.stringify({ type: 'relay', payload: JSON.stringify({ id: payload.id, success: true, result: {} }) }),
+      );
+      await cmdPromise;
+    });
+
     it('updates lastSeenAt on the matching instance when a relay carries senderSessionId', () => {
       connectAndRegister();
       const proxy = BrowserProxyService.getInstance();

--- a/backend/src/services/browser/browser-proxy.service.ts
+++ b/backend/src/services/browser/browser-proxy.service.ts
@@ -485,6 +485,8 @@ export class BrowserProxyService {
    * @param instance - Target instance name or ID (optional if only 1 connected)
    * @param timeoutMs - Command timeout in milliseconds
    * @param agentName - Agent name for extension banner display
+   * @param agentSession - Owning agent session (per-tab binding lookup)
+   * @param agentGoal - What the agent is trying to accomplish (banner display)
    * @returns Response from the Chrome Extension
    * @throws Error if no instances available, target not found, or timeout
    */
@@ -495,6 +497,7 @@ export class BrowserProxyService {
     timeoutMs: number = BROWSER_BRIDGE_CONSTANTS.COMMAND_TIMEOUT_MS,
     agentName?: string,
     agentSession?: string,
+    agentGoal?: string,
   ): Promise<BrowserCommandResponse> {
     if (this.state !== 'connected' || !this.ws) {
       throw new Error('Browser proxy not connected to relay');
@@ -559,6 +562,7 @@ export class BrowserProxyService {
       tool,
       params: resolvedParams,
       agentName,
+      agentGoal,
     });
 
     return new Promise<BrowserCommandResponse>((resolve, reject) => {

--- a/backend/src/services/browser/browser-relay-adapter.service.ts
+++ b/backend/src/services/browser/browser-relay-adapter.service.ts
@@ -171,6 +171,7 @@ export class BrowserRelayAdapter {
    * @param params - Tool parameters
    * @param timeoutMs - Command timeout in milliseconds
    * @param agentName - Optional agent name for display in Extension
+   * @param agentGoal - Optional agent goal/objective for display in Extension
    * @returns Response from the Chrome Extension
    * @throws Error if relay is not available or command times out
    */
@@ -179,6 +180,7 @@ export class BrowserRelayAdapter {
     params?: Record<string, unknown>,
     timeoutMs: number = BROWSER_BRIDGE_CONSTANTS.COMMAND_TIMEOUT_MS,
     agentName?: string,
+    agentGoal?: string,
   ): Promise<BrowserCommandResponse> {
     if (!this.extensionDeviceId) {
       throw new Error('No Extension device ID set — cannot send via relay');
@@ -193,6 +195,9 @@ export class BrowserRelayAdapter {
     const command: BrowserCommand = { id, tool, params };
     if (agentName) {
       command.agentName = agentName;
+    }
+    if (agentGoal) {
+      command.agentGoal = agentGoal;
     }
 
     return new Promise<BrowserCommandResponse>((resolve, reject) => {

--- a/config/skills/_common/lib.sh
+++ b/config/skills/_common/lib.sh
@@ -101,6 +101,12 @@ api_call() {
   # Include agent session identity header for heartbeat tracking
   # Use ${VAR:-} pattern to avoid 'unbound variable' error under set -u (nounset)
   [ -n "${CREWLY_SESSION_NAME:-}" ] && args+=(-H "X-Agent-Session: $CREWLY_SESSION_NAME")
+  # Forward the agent's current goal/objective so user-facing surfaces (e.g.
+  # the Chrome takeover banner) can show *what* the agent is doing. The
+  # backend reads it as the X-Agent-Goal header; callers either export
+  # CREWLY_AGENT_GOAL (auto) or set it per-command (e.g. remote-browser's
+  # --goal override exports it before this call).
+  [ -n "${CREWLY_AGENT_GOAL:-}" ] && args+=(-H "X-Agent-Goal: $CREWLY_AGENT_GOAL")
   [ -n "$body" ] && args+=(-d "$body")
 
   local response

--- a/config/skills/agent/remote-browser/execute.sh
+++ b/config/skills/agent/remote-browser/execute.sh
@@ -42,6 +42,11 @@
 #                       call (drops the X-Agent-Session header).
 #   --active            Only meaningful with `bind-tab`: foreground
 #                       the new tab on creation.
+#   --goal <text>       What you're trying to accomplish. Sent as the
+#                       X-Agent-Goal header so the user's Chrome takeover
+#                       banner shows your objective (e.g. "Verify DMARC
+#                       setup"), not just the current tool. Overrides any
+#                       inherited CREWLY_AGENT_GOAL for this call.
 #
 # Supported actions and their parameters:
 #   status              — connection status (no params)
@@ -86,6 +91,9 @@ EXTRA_PARAMS=""
 TAB_ID=""        # --tab-id <N>: explicit override
 NO_BIND="false"  # --no-bind: drop X-Agent-Session for this call
 FOREGROUND="false" # --active: only meaningful with bind-tab
+GOAL=""          # --goal <text>: what the agent is trying to accomplish
+                 # (shown in the Chrome takeover banner). Overrides any
+                 # inherited CREWLY_AGENT_GOAL for this call.
 
 # Detect legacy JSON argument
 if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
@@ -119,6 +127,10 @@ while [[ $# -gt 0 ]]; do
       CODE="$2"
       shift 2
       ;;
+    --goal|-g)
+      GOAL="$2"
+      shift 2
+      ;;
     --params|-P)
       EXTRA_PARAMS="$2"
       shift 2
@@ -142,6 +154,11 @@ while [[ $# -gt 0 ]]; do
     --help|-h)
       echo "Usage: execute.sh --action navigate --url https://example.com"
       echo "       execute.sh '{\"action\":\"screenshot\"}'"
+      echo "       execute.sh --action navigate --url https://x.com --goal 'Check pricing'"
+      echo ""
+      echo "  --goal <text>  What you're trying to accomplish; shown in the"
+      echo "                 user's Chrome takeover banner. Recommended on the"
+      echo "                 first action of a browser task."
       echo ""
       echo "Actions: status, navigate, screenshot, read-text, click, fill, type,"
       echo "         scroll, hover, press-key, get-element, wait-for-selector,"
@@ -184,6 +201,7 @@ if [ -n "$INPUT_JSON" ]; then
   [ -z "$VALUE" ] && VALUE=$(printf '%s' "$INPUT" | jq -r '.value // empty')
   [ -z "$TEXT" ] && TEXT=$(printf '%s' "$INPUT" | jq -r '.text // empty')
   [ -z "$CODE" ] && CODE=$(printf '%s' "$INPUT" | jq -r '.code // empty')
+  [ -z "$GOAL" ] && GOAL=$(printf '%s' "$INPUT" | jq -r '.goal // empty')
   # Per-tab dispatch fields surfaced in JSON input. CLI flags win over JSON
   # (CLI is more explicit). Empty string = "not provided".
   if [ -z "$TAB_ID" ]; then
@@ -200,7 +218,7 @@ if [ -n "$INPUT_JSON" ]; then
   # Capture all extra fields from JSON input as pass-through params (strip
   # per-tab fields too — they're handled by the dedicated branches below).
   if [ -z "$EXTRA_PARAMS" ]; then
-    EXTRA_PARAMS=$(printf '%s' "$INPUT" | jq -c 'del(.action, .url, .selector, .value, .text, .code, .tabId, .noBind, .active) | if length == 0 then empty else . end' 2>/dev/null || true)
+    EXTRA_PARAMS=$(printf '%s' "$INPUT" | jq -c 'del(.action, .url, .selector, .value, .text, .code, .goal, .tabId, .noBind, .active) | if length == 0 then empty else . end' 2>/dev/null || true)
   fi
 fi
 
@@ -492,6 +510,15 @@ esac
 # `--no-bind` short-circuits backend per-tab routing by stripping the
 # X-Agent-Session header for this single call (api_call reads it from the
 # env). Using a subshell to scope the unset.
+
+# An explicit --goal (or JSON `goal`) overrides any inherited CREWLY_AGENT_GOAL
+# for this call. lib.sh::api_call reads CREWLY_AGENT_GOAL and forwards it as the
+# X-Agent-Goal header, which the backend stamps onto the browser command so the
+# Chrome takeover banner shows what the agent is doing. When --goal is absent we
+# leave CREWLY_AGENT_GOAL untouched (auto path).
+if [ -n "$GOAL" ]; then
+  export CREWLY_AGENT_GOAL="$GOAL"
+fi
 
 run_api_call() {
   if [ "$METHOD" = "GET" ]; then

--- a/config/skills/agent/remote-browser/execute.test.sh
+++ b/config/skills/agent/remote-browser/execute.test.sh
@@ -468,6 +468,30 @@ total_reqs=$(wc -l < "$LOG_FILE" | tr -d ' ')
 assert_eq "stub received 0 requests" "0" "$total_reqs"
 scenario_teardown
 
+# Scenario 20: --goal forwards the X-Agent-Goal header (takeover banner)
+scenario_init "scenario 20: --goal forwards X-Agent-Goal"
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+unset CREWLY_AGENT_GOAL 2>/dev/null || true
+"$SKILL" --action navigate --url https://x.com --goal "Verify DMARC setup" > /dev/null 2>&1 || true
+assert_eq "X-Agent-Goal from --goal" "Verify DMARC setup" "$(request_field 0 headers.X-Agent-Goal)"
+scenario_teardown
+
+# Scenario 21: CREWLY_AGENT_GOAL env auto-forwards; --goal overrides it
+scenario_init "scenario 21: CREWLY_AGENT_GOAL auto-forwards + --goal override"
+queue_response '{"success":true,"data":{}}'
+queue_response '{"success":true,"data":{}}'
+start_stub
+unset CREWLY_SESSION_NAME
+export CREWLY_AGENT_GOAL="Goal from env"
+"$SKILL" --action navigate --url https://x.com > /dev/null 2>&1 || true
+assert_eq "auto X-Agent-Goal from env" "Goal from env" "$(request_field 0 headers.X-Agent-Goal)"
+"$SKILL" --action navigate --url https://y.com --goal "Override goal" > /dev/null 2>&1 || true
+assert_eq "--goal overrides env" "Override goal" "$(request_field 1 headers.X-Agent-Goal)"
+unset CREWLY_AGENT_GOAL
+scenario_teardown
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Adds a per-command **goal** (what the agent is trying to accomplish) alongside the existing `agentName`, so the Chrome extension's takeover banner can show *intent*, not just the tool name:

```
● Crewly · researcher-1
🎯 Verify crewlyai.com DMARC setup
· Reading page…
```

## Changes
- `browser.controller.ts`: `extractAgentGoal` (`X-Agent-Goal` header / `agentGoal` body) + threaded into all 3 dispatch paths. **The controller only forwards** — the goal's value (auto from the agent's current work-item, or an explicit override) is the caller/source's responsibility (next).
- `browser-proxy.service.ts`: `agentGoal` param + `relay_to` payload field.
- `browser-bridge.service.ts`: `BrowserCommand.agentGoal`; `sendCommand` + `sendCommandForAgent` params; threaded to proxy / adapter / direct-WS.
- `browser-relay-adapter.service.ts`: `sendViaRelay` `agentGoal` (legacy path, kept consistent).

## Tests
- controller forwards `X-Agent-Goal` → `sendCommandForAgent` (6th arg)
- proxy `relay_to` payload includes `agentName` + `agentGoal`
- Browser suite **165 green**. (Pre-existing unrelated typecheck errors in non-browser `*.test.ts` left untouched.)

## Companion
Receiving/rendering end: **crewly-extension#8** (renders `Crewly · <name>` + `🎯 <goal>`). Source that *sets* the goal (auto-from-work-item + override) is the final piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)