### PR TITLE
feat(backup): P0 — workspace backup archive builder + crewly backup create

### DIFF
--- a/backend/src/services/backup/backup-archive.service.test.ts
+++ b/backend/src/services/backup/backup-archive.service.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for BackupArchiveService (P0).
+ *
+ * Builds a throwaway CREWLY_HOME + a git-backed project, archives it, and
+ * asserts the manifest scope (includes portable data, excludes machine-
+ * specific/secret/runtime), git provenance, and archive integrity.
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extract as tarExtract } from 'tar';
+import { BackupArchiveService } from './backup-archive.service.js';
+
+const CREATED_AT = '2026-06-07T20:00:00.000Z';
+
+/** Silent logger stub so tests don't spew. */
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as ConstructorParameters<typeof BackupArchiveService>[0];
+
+let home: string;
+let projectPath: string;
+let outDir: string;
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-home-'));
+  outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-out-'));
+  projectPath = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-proj-'));
+
+  // ── Portable globals (should be IN) ──
+  await fs.writeFile(path.join(home, 'settings.json'), JSON.stringify({ theme: 'dark' }), 'utf8');
+  await fs.mkdir(path.join(home, 'teams', 't1'), { recursive: true });
+  await fs.writeFile(path.join(home, 'teams', 't1', 'config.json'), JSON.stringify({ id: 't1' }), 'utf8');
+  await fs.mkdir(path.join(home, 'global-wiki'), { recursive: true });
+  await fs.writeFile(path.join(home, 'global-wiki', 'note.md'), '# learned thing', 'utf8');
+
+  // ── Machine-specific / secret / runtime / recursion (should be OUT) ──
+  await fs.writeFile(path.join(home, 'device.json'), '{"id":"dev-A"}', 'utf8');
+  await fs.mkdir(path.join(home, 'cloud'), { recursive: true });
+  await fs.writeFile(path.join(home, 'cloud', 'config.json'), '{"token":"secret"}', 'utf8');
+  await fs.writeFile(path.join(home, 'telegram-credentials.json'), '{"token":"x"}', 'utf8');
+  await fs.mkdir(path.join(home, 'logs'), { recursive: true });
+  await fs.writeFile(path.join(home, 'logs', 'app.log'), 'noise', 'utf8');
+  await fs.mkdir(path.join(home, 'teams-backup-history'), { recursive: true });
+  await fs.writeFile(path.join(home, 'teams-backup-history', 'teams-backup-000.json'), '{}', 'utf8');
+  await fs.mkdir(path.join(home, 'agents', 'sess-a', 'sessions'), { recursive: true });
+  await fs.writeFile(path.join(home, 'agents', 'sess-a', 'self-model.json'), '{"v":1}', 'utf8'); // IN
+  await fs.writeFile(path.join(home, 'agents', 'sess-a', 'sessions', 'x.jsonl'), 'line', 'utf8'); // OUT (dir + .jsonl)
+
+  // ── A git-backed project with .crewly data ──
+  await fs.mkdir(path.join(projectPath, '.crewly', 'wiki'), { recursive: true });
+  await fs.writeFile(path.join(projectPath, '.crewly', 'wiki', 'arch.md'), '# project wiki', 'utf8');
+  await fs.mkdir(path.join(projectPath, '.crewly', 'logs', 'daily'), { recursive: true });
+  await fs.writeFile(path.join(projectPath, '.crewly', 'logs', 'daily', 'd.md'), 'log', 'utf8'); // OUT
+  const git = (args: string[]) => execFileSync('git', ['-C', projectPath, ...args], { stdio: 'ignore' });
+  git(['init', '-q']);
+  git(['remote', 'add', 'origin', 'git@github.com:acme/web.git']);
+  git(['add', '-A']);
+  git(['-c', 'user.email=t@t.io', '-c', 'user.name=t', 'commit', '-qm', 'init']);
+
+  await fs.writeFile(
+    path.join(home, 'projects.json'),
+    JSON.stringify([{ id: 'p1', name: 'web', path: projectPath }]),
+    'utf8',
+  );
+});
+
+afterEach(async () => {
+  for (const d of [home, outDir, projectPath]) await fs.rm(d, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('BackupArchiveService.createArchive', () => {
+  it('captures portable globals + project .crewly and excludes machine/secret/runtime data', async () => {
+    const svc = new BackupArchiveService(silentLogger);
+    const out = path.join(outDir, 'wb.tar.gz');
+    const { manifest, archivePath } = await svc.createArchive({
+      homePath: home,
+      outPath: out,
+      excludeChatDb: true,
+      createdAt: CREATED_AT,
+    });
+
+    expect(archivePath).toBe(out);
+    expect(await fs.stat(out)).toBeTruthy();
+
+    const globalPaths = manifest.global.map((g) => g.path);
+    // IN
+    expect(globalPaths).toContain('home/settings.json');
+    expect(globalPaths).toContain('home/teams/t1/config.json');
+    expect(globalPaths).toContain('home/global-wiki/note.md');
+    expect(globalPaths).toContain('home/agents/sess-a/self-model.json');
+    // OUT
+    expect(globalPaths).not.toContain('home/device.json');
+    expect(globalPaths.some((p) => p.startsWith('home/cloud/'))).toBe(false);
+    expect(globalPaths).not.toContain('home/telegram-credentials.json');
+    expect(globalPaths.some((p) => p.startsWith('home/logs/'))).toBe(false);
+    expect(globalPaths.some((p) => p.startsWith('home/teams-backup-history/'))).toBe(false);
+    expect(globalPaths.some((p) => p.endsWith('.jsonl'))).toBe(false);
+    expect(globalPaths.some((p) => p.includes('/sessions/'))).toBe(false);
+  });
+
+  it('records each project with git provenance and excludes project logs', async () => {
+    const svc = new BackupArchiveService(silentLogger);
+    const { manifest } = await svc.createArchive({
+      homePath: home,
+      outPath: path.join(outDir, 'wb.tar.gz'),
+      excludeChatDb: true,
+      createdAt: CREATED_AT,
+    });
+
+    expect(manifest.projects).toHaveLength(1);
+    const p = manifest.projects[0];
+    expect(p.id).toBe('p1');
+    expect(p.sourcePath).toBe(projectPath);
+    expect(p.git.remote).toBe('git@github.com:acme/web.git');
+    expect(p.git.commit).toMatch(/^[0-9a-f]{40}$/);
+    const projPaths = p.files.map((f) => f.path);
+    expect(projPaths).toContain('projects/p1/.crewly/wiki/arch.md');
+    expect(projPaths.some((pp) => pp.includes('/logs/'))).toBe(false);
+  });
+
+  it('records chatDb as excluded when the option is set', async () => {
+    const svc = new BackupArchiveService(silentLogger);
+    const { manifest } = await svc.createArchive({
+      homePath: home,
+      outPath: path.join(outDir, 'wb.tar.gz'),
+      excludeChatDb: true,
+      createdAt: CREATED_AT,
+    });
+    expect(manifest.chatDb.included).toBe(false);
+    expect(manifest.chatDb.skippedReason).toBe('excluded by option');
+  });
+
+  it('produces an extractable archive whose files match the manifest checksums', async () => {
+    const svc = new BackupArchiveService(silentLogger);
+    const out = path.join(outDir, 'wb.tar.gz');
+    const { manifest } = await svc.createArchive({
+      homePath: home,
+      outPath: out,
+      excludeChatDb: true,
+      createdAt: CREATED_AT,
+    });
+
+    const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-x-'));
+    try {
+      await tarExtract({ file: out, cwd: extractDir });
+      // manifest.json present + parseable
+      const m = JSON.parse(await fs.readFile(path.join(extractDir, 'manifest.json'), 'utf8'));
+      expect(m.schemaVersion).toBe(manifest.schemaVersion);
+      // a captured file extracted with the right content
+      const settings = await fs.readFile(path.join(extractDir, 'home', 'settings.json'), 'utf8');
+      expect(JSON.parse(settings)).toEqual({ theme: 'dark' });
+      // checksum recorded and non-empty for every entry
+      for (const g of manifest.global) expect(g.sha256).toMatch(/^[0-9a-f]{64}$/);
+    } finally {
+      await fs.rm(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when CREWLY_HOME does not exist', async () => {
+    const svc = new BackupArchiveService(silentLogger);
+    await expect(
+      svc.createArchive({ homePath: path.join(home, 'nope'), createdAt: CREATED_AT, outPath: path.join(outDir, 'x.tgz') }),
+    ).rejects.toThrow(/CREWLY_HOME not found/);
+  });
+});

--- a/backend/src/services/backup/backup-archive.service.ts
+++ b/backend/src/services/backup/backup-archive.service.ts
@@ -1,0 +1,337 @@
+/**
+ * Backup Archive Service (P0)
+ *
+ * Builds a portable workspace backup: a single `.tar.gz` containing a
+ * top-level `manifest.json`, the captured `CREWLY_HOME` globals (under
+ * `home/`), each project's `.crewly/` tree (under `projects/<id>/`), and
+ * optionally `chat.db`.
+ *
+ * Runs locally with no Cloud dependency — `crewly backup create`. The Cloud
+ * upload/park step (Pro-gated) is a later phase and consumes the archive this
+ * service produces. See specs/2026-06-07-workspace-backup.md.
+ *
+ * @module services/backup/backup-archive.service
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { create as tarCreate } from 'tar';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
+import { safeReadJson } from '../../utils/file-io.utils.js';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import {
+  BACKUP_SCHEMA_VERSION,
+  type BackupFileEntry,
+  type BackupManifest,
+  type BackupProjectEntry,
+  type CreateBackupOptions,
+  type CreateBackupResult,
+} from './backup.types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Top-level CREWLY_HOME entries that are MACHINE-SPECIFIC, secret, runtime, or
+ * would cause recursion — never captured. chat.db is handled separately via
+ * the SQLite online backup API, so it's excluded from the generic file walk.
+ */
+const GLOBAL_EXCLUDE_TOPLEVEL = new Set<string>([
+  'device.json',
+  'cloud',
+  'credentials',
+  'telegram-credentials.json',
+  'runtime.json',
+  '.orchestrator-state',
+  'session-state.json',
+  'logs',
+  'teams-backup.json',
+  'teams-backup-history',
+  'backups', // our own output dir
+  'chat.db',
+  'chat.db-wal',
+  'chat.db-shm',
+]);
+
+/** Directory names excluded at ANY depth (runtime/session/log noise). */
+const EXCLUDE_DIR_ANYWHERE = new Set<string>(['sessions', 'logs', '.orchestrator-state']);
+
+/** True for files excluded at any depth (ephemeral session logs). */
+function isExcludedFile(name: string): boolean {
+  return name.endsWith('.jsonl');
+}
+
+/**
+ * Service that builds workspace backup archives.
+ */
+export class BackupArchiveService {
+  private readonly logger: ComponentLogger;
+
+  constructor(logger?: ComponentLogger) {
+    this.logger = logger ?? LoggerService.getInstance().createComponentLogger('BackupArchive');
+  }
+
+  /**
+   * Build a workspace backup archive.
+   *
+   * Captures CREWLY_HOME globals (exclude-based, so new data domains are
+   * picked up automatically), each project's `.crewly/` tree (walked from
+   * projects.json) with git provenance, and chat.db (unless excluded). Stages
+   * everything into a temp dir, writes the manifest, and tars it to `outPath`.
+   *
+   * @param options - Build options (createdAt is required — no clock in lib code)
+   * @returns The archive path, manifest, and total captured bytes
+   * @throws If CREWLY_HOME does not exist or the tar write fails
+   */
+  async createArchive(options: CreateBackupOptions): Promise<CreateBackupResult> {
+    const home = options.homePath ?? getCrewlyHomePath();
+    const homeStat = await fs.stat(home).catch(() => null);
+    if (!homeStat?.isDirectory()) {
+      throw new Error(`CREWLY_HOME not found or not a directory: ${home}`);
+    }
+
+    const outPath =
+      options.outPath ??
+      path.join(home, 'backups', `workspace-${options.createdAt.replace(/[:.]/g, '-')}.tar.gz`);
+
+    const staging = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-backup-'));
+    try {
+      let totalBytes = 0;
+
+      // 1) Global CREWLY_HOME files → staging/home/<rel>
+      const global: BackupFileEntry[] = [];
+      for (const rel of await this.collectGlobalFiles(home)) {
+        const entry = await this.stageFile(home, rel, staging, path.join('home', rel));
+        global.push(entry);
+        totalBytes += entry.bytes;
+      }
+
+      // 2) Per-project .crewly trees → staging/projects/<id>/<rel>
+      const projects = await this.collectProjects(home, staging);
+      for (const p of projects) for (const f of p.files) totalBytes += f.bytes;
+
+      // 3) chat.db via SQLite online backup → staging/chat.db
+      const chatDb = options.excludeChatDb
+        ? { included: false, skippedReason: 'excluded by option' }
+        : await this.captureChatDb(home, staging);
+      if (chatDb.bytes) totalBytes += chatDb.bytes;
+
+      // 4) Manifest
+      const manifest: BackupManifest = {
+        schemaVersion: BACKUP_SCHEMA_VERSION,
+        crewlyVersion: this.readCrewlyVersion(),
+        createdAt: options.createdAt,
+        sourceDeviceId: options.sourceDeviceId ?? null,
+        sourceDeviceName: options.sourceDeviceName ?? null,
+        sourceHomePath: home,
+        ownerSub: options.ownerSub ?? null,
+        global,
+        projects,
+        chatDb,
+        crypto: { mode: 'none' },
+      };
+      await fs.writeFile(path.join(staging, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+
+      // 5) tar.gz the staging dir
+      await fs.mkdir(path.dirname(outPath), { recursive: true });
+      await tarCreate({ gzip: true, file: outPath, cwd: staging }, ['.']);
+
+      this.logger.info('Workspace backup created', {
+        outPath,
+        globalFiles: global.length,
+        projects: projects.length,
+        chatDb: chatDb.included,
+        totalBytes,
+      });
+
+      return { archivePath: outPath, manifest, totalBytes };
+    } finally {
+      await fs.rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Recursively collect capturable global files under CREWLY_HOME (relative
+   * paths). Exclude-based so new data domains are captured automatically.
+   *
+   * @param home - CREWLY_HOME absolute path
+   * @returns Relative file paths (POSIX-style) to capture
+   */
+  private async collectGlobalFiles(home: string): Promise<string[]> {
+    const out: string[] = [];
+    const walk = async (absDir: string, rel: string, isTop: boolean): Promise<void> => {
+      const entries = await fs.readdir(absDir, { withFileTypes: true }).catch(() => []);
+      for (const e of entries) {
+        if (isTop && GLOBAL_EXCLUDE_TOPLEVEL.has(e.name)) continue;
+        if (e.isDirectory() && EXCLUDE_DIR_ANYWHERE.has(e.name)) continue;
+        const childRel = rel ? `${rel}/${e.name}` : e.name;
+        if (e.isDirectory()) {
+          await walk(path.join(absDir, e.name), childRel, false);
+        } else if (e.isFile() && !isExcludedFile(e.name)) {
+          out.push(childRel);
+        }
+      }
+    };
+    await walk(home, '', true);
+    return out;
+  }
+
+  /**
+   * Walk projects.json and capture each project's `.crewly/` tree + git
+   * provenance into staging/projects/<id>/.
+   *
+   * @param home - CREWLY_HOME absolute path
+   * @param staging - staging dir root
+   * @returns Project entries for the manifest
+   */
+  private async collectProjects(home: string, staging: string): Promise<BackupProjectEntry[]> {
+    const projects = await safeReadJson<Array<{ id: string; name: string; path: string }>>(
+      path.join(home, 'projects.json'),
+      [],
+    );
+    const result: BackupProjectEntry[] = [];
+    for (const proj of projects) {
+      const crewlyDir = path.join(proj.path, '.crewly');
+      const dirStat = await fs.stat(crewlyDir).catch(() => null);
+      if (!dirStat?.isDirectory()) continue; // project gone / never initialized
+
+      const files: BackupFileEntry[] = [];
+      const walk = async (absDir: string, rel: string): Promise<void> => {
+        const entries = await fs.readdir(absDir, { withFileTypes: true }).catch(() => []);
+        for (const e of entries) {
+          if (e.isDirectory() && EXCLUDE_DIR_ANYWHERE.has(e.name)) continue;
+          const childRel = rel ? `${rel}/${e.name}` : e.name;
+          if (e.isDirectory()) await walk(path.join(absDir, e.name), childRel);
+          else if (e.isFile() && !isExcludedFile(e.name)) {
+            const archivePath = `projects/${proj.id}/.crewly/${childRel}`;
+            files.push(await this.stageFile(crewlyDir, childRel, staging, archivePath));
+          }
+        }
+      };
+      await walk(crewlyDir, '');
+
+      result.push({
+        id: proj.id,
+        name: proj.name,
+        sourcePath: proj.path,
+        git: await this.readGitProvenance(proj.path),
+        files,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Read `origin` remote + HEAD commit for a project dir (best-effort).
+   *
+   * @param projectPath - Absolute project path
+   * @returns Git provenance (nulls when not a repo / unavailable)
+   */
+  private async readGitProvenance(projectPath: string): Promise<{ remote: string | null; commit: string | null }> {
+    const run = async (args: string[]): Promise<string | null> => {
+      try {
+        const { stdout } = await execFileAsync('git', ['-C', projectPath, ...args], { timeout: 5000 });
+        const v = stdout.trim();
+        return v.length > 0 ? v : null;
+      } catch {
+        return null;
+      }
+    };
+    return {
+      remote: await run(['remote', 'get-url', 'origin']),
+      commit: await run(['rev-parse', 'HEAD']),
+    };
+  }
+
+  /**
+   * Capture chat.db via the SQLite online backup API (consistent snapshot of a
+   * possibly-live DB). Degrades gracefully when chat.db is absent or the native
+   * module can't load — the backup just omits it with a recorded reason.
+   *
+   * @param home - CREWLY_HOME absolute path
+   * @param staging - staging dir root
+   * @returns chat.db manifest record
+   */
+  private async captureChatDb(
+    home: string,
+    staging: string,
+  ): Promise<{ included: boolean; sha256?: string; bytes?: number; skippedReason?: string }> {
+    const dbPath = path.join(home, 'chat.db');
+    if (!(await fs.stat(dbPath).catch(() => null))?.isFile()) {
+      return { included: false, skippedReason: 'chat.db not present' };
+    }
+    const dest = path.join(staging, 'chat.db');
+    try {
+      const mod = (await import('better-sqlite3')) as unknown as {
+        default: new (p: string, opts?: Record<string, unknown>) => { backup: (p: string) => Promise<unknown>; close: () => void };
+      };
+      const Database = mod.default;
+      const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      try {
+        await db.backup(dest);
+      } finally {
+        db.close();
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      this.logger.warn('chat.db capture skipped', { reason });
+      return { included: false, skippedReason: `sqlite backup failed: ${reason}` };
+    }
+    const { sha256, bytes } = await hashAndSize(dest);
+    return { included: true, sha256, bytes };
+  }
+
+  /**
+   * Copy a source file into the staging archive layout, returning its manifest
+   * entry (archive-relative path + sha256 + size).
+   *
+   * @param srcRoot - Root the relative path is resolved against
+   * @param rel - Source path relative to srcRoot (POSIX-style)
+   * @param staging - staging dir root
+   * @param archivePath - Destination path inside the archive
+   * @returns Manifest file entry
+   */
+  private async stageFile(srcRoot: string, rel: string, staging: string, archivePath: string): Promise<BackupFileEntry> {
+    const src = path.join(srcRoot, ...rel.split('/'));
+    const dest = path.join(staging, ...archivePath.split('/'));
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await fs.copyFile(src, dest);
+    const { sha256, bytes } = await hashAndSize(dest);
+    return { path: archivePath, sha256, bytes };
+  }
+
+  /**
+   * Read the running Crewly version (best-effort). Uses npm_package_version —
+   * the same source as tracing.service.ts — which works under both the ESM
+   * runtime and the CJS test runner (no import.meta / __dirname).
+   *
+   * @returns Version string or 'unknown'
+   */
+  private readCrewlyVersion(): string {
+    return process.env.npm_package_version ?? 'unknown';
+  }
+}
+
+/**
+ * Stream a file through SHA-256 and return the hex digest + byte size.
+ *
+ * @param filePath - File to hash
+ * @returns sha256 (hex) and byte size
+ */
+async function hashAndSize(filePath: string): Promise<{ sha256: string; bytes: number }> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    let bytes = 0;
+    const stream = createReadStream(filePath);
+    stream.on('data', (chunk) => {
+      bytes += chunk.length;
+      hash.update(chunk);
+    });
+    stream.on('error', reject);
+    stream.on('end', () => resolve({ sha256: hash.digest('hex'), bytes }));
+  });
+}

--- a/backend/src/services/backup/backup-cloud.client.test.ts
+++ b/backend/src/services/backup/backup-cloud.client.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for BackupCloudClient (P3) — uses an injected fetch returning real
+ * Response objects (no network).
+ */
+
+import * as fs from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BackupCloudClient, BackupNotProError, BackupCloudError } from './backup-cloud.client.js';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'bcc-'));
+});
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+function client(fetchImpl: typeof fetch): BackupCloudClient {
+  return new BackupCloudClient({ baseUrl: 'https://api.crewlyai.com', token: 'tok-123', fetchImpl });
+}
+
+describe('BackupCloudClient', () => {
+  it('list() returns snapshots and sends the bearer token', async () => {
+    let seenAuth: string | undefined;
+    let seenUrl: string | undefined;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      seenUrl = url;
+      seenAuth = (init?.headers as Record<string, string>)?.Authorization;
+      return new Response(JSON.stringify({ success: true, data: { backups: [{ backupId: 'b1' }] } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const items = await client(fetchImpl).list();
+    expect(items).toEqual([{ backupId: 'b1' }]);
+    expect(seenUrl).toBe('https://api.crewlyai.com/api/cloud/backup');
+    expect(seenAuth).toBe('Bearer tok-123');
+  });
+
+  it('push() streams the file with Content-Length + device headers', async () => {
+    const file = path.join(dir, 'wb.tar.gz');
+    await fs.writeFile(file, Buffer.alloc(1234, 7));
+    let init: (RequestInit & { duplex?: string }) | undefined;
+    const fetchImpl = (async (_url: string, i?: RequestInit) => {
+      init = i as RequestInit & { duplex?: string };
+      return new Response(JSON.stringify({ success: true, data: { backupId: 'b9', sizeBytes: 1234 } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const res = await client(fetchImpl).push(file, { backupId: 'b9', deviceName: 'mac.lan', sha256: 'abc' });
+    expect(res.backupId).toBe('b9');
+    expect(init?.method).toBe('POST');
+    const h = init?.headers as Record<string, string>;
+    expect(h['Content-Length']).toBe('1234');
+    expect(h['X-Device-Name']).toBe('mac.lan');
+    expect(h['X-Backup-Sha256']).toBe('abc');
+    expect(init?.duplex).toBe('half');
+    expect(init?.body).toBeTruthy();
+  });
+
+  it('pull() streams the response body to a file', async () => {
+    const payload = Buffer.from('archive-bytes-here');
+    const fetchImpl = (async () => new Response(payload, { status: 200 })) as unknown as typeof fetch;
+    const dest = path.join(dir, 'down', 'wb.tar.gz');
+    await client(fetchImpl).pull('b1', dest);
+    expect(readFileSync(dest).equals(payload)).toBe(true);
+  });
+
+  it('remove() issues a DELETE', async () => {
+    let method: string | undefined;
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      method = init?.method;
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+    await client(fetchImpl).remove('b1');
+    expect(method).toBe('DELETE');
+  });
+
+  it('maps 402 to BackupNotProError', async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ error: 'Cloud backup requires a Pro plan.' }), { status: 402 })) as unknown as typeof fetch;
+    await expect(client(fetchImpl).list()).rejects.toBeInstanceOf(BackupNotProError);
+  });
+
+  it('maps other failures to BackupCloudError with the server message', async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ error: 'Backup not found.' }), { status: 404 })) as unknown as typeof fetch;
+    await expect(client(fetchImpl).remove('missing')).rejects.toThrow(/Backup not found/);
+    await expect(client(fetchImpl).remove('missing')).rejects.toBeInstanceOf(BackupCloudError);
+  });
+});

--- a/backend/src/services/backup/backup-cloud.client.ts
+++ b/backend/src/services/backup/backup-cloud.client.ts
@@ -1,0 +1,160 @@
+/**
+ * Backup Cloud Client (P3)
+ *
+ * OSS-side HTTP client for the Pro-gated cloud backup service
+ * (`/api/cloud/backup`). Used by `crewly backup push/pull/list` to park an
+ * archive in the cloud and pull it back on another machine.
+ *
+ * Transport-only: it streams files to/from the cloud and surfaces a friendly
+ * upgrade error on 402. Auth (access token) + base URL come from
+ * CloudClientService; both are injected so this is testable without the cloud.
+ *
+ * @module services/backup/backup-cloud.client
+ */
+
+import { createReadStream, createWriteStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+/** Thrown when the account isn't Pro (HTTP 402). */
+export class BackupNotProError extends Error {
+  readonly code = 'upgrade_required';
+  constructor(message = 'Cloud backup requires a Pro plan. Upgrade at https://crewlyai.com/pricing.') {
+    super(message);
+    this.name = 'BackupNotProError';
+  }
+}
+
+/** Thrown on any other cloud backup HTTP failure. */
+export class BackupCloudError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'BackupCloudError';
+  }
+}
+
+/** A cloud snapshot as returned by the service (client-facing view). */
+export interface CloudBackupItem {
+  backupId: string;
+  deviceName: string | null;
+  deviceId: string | null;
+  sizeBytes: number;
+  sha256: string | null;
+  cryptoMode: 'sse' | 'none';
+  createdAt: string;
+}
+
+/** Metadata sent with an upload. */
+export interface PushMeta {
+  backupId?: string;
+  deviceName?: string | null;
+  deviceId?: string | null;
+  sha256?: string | null;
+}
+
+/** HTTP client for the cloud backup endpoints. */
+export class BackupCloudClient {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(
+    private readonly opts: { baseUrl: string; token: string; fetchImpl?: typeof fetch },
+  ) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private url(suffix: string): string {
+    return `${this.opts.baseUrl.replace(/\/$/, '')}/api/cloud/backup${suffix}`;
+  }
+
+  private authHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    return { Authorization: `Bearer ${this.opts.token}`, ...extra };
+  }
+
+  /** List this account's cloud snapshots (newest first). */
+  async list(): Promise<CloudBackupItem[]> {
+    const res = await this.fetchImpl(this.url(''), { headers: this.authHeaders() });
+    await this.assertOk(res);
+    const json = (await res.json()) as { data?: { backups?: CloudBackupItem[] } };
+    return json.data?.backups ?? [];
+  }
+
+  /**
+   * Upload an archive to the cloud. Streams the file with its Content-Length so
+   * the service can enforce quota before accepting the blob.
+   *
+   * @param archivePath - Local archive (.tar.gz)
+   * @param meta - Optional backupId + device/sha metadata
+   * @returns The created snapshot record
+   */
+  async push(archivePath: string, meta: PushMeta = {}): Promise<CloudBackupItem> {
+    const stat = await fs.stat(archivePath);
+    const query = meta.backupId ? `?backupId=${encodeURIComponent(meta.backupId)}` : '';
+    const headers = this.authHeaders({
+      'Content-Type': 'application/gzip',
+      'Content-Length': String(stat.size),
+      ...(meta.deviceName ? { 'X-Device-Name': meta.deviceName } : {}),
+      ...(meta.deviceId ? { 'X-Device-Id': meta.deviceId } : {}),
+      ...(meta.sha256 ? { 'X-Backup-Sha256': meta.sha256 } : {}),
+    });
+    const res = await this.fetchImpl(this.url(query), {
+      method: 'POST',
+      headers,
+      body: createReadStream(archivePath) as unknown as RequestInit['body'],
+      // Node fetch requires this for a streaming request body.
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' });
+    await this.assertOk(res);
+    const json = (await res.json()) as { data: CloudBackupItem };
+    return json.data;
+  }
+
+  /**
+   * Download a snapshot to `destPath` (streamed).
+   *
+   * @param backupId - Snapshot id
+   * @param destPath - Local file to write
+   */
+  async pull(backupId: string, destPath: string): Promise<void> {
+    const res = await this.fetchImpl(this.url(`/${encodeURIComponent(backupId)}`), { headers: this.authHeaders() });
+    await this.assertOk(res);
+    if (!res.body) throw new BackupCloudError('Empty download response from cloud.');
+    await fs.mkdir(path.dirname(destPath), { recursive: true });
+    await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(destPath));
+  }
+
+  /** Delete a cloud snapshot. */
+  async remove(backupId: string): Promise<void> {
+    const res = await this.fetchImpl(this.url(`/${encodeURIComponent(backupId)}`), {
+      method: 'DELETE',
+      headers: this.authHeaders(),
+    });
+    await this.assertOk(res);
+  }
+
+  /** Map non-2xx responses to typed errors (402 → upgrade). */
+  private async assertOk(res: Response): Promise<void> {
+    if (res.ok) return;
+    if (res.status === 402) {
+      let msg: string | undefined;
+      try {
+        msg = ((await res.json()) as { error?: string }).error;
+      } catch {
+        /* ignore */
+      }
+      throw new BackupNotProError(msg);
+    }
+    let message = `Cloud backup request failed (HTTP ${res.status}).`;
+    try {
+      const j = (await res.json()) as { error?: string };
+      if (j.error) message = j.error;
+    } catch {
+      /* non-JSON body */
+    }
+    throw new BackupCloudError(message, res.status);
+  }
+}

--- a/backend/src/services/backup/backup-restore.service.test.ts
+++ b/backend/src/services/backup/backup-restore.service.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for BackupRestoreService (P1).
+ *
+ * Builds a real archive from a source home, then restores it onto a separate
+ * target home and asserts file restore, project path-remap, cron reset, runtime
+ * wipe, rollback snapshot, conflict/abort, and integrity/not-found errors.
+ */
+
+import * as fs from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { BackupArchiveService } from './backup-archive.service.js';
+import { BackupRestoreService, RestoreConflictError } from './backup-restore.service.js';
+
+const silent = { info() {}, warn() {}, error() {}, debug() {} } as unknown as ConstructorParameters<
+  typeof BackupRestoreService
+>[0];
+
+let srcHome: string;
+let srcProj: string;
+let targetHome: string;
+let targetProj: string;
+let archive: string;
+
+beforeEach(async () => {
+  srcHome = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-src-'));
+  srcProj = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-srcproj-'));
+  targetHome = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-tgt-'));
+  targetProj = await fs.mkdtemp(path.join(os.tmpdir(), 'wb-tgtproj-'));
+
+  // Source workspace content
+  await fs.writeFile(path.join(srcHome, 'settings.json'), JSON.stringify({ theme: 'dark' }), 'utf8');
+  await fs.mkdir(path.join(srcHome, 'teams', 't1'), { recursive: true });
+  await fs.writeFile(path.join(srcHome, 'teams', 't1', 'config.json'), JSON.stringify({ id: 't1' }), 'utf8');
+  await fs.writeFile(
+    path.join(srcHome, 'recurring-checks.json'),
+    JSON.stringify([{ id: 'c1', cronExpression: '* * * * *', nextRunAt: '2020-01-01T00:00:00.000Z' }]),
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(srcHome, 'projects.json'),
+    JSON.stringify([{ id: 'p1', name: 'web', path: srcProj }]),
+    'utf8',
+  );
+  await fs.mkdir(path.join(srcProj, '.crewly', 'wiki'), { recursive: true });
+  await fs.writeFile(path.join(srcProj, '.crewly', 'wiki', 'arch.md'), '# project wiki', 'utf8');
+
+  archive = path.join(srcHome, 'wb.tar.gz');
+  await new BackupArchiveService(silent).createArchive({
+    homePath: srcHome,
+    outPath: archive,
+    excludeChatDb: true,
+    createdAt: '2026-06-07T20:00:00.000Z',
+  });
+});
+
+afterEach(async () => {
+  for (const d of [srcHome, srcProj, targetHome, targetProj]) {
+    await fs.rm(d, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+describe('BackupRestoreService.preview', () => {
+  it('reports the plan without writing (project path remapped via pathMap)', async () => {
+    const plan = await new BackupRestoreService(silent).preview({
+      archivePath: archive,
+      homePath: targetHome,
+      mode: 'overwrite',
+      pathMap: { [srcProj]: targetProj },
+      now: '2026-06-07T21:00:00.000Z',
+    });
+    expect(plan.globalFileCount).toBeGreaterThan(0);
+    expect(plan.projects).toHaveLength(1);
+    expect(plan.projects[0].targetPath).toBe(targetProj);
+    expect(plan.conflicts.projects).toHaveLength(0);
+    // dry-run: target untouched
+    expect(existsSync(path.join(targetHome, 'settings.json'))).toBe(false);
+  });
+});
+
+describe('BackupRestoreService.restore', () => {
+  it('restores globals + project .crewly, remaps paths, resets cron, makes a rollback snapshot', async () => {
+    const res = await new BackupRestoreService(silent).restore({
+      archivePath: archive,
+      homePath: targetHome,
+      mode: 'overwrite',
+      pathMap: { [srcProj]: targetProj },
+      now: '2026-06-07T21:00:00.000Z',
+    });
+
+    // globals restored
+    expect(JSON.parse(readFileSync(path.join(targetHome, 'settings.json'), 'utf8'))).toEqual({ theme: 'dark' });
+    expect(existsSync(path.join(targetHome, 'teams', 't1', 'config.json'))).toBe(true);
+    // project .crewly restored to the REMAPPED path
+    expect(readFileSync(path.join(targetProj, '.crewly', 'wiki', 'arch.md'), 'utf8')).toBe('# project wiki');
+    // projects.json rewritten to the target path
+    const projects = JSON.parse(readFileSync(path.join(targetHome, 'projects.json'), 'utf8'));
+    expect(projects[0].path).toBe(targetProj);
+    // cron nextRunAt reset
+    const cron = JSON.parse(readFileSync(path.join(targetHome, 'recurring-checks.json'), 'utf8'));
+    expect(cron[0].nextRunAt).toBeNull();
+    // rollback snapshot exists
+    expect(existsSync(res.rollbackSnapshotPath)).toBe(true);
+    expect(res.restoredProjects).toBe(1);
+  });
+
+  it('aborts when the target already has an overlapping project id (default mode)', async () => {
+    await fs.writeFile(
+      path.join(targetHome, 'projects.json'),
+      JSON.stringify([{ id: 'p1', name: 'web-existing', path: '/somewhere' }]),
+      'utf8',
+    );
+    const svc = new BackupRestoreService(silent);
+    await expect(
+      svc.restore({ archivePath: archive, homePath: targetHome, now: '2026-06-07T21:00:00.000Z' }),
+    ).rejects.toBeInstanceOf(RestoreConflictError);
+    // target unchanged (settings not written)
+    expect(existsSync(path.join(targetHome, 'settings.json'))).toBe(false);
+  });
+
+  it('wipes runtime/session state on restore', async () => {
+    await fs.writeFile(path.join(targetHome, 'runtime.json'), '{"pid":123}', 'utf8');
+    await fs.mkdir(path.join(targetHome, '.orchestrator-state'), { recursive: true });
+    await new BackupRestoreService(silent).restore({
+      archivePath: archive,
+      homePath: targetHome,
+      mode: 'overwrite',
+      pathMap: { [srcProj]: targetProj },
+      now: '2026-06-07T21:00:00.000Z',
+    });
+    expect(existsSync(path.join(targetHome, 'runtime.json'))).toBe(false);
+    expect(existsSync(path.join(targetHome, '.orchestrator-state'))).toBe(false);
+  });
+
+  it('throws on a missing archive', async () => {
+    await expect(
+      new BackupRestoreService(silent).restore({
+        archivePath: path.join(srcHome, 'nope.tar.gz'),
+        homePath: targetHome,
+        now: '2026-06-07T21:00:00.000Z',
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('fails integrity check on a tampered archive entry', async () => {
+    // Corrupt the manifest's recorded checksum vs content by editing an extracted
+    // file is hard; instead assert a truncated archive fails to read/verify.
+    const bad = path.join(srcHome, 'bad.tar.gz');
+    await fs.writeFile(bad, Buffer.from('not a real gzip'), 'utf8');
+    await expect(
+      new BackupRestoreService(silent).restore({ archivePath: bad, homePath: targetHome, now: '2026-06-07T21:00:00.000Z' }),
+    ).rejects.toBeTruthy();
+  });
+});

--- a/backend/src/services/backup/backup-restore.service.ts
+++ b/backend/src/services/backup/backup-restore.service.ts
@@ -1,0 +1,390 @@
+/**
+ * Backup Restore Service (P1)
+ *
+ * Restores a workspace archive (produced by BackupArchiveService) onto this
+ * machine to resume work after a machine dies / is replaced.
+ *
+ * Safety model:
+ *   - `preview()` is non-destructive (dry-run) — reports the plan + conflicts.
+ *   - `restore()` snapshots the CURRENT CREWLY_HOME first (rollback), refuses
+ *     on overlapping ids unless mode='overwrite', then applies and — on any
+ *     failure — rolls back from the snapshot.
+ *   - device.json is NEVER in the archive, so the target keeps its own identity.
+ *   - cron `nextRunAt` is reset to null so the scheduler recomputes from
+ *     `cronExpression` (no stale fires); runtime/session state is wiped so
+ *     agents start clean.
+ *
+ * See specs/2026-06-07-workspace-backup.md.
+ *
+ * @module services/backup/backup-restore.service
+ */
+
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { extract as tarExtract } from 'tar';
+import { getCrewlyHomePath } from '../core/crewly-home.utils.js';
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+import {
+  type BackupManifest,
+  type RestoreOptions,
+  type RestorePlan,
+  type RestoreProjectPlan,
+  type RestoreResult,
+  BACKUP_SCHEMA_VERSION,
+} from './backup.types.js';
+
+/** Runtime/session state wiped on restore so agents start clean (relative to home). */
+const RUNTIME_WIPE = ['runtime.json', '.orchestrator-state', 'session-state.json'];
+
+/** Cron files whose `nextRunAt` is reset so the scheduler recomputes. */
+const CRON_FILES = ['recurring-checks.json', 'one-time-checks.json'];
+
+/** Thrown by restore() when mode='abort' and the target has overlapping data. */
+export class RestoreConflictError extends Error {
+  constructor(
+    message: string,
+    public readonly plan: RestorePlan,
+  ) {
+    super(message);
+    this.name = 'RestoreConflictError';
+  }
+}
+
+/**
+ * Service that restores workspace backup archives.
+ */
+export class BackupRestoreService {
+  private readonly logger: ComponentLogger;
+
+  constructor(logger?: ComponentLogger) {
+    this.logger = logger ?? LoggerService.getInstance().createComponentLogger('BackupRestore');
+  }
+
+  /**
+   * Non-destructive restore plan (dry-run): what would be created/overwritten,
+   * id conflicts, resolved project paths, and what's regenerated/discarded.
+   *
+   * @param options - Restore options (mode/pathMap affect conflict + path resolution)
+   * @returns The plan; never writes to disk
+   */
+  async preview(options: RestoreOptions): Promise<RestorePlan> {
+    const home = options.homePath ?? getCrewlyHomePath();
+    const temp = await this.extract(options.archivePath);
+    try {
+      const manifest = await this.readManifest(temp);
+      return await this.buildPlan(manifest, home, options);
+    } finally {
+      await fs.rm(temp, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  /**
+   * Restore the archive onto this machine.
+   *
+   * @param options - Restore options
+   * @returns Summary of what was restored
+   * @throws RestoreConflictError when mode='abort' and ids overlap
+   * @throws Error on integrity failure or unsupported schema (no changes applied)
+   */
+  async restore(options: RestoreOptions): Promise<RestoreResult> {
+    const home = options.homePath ?? getCrewlyHomePath();
+    const mode = options.mode ?? 'abort';
+    const temp = await this.extract(options.archivePath);
+
+    try {
+      const manifest = await this.readManifest(temp);
+      if (manifest.schemaVersion > BACKUP_SCHEMA_VERSION) {
+        throw new Error(
+          `Backup schemaVersion ${manifest.schemaVersion} is newer than supported ${BACKUP_SCHEMA_VERSION}; upgrade Crewly to restore it`,
+        );
+      }
+      await this.verifyChecksums(temp, manifest);
+
+      const plan = await this.buildPlan(manifest, home, options);
+      if (mode === 'abort' && (plan.conflicts.teams.length > 0 || plan.conflicts.projects.length > 0)) {
+        throw new RestoreConflictError(
+          `Restore aborted: target already has ${plan.conflicts.teams.length} team(s) and ${plan.conflicts.projects.length} project(s) from this backup. Re-run with mode='overwrite' to replace them.`,
+          plan,
+        );
+      }
+
+      // 1) Snapshot current home for rollback (best-effort full copy, sans backups/).
+      const rollbackSnapshotPath = path.join(home, 'backups', `pre-restore-${options.now.replace(/[:.]/g, '-')}`);
+      await fs.mkdir(home, { recursive: true });
+      await this.copyTree(home, rollbackSnapshotPath, new Set(['backups']));
+
+      try {
+        // 2) Apply
+        const restoredGlobalFiles = await this.applyGlobals(temp, home);
+        const restoredProjects = await this.applyProjects(temp, manifest, plan);
+        const chatDbRestored = await this.applyChatDb(temp, home, manifest);
+        await this.rewriteProjectsJson(home, plan);
+        await this.resetCron(home);
+        await this.wipeRuntime(home);
+
+        this.logger.info('Workspace restore applied', {
+          restoredGlobalFiles,
+          restoredProjects,
+          chatDbRestored,
+          rollbackSnapshotPath,
+        });
+        return { restoredGlobalFiles, restoredProjects, chatDbRestored, rollbackSnapshotPath, warnings: plan.warnings };
+      } catch (applyErr) {
+        // 3) Rollback from the pre-restore snapshot.
+        this.logger.error('Restore failed mid-apply — rolling back', {
+          error: applyErr instanceof Error ? applyErr.message : String(applyErr),
+        });
+        await this.copyTree(rollbackSnapshotPath, home, new Set(['backups'])).catch(() => undefined);
+        throw applyErr;
+      }
+    } finally {
+      await fs.rm(temp, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /** Extract the archive to a fresh temp dir; returns its path. */
+  private async extract(archivePath: string): Promise<string> {
+    if (!(await fs.stat(archivePath).catch(() => null))?.isFile()) {
+      throw new Error(`Backup archive not found: ${archivePath}`);
+    }
+    const temp = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-restore-'));
+    await tarExtract({ file: archivePath, cwd: temp });
+    return temp;
+  }
+
+  /** Read + minimally validate the manifest from an extracted archive. */
+  private async readManifest(temp: string): Promise<BackupManifest> {
+    const raw = await fs.readFile(path.join(temp, 'manifest.json'), 'utf8').catch(() => null);
+    if (!raw) throw new Error('Invalid backup: manifest.json missing');
+    let manifest: BackupManifest;
+    try {
+      manifest = JSON.parse(raw) as BackupManifest;
+    } catch {
+      throw new Error('Invalid backup: manifest.json is not valid JSON');
+    }
+    if (typeof manifest.schemaVersion !== 'number' || !Array.isArray(manifest.global)) {
+      throw new Error('Invalid backup: manifest is missing required fields');
+    }
+    return manifest;
+  }
+
+  /** Verify every recorded file's sha256 against the extracted bytes. */
+  private async verifyChecksums(temp: string, manifest: BackupManifest): Promise<void> {
+    const entries: Array<{ path: string; sha256: string }> = [
+      ...manifest.global,
+      ...manifest.projects.flatMap((p) => p.files),
+    ];
+    if (manifest.chatDb.included && manifest.chatDb.sha256) {
+      entries.push({ path: 'chat.db', sha256: manifest.chatDb.sha256 });
+    }
+    for (const e of entries) {
+      const abs = path.join(temp, ...e.path.split('/'));
+      const actual = await sha256File(abs).catch(() => null);
+      if (actual !== e.sha256) {
+        throw new Error(`Backup integrity check failed for ${e.path} (checksum mismatch or missing)`);
+      }
+    }
+  }
+
+  /** Build the dry-run plan (conflicts, resolved project paths, warnings). */
+  private async buildPlan(manifest: BackupManifest, home: string, options: RestoreOptions): Promise<RestorePlan> {
+    const warnings: string[] = [];
+
+    // Teams present in the backup (ids parsed from home/teams/<id>/...).
+    const backupTeamIds = new Set<string>();
+    for (const g of manifest.global) {
+      const m = g.path.match(/^home\/teams\/([^/]+)\//);
+      if (m && m[1] !== 'orchestrator') backupTeamIds.add(m[1]);
+    }
+    const targetTeamIds = new Set(
+      (await fs.readdir(path.join(home, 'teams'), { withFileTypes: true }).catch(() => []))
+        .filter((d) => d.isDirectory() && d.name !== 'orchestrator')
+        .map((d) => d.name),
+    );
+    const conflictTeams = [...backupTeamIds].filter((id) => targetTeamIds.has(id));
+
+    const targetProjectIds = new Set(
+      (await this.readJson<Array<{ id: string }>>(path.join(home, 'projects.json'), [])).map((p) => p.id),
+    );
+    const conflictProjects = manifest.projects.map((p) => p.id).filter((id) => targetProjectIds.has(id));
+
+    const projects: RestoreProjectPlan[] = [];
+    for (const p of manifest.projects) {
+      const mapped = options.pathMap?.[p.sourcePath];
+      let targetPath: string | null = null;
+      if (mapped) targetPath = mapped;
+      else if (await this.pathExists(p.sourcePath)) targetPath = p.sourcePath;
+
+      const targetExists = targetPath ? await this.pathExists(targetPath) : false;
+      if (!targetPath) {
+        warnings.push(
+          `Project "${p.name}" (${p.sourcePath}) has no target path on this machine — re-clone ${p.git.remote ?? 'the repo'} and pass --map ${p.sourcePath}=<new-path> to restore its .crewly data.`,
+        );
+      } else if (!targetExists) {
+        warnings.push(`Project "${p.name}" target path ${targetPath} does not exist yet — its .crewly will be created there.`);
+      }
+      projects.push({ id: p.id, name: p.name, sourcePath: p.sourcePath, targetPath, git: p.git, targetExists });
+    }
+
+    return {
+      ok: !(options.mode !== 'overwrite' && (conflictTeams.length > 0 || conflictProjects.length > 0)),
+      manifestCreatedAt: manifest.createdAt,
+      sourceHomePath: manifest.sourceHomePath,
+      conflicts: { teams: conflictTeams, projects: conflictProjects },
+      globalFileCount: manifest.global.length,
+      projects,
+      chatDbIncluded: manifest.chatDb.included,
+      regenerated: ['device.json (kept this machine\'s identity — not in backup)'],
+      discarded: [...RUNTIME_WIPE, 'in-flight cron nextRunAt (recomputed)'],
+      warnings,
+    };
+  }
+
+  /** Copy every manifest global file from temp/home/* into CREWLY_HOME. */
+  private async applyGlobals(temp: string, home: string): Promise<number> {
+    let n = 0;
+    for (const g of (await this.readManifest(temp)).global) {
+      // g.path = 'home/<rel>'
+      const rel = g.path.replace(/^home\//, '');
+      const src = path.join(temp, ...g.path.split('/'));
+      const dest = path.join(home, ...rel.split('/'));
+      await fs.mkdir(path.dirname(dest), { recursive: true });
+      await fs.copyFile(src, dest);
+      n += 1;
+    }
+    return n;
+  }
+
+  /** Copy each resolved project's `.crewly/` from the archive to its target path. */
+  private async applyProjects(temp: string, manifest: BackupManifest, plan: RestorePlan): Promise<number> {
+    let n = 0;
+    const planById = new Map(plan.projects.map((p) => [p.id, p]));
+    for (const proj of manifest.projects) {
+      const target = planById.get(proj.id)?.targetPath;
+      if (!target) continue; // unresolved — warned in the plan
+      for (const f of proj.files) {
+        // f.path = 'projects/<id>/.crewly/<rel>' → dest = <target>/.crewly/<rel>
+        const rel = f.path.replace(new RegExp(`^projects/${proj.id}/`), '');
+        const src = path.join(temp, ...f.path.split('/'));
+        const dest = path.join(target, ...rel.split('/'));
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.copyFile(src, dest);
+      }
+      n += 1;
+    }
+    return n;
+  }
+
+  /** Atomically swap chat.db into place (temp copy → rename). */
+  private async applyChatDb(temp: string, home: string, manifest: BackupManifest): Promise<boolean> {
+    if (!manifest.chatDb.included) return false;
+    const src = path.join(temp, 'chat.db');
+    const finalDest = path.join(home, 'chat.db');
+    const tmpDest = path.join(home, `chat.db.restore-${Date.now()}.tmp`);
+    await fs.mkdir(home, { recursive: true });
+    await fs.copyFile(src, tmpDest);
+    await fs.rename(tmpDest, finalDest);
+    // Drop stale WAL/SHM sidecars so SQLite reopens cleanly from the restored db.
+    for (const sidecar of ['chat.db-wal', 'chat.db-shm']) {
+      await fs.rm(path.join(home, sidecar), { force: true }).catch(() => undefined);
+    }
+    return true;
+  }
+
+  /** Rewrite projects.json `path` entries using the resolved plan mapping. */
+  private async rewriteProjectsJson(home: string, plan: RestorePlan): Promise<void> {
+    const file = path.join(home, 'projects.json');
+    const projects = await this.readJson<Array<{ id: string; path: string }>>(file, []);
+    if (projects.length === 0) return;
+    const targetById = new Map(plan.projects.map((p) => [p.id, p.targetPath]));
+    let changed = false;
+    for (const proj of projects) {
+      const target = targetById.get(proj.id);
+      if (target && target !== proj.path) {
+        proj.path = target;
+        changed = true;
+      }
+    }
+    if (changed) await fs.writeFile(file, JSON.stringify(projects, null, 2), 'utf8');
+  }
+
+  /** Reset cron `nextRunAt` so the scheduler recomputes from cronExpression. */
+  private async resetCron(home: string): Promise<void> {
+    for (const name of CRON_FILES) {
+      const file = path.join(home, name);
+      const items = await this.readJson<Array<Record<string, unknown>>>(file, []);
+      if (!Array.isArray(items) || items.length === 0) continue;
+      let changed = false;
+      for (const item of items) {
+        if ('nextRunAt' in item) {
+          item.nextRunAt = null;
+          changed = true;
+        }
+      }
+      if (changed) await fs.writeFile(file, JSON.stringify(items, null, 2), 'utf8');
+    }
+  }
+
+  /** Remove runtime/session state so agents start clean on the restored machine. */
+  private async wipeRuntime(home: string): Promise<void> {
+    for (const name of RUNTIME_WIPE) {
+      await fs.rm(path.join(home, name), { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  // ---- small fs helpers ----
+
+  /** Recursively copy a directory tree, skipping top-level names in `skipTop`. */
+  private async copyTree(srcDir: string, destDir: string, skipTop: Set<string>): Promise<void> {
+    const entries = await fs.readdir(srcDir, { withFileTypes: true }).catch(() => []);
+    await fs.mkdir(destDir, { recursive: true });
+    for (const e of entries) {
+      if (skipTop.has(e.name)) continue;
+      const s = path.join(srcDir, e.name);
+      const d = path.join(destDir, e.name);
+      if (e.isDirectory()) await this.copyTreeRec(s, d);
+      else if (e.isFile()) await fs.copyFile(s, d);
+    }
+  }
+
+  /** Recursive copy without the top-level skip filter. */
+  private async copyTreeRec(srcDir: string, destDir: string): Promise<void> {
+    await fs.mkdir(destDir, { recursive: true });
+    for (const e of await fs.readdir(srcDir, { withFileTypes: true })) {
+      const s = path.join(srcDir, e.name);
+      const d = path.join(destDir, e.name);
+      if (e.isDirectory()) await this.copyTreeRec(s, d);
+      else if (e.isFile()) await fs.copyFile(s, d);
+    }
+  }
+
+  private async pathExists(p: string): Promise<boolean> {
+    return !!(await fs.stat(p).catch(() => null));
+  }
+
+  private async readJson<T>(file: string, fallback: T): Promise<T> {
+    try {
+      return JSON.parse(await fs.readFile(file, 'utf8')) as T;
+    } catch {
+      return fallback;
+    }
+  }
+}
+
+/** Stream a file through SHA-256 → hex digest. */
+async function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('data', (c) => hash.update(c));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}

--- a/backend/src/services/backup/backup.types.ts
+++ b/backend/src/services/backup/backup.types.ts
@@ -107,3 +107,68 @@ export interface CreateBackupResult {
   /** Total uncompressed bytes captured (for quota/UX). */
   totalBytes: number;
 }
+
+// ---------------------------------------------------------------------------
+// Restore (P1)
+// ---------------------------------------------------------------------------
+
+/** How to handle a target that already has overlapping data. */
+export type RestoreMode = 'abort' | 'overwrite';
+
+/** Options for restoring an archive onto this machine. */
+export interface RestoreOptions {
+  /** Archive (.tar.gz) to restore. */
+  archivePath: string;
+  /** Target CREWLY_HOME. Defaults to getCrewlyHomePath(). */
+  homePath?: string;
+  /** Conflict policy. Default 'abort'. */
+  mode?: RestoreMode;
+  /**
+   * Source→target absolute path remap for projects, e.g.
+   * `{ '/Users/alice/web': '/Users/bob/web' }`. When a source path isn't
+   * mapped, restore reuses it if it exists on the target, else records a
+   * warning and skips that project's `.crewly/` write.
+   */
+  pathMap?: Record<string, string>;
+  /** ISO timestamp used to name the pre-restore rollback snapshot. */
+  now: string;
+}
+
+/** One project's restore plan entry. */
+export interface RestoreProjectPlan {
+  id: string;
+  name: string;
+  sourcePath: string;
+  /** Resolved target path (pathMap → existing sourcePath → null when unresolved). */
+  targetPath: string | null;
+  git: { remote: string | null; commit: string | null };
+  /** Whether the resolved target path currently exists on this machine. */
+  targetExists: boolean;
+}
+
+/** Non-destructive restore plan (dry-run). */
+export interface RestorePlan {
+  /** False when mode='abort' and conflicts exist (apply would refuse). */
+  ok: boolean;
+  manifestCreatedAt: string;
+  sourceHomePath: string;
+  /** Stable ids present on BOTH the backup and this machine (would be overwritten). */
+  conflicts: { teams: string[]; projects: string[] };
+  globalFileCount: number;
+  projects: RestoreProjectPlan[];
+  chatDbIncluded: boolean;
+  /** Things to regenerate (device identity) / discard (runtime/session). */
+  regenerated: string[];
+  discarded: string[];
+  warnings: string[];
+}
+
+/** Result of an applied restore. */
+export interface RestoreResult {
+  restoredGlobalFiles: number;
+  restoredProjects: number;
+  chatDbRestored: boolean;
+  /** Where the pre-restore snapshot of the current CREWLY_HOME was saved. */
+  rollbackSnapshotPath: string;
+  warnings: string[];
+}

--- a/backend/src/services/backup/backup.types.ts
+++ b/backend/src/services/backup/backup.types.ts
@@ -1,0 +1,109 @@
+/**
+ * Types for the Workspace Backup feature.
+ *
+ * A backup is a single `.tar.gz` archive containing a top-level
+ * `manifest.json` plus the captured `CREWLY_HOME` globals, each project's
+ * `.crewly/` tree, and (optionally) `chat.db`. See
+ * specs/2026-06-07-workspace-backup.md.
+ *
+ * @module services/backup/backup.types
+ */
+
+/** Manifest schema version — bump on any breaking layout/field change. */
+export const BACKUP_SCHEMA_VERSION = 1;
+
+/** A single captured file recorded in the manifest for integrity + listing. */
+export interface BackupFileEntry {
+  /** Path inside the archive, relative to the archive root. */
+  path: string;
+  /** SHA-256 of the file content (hex). */
+  sha256: string;
+  /** Size in bytes. */
+  bytes: number;
+}
+
+/** Git provenance for a captured project so restore can re-clone the source tree. */
+export interface BackupProjectGit {
+  /** `origin` remote URL, or null when not a git repo / no origin. */
+  remote: string | null;
+  /** HEAD commit sha, or null when unavailable. */
+  commit: string | null;
+}
+
+/** One project's captured `.crewly/` data + provenance. */
+export interface BackupProjectEntry {
+  /** Stable project id (from projects.json). */
+  id: string;
+  /** Human-readable project name. */
+  name: string;
+  /** Absolute path on the SOURCE machine (used for restore path-rewriting). */
+  sourcePath: string;
+  /** Git provenance for re-clone on restore. */
+  git: BackupProjectGit;
+  /** Captured files under `projects/<id>/` in the archive. */
+  files: BackupFileEntry[];
+}
+
+/** chat.db capture record. */
+export interface BackupChatDb {
+  /** Whether chat.db was included (false when excluded or the native module is absent). */
+  included: boolean;
+  /** SHA-256 of the captured db, when included. */
+  sha256?: string;
+  /** Size in bytes, when included. */
+  bytes?: number;
+  /** Reason it was skipped, when not included. */
+  skippedReason?: string;
+}
+
+/** Encryption envelope descriptor. v1 archives are unencrypted on disk; Cloud adds SSE. */
+export interface BackupCrypto {
+  /** `none` for v1 local archives. `sse` once parked in the cloud. */
+  mode: 'none' | 'sse';
+}
+
+/** Top-level archive manifest. */
+export interface BackupManifest {
+  schemaVersion: number;
+  crewlyVersion: string;
+  /** ISO timestamp — the logical point-in-time of the snapshot. */
+  createdAt: string;
+  /** Source device id (observability only; NEVER restored). */
+  sourceDeviceId: string | null;
+  sourceDeviceName: string | null;
+  /** Source `CREWLY_HOME` absolute path — restore uses it for path rewriting. */
+  sourceHomePath: string;
+  /** Owner account (JWT `sub`/googleId). Null for local-only archives; stamped by Cloud on upload. */
+  ownerSub: string | null;
+  /** Captured CREWLY_HOME global files (relative to `home/` in the archive). */
+  global: BackupFileEntry[];
+  /** Captured per-project `.crewly/` data. */
+  projects: BackupProjectEntry[];
+  chatDb: BackupChatDb;
+  crypto: BackupCrypto;
+}
+
+/** Options for building an archive. */
+export interface CreateBackupOptions {
+  /** Output archive path. Defaults to `CREWLY_HOME/backups/workspace-<ts>.tar.gz`. */
+  outPath?: string;
+  /** Exclude chat.db (smaller archive, avoids SQLite capture). Default false. */
+  excludeChatDb?: boolean;
+  /** Override CREWLY_HOME (tests). Defaults to getCrewlyHomePath(). */
+  homePath?: string;
+  /** ISO timestamp for the snapshot point. Defaults to caller-supplied now (no Date in lib). */
+  createdAt: string;
+  /** Owner sub to stamp (usually null locally; Cloud stamps on upload). */
+  ownerSub?: string | null;
+  /** Source device id/name for the manifest (observability). */
+  sourceDeviceId?: string | null;
+  sourceDeviceName?: string | null;
+}
+
+/** Result of a successful archive build. */
+export interface CreateBackupResult {
+  archivePath: string;
+  manifest: BackupManifest;
+  /** Total uncompressed bytes captured (for quota/UX). */
+  totalBytes: number;
+}

--- a/cli/src/commands/backup.test.ts
+++ b/cli/src/commands/backup.test.ts
@@ -24,6 +24,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { backupCommand } from './backup.js';
+import { CloudClientService } from '../../../backend/src/services/cloud/cloud-client.service.js';
 
 let home: string;
 let outFile: string;
@@ -38,9 +39,14 @@ beforeEach(() => {
   fs.writeFileSync(path.join(home, 'projects.json'), '[]', 'utf8');
   outFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'crewly-out-')), 'wb.tar.gz');
   logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  // getConfigPath() uses os.homedir() (the REAL ~/.crewly/cloud/config.json) —
+  // point it at the temp home so cloud tests never read real creds or hit the
+  // network.
+  jest.spyOn(CloudClientService, 'getConfigPath').mockReturnValue(path.join(home, 'cloud', 'config.json'));
 });
 
 afterEach(() => {
+  jest.restoreAllMocks();
   logSpy.mockRestore();
   if (prevHome === undefined) delete process.env.CREWLY_HOME;
   else process.env.CREWLY_HOME = prevHome;
@@ -61,9 +67,20 @@ describe('backupCommand', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('not-yet-implemented actions report gracefully without throwing', async () => {
-    await expect(backupCommand('push')).resolves.toBeUndefined();
-    await expect(backupCommand('list')).resolves.toBeUndefined();
+  it('push/list without a cloud connection report not-connected (exit 1, no throw)', async () => {
+    // CREWLY_HOME (temp) has no cloud/config.json → not connected.
+    process.exitCode = 0;
+    await expect(backupCommand('push', undefined, {})).resolves.toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+    await expect(backupCommand('list', undefined, {})).resolves.toBeUndefined();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('pull without an id sets a non-zero exit code', async () => {
+    process.exitCode = 0;
+    await backupCommand('pull', undefined, {});
+    expect(process.exitCode).toBe(1);
   });
 
   it('restore without a file sets a non-zero exit code', async () => {

--- a/cli/src/commands/backup.test.ts
+++ b/cli/src/commands/backup.test.ts
@@ -50,7 +50,7 @@ afterEach(() => {
 
 describe('backupCommand', () => {
   it('create builds an archive at --out', async () => {
-    await backupCommand('create', { out: outFile, chatDb: false });
+    await backupCommand('create', undefined, { out: outFile, chatDb: false });
     expect(fs.existsSync(outFile)).toBe(true);
     expect(fs.statSync(outFile).size).toBeGreaterThan(0);
   });
@@ -62,7 +62,31 @@ describe('backupCommand', () => {
   });
 
   it('not-yet-implemented actions report gracefully without throwing', async () => {
-    await expect(backupCommand('restore')).resolves.toBeUndefined();
     await expect(backupCommand('push')).resolves.toBeUndefined();
+    await expect(backupCommand('list')).resolves.toBeUndefined();
+  });
+
+  it('restore without a file sets a non-zero exit code', async () => {
+    process.exitCode = 0;
+    await backupCommand('restore', undefined, {});
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('restore dry-run previews without writing; --apply restores + snapshots', async () => {
+    // Build an archive from this home, then restore it back.
+    await backupCommand('create', undefined, { out: outFile, chatDb: false });
+    const backupsDir = path.join(home, 'backups');
+
+    // Dry-run: no pre-restore snapshot is created.
+    await backupCommand('restore', outFile, {});
+    const afterDryRun = fs.existsSync(backupsDir)
+      ? fs.readdirSync(backupsDir).filter((d) => d.startsWith('pre-restore-'))
+      : [];
+    expect(afterDryRun).toHaveLength(0);
+
+    // Apply: a pre-restore snapshot dir appears.
+    await backupCommand('restore', outFile, { apply: true, mode: 'overwrite' });
+    const afterApply = fs.readdirSync(backupsDir).filter((d) => d.startsWith('pre-restore-'));
+    expect(afterApply.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/cli/src/commands/backup.test.ts
+++ b/cli/src/commands/backup.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the `crewly backup` CLI command (P0: create).
+ */
+
+// chalk is ESM-only and not transformed by the CLI jest setup — mock it
+// (mirrors the other CLI command tests, e.g. service.test.ts).
+jest.mock('chalk', () => ({
+  __esModule: true,
+  default: new Proxy(
+    {},
+    {
+      get: () => {
+        const fn = (s: string) => s;
+        return new Proxy(fn, {
+          get: () => fn,
+          apply: (_t: unknown, _this: unknown, args: string[]) => args[0],
+        });
+      },
+    },
+  ),
+}));
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { backupCommand } from './backup.js';
+
+let home: string;
+let outFile: string;
+let logSpy: jest.SpyInstance;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  prevHome = process.env.CREWLY_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'crewly-home-'));
+  process.env.CREWLY_HOME = home;
+  fs.writeFileSync(path.join(home, 'settings.json'), JSON.stringify({ theme: 'dark' }), 'utf8');
+  fs.writeFileSync(path.join(home, 'projects.json'), '[]', 'utf8');
+  outFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'crewly-out-')), 'wb.tar.gz');
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  if (prevHome === undefined) delete process.env.CREWLY_HOME;
+  else process.env.CREWLY_HOME = prevHome;
+  fs.rmSync(home, { recursive: true, force: true });
+  process.exitCode = 0;
+});
+
+describe('backupCommand', () => {
+  it('create builds an archive at --out', async () => {
+    await backupCommand('create', { out: outFile, chatDb: false });
+    expect(fs.existsSync(outFile)).toBe(true);
+    expect(fs.statSync(outFile).size).toBeGreaterThan(0);
+  });
+
+  it('unknown action sets a non-zero exit code', async () => {
+    process.exitCode = 0;
+    await backupCommand('totally-unknown');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('not-yet-implemented actions report gracefully without throwing', async () => {
+    await expect(backupCommand('restore')).resolves.toBeUndefined();
+    await expect(backupCommand('push')).resolves.toBeUndefined();
+  });
+});

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -13,9 +13,16 @@ import chalk from 'chalk';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
+import fsp from 'fs/promises';
 import { BackupArchiveService } from '../../../backend/src/services/backup/backup-archive.service.js';
 import { BackupRestoreService, RestoreConflictError } from '../../../backend/src/services/backup/backup-restore.service.js';
+import {
+  BackupCloudClient,
+  BackupNotProError,
+  type CloudBackupItem,
+} from '../../../backend/src/services/backup/backup-cloud.client.js';
 import { getCrewlyHomePath } from '../../../backend/src/services/core/crewly-home.utils.js';
+import { CloudClientService } from '../../../backend/src/services/cloud/cloud-client.service.js';
 
 /** Options accepted by `crewly backup`. */
 export interface BackupCommandOptions {
@@ -79,10 +86,13 @@ export async function backupCommand(
       await runRestore(target, options);
       break;
     case 'push':
+      await withCloudErrors(() => runPush(options));
+      break;
     case 'pull':
+      await withCloudErrors(() => runPull(target, options));
+      break;
     case 'list':
-      console.log(chalk.yellow(`'crewly backup ${action}' is not available yet (coming in a later phase).`));
-      console.log(chalk.gray('Available now: crewly backup create | crewly backup restore <file>'));
+      await withCloudErrors(() => runList());
       break;
     default:
       console.log(chalk.red(`Unknown backup action: ${action}`));
@@ -195,4 +205,116 @@ async function runRestore(target: string | undefined, options: BackupCommandOpti
     }
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Cloud (Pro): push / pull / list
+// ---------------------------------------------------------------------------
+
+/** Thrown when there's no persisted Crewly Cloud connection. */
+class CloudNotConnectedError extends Error {
+  constructor() {
+    super('Not connected to Crewly Cloud.');
+  }
+}
+
+/**
+ * Resolve the Cloud API base URL + access token from the persisted config
+ * (~/.crewly/cloud/config.json). Read directly (not via CloudClientService)
+ * so this one-shot CLI doesn't start the singleton's relay-token refresh timer.
+ *
+ * @returns Cloud base URL + token + tier
+ * @throws CloudNotConnectedError when not connected
+ */
+async function resolveCloudAuth(): Promise<{ baseUrl: string; token: string; tier: string }> {
+  try {
+    const raw = await fsp.readFile(CloudClientService.getConfigPath(), 'utf8');
+    const cfg = JSON.parse(raw) as { cloudUrl?: string; token?: string; tier?: string };
+    if (cfg.cloudUrl && cfg.token) return { baseUrl: cfg.cloudUrl, token: cfg.token, tier: cfg.tier ?? 'free' };
+  } catch {
+    /* fall through to not-connected */
+  }
+  throw new CloudNotConnectedError();
+}
+
+/** Wrap a cloud action, mapping not-Pro / not-connected to friendly messages. */
+async function withCloudErrors(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof BackupNotProError) {
+      console.log(chalk.yellow('\n⚠ Cloud backup is a Pro feature.'));
+      console.log(chalk.gray(`  ${err.message}`));
+      process.exitCode = 1;
+    } else if (err instanceof CloudNotConnectedError) {
+      console.log(chalk.red('\nNot connected to Crewly Cloud. Run: crewly cloud login'));
+      process.exitCode = 1;
+    } else {
+      throw err;
+    }
+  }
+}
+
+/** `crewly backup push` — create a local archive and upload it to the cloud. */
+async function runPush(options: BackupCommandOptions): Promise<void> {
+  const auth = await resolveCloudAuth();
+  const home = getCrewlyHomePath();
+  const deviceName = os.hostname();
+  const deviceId = readDeviceId(home);
+
+  console.log(chalk.cyan('Creating workspace backup…'));
+  const svc = new BackupArchiveService();
+  const { archivePath, manifest } = await svc.createArchive({
+    homePath: home,
+    excludeChatDb: options.chatDb === false,
+    createdAt: new Date().toISOString(),
+    sourceDeviceId: deviceId,
+    sourceDeviceName: deviceName,
+  });
+
+  console.log(chalk.cyan('Uploading to Crewly Cloud…'));
+  const client = new BackupCloudClient({ baseUrl: auth.baseUrl, token: auth.token });
+  const item = await client.push(archivePath, { deviceName, deviceId: deviceId ?? undefined });
+
+  console.log(chalk.green('\n✓ Backup pushed to cloud'));
+  console.log(`  ${chalk.bold('Backup id')}  ${item.backupId}`);
+  console.log(`  ${chalk.bold('Size')}       ${humanBytes(item.sizeBytes)} · chat.db ${manifest.chatDb.included ? 'yes' : 'no'}`);
+  console.log(chalk.gray(`\n  Restore on another machine: crewly backup pull ${item.backupId} --apply`));
+}
+
+/** `crewly backup pull <id>` — download a cloud snapshot and restore it. */
+async function runPull(backupId: string | undefined, options: BackupCommandOptions): Promise<void> {
+  if (!backupId) {
+    console.log(chalk.red('Missing backup id. Usage: crewly backup pull <id> [--apply]'));
+    process.exitCode = 1;
+    return;
+  }
+  const auth = await resolveCloudAuth();
+  const client = new BackupCloudClient({ baseUrl: auth.baseUrl, token: auth.token });
+  const dest = path.join(os.tmpdir(), `crewly-pull-${backupId.replace(/[^\w.-]/g, '_')}.tar.gz`);
+
+  console.log(chalk.cyan(`Downloading backup ${backupId} from cloud…`));
+  await client.pull(backupId, dest);
+  console.log(chalk.gray(`  Saved to ${dest}`));
+
+  // Hand off to the restore flow (dry-run by default; --apply commits).
+  await runRestore(dest, options);
+}
+
+/** `crewly backup list` — show this account's cloud snapshots. */
+async function runList(): Promise<void> {
+  const auth = await resolveCloudAuth();
+  const client = new BackupCloudClient({ baseUrl: auth.baseUrl, token: auth.token });
+  const items: CloudBackupItem[] = await client.list();
+  if (items.length === 0) {
+    console.log(chalk.gray('No cloud backups yet. Create one with: crewly backup push'));
+    return;
+  }
+  console.log(chalk.cyan(`\nCloud backups (${items.length})`));
+  for (const it of items) {
+    console.log(
+      `  ${chalk.bold(it.backupId)}  ${it.createdAt}  ${humanBytes(it.sizeBytes)}  ${it.deviceName ?? ''}`,
+    );
+  }
+  console.log(chalk.gray('\n  Restore: crewly backup pull <id> --apply'));
 }

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -14,6 +14,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import { BackupArchiveService } from '../../../backend/src/services/backup/backup-archive.service.js';
+import { BackupRestoreService, RestoreConflictError } from '../../../backend/src/services/backup/backup-restore.service.js';
 import { getCrewlyHomePath } from '../../../backend/src/services/core/crewly-home.utils.js';
 
 /** Options accepted by `crewly backup`. */
@@ -22,6 +23,12 @@ export interface BackupCommandOptions {
   out?: string;
   /** Exclude chat.db from the archive (create). commander sets chatDb=false for --no-chat-db. */
   chatDb?: boolean;
+  /** Restore conflict mode: 'abort' (default) | 'overwrite'. */
+  mode?: string;
+  /** Restore source→target path remaps, each "OLD=NEW" (repeatable). */
+  map?: string[];
+  /** Actually apply the restore. Without this, restore is a dry-run preview. */
+  apply?: boolean;
 }
 
 /** Human-readable byte size. */
@@ -59,21 +66,28 @@ function readDeviceId(home: string): string | null {
  * @param action - Subcommand: `create` (P0). Others are placeholders.
  * @param options - CLI options
  */
-export async function backupCommand(action: string, options: BackupCommandOptions = {}): Promise<void> {
+export async function backupCommand(
+  action: string,
+  target?: string,
+  options: BackupCommandOptions = {},
+): Promise<void> {
   switch (action) {
     case 'create':
       await runCreate(options);
       break;
     case 'restore':
+      await runRestore(target, options);
+      break;
     case 'push':
     case 'pull':
     case 'list':
       console.log(chalk.yellow(`'crewly backup ${action}' is not available yet (coming in a later phase).`));
-      console.log(chalk.gray('Available now: crewly backup create'));
+      console.log(chalk.gray('Available now: crewly backup create | crewly backup restore <file>'));
       break;
     default:
       console.log(chalk.red(`Unknown backup action: ${action}`));
       console.log(chalk.gray('Usage: crewly backup create [--out <file>] [--no-chat-db]'));
+      console.log(chalk.gray('       crewly backup restore <file> [--mode overwrite] [--map OLD=NEW] [--apply]'));
       process.exitCode = 1;
   }
 }
@@ -110,5 +124,75 @@ async function runCreate(options: BackupCommandOptions): Promise<void> {
   console.log(
     `  ${chalk.bold('chat.db')}    ${manifest.chatDb.included ? `included (${humanBytes(manifest.chatDb.bytes ?? 0)})` : `excluded${manifest.chatDb.skippedReason ? ` — ${manifest.chatDb.skippedReason}` : ''}`}`,
   );
-  console.log(chalk.gray('\n  Restore on another machine with: crewly backup restore <file>  (coming soon)'));
+  console.log(chalk.gray('\n  Restore on another machine with: crewly backup restore <file>'));
+}
+
+/**
+ * Restore a workspace archive. Dry-run preview by default; `--apply` to commit.
+ *
+ * @param target - Archive file path
+ * @param options - CLI options (mode/map/apply)
+ */
+async function runRestore(target: string | undefined, options: BackupCommandOptions): Promise<void> {
+  if (!target) {
+    console.log(chalk.red('Missing archive path. Usage: crewly backup restore <file> [--apply]'));
+    process.exitCode = 1;
+    return;
+  }
+  const home = getCrewlyHomePath();
+  const mode = options.mode === 'overwrite' ? 'overwrite' : 'abort';
+  const pathMap: Record<string, string> = {};
+  for (const m of options.map ?? []) {
+    const eq = m.indexOf('=');
+    if (eq <= 0) {
+      console.log(chalk.red(`Invalid --map "${m}" (expected OLD=NEW)`));
+      process.exitCode = 1;
+      return;
+    }
+    pathMap[m.slice(0, eq)] = m.slice(eq + 1);
+  }
+
+  const svc = new BackupRestoreService();
+  const restoreOpts = { archivePath: target, homePath: home, mode: mode as 'abort' | 'overwrite', pathMap, now: new Date().toISOString() };
+
+  // Always show the plan first.
+  const plan = await svc.preview(restoreOpts);
+  console.log(chalk.cyan('\nRestore plan'));
+  console.log(`  ${chalk.bold('From backup')} taken ${plan.manifestCreatedAt} (source home ${plan.sourceHomePath})`);
+  console.log(`  ${chalk.bold('Into')}        ${home}`);
+  console.log(`  ${chalk.bold('Globals')}     ${plan.globalFileCount} files · ${chalk.bold('chat.db')} ${plan.chatDbIncluded ? 'yes' : 'no'}`);
+  console.log(`  ${chalk.bold('Projects')}`);
+  for (const p of plan.projects) {
+    const tgt = p.targetPath ? p.targetPath + (p.targetExists ? '' : ' (will be created)') : chalk.yellow('UNRESOLVED — pass --map');
+    console.log(`    • ${p.name} → ${tgt}`);
+  }
+  if (plan.conflicts.teams.length || plan.conflicts.projects.length) {
+    console.log(chalk.yellow(`  Conflicts: ${plan.conflicts.teams.length} team(s), ${plan.conflicts.projects.length} project(s) already on this machine`));
+  }
+  for (const w of plan.warnings) console.log(chalk.yellow(`  ⚠ ${w}`));
+  console.log(chalk.gray(`  Discards: ${plan.discarded.join(', ')}`));
+
+  if (!options.apply) {
+    console.log(chalk.gray('\n  Dry-run only. Re-run with --apply to restore.'));
+    if (!plan.ok) console.log(chalk.yellow("  Note: conflicts present — add --mode overwrite (a pre-restore snapshot is always saved)."));
+    return;
+  }
+
+  try {
+    console.log(chalk.cyan('\nApplying restore…'));
+    const res = await svc.restore(restoreOpts);
+    console.log(chalk.green('\n✓ Restore complete'));
+    console.log(`  ${chalk.bold('Globals')}    ${res.restoredGlobalFiles} files`);
+    console.log(`  ${chalk.bold('Projects')}   ${res.restoredProjects}`);
+    console.log(`  ${chalk.bold('chat.db')}    ${res.chatDbRestored ? 'restored' : 'not in backup'}`);
+    console.log(`  ${chalk.bold('Rollback')}   ${res.rollbackSnapshotPath}`);
+    console.log(chalk.gray('\n  Restart Crewly so agents pick up the restored workspace.'));
+  } catch (err) {
+    if (err instanceof RestoreConflictError) {
+      console.log(chalk.red('\n✗ Restore aborted — conflicts present. Re-run with --mode overwrite to replace them.'));
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
 }

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -1,0 +1,114 @@
+/**
+ * `crewly backup` — workspace backup CLI (P0: local `create`).
+ *
+ * Builds a portable `.tar.gz` of this machine's workspace (CREWLY_HOME globals
+ * + each project's `.crewly/` + chat.db) that can later be restored on another
+ * machine. Runs fully locally and offline. Cloud push/pull/list (Pro-gated)
+ * land in later phases. See specs/2026-06-07-workspace-backup.md.
+ *
+ * @module cli/commands/backup
+ */
+
+import chalk from 'chalk';
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+import { BackupArchiveService } from '../../../backend/src/services/backup/backup-archive.service.js';
+import { getCrewlyHomePath } from '../../../backend/src/services/core/crewly-home.utils.js';
+
+/** Options accepted by `crewly backup`. */
+export interface BackupCommandOptions {
+  /** Output archive path (create). */
+  out?: string;
+  /** Exclude chat.db from the archive (create). commander sets chatDb=false for --no-chat-db. */
+  chatDb?: boolean;
+}
+
+/** Human-readable byte size. */
+function humanBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+/**
+ * Best-effort source device id from CREWLY_HOME/device.json.
+ *
+ * @param home - CREWLY_HOME path
+ * @returns device id or null
+ */
+function readDeviceId(home: string): string | null {
+  try {
+    const raw = fs.readFileSync(path.join(home, 'device.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { id?: string; deviceId?: string };
+    return parsed.id ?? parsed.deviceId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `crewly backup <action>` dispatcher.
+ *
+ * @param action - Subcommand: `create` (P0). Others are placeholders.
+ * @param options - CLI options
+ */
+export async function backupCommand(action: string, options: BackupCommandOptions = {}): Promise<void> {
+  switch (action) {
+    case 'create':
+      await runCreate(options);
+      break;
+    case 'restore':
+    case 'push':
+    case 'pull':
+    case 'list':
+      console.log(chalk.yellow(`'crewly backup ${action}' is not available yet (coming in a later phase).`));
+      console.log(chalk.gray('Available now: crewly backup create'));
+      break;
+    default:
+      console.log(chalk.red(`Unknown backup action: ${action}`));
+      console.log(chalk.gray('Usage: crewly backup create [--out <file>] [--no-chat-db]'));
+      process.exitCode = 1;
+  }
+}
+
+/**
+ * Build a local workspace archive and print a summary.
+ *
+ * @param options - CLI options
+ */
+async function runCreate(options: BackupCommandOptions): Promise<void> {
+  const home = getCrewlyHomePath();
+  const createdAt = new Date().toISOString();
+  const excludeChatDb = options.chatDb === false; // commander: --no-chat-db → chatDb:false
+
+  console.log(chalk.cyan('Creating workspace backup…'));
+  console.log(chalk.gray(`  CREWLY_HOME: ${home}`));
+
+  const svc = new BackupArchiveService();
+  const { archivePath, manifest, totalBytes } = await svc.createArchive({
+    homePath: home,
+    outPath: options.out,
+    excludeChatDb,
+    createdAt,
+    sourceDeviceId: readDeviceId(home),
+    sourceDeviceName: os.hostname(),
+  });
+
+  const archiveBytes = fs.statSync(archivePath).size;
+  console.log(chalk.green('\n✓ Backup created'));
+  console.log(`  ${chalk.bold('Archive')}    ${archivePath}`);
+  console.log(`  ${chalk.bold('Size')}       ${humanBytes(archiveBytes)} compressed (${humanBytes(totalBytes)} raw)`);
+  console.log(`  ${chalk.bold('Globals')}    ${manifest.global.length} files`);
+  console.log(`  ${chalk.bold('Projects')}   ${manifest.projects.length}`);
+  console.log(
+    `  ${chalk.bold('chat.db')}    ${manifest.chatDb.included ? `included (${humanBytes(manifest.chatDb.bytes ?? 0)})` : `excluded${manifest.chatDb.skippedReason ? ` — ${manifest.chatDb.skippedReason}` : ''}`}`,
+  );
+  console.log(chalk.gray('\n  Restore on another machine with: crewly backup restore <file>  (coming soon)'));
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -124,10 +124,13 @@ program
   .action(serviceCommand);
 
 program
-  .command('backup <action>')
-  .description('Workspace backup (create) — archive this machine to restore on another. Pro: cloud push/pull (soon)')
+  .command('backup <action> [target]')
+  .description('Workspace backup: create | restore <file>. Archive this machine to restore on another. Pro: cloud push/pull (soon)')
   .option('-o, --out <file>', 'Output archive path (create)')
-  .option('--no-chat-db', 'Exclude chat.db from the archive (smaller, faster)')
+  .option('--no-chat-db', 'Exclude chat.db from the archive (create)')
+  .option('--mode <mode>', 'Restore conflict mode: abort (default) | overwrite')
+  .option('--map <mapping...>', 'Restore source→target path remap, OLD=NEW (repeatable)')
+  .option('--apply', 'Apply the restore (without this, restore is a dry-run preview)')
   .action(backupCommand);
 
 program

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import { mcpServerCommand } from './commands/mcp-server.js';
 import { publishCommand } from './commands/publish.js';
 import { seedMarketplaceCommand } from './commands/seed-marketplace.js';
 import { serviceCommand } from './commands/service.js';
+import { backupCommand } from './commands/backup.js';
 import { pairCommand } from './commands/pair.js';
 import { loginCommand, statusCommand as cloudStatusCommand, logoutCommand } from './commands/cloud.js';
 import { DEFAULT_WEB_PORT } from './constants.js';
@@ -121,6 +122,13 @@ program
   .option('-n, --lines <number>', 'Number of log lines to show (default: 50)')
   .option('-f, --follow', 'Follow log output in real-time (logs action)')
   .action(serviceCommand);
+
+program
+  .command('backup <action>')
+  .description('Workspace backup (create) — archive this machine to restore on another. Pro: cloud push/pull (soon)')
+  .option('-o, --out <file>', 'Output archive path (create)')
+  .option('--no-chat-db', 'Exclude chat.db from the archive (smaller, faster)')
+  .action(backupCommand);
 
 program
   .command('pair')


### PR DESCRIPTION
First phase of the **Pro workspace backup/restore** feature (disaster recovery: back up one machine, restore on another via Cloud). Full design in the local spec `specs/2026-06-07-workspace-backup.md` (specs are gitignored).

## What's in P0 (local, free, offline)
- **`BackupArchiveService`** — builds a portable `tar.gz`:
  - CREWLY_HOME globals (**exclude-based** → new data domains auto-captured)
  - each project's **`.crewly/`** tree (walked from `projects.json`) with **git remote + HEAD** provenance (for re-clone on restore)
  - **chat.db** via `better-sqlite3` `.backup()` (online snapshot; graceful skip if the native module/file is absent)
  - per-file **sha256** manifest (schema v1)
  - excludes machine-specific/secret/runtime/recursion: `device.json`, `cloud/`, `credentials/`, `telegram-credentials.json`, `logs/`, `sessions/`, `*.jsonl`, `teams-backup-history/`, …
- **CLI**: `crewly backup create [--out <file>] [--no-chat-db]` (placeholders for restore/push/pull/list).

## Placement (per owner decision)
Engine lives in **OSS** (free local archive — also a nice OSS feature). Cloud **push/pull is Pro-gated at the cloud endpoints** (P2/P3), so no plugin/API extraction needed.

## Tests (52 green)
Archive scope (in/out), git provenance, chat.db exclude, **extract + checksum integrity**, missing-home error; CLI create / unknown action / not-yet-impl.

## Next
P1 = `BackupRestoreService` + `crewly backup restore` (overwrite/abort, path rewrite, device regen, cron recompute, full rollback snapshot, dry-run). Then P2 cloud blob endpoint (DO Spaces, SSE, Pro gate, quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)