### PR TITLE
feat(agent): vendor the crewly-agent runtime into the OSS monorepo

### DIFF
--- a/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
@@ -333,7 +333,7 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
           trimmed === CREWLY_AGENT_MANAGED_COMMAND ||
           (LEGACY_CREWLY_AGENT_SENTINELS as readonly string[]).includes(trimmed)
         ) {
-          return { command: CREWLY_AGENT_MANAGED_COMMAND, useShell: false };
+          return { command: await this.resolveManagedBinary(), useShell: false };
         }
 
         if (CrewlyAgentExternalRuntimeService.SAFE_SHELL_COMMAND_RE.test(trimmed)) {
@@ -350,7 +350,36 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
     } catch {
       // Fall through to default command.
     }
-    return { command: CREWLY_AGENT_MANAGED_COMMAND, useShell: false };
+    return { command: await this.resolveManagedBinary(), useShell: false };
+  }
+
+  /**
+   * Resolve the managed `crewly-agent` runtime to an executable path.
+   *
+   * Prefers the binary VENDORED inside crewly itself at
+   * `packages/crewly-agent/bin/crewly-agent` (relative to the install dir,
+   * {@link this.projectRoot}). This is what makes the in-process runtime work
+   * out of the box now that crewly-agent lives in the OSS monorepo — it
+   * resolves identically whether the engine was started via an npm script
+   * (which puts `node_modules/.bin` on PATH) or directly via `node dist/...`
+   * (which does not), and whether running from a checkout or an installed
+   * npm package (the tarball ships `packages/crewly-agent/`).
+   *
+   * Falls back to the bare {@link CREWLY_AGENT_MANAGED_COMMAND} name (PATH
+   * lookup) for legacy global installs where the vendored copy is absent.
+   *
+   * @returns Absolute path to the vendored binary, or the bare command name
+   */
+  private async resolveManagedBinary(): Promise<string> {
+    const vendored = path.join(
+      this.projectRoot,
+      'packages',
+      'crewly-agent',
+      'bin',
+      'crewly-agent',
+    );
+    const found = await this.lookupOnPath(vendored, undefined);
+    return found ?? CREWLY_AGENT_MANAGED_COMMAND;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.11.3",
+  "version": "1.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.11.3",
+      "version": "1.11.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -1433,7 +1433,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,7 +1449,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,7 +1465,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1484,7 +1481,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1501,7 +1497,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1518,7 +1513,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1535,7 +1529,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1552,7 +1545,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1569,7 +1561,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1586,7 +1577,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1603,7 +1593,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1620,7 +1609,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1637,7 +1625,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1654,7 +1641,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1671,7 +1657,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1688,7 +1673,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1705,7 +1689,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1722,7 +1705,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1739,7 +1721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1756,7 +1737,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1773,7 +1753,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1790,7 +1769,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,7 +1785,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1824,7 +1801,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1841,7 +1817,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1858,7 +1833,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7130,9 +7104,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7140,7 +7114,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bidi-js": {
@@ -8075,6 +8049,10 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crewly-agent": {
+      "resolved": "packages/crewly-agent",
+      "link": true
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -9181,7 +9159,6 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10244,7 +10221,6 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -16737,7 +16713,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -18888,7 +18863,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -21048,6 +21022,30 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/crewly-agent": {
+      "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.58",
+        "@ai-sdk/google": "^3.0.43",
+        "@ai-sdk/openai": "^3.0.41",
+        "ai": "^6.0.116",
+        "better-sqlite3": "^12.10.0",
+        "ollama-ai-provider": "^1.2.0",
+        "tsx": "^4.21.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "crewly-agent": "bin/crewly-agent"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
     "frontend/dist/assets/*.woff2",
     "frontend/dist/logo/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "packages/crewly-agent/bin/",
+    "packages/crewly-agent/src/",
+    "packages/crewly-agent/package.json",
+    "packages/crewly-agent/README.md"
   ],
   "scripts": {
     "build": "npm run build:backend && npm run build:frontend && npm run build:cli",
@@ -109,7 +113,9 @@
     "tar": "^7.5.9",
     "uuid": "^9.0.0",
     "ws": "^8.14.2",
-    "yaml": "^2.3.2"
+    "yaml": "^2.3.2",
+    "tsx": "^4.21.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/packages/crewly-agent/README.md
+++ b/packages/crewly-agent/README.md
@@ -1,0 +1,27 @@
+# crewly-agent
+
+Standalone Crewly Agent executable for the OSS `crewly-agent` runtime.
+
+It speaks a newline-delimited JSON protocol over `stdin` / `stdout`:
+
+- `init`
+- `run`
+- `abort`
+- `get-state`
+- `shutdown`
+
+The OSS backend manages the process through
+`CrewlyAgentExternalRuntimeService` and surfaces logs through the existing
+non-PTY monitoring path.
+
+Current default OSS runtime command:
+
+```sh
+crewly-agent
+```
+
+Intended release model:
+
+- `crewly` OSS owns orchestration, sessions, storage, and UI
+- `crewly-agent` owns the agent runtime executable
+- `crewly-pro` can distribute or enable `crewly-agent` without OSS importing Pro code

--- a/packages/crewly-agent/bin/crewly-agent
+++ b/packages/crewly-agent/bin/crewly-agent
@@ -14,10 +14,15 @@ SCRIPT_DIR="$(cd -P -- "$(dirname -- "${SOURCE}")" && pwd)"
 PACKAGE_DIR="$(cd -P -- "${SCRIPT_DIR}/.." && pwd)"
 
 # Find tsx — first try this package's own node_modules (standalone install),
-# then fall back to Node's resolver (npm-hoisted into a parent project).
+# then resolve it RELATIVE TO THIS PACKAGE (not the cwd). The latter matters
+# because the engine spawns this binary with cwd set to the agent's project
+# directory (outside the crewly install), and as a hoisted workspace package
+# our tsx lives in the parent install's node_modules. Passing `paths:
+# [PACKAGE_DIR]` walks up from packages/crewly-agent → <install>/node_modules,
+# independent of cwd. (A bare require.resolve would resolve from cwd and miss it.)
 TSX_PATH="${PACKAGE_DIR}/node_modules/tsx/dist/cli.mjs"
 if [ ! -f "${TSX_PATH}" ]; then
-  TSX_PATH="$(node -e "try { console.log(require.resolve('tsx/dist/cli.mjs')); } catch { console.log(require.resolve('tsx/cli')); }" 2>/dev/null || true)"
+  TSX_PATH="$(node -e "const o={paths:['${PACKAGE_DIR}']}; try { console.log(require.resolve('tsx/dist/cli.mjs', o)); } catch (e) { try { console.log(require.resolve('tsx/cli', o)); } catch (e2) {} }" 2>/dev/null || true)"
 fi
 
 if [ -z "${TSX_PATH}" ] || [ ! -f "${TSX_PATH}" ]; then

--- a/packages/crewly-agent/bin/crewly-agent
+++ b/packages/crewly-agent/bin/crewly-agent
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the package directory even when installed as a dependency and
+# invoked via a hoisted symlink (e.g. node_modules/.bin/crewly-agent ->
+# ../crewly-agent/bin/crewly-agent).
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "${SOURCE}" ]; do
+  DIR="$(cd -P -- "$(dirname -- "${SOURCE}")" && pwd)"
+  SOURCE="$(readlink -- "${SOURCE}")"
+  [[ "${SOURCE}" != /* ]] && SOURCE="${DIR}/${SOURCE}"
+done
+SCRIPT_DIR="$(cd -P -- "$(dirname -- "${SOURCE}")" && pwd)"
+PACKAGE_DIR="$(cd -P -- "${SCRIPT_DIR}/.." && pwd)"
+
+# Find tsx — first try this package's own node_modules (standalone install),
+# then fall back to Node's resolver (npm-hoisted into a parent project).
+TSX_PATH="${PACKAGE_DIR}/node_modules/tsx/dist/cli.mjs"
+if [ ! -f "${TSX_PATH}" ]; then
+  TSX_PATH="$(node -e "try { console.log(require.resolve('tsx/dist/cli.mjs')); } catch { console.log(require.resolve('tsx/cli')); }" 2>/dev/null || true)"
+fi
+
+if [ -z "${TSX_PATH}" ] || [ ! -f "${TSX_PATH}" ]; then
+  echo "crewly-agent: cannot locate tsx — install via 'npm install crewly-agent' so tsx is present in node_modules." >&2
+  exit 1
+fi
+
+exec node "${TSX_PATH}" "${PACKAGE_DIR}/src/cli.ts" "$@"

--- a/packages/crewly-agent/package.json
+++ b/packages/crewly-agent/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "crewly-agent",
+  "version": "0.1.1",
+  "type": "module",
+  "private": true,
+  "description": "Crewly Agent runtime — the canonical agent reasoning loop crewly spawns as a subprocess. Talks newline-delimited JSON over stdin/stdout. Vendored into the crewly monorepo (formerly the standalone crewly-agent repo).",
+  "bin": {
+    "crewly-agent": "./bin/crewly-agent"
+  },
+  "files": [
+    "bin/",
+    "src/runtime/",
+    "src/cli.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "start": "./bin/crewly-agent",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.58",
+    "@ai-sdk/google": "^3.0.43",
+    "@ai-sdk/openai": "^3.0.41",
+    "ai": "^6.0.116",
+    "better-sqlite3": "^12.10.0",
+    "ollama-ai-provider": "^1.2.0",
+    "tsx": "^4.21.0",
+    "zod": "^3.25.76"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/crewly-agent/src/cli.ts
+++ b/packages/crewly-agent/src/cli.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env -S node --import tsx
+
+import readline from 'node:readline';
+import { AgentRunnerService } from './runtime/agent-runner.service.js';
+import type {
+  AgentRunResult,
+  CrewlyAgentConfig,
+  StreamingEventCallbacks,
+} from './runtime/types.js';
+
+type ParentMessage =
+  | { type: 'init'; config: CrewlyAgentConfig }
+  | { type: 'run'; message: string; conversationId?: string; metadata?: Record<string, string> }
+  | { type: 'abort' }
+  | { type: 'get-state' }
+  | { type: 'shutdown' };
+
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; data: AgentRunResult }
+  | { type: 'error'; error: string; code?: string }
+  | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
+  | { type: 'stream'; event: 'text'; data: { chunk: string } }
+  | { type: 'stream'; event: 'toolStart'; data: { toolName: string; args: Record<string, unknown> } }
+  | { type: 'stream'; event: 'toolFinish'; data: { toolName: string; args: Record<string, unknown>; result: unknown; durationMs: number } }
+  | { type: 'stream'; event: 'stepFinish'; data: { stepIndex: number; hasToolCalls: boolean } }
+  | { type: 'state'; data: { historyLength: number; isProcessing: boolean; isInitialized: boolean } };
+
+let runner: AgentRunnerService | null = null;
+let currentAbort: AbortController | null = null;
+
+function send(message: WorkerMessage): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function log(level: WorkerMessage extends { type: 'log'; level: infer L } ? L : never, message: string): void {
+  send({ type: 'log', level: level as 'debug' | 'info' | 'warn' | 'error', message });
+}
+
+function buildStreamingCallbacks(): StreamingEventCallbacks {
+  return {
+    onTextChunk: (chunk: string) => {
+      send({ type: 'stream', event: 'text', data: { chunk } });
+    },
+    onToolCallStart: (toolName: string, args: Record<string, unknown>) => {
+      send({ type: 'stream', event: 'toolStart', data: { toolName, args } });
+    },
+    onToolCallFinish: (toolName: string, args: Record<string, unknown>, result: unknown, durationMs: number) => {
+      send({ type: 'stream', event: 'toolFinish', data: { toolName, args, result, durationMs } });
+    },
+    onStepFinish: (stepIndex: number, hasToolCalls: boolean) => {
+      send({ type: 'stream', event: 'stepFinish', data: { stepIndex, hasToolCalls } });
+    },
+  };
+}
+
+async function handleMessage(message: ParentMessage): Promise<void> {
+  switch (message.type) {
+    case 'init':
+      try {
+        runner = new AgentRunnerService(message.config);
+        await runner.initialize();
+        send({ type: 'ready' });
+        log('info', `Initialized (${message.config.model.provider}/${message.config.model.modelId})`);
+      } catch (error) {
+        send({
+          type: 'error',
+          error: error instanceof Error ? error.message : String(error),
+          code: 'INIT_FAILED',
+        });
+        runner = null;
+      }
+      break;
+    case 'run':
+      if (!runner || !runner.isInitialized()) {
+        send({ type: 'error', error: 'Worker not initialized', code: 'NOT_INITIALIZED' });
+        return;
+      }
+      currentAbort = new AbortController();
+      try {
+        const result = await runner.run(
+          message.message,
+          message.conversationId,
+          message.metadata,
+          {
+            abortSignal: currentAbort.signal,
+            streaming: buildStreamingCallbacks(),
+          },
+        );
+        currentAbort = null;
+        send({ type: 'result', data: result });
+      } catch (error) {
+        currentAbort = null;
+        send({
+          type: 'error',
+          error: error instanceof Error ? error.message : String(error),
+          code: 'RUN_FAILED',
+        });
+      }
+      break;
+    case 'abort':
+      if (currentAbort) {
+        currentAbort.abort();
+        currentAbort = null;
+      }
+      runner?.abortCurrentRun();
+      log('warn', 'Run aborted by parent');
+      break;
+    case 'get-state':
+      send({
+        type: 'state',
+        data: {
+          historyLength: runner ? runner.getHistoryLength() : 0,
+          isProcessing: runner ? runner.isProcessing() : false,
+          isInitialized: runner ? runner.isInitialized() : false,
+        },
+      });
+      break;
+    case 'shutdown':
+      log('info', 'Shutting down');
+      if (runner) {
+        await runner.shutdown();
+        runner = null;
+      }
+      process.exit(0);
+  }
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let message: ParentMessage;
+  try {
+    message = JSON.parse(trimmed) as ParentMessage;
+  } catch {
+    send({ type: 'error', error: `Invalid JSON input: ${trimmed}`, code: 'INVALID_JSON' });
+    return;
+  }
+
+  handleMessage(message).catch((error) => {
+    send({
+      type: 'error',
+      error: error instanceof Error ? error.message : String(error),
+      code: 'UNHANDLED',
+    });
+  });
+});
+
+process.on('SIGINT', async () => {
+  if (runner) {
+    await runner.shutdown();
+  }
+  process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+  if (runner) {
+    await runner.shutdown();
+  }
+  process.exit(0);
+});
+
+log('info', 'crewly-agent executable started');

--- a/packages/crewly-agent/src/runtime/agent-runner.service.test.ts
+++ b/packages/crewly-agent/src/runtime/agent-runner.service.test.ts
@@ -1,0 +1,2355 @@
+import { describe, it, expect, beforeEach, vi, type Mocked, type MockInstance } from 'vitest';
+import { AgentRunnerService, ToolCallLoopDetector } from './agent-runner.service.js';
+import { ModelManager } from './model-manager.js';
+import { CrewlyApiClient } from './api-client.js';
+import type { CrewlyAgentConfig, SecurityPolicy, AuditEntry } from './types.js';
+
+describe('AgentRunnerService', () => {
+  let runner: AgentRunnerService;
+  let mockModelManager: Mocked<ModelManager>;
+  let mockApiClient: Mocked<CrewlyApiClient>;
+  let mockGenerateText: vi.Mock<any>;
+  const mockModel = { provider: 'mock', modelId: 'test-model' };
+
+  const baseConfig: CrewlyAgentConfig = {
+    model: { provider: 'anthropic', modelId: 'claude-sonnet-4-20250514', temperature: 0.3, maxTokens: 8192 },
+    maxSteps: 10,
+    sessionName: 'test-session',
+    apiBaseUrl: 'http://localhost:8787',
+    systemPrompt: 'You are a test agent.',
+    maxHistoryMessages: 20,
+    compactionThreshold: 0.8,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockGenerateText = vi.fn<any>();
+
+    mockModelManager = {
+      getModel: vi.fn<any>().mockResolvedValue(mockModel),
+      getAvailableProviders: vi.fn<any>(),
+      clearCache: vi.fn<any>(),
+      // I2 — DeepSeek reasoning_content extraction. Defaults to no reasoning
+      // captured (returns null) so non-DeepSeek tests are unaffected.
+      consumeDeepseekReasoning: vi.fn<any>().mockResolvedValue(null),
+    } as any;
+
+    mockApiClient = {
+      get: vi.fn<any>(),
+      post: vi.fn<any>(),
+      delete: vi.fn<any>(),
+    } as any;
+
+    runner = new AgentRunnerService(baseConfig, mockModelManager, mockApiClient);
+    runner._generateTextFn = mockGenerateText;
+  });
+
+  describe('constructor', () => {
+    it('should create with default ModelManager and ApiClient when not provided', () => {
+      const r = new AgentRunnerService(baseConfig);
+      expect(r).toBeDefined();
+      expect(r.isInitialized()).toBe(false);
+    });
+
+    it('should initialize conversation state with empty messages', () => {
+      const state = runner.getState();
+      expect(state.messages).toEqual([]);
+      expect(state.systemPrompt).toBe('You are a test agent.');
+      expect(state.totalTokens).toEqual({ input: 0, output: 0 });
+    });
+  });
+
+  describe('initialize', () => {
+    it('should load the model via ModelManager', async () => {
+      await runner.initialize();
+
+      expect(runner.isInitialized()).toBe(true);
+      expect(mockModelManager.getModel).toHaveBeenCalledWith(baseConfig.model);
+    });
+
+    it('should propagate ModelManager errors', async () => {
+      mockModelManager.getModel.mockRejectedValueOnce(new Error('Invalid API key'));
+
+      await expect(runner.initialize()).rejects.toThrow('Invalid API key');
+      expect(runner.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('run', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should call generateText and return structured result', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Hello from agent',
+        steps: [{ toolCalls: [], toolResults: [] }],
+        usage: { inputTokens: 100, outputTokens: 50 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('Hi there');
+
+      expect(result.text).toBe('Hello from agent');
+      expect(result.steps).toBe(1);
+      expect(result.usage).toEqual({ input: 100, output: 50 });
+      expect(result.toolCalls).toEqual([]);
+      expect(result.finishReason).toBe('stop');
+    });
+
+    it('should add user message and assistant response to history', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      await runner.run('Question');
+
+      expect(runner.getHistoryLength()).toBe(2); // user + assistant
+      const state = runner.getState();
+      expect(state.messages[0]).toEqual({ role: 'user', content: 'Question' });
+      expect(state.messages[1]).toEqual({ role: 'assistant', content: 'Response' });
+    });
+
+    it('should not add assistant message when text is empty', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: '',
+        steps: [{ toolCalls: [], toolResults: [] }],
+        usage: { inputTokens: 10, outputTokens: 0 },
+        finishReason: 'tool-calls',
+      });
+
+      await runner.run('Do something');
+
+      expect(runner.getHistoryLength()).toBe(1); // only user message
+    });
+
+    it('should track tool calls across steps', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Done',
+        steps: [
+          {
+            toolCalls: [
+              { toolCallId: 'tc-1', toolName: 'get_team_status', input: {} },
+            ],
+            toolResults: [
+              { toolCallId: 'tc-1', output: { teams: [] } },
+            ],
+          },
+          {
+            toolCalls: [
+              { toolCallId: 'tc-2', toolName: 'send_message', input: { to: 'sam' } },
+            ],
+            toolResults: [
+              { toolCallId: 'tc-2', output: { success: true } },
+            ],
+          },
+        ],
+        usage: { inputTokens: 200, outputTokens: 100 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('Check status and notify');
+
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls[0].toolName).toBe('get_team_status');
+      expect(result.toolCalls[0].result).toEqual({ teams: [] });
+      expect(result.toolCalls[1].toolName).toBe('send_message');
+      expect(result.steps).toBe(2);
+    });
+
+    it('should accumulate token usage across multiple runs', async () => {
+      mockGenerateText
+        .mockResolvedValueOnce({
+          text: 'First',
+          steps: [],
+          usage: { inputTokens: 100, outputTokens: 50 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          text: 'Second',
+          steps: [],
+          usage: { inputTokens: 200, outputTokens: 75 },
+          finishReason: 'stop',
+        });
+
+      await runner.run('Message 1');
+      await runner.run('Message 2');
+
+      const state = runner.getState();
+      expect(state.totalTokens.input).toBe(300);
+      expect(state.totalTokens.output).toBe(125);
+    });
+
+    it('should handle missing usage gracefully', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Done',
+        steps: [],
+        usage: undefined,
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('Test');
+
+      expect(result.usage).toEqual({ input: 0, output: 0 });
+    });
+
+    it('should throw if not initialized', async () => {
+      const uninitRunner = new AgentRunnerService(baseConfig, mockModelManager, mockApiClient);
+      uninitRunner._generateTextFn = mockGenerateText;
+
+      await expect(uninitRunner.run('Hello')).rejects.toThrow('not initialized');
+    });
+  });
+
+  describe('serial queue', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should process multiple messages serially', async () => {
+      const callOrder: number[] = [];
+
+      mockGenerateText
+        .mockImplementationOnce(async () => {
+          callOrder.push(1);
+          return {
+            text: 'First',
+            steps: [],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push(2);
+          return {
+            text: 'Second',
+            steps: [],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        });
+
+      const [r1, r2] = await Promise.all([
+        runner.run('First'),
+        runner.run('Second'),
+      ]);
+
+      expect(r1.text).toBe('First');
+      expect(r2.text).toBe('Second');
+      expect(callOrder).toEqual([1, 2]);
+    });
+
+    it('should reject queued item if generateText throws', async () => {
+      mockGenerateText.mockRejectedValueOnce(new Error('API error'));
+
+      await expect(runner.run('Fail')).rejects.toThrow('API error');
+    });
+
+    it('should preserve lastKnownConversationId as fallback for messages without explicit conversationId', async () => {
+      // Track which conversationId is passed to generateText via tools argument
+      const capturedConvIds: (string | undefined)[] = [];
+      mockGenerateText
+        .mockImplementation(async (opts: Record<string, unknown>) => {
+          // The tools object is created with the current conversationId.
+          // We verify by checking if report_status tool exists — its closure
+          // captures the conversationId. We call it to extract the value.
+          const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+          if (tools?.report_status) {
+            // Call report_status to see if conversationId is included in the POST body
+            mockApiClient.post.mockResolvedValueOnce({ success: true, data: {} } as any);
+            await tools.report_status.execute({ status: 'in_progress', summary: 'test' });
+            const postCall = mockApiClient.post.mock.calls[mockApiClient.post.mock.calls.length - 1];
+            const body = postCall[1] as Record<string, unknown>;
+            capturedConvIds.push(body.conversationId as string | undefined);
+          }
+          return {
+            text: 'Response',
+            steps: [{ toolCalls: [], toolResults: [] }],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        });
+
+      // First message with conversationId
+      await runner.run('With conv', 'conv-123');
+      // Second message without conversationId (e.g., scheduled check)
+      await runner.run('No conv');
+
+      // First call should have conversationId = 'conv-123'
+      expect(capturedConvIds[0]).toBe('conv-123');
+      // Second call should inherit the last known conversationId as fallback
+      expect(capturedConvIds[1]).toBe('conv-123');
+    });
+
+    it('should update lastKnownConversationId when a new explicit conversationId arrives', async () => {
+      const capturedConvIds: (string | undefined)[] = [];
+      mockGenerateText
+        .mockImplementation(async (opts: Record<string, unknown>) => {
+          const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+          if (tools?.report_status) {
+            mockApiClient.post.mockResolvedValueOnce({ success: true, data: {} } as any);
+            await tools.report_status.execute({ status: 'in_progress', summary: 'test' });
+            const postCall = mockApiClient.post.mock.calls[mockApiClient.post.mock.calls.length - 1];
+            const body = postCall[1] as Record<string, unknown>;
+            capturedConvIds.push(body.conversationId as string | undefined);
+          }
+          return {
+            text: 'Response',
+            steps: [{ toolCalls: [], toolResults: [] }],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        });
+
+      await runner.run('First', 'conv-A');
+      await runner.run('Second', 'conv-B');
+      await runner.run('Third (no conv)');
+
+      expect(capturedConvIds[0]).toBe('conv-A');
+      expect(capturedConvIds[1]).toBe('conv-B');
+      // Third should use conv-B (last known)
+      expect(capturedConvIds[2]).toBe('conv-B');
+    });
+
+    it('should have no conversationId when no message ever provided one', async () => {
+      const capturedConvIds: (string | undefined)[] = [];
+      mockGenerateText
+        .mockImplementation(async (opts: Record<string, unknown>) => {
+          const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+          if (tools?.report_status) {
+            mockApiClient.post.mockResolvedValueOnce({ success: true, data: {} } as any);
+            await tools.report_status.execute({ status: 'in_progress', summary: 'test' });
+            const postCall = mockApiClient.post.mock.calls[mockApiClient.post.mock.calls.length - 1];
+            const body = postCall[1] as Record<string, unknown>;
+            capturedConvIds.push(body.conversationId as string | undefined);
+          }
+          return {
+            text: 'Response',
+            steps: [{ toolCalls: [], toolResults: [] }],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        });
+
+      await runner.run('No conv ever');
+
+      expect(capturedConvIds[0]).toBeUndefined();
+    });
+  });
+
+  describe('context compaction', () => {
+    it('should compact history when messages exceed keepRecent threshold', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 12,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // 6 runs × 2 messages = 12 messages
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+
+      expect(r.getHistoryLength()).toBe(12);
+
+      // AI summarization call for compaction + the actual run
+      mockGenerateText.mockResolvedValueOnce({
+        text: '[Compacted State] Summary of active tasks and decisions',
+        steps: [],
+        usage: { inputTokens: 50, outputTokens: 30 },
+        finishReason: 'stop',
+      });
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Compacted result',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await r.run('After compact');
+
+      const state = r.getState();
+      // Compaction: 2 old messages → 1 AI summary, keep 10 recent, +1 user +1 assistant = 13
+      expect(state.messages.length).toBeLessThan(15);
+      expect(state.messages[0].role).toBe('assistant');
+      expect(String(state.messages[0].content)).toContain('Compacted State');
+    });
+
+    it('should fall back to truncation summary when AI summarization fails', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 12,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // 6 runs × 2 messages = 12 messages
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+
+      // AI summarization fails, then actual run succeeds
+      mockGenerateText.mockRejectedValueOnce(new Error('Model error'));
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'After fallback',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await r.run('After compact');
+
+      const state = r.getState();
+      expect(state.messages.length).toBeLessThan(15);
+      expect(state.messages[0].role).toBe('assistant');
+      expect(String(state.messages[0].content)).toContain('summary');
+    });
+
+    // SKIPPED in standalone: ContextFlushService is currently a no-op stub
+    // (OSS injects a concrete implementation). Re-enable once the service is
+    // ported or the test rewires the stub via dependency injection.
+    it.skip('should include ContextFlushService extracted items in AI summary prompt', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 12,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // 6 runs with messages containing extractable context patterns
+      const contextMessages = [
+        'Currently working on fixing the login endpoint',
+        'Decided to use JWT instead of session cookies',
+        'Port is 8787 for the API server',
+        'User wants concise error messages',
+        'Blocked on database migration failing',
+        'Completed the auth middleware refactor',
+      ];
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(contextMessages[i]);
+      }
+
+      expect(r.getHistoryLength()).toBe(12);
+
+      // Capture the AI summarization prompt to verify extracted items are included
+      let capturedSummaryPrompt = '';
+      mockGenerateText
+        .mockImplementationOnce(async (opts: Record<string, unknown>) => {
+          const msgs = opts.messages as Array<{ content: string }>;
+          capturedSummaryPrompt = msgs[0]?.content || '';
+          return {
+            text: 'Compacted state with critical items',
+            steps: [],
+            usage: { inputTokens: 50, outputTokens: 30 },
+            finishReason: 'stop',
+          };
+        })
+        .mockResolvedValueOnce({
+          text: 'After compact',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      await r.run('Trigger compaction');
+
+      // ContextFlushService should have extracted items from old messages
+      // and they should appear in the AI summary prompt
+      expect(capturedSummaryPrompt).toContain('critical items were auto-extracted');
+      // At minimum, the task_progress and decision patterns should match
+      expect(capturedSummaryPrompt).toContain('task_progress');
+    });
+
+    // SKIPPED in standalone: see preceding ContextFlushService note.
+    it.skip('should include extracted items in fallback summary when AI fails', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 12,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // 6 runs — early messages contain extractable patterns so they end up
+      // in oldMessages (not keepRecent=10). With 12 messages total, the first
+      // 2 messages are old and the rest (10) are recent. So the extractable
+      // content must be in messages 0-1 (runs 0's user+assistant).
+      const userMessages = [
+        'Currently working on fixing the login endpoint',
+        'Message 1',
+        'Message 2',
+        'Message 3',
+        'Message 4',
+        'Message 5',
+      ];
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: i === 0 ? 'Decided to use Redis for caching instead of Memcached' : `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(userMessages[i]);
+      }
+
+      // AI fails, fallback used
+      mockGenerateText.mockRejectedValueOnce(new Error('Model error'));
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'After fallback',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await r.run('After compact');
+
+      const state = r.getState();
+      const summaryContent = String(state.messages[0].content);
+      // Fallback summary should contain extracted critical context section
+      // Old messages include "Currently working on fixing the login endpoint" (task_progress)
+      // and "Decided to use Redis..." (decision)
+      expect(summaryContent).toContain('Extracted critical context');
+      expect(summaryContent).toContain('task_progress');
+    });
+
+    it('should skip compaction when history is small', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 20,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await r.run('Message');
+
+      expect(r.getHistoryLength()).toBe(2);
+    });
+  });
+
+  describe('requestCompaction', () => {
+    it('should return skipped when history is too small', async () => {
+      await runner.initialize();
+      const result = await runner.requestCompaction();
+
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toContain('Too few');
+      expect(result.messagesBefore).toBe(0);
+      expect(result.messagesAfter).toBe(0);
+    });
+
+    it('should perform AI-powered compaction when history is large enough', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 100,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // Build up 12 messages (6 runs × 2)
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+
+      expect(r.getHistoryLength()).toBe(12);
+
+      // AI summarization for compaction
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Structured summary of conversation state with active tasks and decisions',
+        steps: [],
+        usage: { inputTokens: 50, outputTokens: 30 },
+        finishReason: 'stop',
+      });
+
+      const result = await r.requestCompaction();
+
+      expect(result.compacted).toBe(true);
+      expect(result.messagesBefore).toBe(12);
+      expect(result.messagesAfter).toBe(11); // 1 summary + 10 recent
+    });
+
+    it('should return skipped when not initialized', async () => {
+      const r = new AgentRunnerService(baseConfig, mockModelManager, mockApiClient);
+      const result = await r.requestCompaction();
+
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+  });
+
+  describe('getContextBudget', () => {
+    it('should return normal level with zero usage', () => {
+      const budget = runner.getContextBudget();
+
+      expect(budget.totalTokensUsed).toBe(0);
+      expect(budget.usagePercent).toBe(0);
+      expect(budget.level).toBe('normal');
+      expect(budget.messageCount).toBe(0);
+      expect(budget.compactionPending).toBe(false);
+      expect(budget.contextWindowSize).toBeGreaterThan(0);
+    });
+
+    it('should track cumulative token usage', async () => {
+      await runner.initialize();
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [],
+        usage: { inputTokens: 500, outputTokens: 200 },
+        finishReason: 'stop',
+      });
+      await runner.run('Hello');
+
+      const budget = runner.getContextBudget();
+      expect(budget.totalTokensUsed).toBe(700);
+      expect(budget.messageCount).toBe(2); // user + assistant
+    });
+
+    it('should return warning level when approaching threshold', async () => {
+      await runner.initialize();
+      // Use a small context window model to easily trigger warning
+      // Default compactionThreshold is 0.8, warningThreshold is 0.8*0.85 = 0.68
+      // With default context window 128000, need ~87,000 tokens to hit warning
+      // Simulate high token usage
+      for (let i = 0; i < 10; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 5000, outputTokens: 4000 },
+          finishReason: 'stop',
+        });
+        await runner.run(`Message ${i}`);
+      }
+
+      const budget = runner.getContextBudget();
+      // 10 * 9000 = 90,000 tokens. Context window = 200,000 (anthropic claude-sonnet-4-20250514)
+      // 90000/200000 = 0.45, threshold = 0.8, warning at 0.68
+      // Actually need more tokens. Let me check: the model is claude-sonnet-4-20250514 = 200,000
+      // So we'd need 136,000+ for warning (0.68 * 200000)
+      expect(budget.totalTokensUsed).toBe(90000);
+    });
+
+    it('should return critical level when at or above compaction threshold', async () => {
+      // Use a config with a low compaction threshold to trigger critical easily
+      const config = {
+        ...baseConfig,
+        compactionThreshold: 0.1, // 10% threshold for testing
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [],
+        usage: { inputTokens: 15000, outputTokens: 10000 },
+        finishReason: 'stop',
+      });
+      await r.run('Hello');
+
+      const budget = r.getContextBudget();
+      // 25,000 / 200,000 = 0.125 which is >= 0.1 threshold
+      expect(budget.level).toBe('critical');
+      expect(budget.compactionPending).toBe(true);
+      expect(budget.summary).toContain('CRITICAL');
+    });
+
+    it('should set compactionPending when message count exceeds max', async () => {
+      const config = {
+        ...baseConfig,
+        maxHistoryMessages: 4, // Very low for testing
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // 2 runs × 2 messages = 4 messages = maxHistoryMessages
+      for (let i = 0; i < 2; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `R${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`M${i}`);
+      }
+
+      const budget = r.getContextBudget();
+      expect(budget.messageCount).toBe(4);
+      expect(budget.compactionPending).toBe(true);
+    });
+
+    it('should use default context window for unknown models', () => {
+      const config = {
+        ...baseConfig,
+        model: { provider: 'anthropic' as const, modelId: 'unknown-model-xyz', temperature: 0.3, maxTokens: 8192 },
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      const budget = r.getContextBudget();
+
+      expect(budget.contextWindowSize).toBe(128_000); // default fallback
+    });
+
+    it('should not split tool_call/tool_result pairs during compaction', async () => {
+      // Create a runner with low maxHistoryMessages so compaction triggers
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 14,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // Manually set messages to simulate tool call pairs at the split boundary
+      // Position 0-3: older messages, 4: assistant (tool_call), 5: tool (result), 6-13: recent
+      const messages: Array<{ role: string; content: string | object }> = [];
+      for (let i = 0; i < 4; i++) {
+        messages.push({ role: 'user', content: `Old message ${i}` });
+      }
+      // Tool call pair that could get split
+      messages.push({ role: 'assistant', content: [{ type: 'tool_use', id: 'tc1', name: 'bash', input: {} }] });
+      messages.push({ role: 'tool', content: 'tool result for tc1' });
+      // More recent messages
+      for (let i = 0; i < 8; i++) {
+        messages.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `Recent ${i}` });
+      }
+      (r as any).state.messages = messages;
+
+      // Trigger compaction via requestCompaction
+      mockGenerateText.mockResolvedValueOnce({
+        text: '[Summary] Compacted state',
+        steps: [],
+        usage: { inputTokens: 50, outputTokens: 30 },
+        finishReason: 'stop',
+      });
+
+      const result = await r.requestCompaction();
+      expect(result.compacted).toBe(true);
+
+      // Verify: no tool-role message should be the first in the kept recent set
+      // The compaction should have included the assistant tool_call message when it
+      // found the tool result at the split boundary
+      const state = r.getState();
+      if (state.messages.length > 1) {
+        // First message after summary should not be a bare 'tool' role
+        // (it's OK if it's 'user' or 'assistant')
+        const secondMsg = state.messages[1];
+        if (secondMsg.role === 'tool') {
+          // If a tool message is kept, the preceding assistant must also be kept
+          expect(state.messages[0].role).toBe('assistant');
+        }
+      }
+    });
+  });
+
+  describe('budgetWarning in run result', () => {
+    it('should include budgetWarning when token usage is high', async () => {
+      const config = {
+        ...baseConfig,
+        compactionThreshold: 0.001, // extremely low threshold for testing
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Done',
+        steps: [],
+        usage: { inputTokens: 500, outputTokens: 200 },
+        finishReason: 'stop',
+      });
+
+      // The first run triggers compaction (critical threshold), but since there are
+      // fewer than 10 messages, compaction skips. Budget warning should still appear.
+      const result = await r.run('Hello');
+
+      expect(result.budgetWarning).toBeDefined();
+      expect(result.budgetWarning).toContain('CRITICAL');
+    });
+
+    it('should not include budgetWarning when usage is normal', async () => {
+      await runner.initialize();
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Done',
+        steps: [],
+        usage: { inputTokens: 100, outputTokens: 50 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('Hello');
+
+      expect(result.budgetWarning).toBeUndefined();
+    });
+  });
+
+  describe('token-budget-based compaction trigger', () => {
+    it('should trigger compaction when token budget is critical even if message count is low', async () => {
+      // Use a threshold that won't trigger during initial message buildup
+      // but will trigger on the final run after enough tokens accumulate.
+      // Each run uses 150 tokens. After 6 runs: 900 tokens.
+      // Context window for claude-sonnet-4-20250514 = 200,000
+      // Set threshold to 0.004 (0.4%) = 800 tokens
+      // Runs 0-3 won't trigger (0,150,300,450 < 800). Run 4+ will trigger.
+      // But compaction needs >= 10 messages, so runs 4-5 trigger budget-critical
+      // but compactHistory returns early (8 and 10 messages respectively).
+      // Actually run 5 has 10 messages so compaction runs.
+      // Let's use threshold 0.005 = 1000 tokens, so 6 runs of 150 = 900 < 1000.
+      // Then the 7th run triggers at 900 + check >= 1000? No, budget is checked
+      // before the run with existing tokens. After 6 runs = 900 tokens < 1000 = normal.
+      // After 7th run = 900 + 150 = 1050. But check is before run with 900 tokens.
+      // We need threshold to trigger BEFORE a run. So set threshold = 0.004 = 800.
+      // After 5 runs = 750 < 800 (normal). After 6th run's execution → 900.
+      // 7th run check: 900/200000 = 0.0045 >= 0.004 → critical → compaction triggers.
+      // At that point we have 12 messages (6 runs × 2), >= 10, so compaction runs.
+      const config = {
+        ...baseConfig,
+        maxHistoryMessages: 1000, // high message limit, won't trigger by count
+        compactionThreshold: 0.004, // triggers after ~6 runs of 150 tokens each
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // Build up 12 messages (6 runs × 2) and 900 tokens
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 100, outputTokens: 50 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+
+      expect(r.getHistoryLength()).toBe(12);
+      // 900 / 200000 = 0.0045 >= 0.004 → critical
+      expect(r.getContextBudget().level).toBe('critical');
+
+      // Next run should trigger compaction due to token budget being critical
+      // AI summary call + actual run
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Compaction summary of state',
+        steps: [],
+        usage: { inputTokens: 50, outputTokens: 30 },
+        finishReason: 'stop',
+      });
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'After compact',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      await r.run('Trigger compaction by budget');
+
+      // Should have compacted: 1 summary + 10 recent + 1 user + 1 assistant
+      expect(r.getHistoryLength()).toBeLessThan(14);
+      const state = r.getState();
+      expect(String(state.messages[0].content)).toContain('Compacted State');
+    });
+  });
+
+  describe('audit trail', () => {
+    it('should return empty audit log initially', () => {
+      const log = runner.getAuditLog();
+      expect(log).toEqual([]);
+    });
+
+    it('should return default security policy', () => {
+      const policy = runner.getSecurityPolicy();
+      expect(policy.auditEnabled).toBe(true);
+      expect(policy.requireApproval).toEqual([]);
+      expect(policy.blockedTools).toEqual([]);
+      expect(policy.maxAuditEntries).toBe(500);
+    });
+
+    it('should update security policy', () => {
+      runner.updateSecurityPolicy({ requireApproval: ['destructive', 'sensitive'] });
+      const policy = runner.getSecurityPolicy();
+      expect(policy.requireApproval).toEqual(['destructive', 'sensitive']);
+      expect(policy.auditEnabled).toBe(true); // unchanged
+    });
+
+    it('should return a copy of the security policy', () => {
+      const p1 = runner.getSecurityPolicy();
+      const p2 = runner.getSecurityPolicy();
+      expect(p1).not.toBe(p2);
+      expect(p1).toEqual(p2);
+    });
+  });
+
+  describe('approval mode enforcement', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should block tool execution when sensitivity requires approval', async () => {
+      runner.updateSecurityPolicy({ requireApproval: ['destructive'] });
+
+      // When a tool with 'destructive' sensitivity is called, it should be denied
+      // We verify this by running a message that would trigger tool use
+      // and checking the security policy state
+      const policy = runner.getSecurityPolicy();
+      expect(policy.requireApproval).toContain('destructive');
+    });
+
+    it('should allow tool execution when sensitivity is not in requireApproval', async () => {
+      runner.updateSecurityPolicy({ requireApproval: ['destructive'] });
+
+      const policy = runner.getSecurityPolicy();
+      expect(policy.requireApproval).not.toContain('safe');
+      expect(policy.requireApproval).not.toContain('sensitive');
+    });
+
+    it('should block explicitly blocked tools', async () => {
+      runner.updateSecurityPolicy({ blockedTools: ['stop_agent', 'write_file'] });
+
+      const policy = runner.getSecurityPolicy();
+      expect(policy.blockedTools).toContain('stop_agent');
+      expect(policy.blockedTools).toContain('write_file');
+    });
+
+    it('should combine approval and blocked tools', async () => {
+      runner.updateSecurityPolicy({
+        requireApproval: ['destructive', 'sensitive'],
+        blockedTools: ['handle_agent_failure'],
+      });
+
+      const policy = runner.getSecurityPolicy();
+      expect(policy.requireApproval).toEqual(['destructive', 'sensitive']);
+      expect(policy.blockedTools).toEqual(['handle_agent_failure']);
+      expect(policy.auditEnabled).toBe(true); // unchanged
+    });
+  });
+
+  describe('read-only audit mode', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should default readOnlyMode to false', () => {
+      const policy = runner.getSecurityPolicy();
+      expect(policy.readOnlyMode).toBe(false);
+    });
+
+    it('should enable read-only mode via updateSecurityPolicy', () => {
+      runner.updateSecurityPolicy({ readOnlyMode: true });
+      const policy = runner.getSecurityPolicy();
+      expect(policy.readOnlyMode).toBe(true);
+    });
+
+    it('should block write tools when readOnlyMode is active', async () => {
+      runner.updateSecurityPolicy({ readOnlyMode: true });
+
+      // Run a message that triggers a write tool — we check via tool execution
+      // The tool should be blocked by checkApproval before reaching the API
+      let toolResult: unknown;
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        // Try to call write_file — should be blocked
+        toolResult = await tools.write_file.execute({
+          file_path: '/test/file.ts',
+          content: 'blocked content',
+        });
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Try to write');
+
+      expect(toolResult).toBeDefined();
+      expect((toolResult as Record<string, unknown>).success).toBe(false);
+      expect((toolResult as Record<string, unknown>).blocked).toBe(true);
+      expect((toolResult as Record<string, unknown>).error).toContain('read-only');
+      // Should NOT have called the API
+      expect(mockApiClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should allow safe/read-only tools when readOnlyMode is active', async () => {
+      runner.updateSecurityPolicy({ readOnlyMode: true });
+
+      let toolResult: unknown;
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        mockApiClient.get.mockResolvedValueOnce({ success: true, data: [{ name: 'team-a' }], status: 200 } as any);
+        toolResult = await tools.get_team_status.execute({});
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Check teams');
+
+      // Safe tool should work
+      expect(mockApiClient.get).toHaveBeenCalled();
+      expect(toolResult).toEqual([{ name: 'team-a' }]);
+    });
+
+    it('should log blocked write attempts in audit trail during readOnlyMode', async () => {
+      runner.updateSecurityPolicy({ readOnlyMode: true });
+
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        await tools.edit_file.execute({
+          file_path: '/test/file.ts',
+          old_string: 'foo',
+          new_string: 'bar',
+          replace_all: false,
+        });
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Try to edit');
+
+      const auditLog = runner.getAuditLog();
+      expect(auditLog.length).toBeGreaterThanOrEqual(1);
+      const editEntry = auditLog.find(e => e.toolName === 'edit_file');
+      expect(editEntry).toBeDefined();
+      expect(editEntry!.success).toBe(false);
+      expect(editEntry!.error).toContain('read-only');
+    });
+  });
+
+  describe('audit trail with sessionName', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should include sessionName in audit entries', async () => {
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        mockApiClient.get.mockResolvedValueOnce({ success: true, data: [], status: 200 } as any);
+        await tools.get_team_status.execute({});
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Check status');
+
+      const auditLog = runner.getAuditLog();
+      expect(auditLog.length).toBeGreaterThanOrEqual(1);
+      expect(auditLog[0].sessionName).toBe('test-session');
+    });
+  });
+
+  describe('getFilteredAuditLog via get_audit_log tool', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should return actual audit entries via get_audit_log tool', async () => {
+      // First generate some audit data
+      mockGenerateText.mockImplementationOnce(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        mockApiClient.get.mockResolvedValueOnce({ success: true, data: [], status: 200 } as any);
+        await tools.get_team_status.execute({});
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+      await runner.run('Generate audit data');
+
+      // Now query the audit log through the tool
+      let auditResult: Record<string, unknown> | undefined;
+      mockGenerateText.mockImplementationOnce(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        auditResult = await tools.get_audit_log.execute({ limit: 10 }) as Record<string, unknown>;
+        return {
+          text: 'Audit retrieved',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+      await runner.run('Get audit log');
+
+      expect(auditResult).toBeDefined();
+      expect(auditResult!.success).toBe(true);
+      expect(auditResult!.totalEntries).toBeGreaterThanOrEqual(1);
+      const entries = auditResult!.entries as AuditEntry[];
+      expect(entries[0].toolName).toBe('get_team_status');
+    });
+  });
+
+  describe('conversation history integration', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should accumulate messages across consecutive run() calls', async () => {
+      mockGenerateText
+        .mockResolvedValueOnce({
+          text: 'Answer 1',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          text: 'Answer 2',
+          steps: [],
+          usage: { inputTokens: 20, outputTokens: 10 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          text: 'Answer 3',
+          steps: [],
+          usage: { inputTokens: 30, outputTokens: 15 },
+          finishReason: 'stop',
+        });
+
+      await runner.run('Question 1');
+      await runner.run('Question 2');
+      await runner.run('Question 3');
+
+      const state = runner.getState();
+      expect(state.messages).toHaveLength(6); // 3 user + 3 assistant
+      expect(state.messages[0]).toEqual({ role: 'user', content: 'Question 1' });
+      expect(state.messages[1]).toEqual({ role: 'assistant', content: 'Answer 1' });
+      expect(state.messages[2]).toEqual({ role: 'user', content: 'Question 2' });
+      expect(state.messages[3]).toEqual({ role: 'assistant', content: 'Answer 2' });
+      expect(state.messages[4]).toEqual({ role: 'user', content: 'Question 3' });
+      expect(state.messages[5]).toEqual({ role: 'assistant', content: 'Answer 3' });
+    });
+
+    it('should pass prior conversation context to generateText on subsequent calls', async () => {
+      // Capture messages snapshot at each generateText call (array is passed by reference)
+      const capturedMessages: Array<Array<{ role: string; content: string }>> = [];
+
+      mockGenerateText
+        .mockImplementationOnce(async (opts: Record<string, unknown>) => {
+          const msgs = opts.messages as Array<{ role: string; content: string }>;
+          capturedMessages.push([...msgs]);
+          return {
+            text: 'First response',
+            steps: [],
+            usage: { inputTokens: 10, outputTokens: 5 },
+            finishReason: 'stop',
+          };
+        })
+        .mockImplementationOnce(async (opts: Record<string, unknown>) => {
+          const msgs = opts.messages as Array<{ role: string; content: string }>;
+          capturedMessages.push([...msgs]);
+          return {
+            text: 'Second response',
+            steps: [],
+            usage: { inputTokens: 20, outputTokens: 10 },
+            finishReason: 'stop',
+          };
+        });
+
+      await runner.run('Hello');
+      await runner.run('Follow up');
+
+      // First call should have only the new user message
+      expect(capturedMessages[0]).toHaveLength(1);
+      expect(capturedMessages[0][0]).toEqual({ role: 'user', content: 'Hello' });
+
+      // Second call should include prior context: user + assistant + new user
+      expect(capturedMessages[1]).toHaveLength(3);
+      expect(capturedMessages[1][0]).toEqual({ role: 'user', content: 'Hello' });
+      expect(capturedMessages[1][1]).toEqual({ role: 'assistant', content: 'First response' });
+      expect(capturedMessages[1][2]).toEqual({ role: 'user', content: 'Follow up' });
+    });
+
+    it('should trigger compaction when history reaches maxHistoryMessages during run', async () => {
+      // Use a runner with low maxHistoryMessages to trigger compaction
+      const smallHistoryConfig: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 10, // will trigger at 10 messages
+      };
+      const r = new AgentRunnerService(smallHistoryConfig, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // Fill up to 10 messages (5 runs × 2 messages each)
+      for (let i = 0; i < 5; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+      expect(r.getHistoryLength()).toBe(10);
+
+      // Next run should trigger compaction (messages >= maxHistoryMessages)
+      // Compaction needs AI summary call + the actual run call
+      mockGenerateText
+        .mockResolvedValueOnce({
+          // AI summary during compaction
+          text: '[Summary] Previous conversation covered messages 0-4',
+          steps: [],
+          usage: { inputTokens: 50, outputTokens: 20 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          // Actual run response
+          text: 'Post-compaction response',
+          steps: [],
+          usage: { inputTokens: 15, outputTokens: 8 },
+          finishReason: 'stop',
+        });
+
+      const result = await r.run('After compaction');
+
+      expect(result.text).toBe('Post-compaction response');
+      // After compaction: keepRecent=10 messages retained + summary message + new user + new assistant
+      // But since we had exactly 10, compaction keeps 10 recent, and old=0 so it won't compact
+      // Actually compaction requires >= 10 messages to proceed (line 595 check)
+      // The history had 10 messages when the 6th run started, so compaction triggered
+      // keepRecent=10 means all messages are "recent", oldMessages is empty
+      // With < 10 old messages, the compactHistory still proceeds since total >= 10
+      // Let's just verify history didn't grow unbounded
+      expect(r.getHistoryLength()).toBeLessThanOrEqual(14); // bounded
+    });
+
+    it('should return correct getHistoryLength after multiple runs', async () => {
+      expect(runner.getHistoryLength()).toBe(0);
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'R1',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await runner.run('M1');
+      expect(runner.getHistoryLength()).toBe(2);
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'R2',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await runner.run('M2');
+      expect(runner.getHistoryLength()).toBe(4);
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: '',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 0 },
+        finishReason: 'tool-calls',
+      });
+      await runner.run('M3');
+      // Empty response doesn't add assistant message
+      expect(runner.getHistoryLength()).toBe(5);
+    });
+
+    it('should return current messages array via getState after multiple runs', async () => {
+      mockGenerateText
+        .mockResolvedValueOnce({
+          text: 'Alpha',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          text: 'Beta',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      await runner.run('First');
+      await runner.run('Second');
+
+      const state = runner.getState();
+      expect(state.messages).toHaveLength(4);
+      expect(state.messages.map(m => m.content)).toEqual(['First', 'Alpha', 'Second', 'Beta']);
+      expect(state.totalTokens).toEqual({ input: 20, output: 10 });
+    });
+  });
+
+  describe('getState', () => {
+    it('should return a copy of state, not the original', () => {
+      const state1 = runner.getState();
+      const state2 = runner.getState();
+      expect(state1).not.toBe(state2);
+      expect(state1).toEqual(state2);
+    });
+  });
+
+  describe('getHistoryLength', () => {
+    it('should return 0 for fresh runner', () => {
+      expect(runner.getHistoryLength()).toBe(0);
+    });
+  });
+
+  describe('isInitialized', () => {
+    it('should return false before initialize', () => {
+      expect(runner.isInitialized()).toBe(false);
+    });
+
+    it('should return true after initialize', async () => {
+      await runner.initialize();
+      expect(runner.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('long message handling (Bug 1)', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should process messages longer than 500 chars without dropping', async () => {
+      const longMessage = 'A'.repeat(2000);
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Processed long message',
+        steps: [],
+        usage: { inputTokens: 500, outputTokens: 50 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run(longMessage);
+
+      expect(result.text).toBe('Processed long message');
+      // Verify the full message was passed to generateText
+      const callArgs = mockGenerateText.mock.calls[0][0] as Record<string, unknown>;
+      const messages = callArgs.messages as Array<{ role: string; content: string }>;
+      // After run(), assistant response is pushed to the same array reference,
+      // so the user message is second-to-last
+      const userMsg = messages.find(m => m.role === 'user' && m.content.length === 2000);
+      expect(userMsg).toBeDefined();
+      expect(userMsg!.content).toBe(longMessage);
+      expect(userMsg!.content.length).toBe(2000);
+    });
+
+    it('should process messages over 5000 chars without truncation', async () => {
+      const veryLongMessage = 'Task: '.repeat(1000);
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Done',
+        steps: [],
+        usage: { inputTokens: 1000, outputTokens: 20 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run(veryLongMessage);
+      expect(result.text).toBe('Done');
+
+      const callArgs = mockGenerateText.mock.calls[0][0] as Record<string, unknown>;
+      const messages = callArgs.messages as Array<{ role: string; content: string }>;
+      // Find the user message (assistant response is also in array due to shared reference)
+      const userMsg = messages.find(m => m.role === 'user' && m.content === veryLongMessage);
+      expect(userMsg).toBeDefined();
+    });
+
+    it('should not strand messages in the queue (race condition guard)', async () => {
+      // Simulate the scenario where a message arrives right as processQueue exits
+      const messages: string[] = [];
+      mockGenerateText.mockImplementation(async () => {
+        return {
+          text: 'Response',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      // Send multiple messages concurrently
+      const results = await Promise.all([
+        runner.run('Message 1'),
+        runner.run('Message 2'),
+        runner.run('Message 3'),
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].text).toBe('Response');
+      expect(results[1].text).toBe('Response');
+      expect(results[2].text).toBe('Response');
+      expect(mockGenerateText).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('Slack context (Bug 5)', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should store Slack context from metadata', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [{ toolCalls: [], toolResults: [] }],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      await runner.run('Hello', 'conv-123', { channelId: 'D0AC7NF5N7L', threadTs: '123.456' });
+
+      const slackCtx = runner.getSlackContext();
+      expect(slackCtx).toBeDefined();
+      expect(slackCtx!.channelId).toBe('D0AC7NF5N7L');
+      expect(slackCtx!.threadTs).toBe('123.456');
+    });
+
+    it('should pass Slack context to tools via createTools', async () => {
+      // Verify the reply_slack tool gets the Slack context
+      let replySlackResult: unknown;
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        mockApiClient.post.mockResolvedValueOnce({ success: true, data: {} } as any);
+        replySlackResult = await tools.reply_slack.execute({
+          text: 'Hello from agent',
+        });
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Reply to Slack', 'conv-1', { channelId: 'C123', threadTs: '456.789' });
+
+      // The reply_slack should have auto-filled channelId from context
+      expect(mockApiClient.post).toHaveBeenCalledWith('/slack/send', expect.objectContaining({
+        channelId: 'C123',
+        threadTs: '456.789',
+      }));
+    });
+
+    it('should return error when no channelId available', async () => {
+      let replySlackResult: unknown;
+      mockGenerateText.mockImplementation(async (opts: Record<string, unknown>) => {
+        const tools = opts.tools as Record<string, { execute: (args: Record<string, unknown>) => Promise<unknown> }>;
+        replySlackResult = await tools.reply_slack.execute({
+          text: 'No channel',
+        });
+        return {
+          text: 'Done',
+          steps: [{ toolCalls: [], toolResults: [] }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        };
+      });
+
+      await runner.run('Reply without context');
+
+      expect(replySlackResult).toBeDefined();
+      expect((replySlackResult as Record<string, unknown>).success).toBe(false);
+      expect((replySlackResult as Record<string, unknown>).error).toContain('No channelId');
+    });
+  });
+
+  describe('compaction guard (concurrent compaction prevention)', () => {
+    it('should skip compaction when already compacting', async () => {
+      const config: CrewlyAgentConfig = {
+        ...baseConfig,
+        maxHistoryMessages: 12,
+      };
+      const r = new AgentRunnerService(config, mockModelManager, mockApiClient);
+      r._generateTextFn = mockGenerateText;
+      await r.initialize();
+
+      // Fill history to 12 messages (6 runs × 2 messages)
+      for (let i = 0; i < 6; i++) {
+        mockGenerateText.mockResolvedValueOnce({
+          text: `Response ${i}`,
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+        await r.run(`Message ${i}`);
+      }
+
+      expect(r.getHistoryLength()).toBe(12);
+
+      // requestCompaction should succeed
+      // AI summarization + the compaction
+      mockGenerateText.mockResolvedValueOnce({
+        text: '[Summary] Compacted state',
+        steps: [],
+        usage: { inputTokens: 30, outputTokens: 20 },
+        finishReason: 'stop',
+      });
+
+      const result = await r.requestCompaction();
+      expect(result.compacted).toBe(true);
+      expect(result.messagesBefore).toBe(12);
+      expect(result.messagesAfter).toBeLessThan(12);
+    });
+
+    it('should skip compaction when history is too small', async () => {
+      await runner.initialize();
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'Response',
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+      await runner.run('Short history');
+
+      const result = await runner.requestCompaction();
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toContain('Too few messages');
+    });
+  });
+
+  describe('abort', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should return false when no run is in progress', () => {
+      expect(runner.abortCurrentRun()).toBe(false);
+    });
+
+    it('should report processing state via isProcessing()', async () => {
+      expect(runner.isProcessing()).toBe(false);
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'ok', steps: [], usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      await runner.run('test');
+      // After completion, processing should be false again
+      expect(runner.isProcessing()).toBe(false);
+    });
+
+    it('should pass abort signal to generateText when provided', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'ok', steps: [], usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      const abortController = new AbortController();
+      await runner.run('test', undefined, undefined, { abortSignal: abortController.signal });
+
+      // Verify generateText received the abort signal
+      expect(mockGenerateText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          abortSignal: expect.anything(),
+        }),
+      );
+    });
+
+    it('should pass streaming callbacks through options', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'ok', steps: [], usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      });
+
+      const onTextChunk = vi.fn();
+      await runner.run('test', undefined, undefined, {
+        streaming: { onTextChunk },
+      });
+
+      // Callbacks are set on the instance — they won't fire with the mock
+      // but verify no error
+      expect(runner.isProcessing()).toBe(false);
+    });
+  });
+
+  describe('retry with backoff', () => {
+    beforeEach(async () => {
+      await runner.initialize();
+    });
+
+    it('should retry on 429 rate limit error and succeed on retry', async () => {
+      mockGenerateText
+        .mockRejectedValueOnce(new Error('429 Too Many Requests'))
+        .mockResolvedValueOnce({
+          text: 'Success after retry',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      const result = await runner.run('test');
+
+      expect(result.text).toBe('Success after retry');
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on 500 server error with exponential backoff', async () => {
+      mockGenerateText
+        .mockRejectedValueOnce(new Error('500 Internal Server Error'))
+        .mockRejectedValueOnce(new Error('502 Bad Gateway'))
+        .mockResolvedValueOnce({
+          text: 'Recovered',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      const result = await runner.run('test');
+
+      expect(result.text).toBe('Recovered');
+      expect(mockGenerateText).toHaveBeenCalledTimes(3);
+    });
+
+    it('should retry on network errors', async () => {
+      mockGenerateText
+        .mockRejectedValueOnce(new Error('fetch failed: ECONNRESET'))
+        .mockResolvedValueOnce({
+          text: 'OK',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      const result = await runner.run('test');
+
+      expect(result.text).toBe('OK');
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    });
+
+    it('should NOT retry on 401 auth error (non-recoverable)', async () => {
+      mockGenerateText.mockRejectedValue(new Error('401 Unauthorized'));
+
+      await expect(runner.run('test')).rejects.toThrow('401 Unauthorized');
+      expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT retry on 400 bad request (non-recoverable)', async () => {
+      mockGenerateText.mockRejectedValue(new Error('400 Bad Request: invalid model'));
+
+      await expect(runner.run('test')).rejects.toThrow('400 Bad Request');
+      expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    });
+
+    it('should give up after max retries on persistent 429', async () => {
+      mockGenerateText.mockRejectedValue(new Error('429 rate limit exceeded'));
+
+      await expect(runner.run('test')).rejects.toThrow('429 rate limit exceeded');
+      // 1 initial + 3 retries = 4 calls total
+      expect(mockGenerateText).toHaveBeenCalledTimes(4);
+    }, 15000); // 3 retries with exponential backoff take ~7s of wall time
+
+    it('should attempt context compaction on context length error', async () => {
+      // First call: context length error. After compaction, second call succeeds.
+      mockGenerateText
+        .mockRejectedValueOnce(new Error('context length exceeded: too many tokens'))
+        .mockResolvedValueOnce({
+          // AI summary call during compaction — need 10+ messages
+          text: '[Summary]',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        })
+        .mockResolvedValueOnce({
+          text: 'Success after trim',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      // Fill history to make compaction possible (need >= 10 messages)
+      for (let i = 0; i < 5; i++) {
+        runner.getState().messages.push(
+          { role: 'user', content: `msg ${i}` },
+          { role: 'assistant', content: `resp ${i}` },
+        );
+      }
+
+      const result = await runner.run('test after context error');
+
+      // The first generateText throws context error, then compaction + retry
+      expect(result.text).toBe('Success after trim');
+    });
+
+    it('should trim oldest messages if compaction does not help', async () => {
+      // Fill history to make compaction possible
+      for (let i = 0; i < 6; i++) {
+        runner.getState().messages.push(
+          { role: 'user', content: `msg ${i}` },
+          { role: 'assistant', content: `resp ${i}` },
+        );
+      }
+
+      mockGenerateText
+        .mockRejectedValueOnce(new Error('context length exceeded'))
+        .mockResolvedValueOnce({
+          // AI summary during compaction
+          text: '[Summary]',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        })
+        .mockRejectedValueOnce(new Error('context length exceeded'))
+        .mockResolvedValueOnce({
+          text: 'Finally worked',
+          steps: [],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: 'stop',
+        });
+
+      const result = await runner.run('test');
+
+      expect(result.text).toBe('Finally worked');
+      // Messages should have been trimmed
+      expect(runner.getHistoryLength()).toBeLessThan(13);
+    });
+  });
+
+  describe('loop detection in generateText path', () => {
+    it('should detect consecutive identical tool calls and return loop-detected', async () => {
+      await runner.initialize();
+
+      // Simulate 3 identical tool calls (threshold = 3)
+      const identicalToolCall = { toolName: 'bash', toolCallId: 'tc-1', input: { command: 'curl http://example.com/missing' } };
+      mockGenerateText.mockResolvedValueOnce({
+        text: '',
+        steps: [
+          {
+            toolCalls: [identicalToolCall],
+            toolResults: [{ toolCallId: 'tc-1', output: '404 Not Found' }],
+          },
+          {
+            toolCalls: [{ ...identicalToolCall, toolCallId: 'tc-2' }],
+            toolResults: [{ toolCallId: 'tc-2', output: '404 Not Found' }],
+          },
+          {
+            toolCalls: [{ ...identicalToolCall, toolCallId: 'tc-3' }],
+            toolResults: [{ toolCallId: 'tc-3', output: '404 Not Found' }],
+          },
+        ],
+        usage: { inputTokens: 100, outputTokens: 50 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('fetch the page');
+
+      expect(result.finishReason).toBe('loop-detected');
+      expect(result.text).toContain('Loop detected');
+      expect(result.toolCalls).toHaveLength(3);
+    });
+
+    it('should not trigger loop for different tool calls', async () => {
+      await runner.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'All done',
+        steps: [
+          {
+            toolCalls: [{ toolName: 'bash', toolCallId: 'tc-1', input: { command: 'ls' } }],
+            toolResults: [{ toolCallId: 'tc-1', output: 'file1.ts' }],
+          },
+          {
+            toolCalls: [{ toolName: 'bash', toolCallId: 'tc-2', input: { command: 'cat file1.ts' } }],
+            toolResults: [{ toolCallId: 'tc-2', output: 'content' }],
+          },
+          {
+            toolCalls: [{ toolName: 'bash', toolCallId: 'tc-3', input: { command: 'echo done' } }],
+            toolResults: [{ toolCallId: 'tc-3', output: 'done' }],
+          },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('do things');
+
+      expect(result.finishReason).toBe('stop');
+      expect(result.text).toBe('All done');
+    });
+
+    it('should detect error loop from same tool returning errors', async () => {
+      await runner.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: '',
+        steps: [
+          {
+            toolCalls: [{ toolName: 'read_file', toolCallId: 'tc-1', input: { path: '/a.ts' } }],
+            toolResults: [{ toolCallId: 'tc-1', output: 'error: not found' }],
+          },
+          {
+            toolCalls: [{ toolName: 'read_file', toolCallId: 'tc-2', input: { path: '/b.ts' } }],
+            toolResults: [{ toolCallId: 'tc-2', output: 'error: not found' }],
+          },
+          {
+            toolCalls: [{ toolName: 'read_file', toolCallId: 'tc-3', input: { path: '/c.ts' } }],
+            toolResults: [{ toolCallId: 'tc-3', output: 'error: failed to read' }],
+          },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20 },
+        finishReason: 'stop',
+      });
+
+      const result = await runner.run('find the file');
+
+      expect(result.finishReason).toBe('loop-detected');
+      expect(result.text).toContain('Loop detected');
+    });
+
+    it('should inject corrective messages into conversation history on loop', async () => {
+      await runner.initialize();
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: '',
+        steps: [
+          { toolCalls: [{ toolName: 'bash', toolCallId: 'tc-1', input: { command: 'curl x' } }], toolResults: [{ toolCallId: 'tc-1', output: 'ok' }] },
+          { toolCalls: [{ toolName: 'bash', toolCallId: 'tc-2', input: { command: 'curl x' } }], toolResults: [{ toolCallId: 'tc-2', output: 'ok' }] },
+          { toolCalls: [{ toolName: 'bash', toolCallId: 'tc-3', input: { command: 'curl x' } }], toolResults: [{ toolCallId: 'tc-3', output: 'ok' }] },
+        ],
+        usage: { inputTokens: 50, outputTokens: 20 },
+        finishReason: 'stop',
+      });
+
+      await runner.run('test');
+
+      // Should have injected corrective messages
+      const state = runner.getState();
+      const lastUserMsg = state.messages[state.messages.length - 1];
+      expect(lastUserMsg.role).toBe('user');
+      expect(String(lastUserMsg.content)).toContain('LOOP DETECTED');
+      expect(String(lastUserMsg.content)).toContain('different approach');
+    });
+  });
+});
+
+describe('ToolCallLoopDetector', () => {
+  it('should detect consecutive identical tool calls at threshold', () => {
+    const detector = new ToolCallLoopDetector(3, 3);
+
+    expect(detector.recordToolCall('bash', { command: 'ls' }, 'output')).toBe(false);
+    expect(detector.recordToolCall('bash', { command: 'ls' }, 'output')).toBe(false);
+    expect(detector.recordToolCall('bash', { command: 'ls' }, 'output')).toBe(true);
+    expect(detector.loopDetected).toBe(true);
+    expect(detector.loopReason).toContain('Identical tool call repeated 3 times');
+    expect(detector.loopReason).toContain('bash');
+  });
+
+  it('should not trigger for varied tool calls', () => {
+    const detector = new ToolCallLoopDetector(3, 3);
+
+    detector.recordToolCall('bash', { command: 'ls' }, 'output1');
+    detector.recordToolCall('bash', { command: 'pwd' }, 'output2');
+    detector.recordToolCall('bash', { command: 'ls' }, 'output3');
+
+    expect(detector.loopDetected).toBe(false);
+  });
+
+  it('should reset identical counter when a different call appears', () => {
+    const detector = new ToolCallLoopDetector(3, 3);
+
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    // Different call breaks the streak
+    detector.recordToolCall('bash', { command: 'pwd' }, 'ok');
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+
+    expect(detector.loopDetected).toBe(false);
+  });
+
+  it('should detect consecutive error responses from the same tool', () => {
+    const detector = new ToolCallLoopDetector(5, 3);
+
+    detector.recordToolCall('web_fetch', { url: '/a' }, '404 not found');
+    detector.recordToolCall('web_fetch', { url: '/b' }, '404 not found');
+    expect(detector.recordToolCall('web_fetch', { url: '/c' }, '404 not found')).toBe(true);
+
+    expect(detector.loopDetected).toBe(true);
+    expect(detector.loopReason).toContain('returned errors 3 consecutive times');
+  });
+
+  it('should reset error counter when a different tool errors', () => {
+    const detector = new ToolCallLoopDetector(5, 3);
+
+    detector.recordToolCall('web_fetch', { url: '/a' }, '404 not found');
+    detector.recordToolCall('web_fetch', { url: '/b' }, '404 not found');
+    // Different tool resets the error counter
+    detector.recordToolCall('bash', { command: 'x' }, 'error: command not found');
+    detector.recordToolCall('web_fetch', { url: '/c' }, '404 not found');
+
+    expect(detector.loopDetected).toBe(false);
+  });
+
+  it('should reset error counter on successful result', () => {
+    const detector = new ToolCallLoopDetector(5, 3);
+
+    detector.recordToolCall('web_fetch', { url: '/a' }, '404 not found');
+    detector.recordToolCall('web_fetch', { url: '/b' }, '404 not found');
+    // Successful result resets error counter
+    detector.recordToolCall('web_fetch', { url: '/c' }, '<html>OK</html>');
+    detector.recordToolCall('web_fetch', { url: '/d' }, '404 not found');
+
+    expect(detector.loopDetected).toBe(false);
+  });
+
+  it('should detect various error patterns in results', () => {
+    const detector = new ToolCallLoopDetector(10, 2);
+
+    detector.recordToolCall('bash', { command: 'x' }, 'error: connection refused');
+    expect(detector.recordToolCall('bash', { command: 'y' }, 'failed to connect: timeout')).toBe(true);
+    expect(detector.loopReason).toContain('returned errors');
+  });
+
+  it('should stay detected once triggered', () => {
+    const detector = new ToolCallLoopDetector(2, 5);
+
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+
+    expect(detector.loopDetected).toBe(true);
+    // Further calls should still report detected
+    expect(detector.recordToolCall('bash', { command: 'pwd' }, 'ok')).toBe(true);
+  });
+
+  it('should handle null/undefined results without error detection', () => {
+    const detector = new ToolCallLoopDetector(5, 2);
+
+    detector.recordToolCall('tool', {}, null);
+    detector.recordToolCall('tool', {}, undefined);
+
+    expect(detector.loopDetected).toBe(false);
+  });
+
+  it('should use custom thresholds', () => {
+    const detector = new ToolCallLoopDetector(5, 5);
+
+    // 4 identical calls should NOT trigger with threshold 5
+    for (let i = 0; i < 4; i++) {
+      detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    }
+    expect(detector.loopDetected).toBe(false);
+
+    // 5th should trigger
+    detector.recordToolCall('bash', { command: 'ls' }, 'ok');
+    expect(detector.loopDetected).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1: Eval Mode — stripDelegationInstructions
+// ---------------------------------------------------------------------------
+
+describe('AgentRunnerService.stripDelegationInstructions (P1)', () => {
+  it('should remove "delegate 80% of execution tasks" instruction', () => {
+    const prompt = 'You are a TL. delegate 80% of execution tasks to workers. Always verify.';
+    const result = AgentRunnerService.stripDelegationInstructions(prompt);
+    expect(result).not.toContain('delegate 80% of execution tasks');
+    expect(result).toContain('Always verify');
+  });
+
+  it('should remove DELEGATION-FIRST PROTOCOL sections', () => {
+    const prompt = [
+      '## Some section',
+      'DELEGATION-FIRST PROTOCOL: Your core loop:',
+      '1. Analyze',
+      '2. Decompose',
+      '3. Delegate',
+      '',
+      '## Next section',
+      'Important stuff',
+    ].join('\n');
+    const result = AgentRunnerService.stripDelegationInstructions(prompt);
+    expect(result).not.toContain('DELEGATION-FIRST PROTOCOL');
+    expect(result).toContain('Important stuff');
+  });
+
+  it('should remove "Target: delegate 70–80% of execution tasks"', () => {
+    const prompt = 'Be efficient. Target: delegate 70–80% of execution tasks. Also code.';
+    const result = AgentRunnerService.stripDelegationInstructions(prompt);
+    expect(result).not.toContain('Target: delegate 70–80%');
+    expect(result).toContain('Also code');
+  });
+
+  it('should inject eval mode override instructions', () => {
+    const prompt = 'You are a developer.';
+    const result = AgentRunnerService.stripDelegationInstructions(prompt);
+    expect(result).toContain('## Eval Mode Active');
+    expect(result).toContain('Implement directly');
+    expect(result).toContain('Create all output files');
+    expect(result).toContain('Self-check before stopping');
+  });
+
+  it('should handle empty prompt', () => {
+    const result = AgentRunnerService.stripDelegationInstructions('');
+    expect(result).toContain('## Eval Mode Active');
+  });
+
+  it('should clean up consecutive blank lines', () => {
+    const prompt = 'Line 1\n\n\n\n\n\nLine 2';
+    const result = AgentRunnerService.stripDelegationInstructions(prompt);
+    // Should not have more than 3 consecutive newlines
+    expect(result).not.toMatch(/\n{4,}/);
+  });
+
+  it('should apply delegation stripping when evalMode=true in constructor', () => {
+    const config: CrewlyAgentConfig = {
+      model: { provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' },
+      maxSteps: 10,
+      sessionName: 'eval-test',
+      apiBaseUrl: 'http://localhost:8787',
+      systemPrompt: 'You are a TL. delegate 80% of execution tasks. Be thorough.',
+      maxHistoryMessages: 20,
+      compactionThreshold: 0.8,
+      evalMode: true,
+    };
+    const evalRunner = new AgentRunnerService(config);
+    const state = evalRunner.getState();
+    expect(state.systemPrompt).not.toContain('delegate 80% of execution tasks');
+    expect(state.systemPrompt).toContain('## Eval Mode Active');
+  });
+
+  it('should NOT strip delegation when evalMode is false/undefined', () => {
+    const config: CrewlyAgentConfig = {
+      model: { provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' },
+      maxSteps: 10,
+      sessionName: 'normal-test',
+      apiBaseUrl: 'http://localhost:8787',
+      systemPrompt: 'delegate 80% of execution tasks',
+      maxHistoryMessages: 20,
+      compactionThreshold: 0.8,
+    };
+    const normalRunner = new AgentRunnerService(config);
+    const state = normalRunner.getState();
+    expect(state.systemPrompt).toContain('delegate 80% of execution tasks');
+    expect(state.systemPrompt).not.toContain('## Eval Mode Active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P0: Stop Hook — extractExpectedOutputFiles & checkMissingDeliverables
+// ---------------------------------------------------------------------------
+
+describe('AgentRunnerService.extractExpectedOutputFiles (P0)', () => {
+  it('should extract file names from "create X.ts" pattern', () => {
+    const prompt = 'Create health.controller.ts with a GET /health endpoint.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toContain('health.controller.ts');
+  });
+
+  it('should extract file names from "write team-health.json" pattern', () => {
+    const prompt = 'Analyze team status and write team-health.json with the results.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toContain('team-health.json');
+  });
+
+  it('should extract file names from "produce a file called X" pattern', () => {
+    const prompt = 'Produce a file called report.md with your findings.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toContain('report.md');
+  });
+
+  it('should extract file names from backtick-quoted paths', () => {
+    const prompt = 'Implement `user.service.ts` and `user.controller.ts` with the API.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toContain('user.service.ts');
+    expect(files).toContain('user.controller.ts');
+  });
+
+  it('should extract file from "output to X" pattern', () => {
+    const prompt = 'Save output to results.json after processing.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toContain('results.json');
+  });
+
+  it('should not extract glob patterns', () => {
+    const prompt = 'Create *.ts files in the directory.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toEqual([]);
+  });
+
+  it('should return empty array for prompts with no file mentions', () => {
+    const prompt = 'Check the team status and report back.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    expect(files).toEqual([]);
+  });
+
+  it('should deduplicate file names', () => {
+    const prompt = 'Create health.controller.ts. Implement health.controller.ts with exports.';
+    const files = AgentRunnerService.extractExpectedOutputFiles(prompt);
+    const healthFiles = files.filter(f => f === 'health.controller.ts');
+    expect(healthFiles.length).toBe(1);
+  });
+});
+
+describe('AgentRunnerService.checkMissingDeliverables (P0)', () => {
+  it('should return empty when all files are written', () => {
+    const expected = ['health.controller.ts', 'health.controller.test.ts'];
+    const toolCalls = [
+      { toolName: 'write_file', args: { file_path: '/tmp/health.controller.ts' }, result: 'ok' },
+      { toolName: 'write_file', args: { file_path: '/tmp/health.controller.test.ts' }, result: 'ok' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toEqual([]);
+  });
+
+  it('should return missing files when not written', () => {
+    const expected = ['health.controller.ts', 'health.controller.test.ts'];
+    const toolCalls = [
+      { toolName: 'write_file', args: { file_path: '/tmp/health.controller.ts' }, result: 'ok' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toContain('health.controller.test.ts');
+    expect(missing).not.toContain('health.controller.ts');
+  });
+
+  it('should match by basename when full path differs', () => {
+    const expected = ['report.json'];
+    const toolCalls = [
+      { toolName: 'write_file', args: { file_path: '/workspace/output/report.json' }, result: 'ok' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toEqual([]);
+  });
+
+  it('should also check edit_file tool calls', () => {
+    const expected = ['config.ts'];
+    const toolCalls = [
+      { toolName: 'edit_file', args: { file_path: '/src/config.ts' }, result: 'ok' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toEqual([]);
+  });
+
+  it('should return all files when no write tools were used', () => {
+    const expected = ['a.ts', 'b.ts'];
+    const toolCalls = [
+      { toolName: 'read_file', args: { file_path: '/src/a.ts' }, result: 'content' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('should return empty when expectedFiles is empty', () => {
+    const missing = AgentRunnerService.checkMissingDeliverables([], []);
+    expect(missing).toEqual([]);
+  });
+
+  it('should handle write_file with path arg (alternative naming)', () => {
+    const expected = ['data.json'];
+    const toolCalls = [
+      { toolName: 'write_file', args: { path: '/tmp/data.json' }, result: 'ok' },
+    ];
+    const missing = AgentRunnerService.checkMissingDeliverables(expected, toolCalls);
+    expect(missing).toEqual([]);
+  });
+});
+
+/**
+ * B4 — DeepSeek tool_choice passthrough regression test.
+ *
+ * Spec: /Users/yellowsunhy/Desktop/projects/crewly-projects/crewly/.crewly/specs/2026-05-03-crewly-agent-deepseek-gap-list.md
+ *
+ * Background — B4 was originally listed as a 🔴 BLOCKER ("tool_choice 不确定")
+ * estimated at 2h. Live smoke testing on 2026-05-03 INVALIDATED it:
+ *
+ *     ✅ Live test 3/3 runs, toolChoice: { type: 'tool', toolName: 'reply_slack' }
+ *        on deepseek-chat V3 = completely deterministic. Each run returned the
+ *        correct tool_call within 1.4-1.5s, 0 fallback to text, 0 multi-tool drift.
+ *
+ *     runs: [
+ *       { run: 1, ms: 1528, toolName: 'reply_slack', stepCount: 1, err: null },
+ *       { run: 2, ms: 1397, toolName: 'reply_slack', stepCount: 1, err: null },
+ *       { run: 3, ms: 1411, toolName: 'reply_slack', stepCount: 1, err: null },
+ *     ]
+ *     all_picked_reply_slack: true
+ *
+ * Decision (TL): no product-code change for B4 — DO NOT add a retry-with-tool-choice
+ * fallback layer. This regression test pins the current "passthrough" behavior:
+ * agent-runner.service.ts must NOT inject a hardcoded `toolChoice` into the
+ * generateText / streamText call. The default ('auto') lets the model decide,
+ * and the live smoke confirms DeepSeek V3 is reliable under that default.
+ *
+ * If a future change adds `toolChoice: 'required'` or similar to either
+ * the streamText or generateText path, these tests fail — forcing a re-evaluation
+ * against the smoke evidence above.
+ */
+describe('B4 — DeepSeek tool_choice passthrough regression', () => {
+  let runner: AgentRunnerService;
+  let mockGenerateText: vi.Mock<any>;
+
+  const baseConfig: CrewlyAgentConfig = {
+    model: { provider: 'deepseek', modelId: 'deepseek-chat', temperature: 0.3, maxTokens: 8192 },
+    maxSteps: 10,
+    sessionName: 'b4-regression-session',
+    apiBaseUrl: 'http://localhost:8787',
+    systemPrompt: 'You are a deepseek agent.',
+    maxHistoryMessages: 20,
+    compactionThreshold: 0.8,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockGenerateText = vi.fn<any>().mockResolvedValue({
+      text: 'noop',
+      steps: [{ toolCalls: [], toolResults: [] }],
+      usage: { inputTokens: 10, outputTokens: 5 },
+      finishReason: 'stop',
+    });
+
+    const mockModelManager = {
+      getModel: vi.fn<any>().mockResolvedValue({ provider: 'deepseek', modelId: 'deepseek-chat' }),
+      getAvailableProviders: vi.fn<any>(),
+      clearCache: vi.fn<any>(),
+      // I2 — DeepSeek reasoning_content extraction. Mocked as null so the
+      // result.reasoning is undefined for these passthrough regression tests
+      // (they assert tool_choice wiring, not reasoning capture).
+      consumeDeepseekReasoning: vi.fn<any>().mockResolvedValue(null),
+    } as any;
+
+    const mockApiClient = {
+      get: vi.fn<any>(),
+      post: vi.fn<any>(),
+      delete: vi.fn<any>(),
+    } as any;
+
+    runner = new AgentRunnerService(baseConfig, mockModelManager, mockApiClient);
+    runner._generateTextFn = mockGenerateText;
+    await runner.initialize();
+  });
+
+  it('should NOT pass a hardcoded toolChoice to generateText (let SDK default apply)', async () => {
+    await runner.run('say hi');
+
+    expect(mockGenerateText).toHaveBeenCalled();
+    const callArgs = mockGenerateText.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs).toBeDefined();
+
+    // The contract: agent-runner relies on the AI SDK's default toolChoice='auto'.
+    // DeepSeek V3 was validated as deterministic under this default (3/3 smoke runs).
+    // If we ever start passing toolChoice explicitly, this test catches it
+    // and forces a deliberate re-test against deepseek-chat / deepseek-reasoner.
+    expect(callArgs).not.toHaveProperty('toolChoice');
+  });
+
+  it('should NOT pass toolChoice on follow-up generateText calls either', async () => {
+    // Multi-turn conversation — the same passthrough invariant must hold for
+    // every call to the SDK, not just the first one.
+    await runner.run('first turn');
+    await runner.run('second turn');
+
+    expect(mockGenerateText.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const [callArgs] of mockGenerateText.mock.calls) {
+      expect(callArgs).not.toHaveProperty('toolChoice');
+    }
+  });
+
+  it('should pass tools dict but leave toolChoice unset (B4 invariant on tools wiring)', async () => {
+    await runner.run('use a tool');
+
+    const callArgs = mockGenerateText.mock.calls[0]?.[0] as Record<string, unknown>;
+    // tools is wired (the agent has a tool registry), but toolChoice is intentionally absent.
+    expect(callArgs).toHaveProperty('tools');
+    expect(callArgs).not.toHaveProperty('toolChoice');
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // 2026-05-15 — thread isolation per Slack thread / chat thread
+  // Goal: "一个 Slack thread 代表一个 chat thread, 不同 Slack
+  // thread 之间不会串联在一起."
+  //
+  // The runner now keeps a Map<conversationKey, ConversationState>
+  // so the LLM context the model sees for thread A never contains
+  // turns from thread B. The conversationKey is the chat-v2 channel
+  // id (e.g. `slack-D0AC7-1777760999-956969`).
+  // ──────────────────────────────────────────────────────────────────
+  describe('thread isolation (per-conversation state)', () => {
+    it('keeps message histories separate across conversation keys', async () => {
+      // Conversation A — two turns. `run(message, conversationId)`
+      // is positional; conversationId is the second arg.
+      await runner.run('hello from A', 'slack-D0AC7-thread-A');
+      await runner.run('still in A', 'slack-D0AC7-thread-A');
+
+      // Conversation B — one turn
+      await runner.run('hello from B', 'slack-D0AC7-thread-B');
+
+      // Inspect the messages the LLM saw for the third call (B's
+      // run). It must contain ONLY B's user message, never A's.
+      const lastCallArgs = mockGenerateText.mock.calls[
+        mockGenerateText.mock.calls.length - 1
+      ]?.[0] as { messages: Array<{ role: string; content: string }> };
+      const userMessagesSeenByB = lastCallArgs.messages.filter(
+        (m) => m.role === 'user',
+      );
+      expect(userMessagesSeenByB.some((m) => m.content === 'hello from B')).toBe(
+        true,
+      );
+      expect(userMessagesSeenByB.some((m) => m.content === 'hello from A')).toBe(
+        false,
+      );
+      expect(userMessagesSeenByB.some((m) => m.content === 'still in A')).toBe(
+        false,
+      );
+
+      // Two conversation keys are now live.
+      expect(runner.getConversationCount()).toBe(2);
+    });
+
+    it('routes runtime-internal messages (no conversationId) to __default__', async () => {
+      await runner.run('a scheduled-check ping with no thread identity');
+      // First-time creation under the default key — count is 1.
+      expect(runner.getConversationCount()).toBe(1);
+
+      await runner.run('another no-id ping');
+      // Same default bucket — count stays 1.
+      expect(runner.getConversationCount()).toBe(1);
+    });
+
+    it('reuses an existing state when the same conversationId comes back', async () => {
+      await runner.run('first', 'web-conv-x');
+      await runner.run('second', 'web-conv-x');
+
+      // The second run's messages array (seen by the LLM) carries
+      // the first turn — proves we're not creating fresh state per
+      // run for a returning conversation.
+      const secondCall = mockGenerateText.mock.calls[1]?.[0] as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      const userMsgs = secondCall.messages.filter((m) => m.role === 'user');
+      expect(userMsgs.map((m) => m.content)).toEqual(['first', 'second']);
+      expect(runner.getConversationCount()).toBe(1);
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/agent-runner.service.ts
+++ b/packages/crewly-agent/src/runtime/agent-runner.service.ts
@@ -1,0 +1,1827 @@
+/**
+ * Crewly Agent Runner Service
+ *
+ * Core reasoning loop for the Crewly Agent runtime. Wraps Vercel AI SDK's
+ * generateText with conversation history management, context compaction,
+ * and structured result tracking.
+ *
+ * @module services/agent/crewly-agent/agent-runner.service
+ */
+
+import { streamText, generateText, stepCountIs, type ModelMessage, type LanguageModel } from 'ai';
+import { ModelManager } from './model-manager.js';
+import { CrewlyApiClient } from './api-client.js';
+import { createTools } from './tool-registry.js';
+import { connectAndLoadMcpTools } from './mcp-tool-bridge.js';
+import { ApprovalQueueService, type PendingApproval } from './approval-queue.service.js';
+import { OutputFilterService } from './output-filter.service.js';
+import type { ToolDefinition, McpClientLike } from './types.js';
+import {
+  type CrewlyAgentConfig,
+  type ConversationState,
+  type AgentRunResult,
+  type ToolCallRecord,
+  type CompactionResult,
+  type ContextBudgetStatus,
+  type AuditEntry,
+  type SecurityPolicy,
+  type ToolCallbacks,
+  type ApprovalCheckResult,
+  type ToolSensitivity,
+  type AuditLogFilters,
+  type StreamingEventCallbacks,
+  CREWLY_AGENT_DEFAULTS,
+  WRITE_TOOLS,
+  MODEL_CONTEXT_WINDOWS,
+  resolveMaxOutputTokens,
+} from './types.js';
+
+/**
+ * No-op stubs for OSS-internal services. In OSS these resolve to concrete
+ * implementations (tracing, memory flush, MCP client, Slack ID synth). The
+ * standalone runtime runs without those: tracing becomes a passthrough,
+ * context-flush extracts nothing, MCP is disabled unless an external
+ * implementation is injected via tool callbacks, and Slack thread keys
+ * fall back to a deterministic string format compatible with chat-v2.
+ */
+const TRACING_CONSTANTS = {
+  SPANS: { AGENT_RUN: 'agent.run' },
+} as const;
+
+interface TraceServiceLike {
+  withSpan<T>(name: string, options: Record<string, unknown>, fn: () => Promise<T>): Promise<T>;
+}
+
+const TracingService = {
+  getInstance(): TraceServiceLike {
+    return { withSpan: (_n, _o, fn) => fn() };
+  },
+};
+
+interface ContextFlushLike {
+  extract(input: string): string[];
+}
+
+const ContextFlushService = {
+  getInstance(): ContextFlushLike {
+    return { extract: () => [] };
+  },
+};
+
+/**
+ * Standalone has no concrete MCP client by default — tool callbacks can
+ * inject one via `ToolCallbacks.mcpClient` if needed. This class shim
+ * exists only so the rest of the file can `new McpClientService()`
+ * compile-clean; the resulting object is intentionally null-equivalent.
+ */
+class McpClientService implements McpClientLike {
+  connectAll(): Promise<Map<string, Error>> { return Promise.resolve(new Map()); }
+  listTools(): never[] { return []; }
+  callTool(): Promise<never> {
+    return Promise.reject(new Error('No MCP client wired in standalone runtime.'));
+  }
+  disconnectAll(): Promise<void> { return Promise.resolve(); }
+  getConnectedServers(): string[] { return []; }
+}
+
+/**
+ * Mirror of OSS chat-v2 `synthesizeSlackConversationId` — keep the wire
+ * format identical so per-conversation state keys match across runtimes.
+ */
+function synthesizeSlackConversationId(channelId: string, threadTs: string): string {
+  return `slack-${channelId}-${String(threadTs).replace('.', '-')}`;
+}
+
+/**
+ * Fingerprint a tool call for comparison: deterministic JSON of name + args.
+ */
+function toolCallFingerprint(toolName: string, args: Record<string, unknown>): string {
+  return JSON.stringify({ t: toolName, a: args });
+}
+
+/**
+ * Detects looping behavior in tool calls: consecutive identical calls or
+ * consecutive error responses from the same tool.
+ *
+ * Usage: create per-run, call `recordToolCall()` in onStepFinish, check `loopDetected`.
+ */
+export class ToolCallLoopDetector {
+  /** Consecutive identical tool call fingerprints */
+  private consecutiveIdentical = 0;
+  private lastFingerprint: string | null = null;
+  /** Consecutive error results from the same tool */
+  private consecutiveErrors = 0;
+  private lastErrorTool: string | null = null;
+  /** Whether a loop was detected */
+  loopDetected = false;
+  /** Human-readable reason when loop is detected */
+  loopReason = '';
+
+  constructor(
+    private readonly identicalThreshold: number = CREWLY_AGENT_DEFAULTS.LOOP_DETECTION_THRESHOLD,
+    private readonly errorThreshold: number = CREWLY_AGENT_DEFAULTS.ERROR_LOOP_THRESHOLD,
+  ) {}
+
+  /**
+   * Record a tool call and check for loop patterns.
+   *
+   * @param toolName - Name of the tool called
+   * @param args - Arguments passed to the tool
+   * @param result - Result returned by the tool
+   * @returns True if a loop was just detected on this call
+   */
+  recordToolCall(toolName: string, args: Record<string, unknown>, result: unknown): boolean {
+    if (this.loopDetected) return true;
+
+    // 1. Check consecutive identical calls
+    const fp = toolCallFingerprint(toolName, args);
+    if (fp === this.lastFingerprint) {
+      this.consecutiveIdentical++;
+    } else {
+      this.consecutiveIdentical = 1;
+      this.lastFingerprint = fp;
+    }
+
+    if (this.consecutiveIdentical >= this.identicalThreshold) {
+      this.loopDetected = true;
+      this.loopReason = `Identical tool call repeated ${this.consecutiveIdentical} times: ${toolName}(${JSON.stringify(args).slice(0, 120)})`;
+      return true;
+    }
+
+    // 2. Check consecutive error results (404, 4xx, 5xx, error strings)
+    if (this.isErrorResult(result)) {
+      if (toolName === this.lastErrorTool) {
+        this.consecutiveErrors++;
+      } else {
+        this.consecutiveErrors = 1;
+        this.lastErrorTool = toolName;
+      }
+      if (this.consecutiveErrors >= this.errorThreshold) {
+        this.loopDetected = true;
+        this.loopReason = `Tool "${toolName}" returned errors ${this.consecutiveErrors} consecutive times. Last result: ${String(result).slice(0, 200)}`;
+        return true;
+      }
+    } else {
+      this.consecutiveErrors = 0;
+      this.lastErrorTool = null;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if a tool result looks like an error (404, HTTP error codes, error strings).
+   */
+  private isErrorResult(result: unknown): boolean {
+    if (result === null || result === undefined) return false;
+    const str = typeof result === 'string' ? result : JSON.stringify(result);
+    // Match common error patterns: HTTP 4xx/5xx, "error", "not found", "failed"
+    return /\b(404|403|500|502|503|4\d{2}|5\d{2})\b/.test(str)
+      || /\b(error|not\s*found|failed|refused|denied|timeout)\b/i.test(str);
+  }
+}
+
+/**
+ * Core agent runner that manages the AI SDK generateText loop.
+ *
+ * Responsibilities:
+ * - Maintains conversation history (messages array)
+ * - Calls generateText with tools and maxSteps for agentic behavior
+ * - Tracks token usage across invocations
+ * - Triggers context compaction when history grows too large
+ * - Serializes concurrent message handling
+ *
+ * @example
+ * ```typescript
+ * const runner = new AgentRunnerService(config);
+ * await runner.initialize();
+ * const result = await runner.run('Check all team statuses');
+ * ```
+ */
+/** Function type for generateText — used for dependency injection in tests */
+type GenerateTextFn = (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+export class AgentRunnerService {
+  private config: CrewlyAgentConfig;
+  private modelManager: ModelManager;
+  private apiClient: CrewlyApiClient;
+  private model: LanguageModel | null = null;
+  /**
+   * Per-conversation state map. Each Slack thread (or web chat
+   * conversation) gets its own `ConversationState` so the LLM
+   * context is isolated — messages from thread A never leak into
+   * the prompt when responding to thread B. The conversation key
+   * is the chat-v2 channel id (e.g. `slack-D0AC7-1777760999-956969`)
+   * derived from the inbound message's `[CHAT:xxx]` marker, the
+   * `[SLACK:channel:threadTs]` marker, or — if neither is present
+   * — the literal `__default__` for runtime cases like REPL or
+   * scheduled-check inputs that have no thread identity.
+   *
+   * 2026-05-15 fix per goal: "一个 Slack thread 代表一个 chat
+   * thread, 不同 Slack thread 之间不会串联在一起."
+   */
+  private conversationStates: Map<string, ConversationState> = new Map();
+  /**
+   * Active conversation key for the message currently being
+   * processed. `processQueue` sets this before each `executeRun`
+   * so the getter `this.state` resolves to the right per-thread
+   * state without every call site needing to know about the map.
+   */
+  private currentConversationKey: string = '__default__';
+  /**
+   * Effective system prompt — captured at construction time and
+   * applied to every fresh per-conversation state created on
+   * demand. Held on the instance so `getOrCreateState` doesn't
+   * need to recompute the eval-mode stripping logic.
+   */
+  private readonly effectiveSystemPrompt: string;
+  /**
+   * Soft cap on how many distinct conversation states we hold in
+   * memory. When exceeded, the least-recently-active state is
+   * evicted (its messages live on in chat-v2 SQLite so the next
+   * access can re-hydrate). Prevents unbounded growth when a busy
+   * agent participates in thousands of Slack threads over time.
+   */
+  private readonly MAX_LIVE_CONVERSATIONS = 100;
+
+  /**
+   * Backward-compatible getter: every existing `this.state.X`
+   * call site automatically routes to the active per-conversation
+   * state. Lazy-creates a fresh state on first access for a new
+   * conversation key.
+   */
+  private get state(): ConversationState {
+    return this.getOrCreateConversationState(this.currentConversationKey);
+  }
+
+  /**
+   * Look up or create the ConversationState for a given key.
+   * Evicts the least-recently-active state when the live-set
+   * size exceeds {@link MAX_LIVE_CONVERSATIONS}.
+   *
+   * @param key - Conversation key (chat-v2 channel id or `__default__`)
+   * @returns The per-conversation state object
+   */
+  private getOrCreateConversationState(key: string): ConversationState {
+    let s = this.conversationStates.get(key);
+    if (!s) {
+      s = {
+        messages: [],
+        systemPrompt: this.effectiveSystemPrompt,
+        totalTokens: { input: 0, output: 0 },
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+      };
+      this.conversationStates.set(key, s);
+
+      // LRU eviction — pop the oldest by `lastActivityAt`. Map
+      // preserves insertion order but we want recency, so scan
+      // once on overflow rather than maintain a separate index.
+      if (this.conversationStates.size > this.MAX_LIVE_CONVERSATIONS) {
+        let evictKey: string | null = null;
+        let evictedAt: number = Infinity;
+        for (const [k, v] of this.conversationStates) {
+          if (k === key) continue;
+          const t = v.lastActivityAt.getTime();
+          if (t < evictedAt) {
+            evictedAt = t;
+            evictKey = k;
+          }
+        }
+        if (evictKey !== null) this.conversationStates.delete(evictKey);
+      }
+    }
+    return s;
+  }
+
+  /**
+   * Test / introspection helper — number of active conversation
+   * states the runner currently holds. Surfaces in
+   * `getConversationStatus` for observability.
+   *
+   * @returns Number of live per-conversation states
+   */
+  public getConversationCount(): number {
+    return this.conversationStates.size;
+  }
+
+  private processing = false;
+  private messageQueue: Array<{ message: string; conversationId?: string; metadata?: Record<string, string>; resolve: (result: AgentRunResult) => void; reject: (error: Error) => void; options?: { abortSignal?: AbortSignal; streaming?: StreamingEventCallbacks } }> = [];
+  private auditLog: AuditEntry[] = [];
+  private securityPolicy: SecurityPolicy;
+  /** Current conversationId extracted from [CHAT:xxx] prefix */
+  private currentConversationId?: string;
+  /** Last known conversationId — used as fallback when a message has no explicit conversationId */
+  private lastKnownConversationId?: string;
+  /** Current Slack context (channelId + threadTs) for routing NOTIFY responses */
+  private currentSlackContext?: { channelId: string; threadTs?: string };
+  /** MCP client for external tool integration */
+  private mcpClient: McpClientService | null = null;
+  /** Cached MCP tool definitions loaded during initialization */
+  private mcpToolDefs: Record<string, ToolDefinition> = {};
+  /** Approval queue for tools requiring explicit approval (shared singleton) */
+  private approvalQueue: ApprovalQueueService = ApprovalQueueService.getInstance();
+  private tracing = TracingService.getInstance();
+  /** Guards against concurrent compaction — only one compaction at a time */
+  private compacting = false;
+  /** AbortController for the current run — allows external cancellation */
+  private currentRunAbort: AbortController | null = null;
+  /** Streaming event callbacks — set per run by the runtime service */
+  private streamingCallbacks: StreamingEventCallbacks = {};
+  /** Output filter for redacting API keys from agent responses */
+  private outputFilter: OutputFilterService = new OutputFilterService();
+  /** @internal Override for testing — replaces the AI SDK generateText call */
+  _generateTextFn: GenerateTextFn | null = null;
+
+  /**
+   * Create a new AgentRunnerService.
+   *
+   * @param config - Agent configuration
+   * @param modelManager - Optional model manager instance (for testing)
+   * @param apiClient - Optional API client instance (for testing)
+   */
+  constructor(
+    config: CrewlyAgentConfig,
+    modelManager?: ModelManager,
+    apiClient?: CrewlyApiClient,
+  ) {
+    this.config = config;
+    this.modelManager = modelManager || new ModelManager();
+    this.apiClient = apiClient || new CrewlyApiClient(
+      config.apiBaseUrl,
+      config.sessionName,
+    );
+    this.securityPolicy = { ...CREWLY_AGENT_DEFAULTS.SECURITY_POLICY };
+    // In eval mode, strip delegation-first instructions so agent implements directly
+    this.effectiveSystemPrompt = config.evalMode
+      ? AgentRunnerService.stripDelegationInstructions(config.systemPrompt)
+      : config.systemPrompt;
+    // Conversation states are lazy-created on first access via the
+    // `state` getter, so we don't need to seed `__default__` here.
+    // The first message processed will create whichever conversation
+    // it targets.
+  }
+
+  // ---------------------------------------------------------------------------
+  // Eval Mode: Delegation Stripping (P1)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Regex patterns that match TL delegation-first instructions in the system prompt.
+   * These cause the agent to delegate instead of implementing in eval sandboxes.
+   */
+  private static readonly DELEGATION_PATTERNS: RegExp[] = [
+    // "delegate 80% of execution tasks" and variants
+    /delegate\s+\d+%?\s+of\s+execution\s+tasks?/gi,
+    // "DELEGATION-FIRST PROTOCOL" sections
+    /DELEGATION-FIRST\s+PROTOCOL[^]*?(?=\n#{1,3}\s|\n---|\Z)/gm,
+    // "Only implement yourself when:" blocks
+    /\*\*Only implement yourself\*\*\s+when:[^]*?(?=\n#{1,3}\s|\n---|\n\n\*\*)/gm,
+    // "Your core loop on every task is:" delegation loop
+    /Your core loop on every task is:[^]*?(?=\n#{1,3}\s|\n---)/gm,
+    // "Target: delegate 70–80% of execution tasks"
+    /Target:\s*delegate\s+\d+[–-]\d+%\s+of\s+execution\s+tasks\.?/gi,
+    // Entire "Team Lead Delegation SOP" section
+    /#+\s*Team Lead Delegation SOP[^]*?(?=\n#{1,2}\s[^#]|\Z)/gm,
+    // "ANTI-PATTERNS" that tell TL not to implement
+    /These are ANTI-PATTERNS\.\s*The TL must avoid:[^]*?(?=\n#{1,3}\s|\n---)/gm,
+  ];
+
+  /**
+   * Eval-mode override instruction injected after stripping delegation instructions.
+   * Tells the agent to implement directly.
+   */
+  private static readonly EVAL_MODE_OVERRIDE = [
+    '',
+    '## Eval Mode Active',
+    '',
+    'You are running in evaluation mode. IMPORTANT behavioral overrides:',
+    '- **Implement directly** — Do NOT delegate tasks to workers. Write code yourself.',
+    '- **Create all output files** — If the task asks you to create a file, you MUST write it using write_file or edit_file.',
+    '- **Use standard tool names** — Use handle-failure, delegate-task, send-message for collaboration actions.',
+    '- **Materialize deliverables** — After gathering information, always produce the required output files before finishing.',
+    '- **Self-check before stopping** — Before you finish, verify: "Have I created every file/artifact the task requested?"',
+    '',
+  ].join('\n');
+
+  /**
+   * Strip delegation-first instructions from a system prompt for eval mode.
+   *
+   * Removes TL delegation SOP sections, delegation-first protocol blocks,
+   * and anti-pattern warnings that cause the agent to delegate instead of
+   * implementing. Injects an eval-mode override instruction.
+   *
+   * @param prompt - Original system prompt
+   * @returns Cleaned prompt with eval-mode overrides
+   */
+  static stripDelegationInstructions(prompt: string): string {
+    let cleaned = prompt;
+    for (const pattern of AgentRunnerService.DELEGATION_PATTERNS) {
+      cleaned = cleaned.replace(pattern, '');
+    }
+    // Remove consecutive blank lines left by stripping
+    cleaned = cleaned.replace(/\n{4,}/g, '\n\n\n');
+    // Inject eval mode override at the end
+    cleaned = cleaned.trimEnd() + '\n' + AgentRunnerService.EVAL_MODE_OVERRIDE;
+    return cleaned;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Post-Execution Deliverable Check (P0 - Stop Hook)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Patterns that indicate the task expects a file to be created.
+   * Matches phrases like "create health.controller.ts", "write team-health.json",
+   * "produce a report file", etc.
+   */
+  private static readonly FILE_CREATION_PATTERNS: RegExp[] = [
+    // Note: longer extensions (json, tsx, jsx, yaml) must come before shorter ones (js, ts) to avoid partial matches
+    /(?:create|write|produce|generate|build|implement)\s+(?:a\s+)?(?:file\s+(?:called|named)\s+)?[`"']?(\S+\.(?:tsx|jsx|json|yaml|yml|html|css|ts|js|md|txt))\b[`"']?/gi,
+    /(?:output|save|write)\s+(?:to|into)\s+[`"']?(\S+\.(?:tsx|jsx|json|yaml|yml|html|css|ts|js|md|txt))\b[`"']?/gi,
+    /[`"'](\S+\.(?:tsx|jsx|json|yaml|yml|html|css|ts|js|md|txt))[`"']\s+(?:file|should be created|must be created)/gi,
+    // Backtick-quoted file paths — commonly used in task prompts
+    /`(\S+\.(?:tsx|jsx|json|yaml|yml|html|css|ts|js|md|txt))`/gi,
+  ];
+
+  /**
+   * Extract expected output file names from the task prompt.
+   *
+   * Scans the message for file creation patterns and returns the
+   * list of file names the task expects to be produced.
+   *
+   * @param taskPrompt - The original task prompt/message
+   * @returns Array of expected file names (basename only)
+   */
+  static extractExpectedOutputFiles(taskPrompt: string): string[] {
+    const files = new Set<string>();
+    for (const pattern of AgentRunnerService.FILE_CREATION_PATTERNS) {
+      // Reset lastIndex for global regex
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(taskPrompt)) !== null) {
+        const fileName = match[1];
+        if (fileName && !fileName.includes('*') && fileName.length < 100) {
+          files.add(fileName);
+        }
+      }
+    }
+    return Array.from(files);
+  }
+
+  /**
+   * Check if the agent's tool calls produced the expected output files.
+   *
+   * Examines write_file and edit_file tool calls to see if the expected
+   * files were written. Returns the list of missing files.
+   *
+   * @param expectedFiles - File names expected to be created
+   * @param toolCalls     - Tool calls made during the run
+   * @returns Array of file names that were NOT written
+   */
+  static checkMissingDeliverables(
+    expectedFiles: string[],
+    toolCalls: ToolCallRecord[],
+  ): string[] {
+    if (expectedFiles.length === 0) return [];
+
+    // Collect all files written by write_file or edit_file tools
+    const writtenFiles = new Set<string>();
+    for (const tc of toolCalls) {
+      if (tc.toolName === 'write_file' || tc.toolName === 'edit_file') {
+        const filePath = (tc.args as Record<string, unknown>).file_path
+          ?? (tc.args as Record<string, unknown>).path
+          ?? '';
+        if (typeof filePath === 'string' && filePath) {
+          // Extract basename for comparison
+          const basename = filePath.split('/').pop() ?? filePath;
+          writtenFiles.add(basename);
+          writtenFiles.add(filePath); // Also add full path
+        }
+      }
+    }
+
+    return expectedFiles.filter((f) => {
+      const basename = f.split('/').pop() ?? f;
+      return !writtenFiles.has(f) && !writtenFiles.has(basename);
+    });
+  }
+
+  /**
+   * Initialize the agent runner by loading the model.
+   * Must be called before run().
+   *
+   * @throws Error if the model cannot be loaded
+   */
+  async initialize(): Promise<void> {
+    this.model = await this.modelManager.getModel(this.config.model);
+
+    // Connect to configured MCP servers and load their tools
+    if (this.config.mcpServers && Object.keys(this.config.mcpServers).length > 0) {
+      this.mcpClient = new McpClientService();
+      const { tools, errors } = await connectAndLoadMcpTools(
+        this.mcpClient,
+        this.config.mcpServers,
+        this.config.mcpSensitivityOverrides,
+      );
+      this.mcpToolDefs = tools;
+
+      if (errors.size > 0) {
+        for (const [name, error] of errors.entries()) {
+          // Log but don't fail — partial MCP availability is acceptable
+          console.warn(`MCP server "${name}" failed to connect: ${error.message}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Run the agent with a new user message.
+   *
+   * Messages are queued and processed serially to prevent concurrent
+   * generateText calls which would corrupt conversation state.
+   *
+   * @param message - User/system message to process
+   * @param conversationId - Optional conversation ID for routing
+   * @param metadata - Optional metadata (Slack context, etc.)
+   * @param options - Optional abort signal and streaming callbacks
+   * @returns Result of the agent run including text, tool calls, and usage
+   */
+  async run(
+    message: string,
+    conversationId?: string,
+    metadata?: Record<string, string>,
+    options?: { abortSignal?: AbortSignal; streaming?: StreamingEventCallbacks },
+  ): Promise<AgentRunResult> {
+    return new Promise<AgentRunResult>((resolve, reject) => {
+      this.messageQueue.push({ message, conversationId, metadata, resolve, reject, options });
+      if (!this.processing) {
+        this.processQueue();
+      }
+    });
+  }
+
+  /**
+   * Abort the current in-progress run.
+   * Signals the active streamText/generateText call to cancel.
+   *
+   * @returns True if an active run was aborted, false if no run was in progress
+   */
+  abortCurrentRun(): boolean {
+    if (this.currentRunAbort) {
+      this.currentRunAbort.abort();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Check if the agent is currently processing a message.
+   *
+   * @returns True if processing is in progress
+   */
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  /**
+   * Get current conversation state (for inspection/debugging).
+   *
+   * @returns Current conversation state
+   */
+  getState(): ConversationState {
+    return { ...this.state };
+  }
+
+  /**
+   * Shut down the agent runner, disconnecting MCP servers.
+   *
+   * Should be called when the agent session ends to clean up
+   * child processes spawned by MCP server connections.
+   */
+  async shutdown(): Promise<void> {
+    if (this.mcpClient) {
+      await this.mcpClient.disconnectAll();
+      this.mcpClient = null;
+      this.mcpToolDefs = {};
+    }
+  }
+
+  /**
+   * Get the names of connected MCP servers.
+   *
+   * @returns Array of server names, or empty if no MCP client is configured
+   */
+  getMcpServerNames(): string[] {
+    return this.mcpClient?.getConnectedServers() ?? [];
+  }
+
+  /**
+   * Get the number of MCP tools currently loaded.
+   *
+   * @returns Number of MCP tool definitions
+   */
+  getMcpToolCount(): number {
+    return Object.keys(this.mcpToolDefs).length;
+  }
+
+  /**
+   * Get the current Slack context (channelId + threadTs).
+   * Used by the runtime service to inject Slack awareness into the agent.
+   *
+   * @returns Current Slack context or undefined
+   */
+  getSlackContext(): { channelId: string; threadTs?: string } | undefined {
+    return this.currentSlackContext;
+  }
+
+  /**
+   * Get the number of messages in the conversation history.
+   *
+   * @returns Message count
+   */
+  getHistoryLength(): number {
+    return this.state.messages.length;
+  }
+
+  /**
+   * Check if the agent runner has been initialized.
+   *
+   * @returns True if initialize() has been called successfully
+   */
+  isInitialized(): boolean {
+    return this.model !== null;
+  }
+
+  /**
+   * Get current context budget status.
+   *
+   * Calculates token usage as a percentage of the model's context window
+   * and determines the budget level (normal/warning/critical).
+   *
+   * @returns ContextBudgetStatus with usage stats and level
+   */
+  getContextBudget(): ContextBudgetStatus {
+    const totalTokensUsed = this.state.totalTokens.input + this.state.totalTokens.output;
+    const contextWindowSize = MODEL_CONTEXT_WINDOWS[this.config.model.modelId]
+      ?? MODEL_CONTEXT_WINDOWS.default;
+    const usagePercent = contextWindowSize > 0
+      ? totalTokensUsed / contextWindowSize
+      : 0;
+
+    const threshold = this.config.compactionThreshold;
+    const warningThreshold = threshold * 0.85; // warn at 85% of compaction threshold
+    let level: ContextBudgetStatus['level'] = 'normal';
+    if (usagePercent >= threshold) {
+      level = 'critical';
+    } else if (usagePercent >= warningThreshold) {
+      level = 'warning';
+    }
+
+    const compactionPending = this.state.messages.length >= this.config.maxHistoryMessages
+      || usagePercent >= threshold;
+
+    const pct = (usagePercent * 100).toFixed(1);
+    let summary = `${pct}% of context budget used (${totalTokensUsed.toLocaleString()}/${contextWindowSize.toLocaleString()} tokens, ${this.state.messages.length} messages)`;
+    if (level === 'critical') {
+      summary += ' — CRITICAL: compaction recommended immediately';
+    } else if (level === 'warning') {
+      summary += ' — WARNING: approaching compaction threshold';
+    }
+
+    return {
+      totalTokensUsed,
+      contextWindowSize,
+      usagePercent,
+      level,
+      messageCount: this.state.messages.length,
+      compactionPending,
+      summary,
+    };
+  }
+
+  /**
+   * Process queued messages serially.
+   */
+  private async processQueue(): Promise<void> {
+    this.processing = true;
+    while (this.messageQueue.length > 0) {
+      const item = this.messageQueue.shift()!;
+      try {
+        // Update current conversationId for tool context.
+        // If the incoming message has an explicit conversationId, use it and
+        // remember it for future messages. If not, fall back to the last known
+        // conversationId so tools (especially [NOTIFY] output) can still route
+        // responses correctly for system messages like scheduled checks.
+        if (item.conversationId) {
+          this.currentConversationId = item.conversationId;
+          this.lastKnownConversationId = item.conversationId;
+        } else {
+          this.currentConversationId = this.lastKnownConversationId;
+        }
+        // Update Slack context from message metadata (Bug 5 fix).
+        // When a message arrives via Slack, metadata contains channelId + threadTs
+        // so the agent's tools (reply_slack) know where to reply.
+        if (item.metadata?.channelId) {
+          this.currentSlackContext = {
+            channelId: item.metadata.channelId,
+            threadTs: item.metadata.threadTs,
+          };
+        }
+        // 2026-05-15 thread isolation: pick the per-conversation
+        // state for this message so the LLM sees only this thread's
+        // history. Prefer the explicit conversationId; for Slack
+        // inbound that has no conversationId yet (rare path), derive
+        // it from the channelId+threadTs marker using the same
+        // `slack-${channelId}-${threadTs}` shape persistSlackInbound
+        // and `/slack/send` use, so chat-v2 channel ids and runner
+        // conversation keys stay aligned. Fall back to `__default__`
+        // for runtime-internal messages (scheduled checks, system
+        // events) that have no thread identity.
+        const resolvedConvKey: string =
+          item.conversationId ??
+          (item.metadata?.channelId && item.metadata?.threadTs
+            ? synthesizeSlackConversationId(
+                String(item.metadata.channelId),
+                String(item.metadata.threadTs),
+              )
+            : this.lastKnownConversationId ?? '__default__');
+        this.currentConversationKey = resolvedConvKey;
+        // Set streaming callbacks for this run
+        this.streamingCallbacks = item.options?.streaming ?? {};
+        const result = await this.tracing.withSpan(TRACING_CONSTANTS.SPANS.AGENT_RUN, {
+          attributes: {
+            'agent.session': this.config.sessionName,
+            'agent.role': this.config.role,
+          }
+        }, async () => {
+          return this.executeRun(item.message, item.options?.abortSignal);
+        });
+        item.resolve(result);
+      } catch (error) {
+        item.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    }
+    this.processing = false;
+
+    // Re-check: a message may have been pushed between the while-loop exit
+    // condition check and this.processing = false. Without this guard, the
+    // queued message would be stranded — nobody restarts processQueue.
+    if (this.messageQueue.length > 0) {
+      this.processQueue();
+    }
+  }
+
+  /**
+   * Execute a single streamText run with the current conversation context.
+   *
+   * Uses streamText for real-time token emission and tool call feedback.
+   * Falls back to generateText when _generateTextFn is set (testing).
+   *
+   * @param message - New message to add to the conversation
+   * @param externalAbortSignal - Optional external abort signal for cancellation
+   * @returns Agent run result
+   */
+  private async executeRun(message: string, externalAbortSignal?: AbortSignal): Promise<AgentRunResult> {
+    if (!this.model) {
+      throw new Error('AgentRunner not initialized. Call initialize() first.');
+    }
+
+    // Check if compaction is needed before adding new message
+    // Trigger on message count OR token budget threshold
+    const budget = this.getContextBudget();
+    if (this.state.messages.length >= this.config.maxHistoryMessages || budget.level === 'critical') {
+      await this.compactHistory();
+    }
+
+    // Add user message to history
+    this.state.messages.push({ role: 'user', content: message });
+    this.state.lastActivityAt = new Date();
+
+    // Build tools with callbacks for compaction, audit, and security enforcement
+    const callbacks: ToolCallbacks = {
+      onCompactMemory: () => this.requestCompaction(),
+      onGetContextBudget: () => this.getContextBudget(),
+      onAuditLog: (entry: AuditEntry) => this.recordAudit({ ...entry, sessionName: this.config.sessionName }),
+      onCheckApproval: (toolName: string, sensitivity: ToolSensitivity) => this.checkApproval(toolName, sensitivity),
+      onGetAuditLog: (filters: AuditLogFilters) => this.getFilteredAuditLog(filters),
+      onEnqueueApproval: (toolName: string, sensitivity: ToolSensitivity, args: Record<string, unknown>) => {
+        const approval = this.approvalQueue.enqueue(this.config.sessionName, toolName, sensitivity, args);
+        return { approvalId: approval.id };
+      },
+    };
+    const mcpTools = Object.keys(this.mcpToolDefs).length > 0 ? this.mcpToolDefs : undefined;
+    const tools = createTools(this.apiClient, this.config.sessionName, this.config.projectPath, callbacks, this.currentConversationId, this.currentSlackContext, mcpTools);
+
+    // Create abort controller that merges external signal with internal control
+    const runAbort = new AbortController();
+    this.currentRunAbort = runAbort;
+
+    // If external signal is already aborted, abort immediately
+    if (externalAbortSignal?.aborted) {
+      runAbort.abort();
+    } else if (externalAbortSignal) {
+      externalAbortSignal.addEventListener('abort', () => runAbort.abort(), { once: true });
+    }
+
+    try {
+      // If a test override is set, use generateText path (backward compatible)
+      if (this._generateTextFn) {
+        return await this.executeRunWithGenerateText(tools, runAbort.signal);
+      }
+
+      // Production path: streamText for real-time feedback
+      return await this.executeRunWithStreamText(tools, runAbort.signal);
+    } finally {
+      this.currentRunAbort = null;
+    }
+  }
+
+  /**
+   * Check if an error is recoverable and eligible for automatic retry.
+   *
+   * Recoverable errors include:
+   * - HTTP 429 (rate limit)
+   * - HTTP 5xx (server errors)
+   * - Network timeouts and connection errors
+   *
+   * @param error - The error to classify
+   * @returns True if the error is recoverable
+   */
+  private isRecoverableError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    const statusMatch = msg.match(/\b(429|5\d{2})\b/);
+    if (statusMatch) return true;
+    if (msg.includes('rate limit') || msg.includes('too many requests')) return true;
+    if (msg.includes('timeout') || msg.includes('econnreset') || msg.includes('econnrefused')) return true;
+    if (msg.includes('network') || msg.includes('fetch failed') || msg.includes('socket hang up')) return true;
+    if (msg.includes('service unavailable') || msg.includes('internal server error')) return true;
+    return false;
+  }
+
+  /**
+   * Check if an error indicates the context length was exceeded.
+   *
+   * @param error - The error to classify
+   * @returns True if the error is a context length exceeded error
+   */
+  private isContextLengthError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const msg = error.message.toLowerCase();
+    return msg.includes('context length') || msg.includes('token limit')
+      || msg.includes('max_tokens') || msg.includes('context window')
+      || msg.includes('too long') || msg.includes('maximum context');
+  }
+
+  /**
+   * Sleep for a specified duration.
+   *
+   * @param ms - Milliseconds to sleep
+   * @returns Promise that resolves after the delay
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Execute run using streamText for real-time streaming output.
+   * This is the production path — emits events as tokens arrive.
+   *
+   * Includes automatic retry with exponential backoff for recoverable errors
+   * (429, 5xx, network) and progressive context trimming for context length errors.
+   */
+  private async executeRunWithStreamText(
+    tools: Record<string, unknown>,
+    abortSignal: AbortSignal,
+  ): Promise<AgentRunResult> {
+    const maxRetries = CREWLY_AGENT_DEFAULTS.MAX_RETRIES;
+    const baseDelay = CREWLY_AGENT_DEFAULTS.RETRY_BASE_DELAY_MS;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.executeStreamTextAttempt(tools, abortSignal);
+      } catch (error) {
+        // Context length exceeded — try compaction then retry once
+        if (this.isContextLengthError(error)) {
+          this.streamingCallbacks.onTextChunk?.('[retry] Context length exceeded, compacting history...\n');
+          const compactionResult = await this.requestCompaction();
+          if (compactionResult.compacted) {
+            try {
+              return await this.executeStreamTextAttempt(tools, abortSignal);
+            } catch (retryError) {
+              // If still too long, remove earliest non-system messages and try once more
+              if (this.isContextLengthError(retryError) && this.state.messages.length > 2) {
+                this.streamingCallbacks.onTextChunk?.('[retry] Still too long, trimming oldest messages...\n');
+                this.trimOldestNonSystemMessages();
+                return await this.executeStreamTextAttempt(tools, abortSignal);
+              }
+              throw retryError;
+            }
+          }
+        }
+
+        // Recoverable error — retry with backoff
+        if (this.isRecoverableError(error) && attempt < maxRetries) {
+          const delay = baseDelay * Math.pow(2, attempt);
+          this.streamingCallbacks.onTextChunk?.(`[retry] Recoverable error (attempt ${attempt + 1}/${maxRetries}), retrying in ${delay}ms...\n`);
+          await this.sleep(delay);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    // Unreachable — the loop always returns or throws
+    throw new Error('Retry loop exhausted without result');
+  }
+
+  /**
+   * Single attempt of streamText execution (no retry logic).
+   */
+  private async executeStreamTextAttempt(
+    tools: Record<string, unknown>,
+    abortSignal: AbortSignal,
+  ): Promise<AgentRunResult> {
+    const toolCalls: ToolCallRecord[] = [];
+    let stepCount = 0;
+    const loopDetector = new ToolCallLoopDetector();
+    // Local abort controller so we can abort on loop detection
+    const loopAbort = new AbortController();
+    const mergedSignal = AbortSignal.any([abortSignal, loopAbort.signal]);
+
+    const streamResult = streamText({
+      model: this.model!,
+      system: this.state.systemPrompt,
+      messages: this.state.messages,
+      tools: tools as any,
+      stopWhen: stepCountIs(this.config.maxSteps),
+      temperature: this.config.model.temperature,
+      maxOutputTokens: resolveMaxOutputTokens(this.config.model),
+      abortSignal: mergedSignal,
+      onChunk: ({ chunk }: { chunk: { type: string; text?: string } }) => {
+        // Emit text chunks in real-time
+        if (chunk.type === 'text-delta' && chunk.text) {
+          this.streamingCallbacks.onTextChunk?.(chunk.text);
+        }
+      },
+      experimental_onToolCallStart: (event: any) => {
+        const tc = event.toolCall;
+        const args = tc?.args ?? tc?.input ?? {};
+        this.streamingCallbacks.onToolCallStart?.(tc?.toolName ?? 'unknown', (typeof args === 'string' ? JSON.parse(args) : args) as Record<string, unknown>);
+      },
+      experimental_onToolCallFinish: (event: any) => {
+        const tc = event.toolCall;
+        const args = tc?.args ?? tc?.input ?? {};
+        this.streamingCallbacks.onToolCallFinish?.(tc?.toolName ?? 'unknown', (typeof args === 'string' ? JSON.parse(args) : args) as Record<string, unknown>, event.toolResult, event.durationMs ?? 0);
+      },
+      onStepFinish: ({ toolCalls: stepToolCalls, toolResults }: { stepNumber: number; toolCalls?: Array<{ toolName: string; toolCallId: string }>; toolResults?: Array<{ toolCallId: string; output?: unknown }> }) => {
+        stepCount++;
+        const hasTools = (stepToolCalls?.length ?? 0) > 0;
+
+        // Collect tool calls from this step and check for loops
+        if (stepToolCalls) {
+          for (const tc of stepToolCalls) {
+            const args = (tc as Record<string, unknown>).input as Record<string, unknown> ?? {};
+            const result = toolResults?.find(
+              (tr: { toolCallId: string }) => tr.toolCallId === tc.toolCallId,
+            )?.output;
+            toolCalls.push({ toolName: tc.toolName, args, result });
+            loopDetector.recordToolCall(tc.toolName, args, result);
+          }
+        }
+
+        // Abort if loop detected — will be caught below
+        if (loopDetector.loopDetected) {
+          console.warn('[AgentRunner] Loop detected, aborting run:', loopDetector.loopReason);
+          loopAbort.abort();
+        }
+
+        this.streamingCallbacks.onStepFinish?.(stepCount, hasTools);
+      },
+    });
+
+    // I2 — DeepSeek reasoning buffer leak guard.
+    // The DeepSeek custom fetch wrapper accumulates parser handles per HTTP call.
+    // If streamText throws (timeout, network) BEFORE the success-path consume runs,
+    // those handles never drain and leak across run boundaries. The try/finally
+    // guarantees a consume call happens on every exit path. Consume-once
+    // semantics in ModelManager make double-call on the success path harmless
+    // (second call returns null).
+    try {
+      // Await the full result (stream completes when all steps are done or aborted)
+      let result;
+      try {
+        result = await streamResult;
+      } catch (err) {
+        // If aborted due to loop detection, handle gracefully
+        if (loopDetector.loopDetected) {
+          return this.handleLoopDetected(loopDetector, toolCalls, stepCount);
+        }
+        throw err;
+      }
+
+      // Also check post-completion in case the loop threshold was hit on the final step
+      if (loopDetector.loopDetected) {
+        return this.handleLoopDetected(loopDetector, toolCalls, stepCount);
+      }
+
+      // Warn if tool call count is excessive (polling dead-loop protection)
+      const maxToolCalls = CREWLY_AGENT_DEFAULTS.MAX_TOOL_CALLS_PER_RESPONSE;
+      if (toolCalls.length > maxToolCalls) {
+        console.warn('[AgentRunner] Excessive tool calls in single response:', {
+          count: toolCalls.length,
+          limit: maxToolCalls,
+          topTools: toolCalls.slice(0, 5).map(tc => tc.toolName),
+        });
+      }
+
+      // Add assistant response to history
+      let text = await result.text;
+      if (text) {
+        this.state.messages.push({ role: 'assistant', content: text });
+      }
+
+      // Empty response fallback: if model made tool calls but produced no text summary,
+      // prompt it once more to generate a summary (prevents silent completions)
+      if (!text && toolCalls.length > 0) {
+        console.warn('[AgentRunner] Empty text response after tool calls, requesting summary fallback');
+        const fallbackResult = await this.requestSummaryFallback();
+        if (fallbackResult) {
+          text = fallbackResult;
+        }
+      }
+
+      // Security guardrail: redact any API keys from agent output
+      if (text) {
+        const scanResult = this.outputFilter.scan(text);
+        if (scanResult.detected) {
+          console.warn('[AgentRunner] API keys redacted from output:', scanResult.matchedPatterns);
+          text = scanResult.redactedText;
+        }
+      }
+
+      // Update token tracking
+      const resultUsage = await result.usage;
+      const usage = {
+        input: resultUsage?.inputTokens ?? 0,
+        output: resultUsage?.outputTokens ?? 0,
+      };
+      this.state.totalTokens.input += usage.input;
+      this.state.totalTokens.output += usage.output;
+
+      // Check budget after token update
+      const postBudget = this.getContextBudget();
+      const budgetWarning = postBudget.level !== 'normal' ? postBudget.summary : undefined;
+
+      const finishReason = await result.finishReason;
+
+      // P0 Stop Hook: In eval mode, check if required output files were created.
+      // If deliverables are missing, inject a corrective message and do one more run.
+      // Note: If loop was detected, we already returned early via handleLoopDetected.
+      if (this.config.evalMode) {
+        const stopHookResult = await this.executeStopHook(toolCalls, tools, abortSignal);
+        if (stopHookResult) {
+          // Merge tool calls and update text from the follow-up run
+          toolCalls.push(...stopHookResult.toolCalls);
+          if (stopHookResult.text) {
+            text = stopHookResult.text;
+          }
+        }
+      }
+
+      // I2 — DeepSeek-R1 reasoning_content drain.
+      // After streamResult is fully drained, pull any reasoning the custom fetch
+      // wrapper accumulated for this run. Returns null for non-DeepSeek providers
+      // (the wrapper only runs on the DeepSeek provider path) or when no
+      // reasoning was produced.
+      const reasoning = this.config.model.provider === 'deepseek'
+        ? await this.modelManager.consumeDeepseekReasoning()
+        : undefined;
+
+      return {
+        text,
+        steps: stepCount,
+        usage,
+        toolCalls,
+        finishReason,
+        budgetWarning,
+        reasoning,
+      };
+    } finally {
+      // Cleanup-drain — if try block threw before the success-path consume,
+      // this prevents the parser handle array from leaking across runs.
+      // Safe on success path: consume-once semantics return null on 2nd call.
+      if (this.config.model.provider === 'deepseek') {
+        try {
+          await this.modelManager.consumeDeepseekReasoning();
+        } catch (e) {
+          console.warn('[AgentRunner] DeepSeek reasoning cleanup-drain failed:', e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Execute run using generateText (batch mode).
+   * Used when _generateTextFn is set for testing, or as fallback.
+   *
+   * Includes automatic retry with exponential backoff for recoverable errors
+   * and progressive context trimming for context length errors.
+   */
+  private async executeRunWithGenerateText(
+    tools: Record<string, unknown>,
+    abortSignal: AbortSignal,
+  ): Promise<AgentRunResult> {
+    const maxRetries = CREWLY_AGENT_DEFAULTS.MAX_RETRIES;
+    const baseDelay = CREWLY_AGENT_DEFAULTS.RETRY_BASE_DELAY_MS;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.executeGenerateTextAttempt(tools, abortSignal);
+      } catch (error) {
+        // Context length exceeded — try compaction then retry once
+        if (this.isContextLengthError(error)) {
+          const compactionResult = await this.requestCompaction();
+          if (compactionResult.compacted) {
+            try {
+              return await this.executeGenerateTextAttempt(tools, abortSignal);
+            } catch (retryError) {
+              if (this.isContextLengthError(retryError) && this.state.messages.length > 2) {
+                this.trimOldestNonSystemMessages();
+                return await this.executeGenerateTextAttempt(tools, abortSignal);
+              }
+              throw retryError;
+            }
+          }
+        }
+
+        // Recoverable error — retry with backoff
+        if (this.isRecoverableError(error) && attempt < maxRetries) {
+          const delay = baseDelay * Math.pow(2, attempt);
+          await this.sleep(delay);
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw new Error('Retry loop exhausted without result');
+  }
+
+  /**
+   * Single attempt of generateText execution (no retry logic).
+   */
+  private async executeGenerateTextAttempt(
+    tools: Record<string, unknown>,
+    abortSignal: AbortSignal,
+  ): Promise<AgentRunResult> {
+    const generateFn = this._generateTextFn || (generateText as Function);
+    const result = await generateFn({
+      model: this.model,
+      system: this.state.systemPrompt,
+      messages: this.state.messages,
+      tools,
+      stopWhen: stepCountIs(this.config.maxSteps),
+      temperature: this.config.model.temperature,
+      maxOutputTokens: resolveMaxOutputTokens(this.config.model),
+      abortSignal,
+    });
+
+    // Track tool calls across all steps with loop detection
+    const toolCalls: ToolCallRecord[] = [];
+    const loopDetector = new ToolCallLoopDetector();
+    for (const step of result.steps) {
+      if (step.toolCalls) {
+        for (const tc of step.toolCalls) {
+          const args = (tc as Record<string, unknown>).input as Record<string, unknown> ?? {};
+          const tcResult = step.toolResults?.find(
+            (tr: { toolCallId: string }) => tr.toolCallId === tc.toolCallId,
+          )?.output;
+          toolCalls.push({ toolName: tc.toolName, args, result: tcResult });
+          loopDetector.recordToolCall(tc.toolName, args, tcResult);
+        }
+      }
+    }
+
+    // If loop detected in generateText path, handle gracefully
+    if (loopDetector.loopDetected) {
+      console.warn('[AgentRunner] Loop detected in generateText:', loopDetector.loopReason);
+      return this.handleLoopDetected(loopDetector, toolCalls, result.steps.length);
+    }
+
+    // Warn if tool call count is excessive
+    const maxToolCalls = CREWLY_AGENT_DEFAULTS.MAX_TOOL_CALLS_PER_RESPONSE;
+    if (toolCalls.length > maxToolCalls) {
+      console.warn('[AgentRunner] Excessive tool calls in single response:', {
+        count: toolCalls.length,
+        limit: maxToolCalls,
+        topTools: toolCalls.slice(0, 5).map(tc => tc.toolName),
+      });
+    }
+
+    // Add assistant response to history
+    let finalText = result.text;
+    if (finalText) {
+      this.state.messages.push({ role: 'assistant', content: finalText });
+    }
+
+    // Empty response fallback: if model made tool calls but produced no text summary,
+    // prompt it once more to generate a summary (prevents silent completions)
+    if (!finalText && toolCalls.length > 0) {
+      console.warn('[AgentRunner] Empty text response after tool calls, requesting summary fallback');
+      const fallbackResult = await this.requestSummaryFallback();
+      if (fallbackResult) {
+        finalText = fallbackResult;
+      }
+    }
+
+    // Security guardrail: redact any API keys from agent output
+    if (finalText) {
+      const scanResult = this.outputFilter.scan(finalText);
+      if (scanResult.detected) {
+        console.warn('[AgentRunner] API keys redacted from output:', scanResult.matchedPatterns);
+        finalText = scanResult.redactedText;
+      }
+    }
+
+    // Update token tracking
+    const usage = {
+      input: result.usage?.inputTokens ?? 0,
+      output: result.usage?.outputTokens ?? 0,
+    };
+    this.state.totalTokens.input += usage.input;
+    this.state.totalTokens.output += usage.output;
+
+    // Check budget after token update and attach warning if approaching limits
+    const postBudget = this.getContextBudget();
+    const budgetWarning = postBudget.level !== 'normal' ? postBudget.summary : undefined;
+
+    // P0 Stop Hook: In eval mode, check if required output files were created.
+    // Note: If loop was detected via loopDetector, we already returned early.
+    if (this.config.evalMode) {
+      const stopHookResult = await this.executeStopHook(toolCalls, tools, abortSignal);
+      if (stopHookResult) {
+        toolCalls.push(...stopHookResult.toolCalls);
+        if (stopHookResult.text) {
+          finalText = stopHookResult.text;
+        }
+      }
+    }
+
+    // I2 — DeepSeek-R1 reasoning_content drain (generateText path).
+    // Same as the streamText path: pull buffered reasoning the custom fetch
+    // wrapper accumulated. Returns null for non-DeepSeek providers.
+    const reasoning = this.config.model.provider === 'deepseek'
+      ? await this.modelManager.consumeDeepseekReasoning()
+      : undefined;
+
+    return {
+      text: finalText,
+      steps: result.steps.length,
+      usage,
+      toolCalls,
+      finishReason: result.finishReason,
+      budgetWarning,
+      reasoning,
+    };
+  }
+
+  /**
+   * Remove the oldest non-system messages to reduce context size.
+   * Preserves the most recent messages and any system-role messages.
+   */
+  private trimOldestNonSystemMessages(): void {
+    // Remove up to 5 of the oldest non-system messages
+    let removed = 0;
+    const maxRemove = 5;
+    this.state.messages = this.state.messages.filter((msg) => {
+      if (removed >= maxRemove) return true;
+      if (msg.role === 'system') return true;
+      removed++;
+      return false;
+    });
+  }
+
+  /**
+   * Handle a detected tool call loop by injecting a corrective system message
+   * into conversation history and returning a structured result.
+   *
+   * @param detector - The loop detector with reason details
+   * @param toolCalls - Tool calls collected so far
+   * @param steps - Number of steps taken
+   * @returns AgentRunResult with the loop warning as text
+   */
+  private handleLoopDetected(
+    detector: ToolCallLoopDetector,
+    toolCalls: ToolCallRecord[],
+    steps: number,
+  ): AgentRunResult {
+    const guidance = `[LOOP DETECTED] ${detector.loopReason}. ` +
+      'You are repeating the same action without progress. ' +
+      'STOP and try a different approach: use a different tool, change the arguments, ' +
+      'skip this step, or ask for help. Do NOT repeat the same call again.';
+
+    // Inject corrective message so the model sees it on the next run
+    this.state.messages.push({ role: 'assistant', content: `[Loop detected — halting. ${detector.loopReason}]` });
+    this.state.messages.push({ role: 'user', content: guidance });
+
+    this.streamingCallbacks.onTextChunk?.(`\n⚠️ ${guidance}\n`);
+
+    return {
+      text: `[Loop detected] ${detector.loopReason}`,
+      steps,
+      usage: { input: 0, output: 0 },
+      toolCalls,
+      finishReason: 'loop-detected',
+      budgetWarning: undefined,
+    };
+  }
+
+  /**
+   * Execute the Stop Hook: check if the agent produced all required deliverables.
+   *
+   * Scans the original task prompt (first user message) for expected output files,
+   * then checks if write_file/edit_file tool calls created them. If files are
+   * missing, injects a corrective prompt and runs one more generateText call
+   * with tools so the agent can create the missing deliverables.
+   *
+   * Inspired by Claude Code's Stop hook which blocks the agent from finishing
+   * until task requirements are met.
+   *
+   * @param toolCalls   - Tool calls made so far
+   * @param tools       - Available tools for the follow-up run
+   * @param abortSignal - Abort signal for cancellation
+   * @returns Additional AgentRunResult from the follow-up, or null if no action needed
+   */
+  private async executeStopHook(
+    toolCalls: ToolCallRecord[],
+    tools: Record<string, unknown>,
+    abortSignal: AbortSignal,
+  ): Promise<AgentRunResult | null> {
+    if (!this.model) return null;
+
+    // Find the original task prompt (first user message)
+    const firstUserMsg = this.state.messages.find((m) => m.role === 'user');
+    if (!firstUserMsg) return null;
+    const taskPrompt = typeof firstUserMsg.content === 'string'
+      ? firstUserMsg.content
+      : JSON.stringify(firstUserMsg.content);
+
+    // Extract expected output files from the task prompt
+    const expectedFiles = AgentRunnerService.extractExpectedOutputFiles(taskPrompt);
+    if (expectedFiles.length === 0) return null;
+
+    // Check which files are missing
+    const missingFiles = AgentRunnerService.checkMissingDeliverables(expectedFiles, toolCalls);
+    if (missingFiles.length === 0) return null;
+
+    // Inject corrective message
+    const stopMessage = [
+      '[STOP HOOK — Deliverable Check Failed]',
+      '',
+      `The task requires you to create these files: ${expectedFiles.map(f => '`' + f + '`').join(', ')}`,
+      `Missing files: ${missingFiles.map(f => '`' + f + '`').join(', ')}`,
+      '',
+      'You MUST create these files before finishing. Use write_file to create each missing file now.',
+      'Do NOT delegate this work. Implement and write the files directly.',
+    ].join('\n');
+
+    this.state.messages.push({ role: 'user', content: stopMessage });
+    this.streamingCallbacks.onTextChunk?.(`\n⚠️ Stop Hook: Missing deliverables: ${missingFiles.join(', ')}. Running follow-up...\n`);
+
+    try {
+      // Run one more round with tools to create missing files
+      const followUp = await generateText({
+        model: this.model,
+        system: this.state.systemPrompt,
+        messages: this.state.messages,
+        tools: tools as any,
+        stopWhen: stepCountIs(20), // Limited steps for follow-up
+        temperature: this.config.model.temperature,
+        maxOutputTokens: resolveMaxOutputTokens(this.config.model),
+        abortSignal,
+      });
+
+      // Extract results from the generateText response using safe property access
+      const followUpResult = followUp as unknown as Record<string, unknown>;
+      const steps = (followUpResult.steps as Array<Record<string, unknown>>) ?? [];
+      const text = (followUpResult.text as string) ?? '';
+      const followUpUsage = followUpResult.usage as { inputTokens?: number; outputTokens?: number } | undefined;
+      const finishReason = (followUpResult.finishReason as string) ?? 'stop';
+
+      const followUpToolCalls: ToolCallRecord[] = [];
+      for (const step of steps) {
+        if (step.toolCalls) {
+          for (const tc of step.toolCalls as Array<{ toolName: string; input?: Record<string, unknown> }>) {
+            const args = tc.input ?? {};
+            followUpToolCalls.push({ toolName: tc.toolName, args, result: undefined });
+          }
+        }
+      }
+
+      if (text) {
+        this.state.messages.push({ role: 'assistant', content: text });
+      }
+
+      // Track follow-up token usage
+      if (followUpUsage) {
+        this.state.totalTokens.input += followUpUsage.inputTokens ?? 0;
+        this.state.totalTokens.output += followUpUsage.outputTokens ?? 0;
+      }
+
+      return {
+        text,
+        steps: steps.length,
+        usage: {
+          input: followUpUsage?.inputTokens ?? 0,
+          output: followUpUsage?.outputTokens ?? 0,
+        },
+        toolCalls: followUpToolCalls,
+        finishReason,
+      };
+    } catch (err) {
+      console.warn('[AgentRunner] Stop hook follow-up failed:', err instanceof Error ? err.message : err);
+      return null;
+    }
+  }
+
+  /**
+   * Request a text summary from the model when the previous response had tool calls
+   * but no text output. Injects a follow-up user message and makes a single
+   * generateText call with no tools to force a text-only response.
+   *
+   * @returns The summary text, or empty string if the fallback also fails
+   */
+  private async requestSummaryFallback(): Promise<string> {
+    if (!this.model) return '';
+
+    const prompt =
+      '请用文字总结你刚才完成的工作和发现的结果，然后调用report-status汇报。' +
+      'Please summarize what you just did, what you found, and any issues encountered. ' +
+      'Then call report-status to report your status.';
+
+    this.state.messages.push({ role: 'user', content: prompt });
+
+    try {
+      const fallback = await generateText({
+        model: this.model,
+        system: this.state.systemPrompt,
+        messages: this.state.messages,
+        maxOutputTokens: resolveMaxOutputTokens(this.config.model),
+        temperature: this.config.model.temperature,
+      });
+
+      const text = fallback.text || '';
+      if (text) {
+        this.state.messages.push({ role: 'assistant', content: text });
+        this.streamingCallbacks.onTextChunk?.(text);
+
+        // Track fallback token usage
+        const fallbackUsage = fallback.usage;
+        if (fallbackUsage) {
+          this.state.totalTokens.input += fallbackUsage.inputTokens ?? 0;
+          this.state.totalTokens.output += fallbackUsage.outputTokens ?? 0;
+        }
+      }
+
+      return text;
+    } catch (err) {
+      console.error('[AgentRunner] Summary fallback failed:', err instanceof Error ? err.message : err);
+      return '';
+    }
+  }
+
+  /**
+   * Public method for agent-initiated context compaction.
+   * Called by the compact_memory tool to intelligently summarize conversation state.
+   *
+   * Uses the model to generate a structured summary preserving:
+   * - Active tasks and their status
+   * - Key decisions made
+   * - Important findings and blockers
+   * - Current working context
+   *
+   * @returns CompactionResult with before/after stats
+   */
+  async requestCompaction(): Promise<CompactionResult> {
+    if (!this.model || this.state.messages.length < 10) {
+      return {
+        compacted: false,
+        messagesBefore: this.state.messages.length,
+        messagesAfter: this.state.messages.length,
+        reason: this.state.messages.length < 10
+          ? 'Too few messages to compact'
+          : 'Model not initialized',
+      };
+    }
+    return this.compactHistory();
+  }
+
+  /**
+   * Get the security audit log.
+   *
+   * @param limit - Maximum number of entries to return (most recent first)
+   * @returns Array of audit entries
+   */
+  getAuditLog(limit?: number): AuditEntry[] {
+    const entries = [...this.auditLog].reverse();
+    return limit ? entries.slice(0, limit) : entries;
+  }
+
+  /**
+   * Get the current security policy.
+   *
+   * @returns Current security policy configuration
+   */
+  getSecurityPolicy(): SecurityPolicy {
+    return { ...this.securityPolicy };
+  }
+
+  /**
+   * Update the security policy.
+   *
+   * @param updates - Partial security policy to merge
+   */
+  updateSecurityPolicy(updates: Partial<SecurityPolicy>): void {
+    this.securityPolicy = { ...this.securityPolicy, ...updates };
+  }
+
+  /**
+   * Get the approval queue service instance.
+   * Used by the approvals controller to manage pending approvals.
+   *
+   * @returns The ApprovalQueueService instance
+   */
+  getApprovalQueue(): ApprovalQueueService {
+    return this.approvalQueue;
+  }
+
+  /**
+   * Record an audit entry for a tool invocation.
+   *
+   * @param entry - Audit entry to record
+   */
+  private recordAudit(entry: AuditEntry): void {
+    if (!this.securityPolicy.auditEnabled) return;
+
+    this.auditLog.push(entry);
+
+    // Enforce max entries limit
+    if (this.auditLog.length > this.securityPolicy.maxAuditEntries) {
+      this.auditLog = this.auditLog.slice(-this.securityPolicy.maxAuditEntries);
+    }
+  }
+
+  /**
+   * Check if a tool is allowed to execute under the current security policy.
+   *
+   * Evaluates the tool against two checks:
+   * 1. blockedTools — tools explicitly blocked by name (returns blocked=true)
+   * 2. requireApproval — tools whose sensitivity requires approval (returns requiresApproval=true)
+   *
+   * @param toolName - Name of the tool being invoked
+   * @param sensitivity - Sensitivity classification of the tool
+   * @returns ApprovalCheckResult indicating if execution is allowed
+   */
+  private checkApproval(toolName: string, sensitivity: ToolSensitivity): ApprovalCheckResult {
+    // Check read-only mode — block all write/modify tools
+    if (this.securityPolicy.readOnlyMode && WRITE_TOOLS.includes(toolName)) {
+      return {
+        allowed: false,
+        blocked: true,
+        reason: `Tool '${toolName}' is blocked — read-only audit mode is active`,
+      };
+    }
+
+    // Check blocked tools
+    if (this.securityPolicy.blockedTools.includes(toolName)) {
+      return {
+        allowed: false,
+        blocked: true,
+        reason: `Tool '${toolName}' is blocked by security policy`,
+      };
+    }
+
+    // Check approval requirements
+    if (this.securityPolicy.requireApproval.includes(sensitivity)) {
+      return {
+        allowed: false,
+        blocked: false,
+        reason: `Tool '${toolName}' (${sensitivity}) requires approval — approval mode is active for '${sensitivity}' tools`,
+      };
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * Get filtered audit log entries.
+   *
+   * @param filters - Query filters for limit, sensitivity, and toolName
+   * @returns Filtered audit entries (most recent first)
+   */
+  private getFilteredAuditLog(filters: AuditLogFilters): AuditEntry[] {
+    let entries = [...this.auditLog].reverse();
+
+    if (filters.sensitivity) {
+      entries = entries.filter(e => e.sensitivity === filters.sensitivity);
+    }
+    if (filters.toolName) {
+      entries = entries.filter(e => e.toolName === filters.toolName);
+    }
+
+    return entries.slice(0, filters.limit);
+  }
+
+  /**
+   * Compact conversation history using AI-generated structured summary.
+   *
+   * Keeps the most recent messages and uses the model to generate an
+   * intelligent summary of older messages that preserves critical state:
+   * decisions, active tasks, findings, and working context.
+   *
+   * Falls back to truncation-based summary if AI summarization fails.
+   *
+   * @returns CompactionResult with before/after statistics
+   */
+  private async compactHistory(): Promise<CompactionResult> {
+    // Guard against concurrent compaction — if already compacting, skip
+    if (this.compacting) {
+      return {
+        compacted: false,
+        messagesBefore: this.state.messages.length,
+        messagesAfter: this.state.messages.length,
+        reason: 'Compaction already in progress',
+      };
+    }
+
+    if (!this.model || this.state.messages.length < 10) {
+      return {
+        compacted: false,
+        messagesBefore: this.state.messages.length,
+        messagesAfter: this.state.messages.length,
+        reason: 'History too small to compact',
+      };
+    }
+
+    this.compacting = true;
+    try {
+
+    const messagesBefore = this.state.messages.length;
+    // Determine the split point: keep at least 10 recent messages but adjust
+    // to avoid breaking tool_call/tool_result pairs. If the first "recent"
+    // message is a tool result (role === 'tool'), extend keepRecent backwards
+    // to include its paired assistant tool_call message.
+    let keepRecent = Math.min(10, this.state.messages.length - 2);
+    if (keepRecent < 2) keepRecent = 2;
+
+    // Expand keepRecent if we'd split inside a tool call pair
+    let splitIdx = this.state.messages.length - keepRecent;
+    while (splitIdx > 0 && splitIdx < this.state.messages.length) {
+      const firstKept = this.state.messages[splitIdx];
+      // If the first kept message is a tool result, we must also keep the
+      // preceding assistant message that contained the tool_call
+      if (firstKept.role === 'tool') {
+        splitIdx--;
+        keepRecent++;
+      } else {
+        break;
+      }
+    }
+
+    const oldMessages = this.state.messages.slice(0, splitIdx);
+    const recentMessages = this.state.messages.slice(splitIdx);
+
+    // Pre-compaction context flush (#153): extract critical items from old
+    // messages so they can be explicitly included in the AI summary prompt.
+    // This ensures task progress, decisions, technical details, and blockers
+    // survive compaction even if the AI summary would otherwise miss them.
+    const flushService = ContextFlushService.getInstance();
+    const oldText = oldMessages.map(msg => {
+      const content = typeof msg.content === 'string'
+        ? msg.content
+        : JSON.stringify(msg.content);
+      return content;
+    }).join('\n');
+    const extractedItems = flushService.extract(oldText);
+
+    // Attempt AI-powered summarization
+    let summaryText: string;
+    try {
+      summaryText = await this.generateAISummary(oldMessages, extractedItems);
+    } catch {
+      // Fallback to truncation-based summary
+      summaryText = this.generateFallbackSummary(oldMessages, extractedItems);
+    }
+
+    this.state.messages = [
+      { role: 'assistant', content: summaryText },
+      ...recentMessages,
+    ];
+
+    return {
+      compacted: true,
+      messagesBefore,
+      messagesAfter: this.state.messages.length,
+    };
+    } finally {
+      this.compacting = false;
+    }
+  }
+
+  /**
+   * Generate an AI-powered structured summary of conversation messages.
+   *
+   * Asks the model to extract and preserve critical state from the
+   * conversation history in a structured format. Pre-extracted critical
+   * items from ContextFlushService are included in the prompt to ensure
+   * they are preserved even if the AI would otherwise miss them.
+   *
+   * @param messages - Messages to summarize
+   * @param extractedItems - Critical items extracted by ContextFlushService
+   * @returns Structured summary string
+   */
+  private async generateAISummary(
+    messages: ModelMessage[],
+    extractedItems: import('../../memory/context-flush.service.js').ExtractedContextItem[] = [],
+  ): Promise<string> {
+    const conversationText = messages.map(msg => {
+      const content = typeof msg.content === 'string'
+        ? msg.content.substring(0, 2000)
+        : JSON.stringify(msg.content).substring(0, 2000);
+      return `[${msg.role}]: ${content}`;
+    }).join('\n');
+
+    // Build critical items section if any were extracted
+    let criticalItemsSection = '';
+    if (extractedItems.length > 0) {
+      const itemLines = extractedItems.map(
+        item => `- [${item.category}] ${item.content} (confidence: ${item.confidence})`,
+      ).join('\n');
+      criticalItemsSection = `\n\nIMPORTANT — The following critical items were auto-extracted and MUST appear in your summary:\n${itemLines}\n`;
+    }
+
+    const summarizationPrompt = `Summarize this conversation history into a structured state snapshot. Preserve ALL of the following if present:
+
+1. **Active Tasks**: What tasks are in progress, assigned to whom, their status
+2. **Decisions Made**: Key decisions and their rationale
+3. **Key Findings**: Important discoveries, patterns, or blockers found
+4. **Current Context**: What the agent is currently working on
+5. **Pending Items**: Anything awaiting response or follow-up
+${criticalItemsSection}
+Be concise but complete. This summary replaces the original messages.
+
+Conversation (${messages.length} messages):
+${conversationText}`;
+
+    const generateFn = this._generateTextFn || (generateText as Function);
+    const result = await generateFn({
+      model: this.model,
+      messages: [{ role: 'user', content: summarizationPrompt }],
+      maxOutputTokens: 2048,
+      temperature: 0.1,
+    });
+
+    const summary = result.text || '';
+    if (!summary || summary.length < 20) {
+      throw new Error('AI summary too short, falling back');
+    }
+
+    return `[Compacted State — ${messages.length} messages summarized]\n\n${summary}`;
+  }
+
+  /**
+   * Generate a truncation-based fallback summary when AI summarization fails.
+   * Includes pre-extracted critical items so they survive compaction.
+   *
+   * @param messages - Messages to summarize
+   * @param extractedItems - Critical items extracted by ContextFlushService
+   * @returns Simple concatenated summary string
+   */
+  private generateFallbackSummary(
+    messages: ModelMessage[],
+    extractedItems: import('../../memory/context-flush.service.js').ExtractedContextItem[] = [],
+  ): string {
+    const summaryParts: string[] = [];
+    for (const msg of messages) {
+      const content = typeof msg.content === 'string'
+        ? msg.content.substring(0, 1000)
+        : JSON.stringify(msg.content).substring(0, 1000);
+      summaryParts.push(`[${msg.role}]: ${content}`);
+    }
+
+    let result = `Previous conversation summary (${messages.length} messages compressed):\n${summaryParts.join('\n')}`;
+
+    if (extractedItems.length > 0) {
+      const itemLines = extractedItems.map(
+        item => `- [${item.category}] ${item.content}`,
+      ).join('\n');
+      result += `\n\nExtracted critical context:\n${itemLines}`;
+    }
+
+    return result;
+  }
+}

--- a/packages/crewly-agent/src/runtime/agent-stream.service.test.ts
+++ b/packages/crewly-agent/src/runtime/agent-stream.service.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for AgentStreamService
+ *
+ * @module services/agent/crewly-agent/agent-stream.service.test
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mocked, type MockInstance } from 'vitest';
+import {
+  AgentStreamService,
+  type AgentStreamEvent,
+  type TextChunkEvent,
+  type ToolCallStartEvent,
+  type ToolCallFinishEvent,
+  type StepFinishEvent,
+} from './agent-stream.service.js';
+
+describe('AgentStreamService', () => {
+  beforeEach(() => {
+    AgentStreamService.resetInstance();
+  });
+
+  it('should return the same singleton instance', () => {
+    const a = AgentStreamService.getInstance();
+    const b = AgentStreamService.getInstance();
+    expect(a).toBe(b);
+  });
+
+  it('should return a new instance after reset', () => {
+    const a = AgentStreamService.getInstance();
+    AgentStreamService.resetInstance();
+    const b = AgentStreamService.getInstance();
+    expect(a).not.toBe(b);
+  });
+
+  describe('emitTextChunk', () => {
+    it('should emit a text_chunk event with correct shape', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      service.emitTextChunk('test-agent', 'Hello ');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const event = handler.mock.calls[0][0] as TextChunkEvent;
+      expect(event.type).toBe('text_chunk');
+      expect(event.sessionName).toBe('test-agent');
+      expect(event.text).toBe('Hello ');
+      expect(event.timestamp).toBeDefined();
+    });
+  });
+
+  describe('emitToolCallStart', () => {
+    it('should emit a tool_call_start event with args preview', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      service.emitToolCallStart('test-agent', 'bash_exec', { command: 'ls -la' });
+
+      const event = handler.mock.calls[0][0] as ToolCallStartEvent;
+      expect(event.type).toBe('tool_call_start');
+      expect(event.toolName).toBe('bash_exec');
+      expect(event.argsPreview).toContain('ls -la');
+    });
+
+    it('should truncate long args to 200 chars', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      const longArg = 'x'.repeat(300);
+      service.emitToolCallStart('test-agent', 'write_file', { content: longArg });
+
+      const event = handler.mock.calls[0][0] as ToolCallStartEvent;
+      expect(event.argsPreview.length).toBeLessThanOrEqual(200);
+    });
+  });
+
+  describe('emitToolCallFinish', () => {
+    it('should emit a tool_call_finish event with duration', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      service.emitToolCallFinish('test-agent', 'bash_exec', { command: 'pwd' }, '/home/user', 42);
+
+      const event = handler.mock.calls[0][0] as ToolCallFinishEvent;
+      expect(event.type).toBe('tool_call_finish');
+      expect(event.toolName).toBe('bash_exec');
+      expect(event.resultPreview).toContain('/home/user');
+      expect(event.durationMs).toBe(42);
+    });
+
+    it('should handle null result gracefully', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      service.emitToolCallFinish('test-agent', 'send_message', {}, null, 10);
+
+      const event = handler.mock.calls[0][0] as ToolCallFinishEvent;
+      expect(event.resultPreview).toBe('void');
+    });
+  });
+
+  describe('emitStepFinish', () => {
+    it('should emit a step_finish event', () => {
+      const service = AgentStreamService.getInstance();
+      const handler = vi.fn();
+      service.on('stream', handler);
+
+      service.emitStepFinish('test-agent', 3, true);
+
+      const event = handler.mock.calls[0][0] as StepFinishEvent;
+      expect(event.type).toBe('step_finish');
+      expect(event.stepIndex).toBe(3);
+      expect(event.hasToolCalls).toBe(true);
+    });
+  });
+
+  describe('multiple subscribers', () => {
+    it('should deliver events to all subscribers', () => {
+      const service = AgentStreamService.getInstance();
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      service.on('stream', handler1);
+      service.on('stream', handler2);
+
+      service.emitTextChunk('test-agent', 'hello');
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+
+    it('should filter by sessionName at subscriber level', () => {
+      const service = AgentStreamService.getInstance();
+      const agentAEvents: AgentStreamEvent[] = [];
+      const agentBEvents: AgentStreamEvent[] = [];
+
+      service.on('stream', (event: AgentStreamEvent) => {
+        if (event.sessionName === 'agent-a') agentAEvents.push(event);
+        if (event.sessionName === 'agent-b') agentBEvents.push(event);
+      });
+
+      service.emitTextChunk('agent-a', 'hello');
+      service.emitTextChunk('agent-b', 'world');
+      service.emitTextChunk('agent-a', '!');
+
+      expect(agentAEvents).toHaveLength(2);
+      expect(agentBEvents).toHaveLength(1);
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/agent-stream.service.ts
+++ b/packages/crewly-agent/src/runtime/agent-stream.service.ts
@@ -1,0 +1,225 @@
+/**
+ * Agent Stream Service
+ *
+ * Singleton EventEmitter that broadcasts structured streaming events from
+ * in-process Crewly Agent runtimes. SSE endpoints subscribe to this service
+ * to forward real-time agent output to the frontend Dashboard.
+ *
+ * Event types:
+ * - text_chunk: Incremental text from the model
+ * - tool_call_start: A tool call has started executing
+ * - tool_call_finish: A tool call completed (with result and duration)
+ * - step_finish: A reasoning step completed
+ *
+ * @module services/agent/crewly-agent/agent-stream
+ */
+
+import { EventEmitter } from 'events';
+
+/**
+ * Streaming event types emitted to SSE clients
+ */
+export type StreamEventType =
+  | 'text_chunk'
+  | 'tool_call_start'
+  | 'tool_call_finish'
+  | 'step_finish'
+  | 'connected'
+  | 'heartbeat';
+
+/**
+ * Base shape for all stream events
+ */
+export interface StreamEvent {
+  /** Event type */
+  type: StreamEventType;
+  /** Agent session name */
+  sessionName: string;
+  /** ISO timestamp */
+  timestamp: string;
+}
+
+/**
+ * Text chunk event — incremental model output
+ */
+export interface TextChunkEvent extends StreamEvent {
+  type: 'text_chunk';
+  /** Text content */
+  text: string;
+}
+
+/**
+ * Tool call start event
+ */
+export interface ToolCallStartEvent extends StreamEvent {
+  type: 'tool_call_start';
+  /** Name of the tool being called */
+  toolName: string;
+  /** Arguments passed to the tool (serialized preview) */
+  argsPreview: string;
+}
+
+/**
+ * Tool call finish event
+ */
+export interface ToolCallFinishEvent extends StreamEvent {
+  type: 'tool_call_finish';
+  /** Name of the tool that completed */
+  toolName: string;
+  /** Arguments passed to the tool (serialized preview) */
+  argsPreview: string;
+  /** Result preview (truncated) */
+  resultPreview: string;
+  /** Execution duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Step finish event — a reasoning step completed
+ */
+export interface StepFinishEvent extends StreamEvent {
+  type: 'step_finish';
+  /** Step index (1-based) */
+  stepIndex: number;
+  /** Whether this step included tool calls */
+  hasToolCalls: boolean;
+}
+
+/**
+ * Union of all stream event types
+ */
+export type AgentStreamEvent =
+  | TextChunkEvent
+  | ToolCallStartEvent
+  | ToolCallFinishEvent
+  | StepFinishEvent;
+
+/** Maximum preview length for serialized args/results */
+const MAX_PREVIEW_LENGTH = 200;
+
+/**
+ * Singleton service that broadcasts agent streaming events.
+ *
+ * Runtime services call emit methods when streaming callbacks fire.
+ * SSE endpoints subscribe via the EventEmitter 'stream' event.
+ *
+ * @example
+ * ```typescript
+ * const streamService = AgentStreamService.getInstance();
+ *
+ * // Publish events (from runtime)
+ * streamService.emitTextChunk('my-agent', 'Hello ');
+ *
+ * // Subscribe (from SSE endpoint)
+ * streamService.on('stream', (event: AgentStreamEvent) => {
+ *   if (event.sessionName === targetSession) {
+ *     res.write(`data: ${JSON.stringify(event)}\n\n`);
+ *   }
+ * });
+ * ```
+ */
+export class AgentStreamService extends EventEmitter {
+  private static instance: AgentStreamService | null = null;
+
+  /**
+   * Get the singleton instance.
+   *
+   * @returns Shared AgentStreamService instance
+   */
+  static getInstance(): AgentStreamService {
+    if (!AgentStreamService.instance) {
+      AgentStreamService.instance = new AgentStreamService();
+    }
+    return AgentStreamService.instance;
+  }
+
+  /**
+   * Reset the singleton (for testing).
+   */
+  static resetInstance(): void {
+    if (AgentStreamService.instance) {
+      AgentStreamService.instance.removeAllListeners();
+    }
+    AgentStreamService.instance = null;
+  }
+
+  /**
+   * Emit a text chunk event.
+   *
+   * @param sessionName - Agent session name
+   * @param text - Text content
+   */
+  emitTextChunk(sessionName: string, text: string): void {
+    const event: TextChunkEvent = {
+      type: 'text_chunk',
+      sessionName,
+      timestamp: new Date().toISOString(),
+      text,
+    };
+    this.emit('stream', event);
+  }
+
+  /**
+   * Emit a tool call start event.
+   *
+   * @param sessionName - Agent session name
+   * @param toolName - Name of the tool
+   * @param args - Tool arguments
+   */
+  emitToolCallStart(sessionName: string, toolName: string, args: Record<string, unknown>): void {
+    const event: ToolCallStartEvent = {
+      type: 'tool_call_start',
+      sessionName,
+      timestamp: new Date().toISOString(),
+      toolName,
+      argsPreview: JSON.stringify(args).substring(0, MAX_PREVIEW_LENGTH),
+    };
+    this.emit('stream', event);
+  }
+
+  /**
+   * Emit a tool call finish event.
+   *
+   * @param sessionName - Agent session name
+   * @param toolName - Name of the tool
+   * @param args - Tool arguments
+   * @param result - Tool execution result
+   * @param durationMs - Execution time in milliseconds
+   */
+  emitToolCallFinish(
+    sessionName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    result: unknown,
+    durationMs: number,
+  ): void {
+    const event: ToolCallFinishEvent = {
+      type: 'tool_call_finish',
+      sessionName,
+      timestamp: new Date().toISOString(),
+      toolName,
+      argsPreview: JSON.stringify(args).substring(0, MAX_PREVIEW_LENGTH),
+      resultPreview: result ? JSON.stringify(result).substring(0, MAX_PREVIEW_LENGTH) : 'void',
+      durationMs,
+    };
+    this.emit('stream', event);
+  }
+
+  /**
+   * Emit a step finish event.
+   *
+   * @param sessionName - Agent session name
+   * @param stepIndex - Step number (1-based)
+   * @param hasToolCalls - Whether the step included tool calls
+   */
+  emitStepFinish(sessionName: string, stepIndex: number, hasToolCalls: boolean): void {
+    const event: StepFinishEvent = {
+      type: 'step_finish',
+      sessionName,
+      timestamp: new Date().toISOString(),
+      stepIndex,
+      hasToolCalls,
+    };
+    this.emit('stream', event);
+  }
+}

--- a/packages/crewly-agent/src/runtime/agent-worker.test.ts
+++ b/packages/crewly-agent/src/runtime/agent-worker.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for Agent Worker IPC protocol and CrewlyAgentRuntimeService worker mode.
+ *
+ * Tests the IPC message types and worker lifecycle without actually forking
+ * a real child process (which would require full AI SDK setup).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ParentMessage, WorkerMessage } from './agent-worker.js';
+
+describe('Agent Worker IPC Protocol', () => {
+  describe('ParentMessage types', () => {
+    it('should accept init message with config', () => {
+      const msg: ParentMessage = {
+        type: 'init',
+        config: {
+          model: { provider: 'google', modelId: 'gemini-3-flash-preview' },
+          maxSteps: 500,
+          sessionName: 'test-session',
+          apiBaseUrl: 'http://localhost:8787',
+          systemPrompt: 'You are a test agent.',
+          maxHistoryMessages: 100,
+          compactionThreshold: 0.8,
+        },
+      };
+      expect(msg.type).toBe('init');
+      expect(msg.config.sessionName).toBe('test-session');
+      expect(msg.config.maxSteps).toBe(500);
+    });
+
+    it('should accept run message with optional fields', () => {
+      const msg: ParentMessage = {
+        type: 'run',
+        message: 'Hello',
+        conversationId: 'conv-123',
+        metadata: { channelId: 'C123' },
+      };
+      expect(msg.type).toBe('run');
+      expect(msg.message).toBe('Hello');
+      expect(msg.conversationId).toBe('conv-123');
+    });
+
+    it('should accept run message without optional fields', () => {
+      const msg: ParentMessage = {
+        type: 'run',
+        message: 'Hello',
+      };
+      expect(msg.type).toBe('run');
+      expect(msg.conversationId).toBeUndefined();
+    });
+
+    it('should accept abort message', () => {
+      const msg: ParentMessage = { type: 'abort' };
+      expect(msg.type).toBe('abort');
+    });
+
+    it('should accept get-state message', () => {
+      const msg: ParentMessage = { type: 'get-state' };
+      expect(msg.type).toBe('get-state');
+    });
+
+    it('should accept shutdown message', () => {
+      const msg: ParentMessage = { type: 'shutdown' };
+      expect(msg.type).toBe('shutdown');
+    });
+  });
+
+  describe('WorkerMessage types', () => {
+    it('should accept ready message', () => {
+      const msg: WorkerMessage = { type: 'ready' };
+      expect(msg.type).toBe('ready');
+    });
+
+    it('should accept result message with AgentRunResult', () => {
+      const msg: WorkerMessage = {
+        type: 'result',
+        data: {
+          text: 'Done',
+          steps: 3,
+          usage: { input: 100, output: 50 },
+          toolCalls: [{ toolName: 'bash_exec', args: { command: 'ls' }, result: 'files' }],
+          finishReason: 'stop',
+        },
+      };
+      expect(msg.type).toBe('result');
+      expect(msg.data.steps).toBe(3);
+      expect(msg.data.toolCalls).toHaveLength(1);
+    });
+
+    it('should accept error message with code', () => {
+      const msg: WorkerMessage = {
+        type: 'error',
+        error: 'Init failed: bad API key',
+        code: 'INIT_FAILED',
+      };
+      expect(msg.type).toBe('error');
+      expect(msg.error).toContain('Init failed');
+      expect(msg.code).toBe('INIT_FAILED');
+    });
+
+    it('should accept log message at all levels', () => {
+      const levels: Array<'debug' | 'info' | 'warn' | 'error'> = ['debug', 'info', 'warn', 'error'];
+      for (const level of levels) {
+        const msg: WorkerMessage = { type: 'log', level, message: `Test ${level}` };
+        expect(msg.level).toBe(level);
+      }
+    });
+
+    it('should accept stream text event', () => {
+      const msg: WorkerMessage = {
+        type: 'stream',
+        event: 'text',
+        data: { chunk: 'Hello world' },
+      };
+      expect(msg.type).toBe('stream');
+      expect(msg.event).toBe('text');
+    });
+
+    it('should accept stream toolStart event', () => {
+      const msg: WorkerMessage = {
+        type: 'stream',
+        event: 'toolStart',
+        data: { toolName: 'bash_exec', args: { command: 'npm test' } },
+      };
+      expect(msg.event).toBe('toolStart');
+      expect(msg.data.toolName).toBe('bash_exec');
+    });
+
+    it('should accept stream toolFinish event', () => {
+      const msg: WorkerMessage = {
+        type: 'stream',
+        event: 'toolFinish',
+        data: {
+          toolName: 'bash_exec',
+          args: { command: 'npm test' },
+          result: 'All tests passed',
+          durationMs: 1234,
+        },
+      };
+      expect(msg.event).toBe('toolFinish');
+      expect(msg.data.durationMs).toBe(1234);
+    });
+
+    it('should accept stream stepFinish event', () => {
+      const msg: WorkerMessage = {
+        type: 'stream',
+        event: 'stepFinish',
+        data: { stepIndex: 2, hasToolCalls: true },
+      };
+      expect(msg.event).toBe('stepFinish');
+      expect(msg.data.stepIndex).toBe(2);
+    });
+
+    it('should accept state message', () => {
+      const msg: WorkerMessage = {
+        type: 'state',
+        data: {
+          historyLength: 10,
+          isProcessing: false,
+          isInitialized: true,
+        },
+      };
+      expect(msg.type).toBe('state');
+      expect(msg.data.historyLength).toBe(10);
+    });
+  });
+});
+
+// Worker mode tests for CrewlyAgentRuntimeService are in
+// crewly-agent-runtime.service.test.ts alongside the existing tests,
+// since they share the same mock setup.

--- a/packages/crewly-agent/src/runtime/agent-worker.ts
+++ b/packages/crewly-agent/src/runtime/agent-worker.ts
@@ -1,0 +1,193 @@
+/**
+ * Agent Worker Process
+ *
+ * Standalone Node.js child process that wraps AgentRunnerService for
+ * isolated agent execution. Communicates with the parent process via
+ * IPC messages (Node.js child_process.fork() protocol).
+ *
+ * This enables hot-reload of agent code without restarting the main
+ * backend process, and crash isolation so a worker failure doesn't
+ * bring down the server.
+ *
+ * @module services/agent/crewly-agent/agent-worker
+ */
+
+import { AgentRunnerService } from './agent-runner.service.js';
+import type {
+  CrewlyAgentConfig,
+  AgentRunResult,
+  StreamingEventCallbacks,
+} from './types.js';
+
+// ===== IPC Message Types =====
+
+/**
+ * Messages sent from the parent process to this worker.
+ */
+export type ParentMessage =
+  | { type: 'init'; config: CrewlyAgentConfig }
+  | { type: 'run'; message: string; conversationId?: string; metadata?: Record<string, string> }
+  | { type: 'abort' }
+  | { type: 'get-state' }
+  | { type: 'shutdown' };
+
+/**
+ * Messages sent from this worker to the parent process.
+ */
+export type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; data: AgentRunResult }
+  | { type: 'error'; error: string; code?: string }
+  | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
+  | { type: 'stream'; event: 'text'; data: { chunk: string } }
+  | { type: 'stream'; event: 'toolStart'; data: { toolName: string; args: Record<string, unknown> } }
+  | { type: 'stream'; event: 'toolFinish'; data: { toolName: string; args: Record<string, unknown>; result: unknown; durationMs: number } }
+  | { type: 'stream'; event: 'stepFinish'; data: { stepIndex: number; hasToolCalls: boolean } }
+  | { type: 'state'; data: { historyLength: number; isProcessing: boolean; isInitialized: boolean } };
+
+// ===== Worker State =====
+
+let runner: AgentRunnerService | null = null;
+
+/**
+ * Send a typed message to the parent process.
+ *
+ * @param msg - Worker message to send
+ */
+function send(msg: WorkerMessage): void {
+  if (process.send) {
+    process.send(msg);
+  }
+}
+
+/**
+ * Build streaming callbacks that forward events to the parent via IPC.
+ *
+ * @returns StreamingEventCallbacks that emit IPC messages
+ */
+function buildStreamingCallbacks(): StreamingEventCallbacks {
+  return {
+    onTextChunk: (chunk: string) => {
+      send({ type: 'stream', event: 'text', data: { chunk } });
+    },
+    onToolCallStart: (toolName: string, args: Record<string, unknown>) => {
+      send({ type: 'stream', event: 'toolStart', data: { toolName, args } });
+    },
+    onToolCallFinish: (toolName: string, args: Record<string, unknown>, result: unknown, durationMs: number) => {
+      send({ type: 'stream', event: 'toolFinish', data: { toolName, args, result, durationMs } });
+    },
+    onStepFinish: (stepIndex: number, hasToolCalls: boolean) => {
+      send({ type: 'stream', event: 'stepFinish', data: { stepIndex, hasToolCalls } });
+    },
+  };
+}
+
+/** AbortController for the currently executing run */
+let currentAbort: AbortController | null = null;
+
+/**
+ * Handle incoming messages from the parent process.
+ *
+ * @param msg - Parent message received via IPC
+ */
+async function handleMessage(msg: ParentMessage): Promise<void> {
+  switch (msg.type) {
+    case 'init': {
+      try {
+        runner = new AgentRunnerService(msg.config);
+        await runner.initialize();
+        send({ type: 'ready' });
+        send({ type: 'log', level: 'info', message: `Worker initialized (${msg.config.model.provider}/${msg.config.model.modelId})` });
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        send({ type: 'error', error: `Init failed: ${errMsg}`, code: 'INIT_FAILED' });
+        runner = null;
+      }
+      break;
+    }
+
+    case 'run': {
+      if (!runner || !runner.isInitialized()) {
+        send({ type: 'error', error: 'Worker not initialized', code: 'NOT_INITIALIZED' });
+        return;
+      }
+
+      currentAbort = new AbortController();
+      const streamingCallbacks = buildStreamingCallbacks();
+
+      try {
+        const result = await runner.run(msg.message, msg.conversationId, msg.metadata, {
+          abortSignal: currentAbort.signal,
+          streaming: streamingCallbacks,
+        });
+        currentAbort = null;
+        send({ type: 'result', data: result });
+      } catch (err) {
+        currentAbort = null;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        send({ type: 'error', error: errMsg, code: 'RUN_FAILED' });
+      }
+      break;
+    }
+
+    case 'abort': {
+      if (currentAbort) {
+        currentAbort.abort();
+        currentAbort = null;
+        send({ type: 'log', level: 'warn', message: 'Run aborted by parent' });
+      }
+      if (runner) {
+        runner.abortCurrentRun();
+      }
+      break;
+    }
+
+    case 'get-state': {
+      send({
+        type: 'state',
+        data: {
+          historyLength: runner ? runner.getHistoryLength() : 0,
+          isProcessing: runner ? runner.isProcessing() : false,
+          isInitialized: runner ? runner.isInitialized() : false,
+        },
+      });
+      break;
+    }
+
+    case 'shutdown': {
+      send({ type: 'log', level: 'info', message: 'Worker shutting down' });
+      if (runner) {
+        await runner.shutdown();
+        runner = null;
+      }
+      // Give IPC a moment to flush, then exit
+      setTimeout(() => process.exit(0), 100);
+      break;
+    }
+  }
+}
+
+// ===== Process Setup =====
+
+// Listen for IPC messages from parent
+process.on('message', (msg: ParentMessage) => {
+  handleMessage(msg).catch((err) => {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    send({ type: 'error', error: `Unhandled worker error: ${errMsg}`, code: 'UNHANDLED' });
+  });
+});
+
+// Handle uncaught exceptions — report to parent before crashing
+process.on('uncaughtException', (err) => {
+  send({ type: 'error', error: `Worker crash (uncaughtException): ${err.message}`, code: 'CRASH' });
+  setTimeout(() => process.exit(1), 100);
+});
+
+process.on('unhandledRejection', (reason) => {
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  send({ type: 'error', error: `Worker crash (unhandledRejection): ${msg}`, code: 'CRASH' });
+  setTimeout(() => process.exit(1), 100);
+});
+
+// Signal ready to receive init
+send({ type: 'log', level: 'info', message: 'Agent worker process started, awaiting init' });

--- a/packages/crewly-agent/src/runtime/api-client.ts
+++ b/packages/crewly-agent/src/runtime/api-client.ts
@@ -1,0 +1,143 @@
+/**
+ * Crewly Agent API Client
+ *
+ * Lightweight HTTP client for calling the Crewly backend REST API.
+ * Replaces the bash curl wrapper used by orchestrator skill scripts
+ * with direct fetch() calls for in-process tool execution.
+ *
+ * @module services/agent/crewly-agent/api-client
+ */
+
+import { CREWLY_AGENT_DEFAULTS, type ApiCallResult } from './types.js';
+
+/**
+ * HTTP client for the Crewly backend REST API.
+ *
+ * Each tool in the ToolRegistry uses this client to make API calls
+ * instead of shelling out to bash scripts.
+ *
+ * @example
+ * ```typescript
+ * const client = new CrewlyApiClient('http://localhost:8787', 'crewly-orc');
+ * const result = await client.get('/teams');
+ * const result2 = await client.post('/terminal/agent-sam/deliver', { message: 'Hello' });
+ * ```
+ */
+export class CrewlyApiClient {
+  private baseUrl: string;
+  private sessionName: string;
+  private timeoutMs: number;
+
+  /**
+   * Create a new API client instance.
+   *
+   * @param baseUrl - Base URL for the Crewly API (e.g., 'http://localhost:8787')
+   * @param sessionName - Agent session name for the X-Agent-Session header
+   * @param timeoutMs - Request timeout in milliseconds
+   */
+  constructor(
+    baseUrl: string = CREWLY_AGENT_DEFAULTS.API_BASE_URL,
+    sessionName: string = 'crewly-orc',
+    timeoutMs: number = CREWLY_AGENT_DEFAULTS.API_TIMEOUT_MS,
+  ) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.sessionName = sessionName;
+    this.timeoutMs = timeoutMs;
+  }
+
+  /**
+   * Make a GET request to the Crewly API.
+   *
+   * @param endpoint - API endpoint path (e.g., '/teams')
+   * @returns API call result with parsed JSON data
+   */
+  async get<T = unknown>(endpoint: string): Promise<ApiCallResult<T>> {
+    return this.request<T>('GET', endpoint);
+  }
+
+  /**
+   * Make a POST request to the Crewly API.
+   *
+   * @param endpoint - API endpoint path (e.g., '/terminal/agent-sam/deliver')
+   * @param body - Request body to send as JSON
+   * @returns API call result with parsed JSON data
+   */
+  async post<T = unknown>(endpoint: string, body: unknown): Promise<ApiCallResult<T>> {
+    return this.request<T>('POST', endpoint, body);
+  }
+
+  /**
+   * Make a DELETE request to the Crewly API.
+   *
+   * @param endpoint - API endpoint path (e.g., '/schedule/check-123')
+   * @returns API call result with parsed JSON data
+   */
+  async delete<T = unknown>(endpoint: string): Promise<ApiCallResult<T>> {
+    return this.request<T>('DELETE', endpoint);
+  }
+
+  /**
+   * Internal request method handling fetch, timeout, and error mapping.
+   *
+   * @param method - HTTP method
+   * @param endpoint - API endpoint path
+   * @param body - Optional request body
+   * @returns Parsed API call result
+   */
+  private async request<T>(method: string, endpoint: string, body?: unknown): Promise<ApiCallResult<T>> {
+    const url = `${this.baseUrl}/api${endpoint}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.sessionName) {
+        headers['X-Agent-Session'] = this.sessionName;
+      }
+
+      const init: RequestInit = {
+        method,
+        headers,
+        signal: controller.signal,
+      };
+      if (body !== undefined) {
+        init.body = JSON.stringify(body);
+      }
+
+      const response = await fetch(url, init);
+      const responseBody = await response.text();
+
+      let data: T | undefined;
+      try {
+        const parsed = JSON.parse(responseBody);
+        data = parsed.data !== undefined ? parsed.data : parsed;
+      } catch {
+        data = responseBody as unknown as T;
+      }
+
+      if (response.ok) {
+        return { success: true, data, status: response.status };
+      }
+      return {
+        success: false,
+        error: typeof data === 'object' && data !== null && 'error' in data
+          ? String((data as Record<string, unknown>).error)
+          : `HTTP ${response.status}`,
+        status: response.status,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return { success: false, error: `Request timeout after ${this.timeoutMs}ms`, status: 0 };
+      }
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        status: 0,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/packages/crewly-agent/src/runtime/approval-queue.service.ts
+++ b/packages/crewly-agent/src/runtime/approval-queue.service.ts
@@ -1,0 +1,307 @@
+/**
+ * Approval Queue Service
+ *
+ * Manages pending tool approval requests for the Crewly Agent runtime.
+ * When a tool requires approval (based on SecurityPolicy.requireApproval),
+ * execution is blocked and a PendingApproval entry is created. External
+ * callers (API, auditor) can then approve or reject the request.
+ *
+ * @module services/agent/crewly-agent/approval-queue.service
+ */
+
+import type { ToolSensitivity } from './types.js';
+
+/** Maximum number of pending approvals before oldest are auto-rejected */
+const MAX_PENDING_APPROVALS = 100;
+
+/** Default TTL for pending approvals in milliseconds (10 minutes) */
+const DEFAULT_APPROVAL_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Status of an approval request.
+ */
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'expired';
+
+/**
+ * A single pending approval entry.
+ */
+export interface PendingApproval {
+  /** Unique approval ID */
+  id: string;
+  /** Agent session that requested the tool call */
+  sessionName: string;
+  /** Name of the tool awaiting approval */
+  toolName: string;
+  /** Sensitivity classification of the tool */
+  sensitivity: ToolSensitivity;
+  /** Sanitized arguments passed to the tool */
+  args: Record<string, unknown>;
+  /** Current status */
+  status: ApprovalStatus;
+  /** ISO timestamp when the approval was requested */
+  requestedAt: string;
+  /** ISO timestamp when the approval was resolved (approved/rejected/expired) */
+  resolvedAt?: string;
+  /** Who resolved the approval (e.g. 'api', 'auditor', 'auto-expire') */
+  resolvedBy?: string;
+  /** Reason for rejection (if rejected) */
+  reason?: string;
+}
+
+/**
+ * Result of resolving (approve/reject) an approval request.
+ */
+export interface ApprovalResolution {
+  /** Whether the resolution was successful */
+  success: boolean;
+  /** The resolved approval entry */
+  approval?: PendingApproval;
+  /** Error message if resolution failed */
+  error?: string;
+}
+
+/**
+ * In-memory approval queue for tool execution requests.
+ *
+ * Stores pending approvals and provides approve/reject operations.
+ * Approvals that exceed the TTL are automatically marked as expired
+ * when queried.
+ *
+ * @example
+ * ```typescript
+ * const queue = new ApprovalQueueService();
+ * const approval = queue.enqueue('session-1', 'edit_file', 'destructive', { path: '/foo' });
+ * // Later, approve it:
+ * const result = queue.approve(approval.id, 'api');
+ * ```
+ */
+export class ApprovalQueueService {
+  private static instance: ApprovalQueueService | null = null;
+  private approvals: Map<string, PendingApproval> = new Map();
+  private idCounter = 0;
+  private ttlMs: number;
+
+  /**
+   * Get the shared singleton instance.
+   * All agent-runners and API controllers share the same queue.
+   *
+   * @returns The shared ApprovalQueueService instance
+   */
+  static getInstance(): ApprovalQueueService {
+    if (!ApprovalQueueService.instance) {
+      ApprovalQueueService.instance = new ApprovalQueueService();
+    }
+    return ApprovalQueueService.instance;
+  }
+
+  /**
+   * Reset the singleton instance (for testing only).
+   */
+  static resetInstance(): void {
+    ApprovalQueueService.instance = null;
+  }
+
+  /**
+   * Create a new ApprovalQueueService.
+   *
+   * @param ttlMs - Time-to-live for pending approvals in milliseconds
+   */
+  constructor(ttlMs: number = DEFAULT_APPROVAL_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  /**
+   * Add a new approval request to the queue.
+   *
+   * @param sessionName - Agent session requesting approval
+   * @param toolName - Name of the tool
+   * @param sensitivity - Sensitivity classification
+   * @param args - Sanitized tool arguments
+   * @returns The created PendingApproval entry
+   */
+  enqueue(
+    sessionName: string,
+    toolName: string,
+    sensitivity: ToolSensitivity,
+    args: Record<string, unknown>,
+  ): PendingApproval {
+    this.expireStale();
+
+    // Enforce max pending limit — reject oldest if full
+    if (this.getPendingCount() >= MAX_PENDING_APPROVALS) {
+      const oldest = this.getOldestPending();
+      if (oldest) {
+        oldest.status = 'rejected';
+        oldest.resolvedAt = new Date().toISOString();
+        oldest.resolvedBy = 'auto-overflow';
+        oldest.reason = 'Approval queue overflow — auto-rejected oldest entry';
+      }
+    }
+
+    this.idCounter++;
+    const id = `approval-${this.idCounter}-${Date.now()}`;
+
+    const approval: PendingApproval = {
+      id,
+      sessionName,
+      toolName,
+      sensitivity,
+      args,
+      status: 'pending',
+      requestedAt: new Date().toISOString(),
+    };
+
+    this.approvals.set(id, approval);
+    return approval;
+  }
+
+  /**
+   * Approve a pending approval request.
+   *
+   * @param id - Approval ID to approve
+   * @param resolvedBy - Who is approving (e.g. 'api', 'auditor')
+   * @returns Resolution result
+   */
+  approve(id: string, resolvedBy: string = 'api'): ApprovalResolution {
+    return this.resolve(id, 'approved', resolvedBy);
+  }
+
+  /**
+   * Reject a pending approval request.
+   *
+   * @param id - Approval ID to reject
+   * @param resolvedBy - Who is rejecting
+   * @param reason - Reason for rejection
+   * @returns Resolution result
+   */
+  reject(id: string, resolvedBy: string = 'api', reason?: string): ApprovalResolution {
+    return this.resolve(id, 'rejected', resolvedBy, reason);
+  }
+
+  /**
+   * Get all pending approval requests.
+   *
+   * @param sessionName - Optional filter by session name
+   * @returns Array of pending approvals
+   */
+  getPending(sessionName?: string): PendingApproval[] {
+    this.expireStale();
+    const pending: PendingApproval[] = [];
+    for (const approval of this.approvals.values()) {
+      if (approval.status !== 'pending') continue;
+      if (sessionName && approval.sessionName !== sessionName) continue;
+      pending.push({ ...approval });
+    }
+    return pending;
+  }
+
+  /**
+   * Get a specific approval by ID.
+   *
+   * @param id - Approval ID
+   * @returns The approval entry or undefined
+   */
+  getById(id: string): PendingApproval | undefined {
+    const approval = this.approvals.get(id);
+    if (!approval) return undefined;
+    return { ...approval };
+  }
+
+  /**
+   * Get the count of currently pending approvals.
+   *
+   * @returns Number of pending approvals
+   */
+  getPendingCount(): number {
+    let count = 0;
+    for (const approval of this.approvals.values()) {
+      if (approval.status === 'pending') count++;
+    }
+    return count;
+  }
+
+  /**
+   * Clear all approvals (for testing or reset).
+   */
+  clear(): void {
+    this.approvals.clear();
+    this.idCounter = 0;
+  }
+
+  /**
+   * Resolve a pending approval with the given status.
+   *
+   * @param id - Approval ID
+   * @param status - New status
+   * @param resolvedBy - Who resolved it
+   * @param reason - Optional reason (for rejections)
+   * @returns Resolution result
+   */
+  private resolve(
+    id: string,
+    status: 'approved' | 'rejected',
+    resolvedBy: string,
+    reason?: string,
+  ): ApprovalResolution {
+    const approval = this.approvals.get(id);
+    if (!approval) {
+      return { success: false, error: `Approval '${id}' not found` };
+    }
+    if (approval.status !== 'pending') {
+      return {
+        success: false,
+        error: `Approval '${id}' is already ${approval.status}`,
+        approval: { ...approval },
+      };
+    }
+
+    approval.status = status;
+    approval.resolvedAt = new Date().toISOString();
+    approval.resolvedBy = resolvedBy;
+    if (reason) approval.reason = reason;
+
+    return { success: true, approval: { ...approval } };
+  }
+
+  /**
+   * Expire stale pending approvals that have exceeded the TTL.
+   */
+  private expireStale(): void {
+    const now = Date.now();
+    const resolvedRetentionMs = this.ttlMs * 3; // Keep resolved entries 3x TTL then prune
+
+    for (const [id, approval] of this.approvals.entries()) {
+      if (approval.status === 'pending') {
+        const requestedAt = new Date(approval.requestedAt).getTime();
+        if (now - requestedAt > this.ttlMs) {
+          approval.status = 'expired';
+          approval.resolvedAt = new Date().toISOString();
+          approval.resolvedBy = 'auto-expire';
+          approval.reason = 'Approval request expired';
+        }
+      } else if (approval.resolvedAt) {
+        // Prune resolved entries that are older than retention window
+        const resolvedAt = new Date(approval.resolvedAt).getTime();
+        if (now - resolvedAt > resolvedRetentionMs) {
+          this.approvals.delete(id);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the oldest pending approval.
+   *
+   * @returns Oldest pending approval or undefined
+   */
+  private getOldestPending(): PendingApproval | undefined {
+    let oldest: PendingApproval | undefined;
+    for (const approval of this.approvals.values()) {
+      if (approval.status !== 'pending') continue;
+      if (!oldest || approval.requestedAt < oldest.requestedAt) {
+        oldest = approval;
+      }
+    }
+    return oldest;
+  }
+}

--- a/packages/crewly-agent/src/runtime/audit-log.service.test.ts
+++ b/packages/crewly-agent/src/runtime/audit-log.service.test.ts
@@ -1,0 +1,208 @@
+/**
+ * AuditLogService Tests
+ *
+ * Tests for the SQLite-backed persistent audit log service.
+ *
+ * @module services/agent/crewly-agent/audit-log.service.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { AuditLogService } from './audit-log.service.js';
+import type { AuditEntry } from './types.js';
+
+describe('AuditLogService', () => {
+  let service: AuditLogService;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'audit-log-test-'));
+    service = new AuditLogService(tempDir);
+    service.initialize();
+  });
+
+  afterEach(() => {
+    service.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /** Helper to create a valid AuditEntry */
+  function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+    return {
+      timestamp: new Date().toISOString(),
+      sessionName: 'test-session',
+      toolName: 'edit_file',
+      sensitivity: 'destructive',
+      args: { path: '/tmp/test.txt' },
+      success: true,
+      durationMs: 42,
+      ...overrides,
+    };
+  }
+
+  describe('initialize()', () => {
+    it('should create the database and tables', () => {
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    it('should be idempotent', () => {
+      service.initialize(); // second call should not throw
+      expect(service.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('append()', () => {
+    it('should insert a tool-call audit entry', () => {
+      service.append(makeEntry());
+      const rows = service.query({ limit: 10 });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].toolName).toBe('edit_file');
+      expect(rows[0].action).toBe('tool_call');
+      expect(rows[0].success).toBe(true);
+      expect(rows[0].args.path).toBe('/tmp/test.txt');
+    });
+
+    it('should store failed entries', () => {
+      service.append(makeEntry({ success: false, error: 'Permission denied' }));
+      const rows = service.query({ limit: 10 });
+      expect(rows[0].success).toBe(false);
+      expect(rows[0].error).toBe('Permission denied');
+    });
+
+    it('should throw if not initialized', () => {
+      const uninit = new AuditLogService(tempDir, 'other.sqlite');
+      expect(() => uninit.append(makeEntry())).toThrow('not initialized');
+    });
+  });
+
+  describe('logApprovalEvent()', () => {
+    it('should log an approval_granted event', () => {
+      service.logApprovalEvent(
+        'approval-1', 'sess-1', 'rm_file', 'destructive', 'approval_granted', 'api',
+      );
+      const rows = service.query({ limit: 10 });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].action).toBe('approval_granted');
+      expect(rows[0].resolvedBy).toBe('api');
+      expect(rows[0].approvalId).toBe('approval-1');
+    });
+
+    it('should log an approval_rejected event', () => {
+      service.logApprovalEvent(
+        'approval-2', 'sess-1', 'git_push', 'destructive', 'approval_rejected', 'auditor',
+      );
+      const rows = service.query({ limit: 10 });
+      expect(rows[0].action).toBe('approval_rejected');
+      expect(rows[0].resolvedBy).toBe('auditor');
+    });
+
+    it('should log an approval_expired event', () => {
+      service.logApprovalEvent(
+        'approval-3', 'sess-1', 'curl', 'destructive', 'approval_expired', 'auto-expire',
+      );
+      const rows = service.query({ limit: 10 });
+      expect(rows[0].action).toBe('approval_expired');
+    });
+  });
+
+  describe('query()', () => {
+    beforeEach(() => {
+      // Insert diverse entries
+      service.append(makeEntry({ sessionName: 'sess-1', toolName: 'read_file', sensitivity: 'safe', timestamp: '2026-01-01T00:00:00Z' }));
+      service.append(makeEntry({ sessionName: 'sess-1', toolName: 'edit_file', sensitivity: 'destructive', timestamp: '2026-01-02T00:00:00Z' }));
+      service.append(makeEntry({ sessionName: 'sess-2', toolName: 'git_push', sensitivity: 'destructive', timestamp: '2026-01-03T00:00:00Z' }));
+      service.logApprovalEvent('a-1', 'sess-1', 'rm_file', 'destructive', 'approval_granted', 'api');
+    });
+
+    it('should return entries in reverse chronological order', () => {
+      const rows = service.query({ limit: 100 });
+      expect(rows).toHaveLength(4);
+      // Most recent (approval event) should be first
+      expect(rows[0].action).toBe('approval_granted');
+    });
+
+    it('should filter by sessionName', () => {
+      const rows = service.query({ limit: 100, sessionName: 'sess-2' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].toolName).toBe('git_push');
+    });
+
+    it('should filter by sensitivity', () => {
+      const rows = service.query({ limit: 100, sensitivity: 'safe' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].toolName).toBe('read_file');
+    });
+
+    it('should filter by toolName', () => {
+      const rows = service.query({ limit: 100, toolName: 'edit_file' });
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should filter by action', () => {
+      const rows = service.query({ limit: 100, action: 'approval_granted' });
+      expect(rows).toHaveLength(1);
+    });
+
+    it('should filter by since', () => {
+      const rows = service.query({ limit: 100, since: '2026-01-02T00:00:00Z' });
+      // Should include entries from Jan 2, Jan 3, and the approval event
+      expect(rows.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should filter by until', () => {
+      const rows = service.query({ limit: 100, until: '2026-01-01T23:59:59Z' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].toolName).toBe('read_file');
+    });
+
+    it('should respect limit', () => {
+      const rows = service.query({ limit: 2 });
+      expect(rows).toHaveLength(2);
+    });
+
+    it('should support offset for pagination', () => {
+      const page1 = service.query({ limit: 2, offset: 0 });
+      const page2 = service.query({ limit: 2, offset: 2 });
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+      expect(page1[0].id).not.toBe(page2[0].id);
+    });
+  });
+
+  describe('count()', () => {
+    it('should return total entry count', () => {
+      service.append(makeEntry());
+      service.append(makeEntry());
+      service.append(makeEntry());
+      expect(service.count()).toBe(3);
+    });
+
+    it('should filter count by sessionName', () => {
+      service.append(makeEntry({ sessionName: 'a' }));
+      service.append(makeEntry({ sessionName: 'b' }));
+      service.append(makeEntry({ sessionName: 'a' }));
+      expect(service.count({ sessionName: 'a' })).toBe(2);
+    });
+  });
+
+  describe('close()', () => {
+    it('should close the database and reset state', () => {
+      service.close();
+      expect(service.isInitialized()).toBe(false);
+    });
+
+    it('should be safe to call multiple times', () => {
+      service.close();
+      service.close(); // no throw
+    });
+  });
+
+  describe('getDbPath()', () => {
+    it('should return the database file path', () => {
+      expect(service.getDbPath()).toContain('audit-log.sqlite');
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/audit-log.service.ts
+++ b/packages/crewly-agent/src/runtime/audit-log.service.ts
@@ -1,0 +1,332 @@
+/**
+ * Persistent Audit Log Service (SQLite)
+ *
+ * Provides durable, queryable audit logging using better-sqlite3.
+ * Replaces the append-only JSONL approach with a proper relational store
+ * that supports efficient filtering, pagination, and aggregation.
+ *
+ * Single WAL-mode database shared across all sessions. Thread-safe for
+ * the single-threaded Node.js event loop (better-sqlite3 is synchronous).
+ *
+ * @module services/agent/crewly-agent/audit-log.service
+ */
+
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import { mkdirSync } from 'fs';
+import type { AuditEntry, AuditLogFilters, ToolSensitivity } from './types.js';
+
+/** Default database filename */
+const DB_FILENAME = 'audit-log.sqlite';
+
+/** Default directory under .crewly */
+const AUDIT_DIR = 'audit-logs';
+
+/** Maximum rows returned by a single query */
+const MAX_QUERY_LIMIT = 10000;
+
+/**
+ * Extended audit entry stored in the database.
+ * Adds an auto-incremented row ID and an action field for approval events.
+ */
+export interface AuditLogRow extends AuditEntry {
+  /** Auto-incremented row ID */
+  id: number;
+  /** Action type: 'tool_call' | 'approval_granted' | 'approval_rejected' | 'approval_expired' */
+  action: string;
+  /** Who resolved an approval (e.g. 'api', 'auditor', 'auto-expire') */
+  resolvedBy?: string;
+  /** Approval ID if this entry relates to an approval event */
+  approvalId?: string;
+}
+
+/**
+ * Query filters for the audit log, extending the base AuditLogFilters.
+ */
+export interface AuditLogQueryFilters extends AuditLogFilters {
+  /** Filter by session name */
+  sessionName?: string;
+  /** Filter by action type */
+  action?: string;
+  /** Filter entries after this ISO timestamp */
+  since?: string;
+  /** Filter entries before this ISO timestamp */
+  until?: string;
+  /** Offset for pagination */
+  offset?: number;
+}
+
+/**
+ * SQLite-backed persistent audit log service.
+ *
+ * @example
+ * ```typescript
+ * const log = new AuditLogService('/path/to/.crewly');
+ * log.initialize();
+ * log.append(auditEntry);
+ * log.logApprovalEvent('approval-123', 'session-1', 'edit_file', 'destructive', 'approved', 'api');
+ * const entries = log.query({ limit: 50, sessionName: 'session-1' });
+ * log.close();
+ * ```
+ */
+export class AuditLogService {
+  private db: Database.Database | null = null;
+  private dbPath: string;
+  private initialized = false;
+
+  /** Prepared statements for performance */
+  private stmtInsert: Database.Statement | null = null;
+  private stmtInsertApproval: Database.Statement | null = null;
+
+  /**
+   * Create a new AuditLogService.
+   *
+   * @param crewlyHome - Path to the .crewly directory
+   * @param dbFilename - Database filename (default: audit-log.sqlite)
+   */
+  constructor(crewlyHome: string, dbFilename: string = DB_FILENAME) {
+    const dir = join(crewlyHome, AUDIT_DIR);
+    this.dbPath = join(dir, dbFilename);
+  }
+
+  /**
+   * Initialize the database, creating tables if needed.
+   * Enables WAL mode for better concurrent read performance.
+   */
+  initialize(): void {
+    if (this.initialized) return;
+
+    // Ensure directory exists
+    const dir = join(this.dbPath, '..');
+    mkdirSync(dir, { recursive: true });
+
+    this.db = new Database(this.dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS audit_log (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp     TEXT    NOT NULL,
+        session_name  TEXT,
+        tool_name     TEXT    NOT NULL,
+        sensitivity   TEXT    NOT NULL,
+        args          TEXT    NOT NULL DEFAULT '{}',
+        success       INTEGER NOT NULL DEFAULT 1,
+        error         TEXT,
+        duration_ms   REAL    NOT NULL DEFAULT 0,
+        action        TEXT    NOT NULL DEFAULT 'tool_call',
+        resolved_by   TEXT,
+        approval_id   TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
+      CREATE INDEX IF NOT EXISTS idx_audit_session   ON audit_log(session_name);
+      CREATE INDEX IF NOT EXISTS idx_audit_action    ON audit_log(action);
+      CREATE INDEX IF NOT EXISTS idx_audit_tool      ON audit_log(tool_name);
+    `);
+
+    this.stmtInsert = this.db.prepare(`
+      INSERT INTO audit_log (timestamp, session_name, tool_name, sensitivity, args, success, error, duration_ms, action)
+      VALUES (@timestamp, @sessionName, @toolName, @sensitivity, @args, @success, @error, @durationMs, 'tool_call')
+    `);
+
+    this.stmtInsertApproval = this.db.prepare(`
+      INSERT INTO audit_log (timestamp, session_name, tool_name, sensitivity, args, success, duration_ms, action, resolved_by, approval_id)
+      VALUES (@timestamp, @sessionName, @toolName, @sensitivity, @args, 1, 0, @action, @resolvedBy, @approvalId)
+    `);
+
+    this.initialized = true;
+  }
+
+  /**
+   * Append a tool-call audit entry.
+   *
+   * @param entry - The AuditEntry from the agent runtime
+   */
+  append(entry: AuditEntry): void {
+    this.ensureInitialized();
+    this.stmtInsert!.run({
+      timestamp: entry.timestamp,
+      sessionName: entry.sessionName ?? null,
+      toolName: entry.toolName,
+      sensitivity: entry.sensitivity,
+      args: JSON.stringify(entry.args),
+      success: entry.success ? 1 : 0,
+      error: entry.error ?? null,
+      durationMs: entry.durationMs,
+    });
+  }
+
+  /**
+   * Log an approval lifecycle event (granted, rejected, expired).
+   *
+   * @param approvalId - The approval request ID
+   * @param sessionName - Agent session name
+   * @param toolName - Tool that was approved/rejected
+   * @param sensitivity - Sensitivity classification
+   * @param action - 'approval_granted' | 'approval_rejected' | 'approval_expired'
+   * @param resolvedBy - Who resolved it
+   */
+  logApprovalEvent(
+    approvalId: string,
+    sessionName: string,
+    toolName: string,
+    sensitivity: ToolSensitivity,
+    action: 'approval_granted' | 'approval_rejected' | 'approval_expired',
+    resolvedBy: string,
+  ): void {
+    this.ensureInitialized();
+    this.stmtInsertApproval!.run({
+      timestamp: new Date().toISOString(),
+      sessionName,
+      toolName,
+      sensitivity,
+      args: '{}',
+      action,
+      resolvedBy,
+      approvalId,
+    });
+  }
+
+  /**
+   * Query audit log entries with filters and pagination.
+   *
+   * @param filters - Query filters
+   * @returns Array of audit log rows, most recent first
+   */
+  query(filters: AuditLogQueryFilters): AuditLogRow[] {
+    this.ensureInitialized();
+
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (filters.sessionName) {
+      conditions.push('session_name = @sessionName');
+      params.sessionName = filters.sessionName;
+    }
+    if (filters.sensitivity) {
+      conditions.push('sensitivity = @sensitivity');
+      params.sensitivity = filters.sensitivity;
+    }
+    if (filters.toolName) {
+      conditions.push('tool_name = @toolName');
+      params.toolName = filters.toolName;
+    }
+    if (filters.action) {
+      conditions.push('action = @action');
+      params.action = filters.action;
+    }
+    if (filters.since) {
+      conditions.push('timestamp >= @since');
+      params.since = filters.since;
+    }
+    if (filters.until) {
+      conditions.push('timestamp <= @until');
+      params.until = filters.until;
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = Math.min(filters.limit || 100, MAX_QUERY_LIMIT);
+    const offset = filters.offset || 0;
+
+    const sql = `
+      SELECT id, timestamp, session_name, tool_name, sensitivity, args,
+             success, error, duration_ms, action, resolved_by, approval_id
+      FROM audit_log
+      ${where}
+      ORDER BY id DESC
+      LIMIT @limit OFFSET @offset
+    `;
+
+    params.limit = limit;
+    params.offset = offset;
+
+    const rows = this.db!.prepare(sql).all(params) as Array<Record<string, unknown>>;
+
+    return rows.map(row => ({
+      id: row.id as number,
+      timestamp: row.timestamp as string,
+      sessionName: row.session_name as string | undefined,
+      toolName: row.tool_name as string,
+      sensitivity: row.sensitivity as ToolSensitivity,
+      args: JSON.parse((row.args as string) || '{}'),
+      success: (row.success as number) === 1,
+      error: row.error as string | undefined,
+      durationMs: row.duration_ms as number,
+      action: row.action as string,
+      resolvedBy: row.resolved_by as string | undefined,
+      approvalId: row.approval_id as string | undefined,
+    }));
+  }
+
+  /**
+   * Get total count of entries matching filters (for pagination).
+   *
+   * @param filters - Same filters as query (limit/offset ignored)
+   * @returns Total matching row count
+   */
+  count(filters: Partial<AuditLogQueryFilters> = {}): number {
+    this.ensureInitialized();
+
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (filters.sessionName) {
+      conditions.push('session_name = @sessionName');
+      params.sessionName = filters.sessionName;
+    }
+    if (filters.action) {
+      conditions.push('action = @action');
+      params.action = filters.action;
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `SELECT COUNT(*) as cnt FROM audit_log ${where}`;
+    const row = this.db!.prepare(sql).get(params) as { cnt: number };
+    return row.cnt;
+  }
+
+  /**
+   * Get the database file path.
+   *
+   * @returns Absolute path to the SQLite database
+   */
+  getDbPath(): string {
+    return this.dbPath;
+  }
+
+  /**
+   * Check if the service is initialized.
+   *
+   * @returns True if initialize() has been called
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Close the database connection.
+   * Safe to call multiple times.
+   */
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+      this.stmtInsert = null;
+      this.stmtInsertApproval = null;
+      this.initialized = false;
+    }
+  }
+
+  /**
+   * Ensure the service is initialized before operations.
+   *
+   * @throws Error if not initialized
+   */
+  private ensureInitialized(): void {
+    if (!this.initialized || !this.db) {
+      throw new Error('AuditLogService not initialized. Call initialize() first.');
+    }
+  }
+}

--- a/packages/crewly-agent/src/runtime/audit-trail.service.test.ts
+++ b/packages/crewly-agent/src/runtime/audit-trail.service.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fsPromises } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { AuditTrailService } from './audit-trail.service.js';
+import type { AuditEntry } from './types.js';
+
+describe('AuditTrailService', () => {
+  let service: AuditTrailService;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsPromises.mkdtemp(join(tmpdir(), 'crewly-audit-test-'));
+    service = new AuditTrailService(tempDir, 'test-agent-session');
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const makeEntry = (overrides?: Partial<AuditEntry>): AuditEntry => ({
+    timestamp: new Date().toISOString(),
+    sessionName: 'test-agent-session',
+    toolName: 'get_team_status',
+    sensitivity: 'safe',
+    args: {},
+    success: true,
+    durationMs: 15,
+    ...overrides,
+  });
+
+  describe('initialize', () => {
+    it('should create the audit-logs directory', async () => {
+      await service.initialize();
+
+      const stat = await fsPromises.stat(join(tempDir, 'audit-logs'));
+      expect(stat.isDirectory()).toBe(true);
+    });
+
+    it('should set initialized flag', async () => {
+      expect(service.isInitialized()).toBe(false);
+      await service.initialize();
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    it('should be idempotent (safe to call multiple times)', async () => {
+      await service.initialize();
+      await service.initialize();
+      expect(service.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('append', () => {
+    it('should throw if not initialized', async () => {
+      await expect(service.append(makeEntry())).rejects.toThrow('not initialized');
+    });
+
+    it('should write entry as JSONL line', async () => {
+      await service.initialize();
+      const entry = makeEntry();
+      await service.append(entry);
+
+      const content = await fsPromises.readFile(service.getLogFilePath(), 'utf8');
+      const parsed = JSON.parse(content.trim());
+      expect(parsed.toolName).toBe('get_team_status');
+      expect(parsed.sessionName).toBe('test-agent-session');
+    });
+
+    it('should append multiple entries on separate lines', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'tool_a' }));
+      await service.append(makeEntry({ toolName: 'tool_b' }));
+      await service.append(makeEntry({ toolName: 'tool_c' }));
+
+      const content = await fsPromises.readFile(service.getLogFilePath(), 'utf8');
+      const lines = content.trim().split('\n');
+      expect(lines).toHaveLength(3);
+      expect(JSON.parse(lines[0]).toolName).toBe('tool_a');
+      expect(JSON.parse(lines[2]).toolName).toBe('tool_c');
+    });
+  });
+
+  describe('query', () => {
+    it('should throw if not initialized', async () => {
+      await expect(service.query({ limit: 10 })).rejects.toThrow('not initialized');
+    });
+
+    it('should return empty array when log file does not exist', async () => {
+      await service.initialize();
+      const entries = await service.query({ limit: 50 });
+      expect(entries).toEqual([]);
+    });
+
+    it('should return entries in reverse chronological order', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'first', timestamp: '2026-01-01T00:00:00Z' }));
+      await service.append(makeEntry({ toolName: 'second', timestamp: '2026-01-01T00:01:00Z' }));
+      await service.append(makeEntry({ toolName: 'third', timestamp: '2026-01-01T00:02:00Z' }));
+
+      const entries = await service.query({ limit: 50 });
+      expect(entries).toHaveLength(3);
+      expect(entries[0].toolName).toBe('third');
+      expect(entries[2].toolName).toBe('first');
+    });
+
+    it('should respect limit parameter', async () => {
+      await service.initialize();
+      for (let i = 0; i < 10; i++) {
+        await service.append(makeEntry({ toolName: `tool_${i}` }));
+      }
+
+      const entries = await service.query({ limit: 3 });
+      expect(entries).toHaveLength(3);
+      expect(entries[0].toolName).toBe('tool_9');
+    });
+
+    it('should filter by sensitivity', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'safe_tool', sensitivity: 'safe' }));
+      await service.append(makeEntry({ toolName: 'sensitive_tool', sensitivity: 'sensitive' }));
+      await service.append(makeEntry({ toolName: 'destructive_tool', sensitivity: 'destructive' }));
+
+      const entries = await service.query({ limit: 50, sensitivity: 'sensitive' });
+      expect(entries).toHaveLength(1);
+      expect(entries[0].toolName).toBe('sensitive_tool');
+    });
+
+    it('should filter by toolName', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'edit_file' }));
+      await service.append(makeEntry({ toolName: 'read_file' }));
+      await service.append(makeEntry({ toolName: 'edit_file' }));
+
+      const entries = await service.query({ limit: 50, toolName: 'edit_file' });
+      expect(entries).toHaveLength(2);
+    });
+
+    it('should combine sensitivity and toolName filters', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'edit_file', sensitivity: 'destructive' }));
+      await service.append(makeEntry({ toolName: 'read_file', sensitivity: 'safe' }));
+      await service.append(makeEntry({ toolName: 'edit_file', sensitivity: 'safe' }));
+
+      const entries = await service.query({ limit: 50, sensitivity: 'destructive', toolName: 'edit_file' });
+      expect(entries).toHaveLength(1);
+    });
+
+    it('should skip malformed lines gracefully', async () => {
+      await service.initialize();
+      await service.append(makeEntry({ toolName: 'valid' }));
+      // Manually write a malformed line
+      await fsPromises.appendFile(service.getLogFilePath(), 'not-valid-json\n', 'utf8');
+      await service.append(makeEntry({ toolName: 'also_valid' }));
+
+      const entries = await service.query({ limit: 50 });
+      expect(entries).toHaveLength(2);
+      expect(entries[0].toolName).toBe('also_valid');
+      expect(entries[1].toolName).toBe('valid');
+    });
+  });
+
+  describe('getLogFilePath', () => {
+    it('should return path under audit-logs directory', () => {
+      const path = service.getLogFilePath();
+      expect(path).toContain('audit-logs');
+      expect(path).toContain('test-agent-session');
+      expect(path.endsWith('.jsonl')).toBe(true);
+    });
+
+    it('should sanitize special characters in session name', () => {
+      const specialService = new AuditTrailService(tempDir, 'agent/with spaces!');
+      const path = specialService.getLogFilePath();
+      expect(path).not.toContain('/with');
+      expect(path).not.toContain(' ');
+      expect(path).not.toContain('!');
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/audit-trail.service.ts
+++ b/packages/crewly-agent/src/runtime/audit-trail.service.ts
@@ -1,0 +1,151 @@
+/**
+ * Audit Trail Service
+ *
+ * Provides file-based persistence for the security audit trail.
+ * Writes audit entries as append-only JSONL (one JSON object per line)
+ * for structured, queryable audit logging.
+ *
+ * @module services/agent/crewly-agent/audit-trail.service
+ */
+
+import { promises as fsPromises } from 'fs';
+import { join } from 'path';
+import type { AuditEntry, AuditLogFilters } from './types.js';
+
+/** Default directory name for audit logs under .crewly */
+const AUDIT_DIR = 'audit-logs';
+
+/** Maximum lines to read when querying the log file */
+const MAX_QUERY_LINES = 10000;
+
+/**
+ * File-based audit trail service.
+ *
+ * Persists audit entries as append-only JSONL files organized by session.
+ * Each session gets its own log file for easy per-agent auditing.
+ *
+ * @example
+ * ```typescript
+ * const trail = new AuditTrailService('/path/to/.crewly', 'agent-session-1');
+ * await trail.initialize();
+ * await trail.append(auditEntry);
+ * const entries = await trail.query({ limit: 50 });
+ * ```
+ */
+export class AuditTrailService {
+  private crewlyHome: string;
+  private sessionName: string;
+  private logDir: string;
+  private logFile: string;
+  private initialized = false;
+
+  /**
+   * Create a new AuditTrailService.
+   *
+   * @param crewlyHome - Path to the .crewly directory
+   * @param sessionName - Agent session name for log file naming
+   */
+  constructor(crewlyHome: string, sessionName: string) {
+    this.crewlyHome = crewlyHome;
+    this.sessionName = sessionName;
+    this.logDir = join(crewlyHome, AUDIT_DIR);
+    this.logFile = join(this.logDir, `${sanitizeFilename(sessionName)}.jsonl`);
+  }
+
+  /**
+   * Initialize the audit trail by ensuring the log directory exists.
+   *
+   * @throws Error if directory creation fails
+   */
+  async initialize(): Promise<void> {
+    await fsPromises.mkdir(this.logDir, { recursive: true });
+    this.initialized = true;
+  }
+
+  /**
+   * Append an audit entry to the log file.
+   *
+   * @param entry - Audit entry to persist
+   * @throws Error if not initialized or write fails
+   */
+  async append(entry: AuditEntry): Promise<void> {
+    if (!this.initialized) {
+      throw new Error('AuditTrailService not initialized. Call initialize() first.');
+    }
+    const line = JSON.stringify(entry) + '\n';
+    await fsPromises.appendFile(this.logFile, line, 'utf8');
+  }
+
+  /**
+   * Query persisted audit entries with optional filters.
+   *
+   * Reads the log file and returns matching entries in reverse
+   * chronological order (most recent first).
+   *
+   * @param filters - Query filters for limit, sensitivity, and toolName
+   * @returns Filtered audit entries
+   */
+  async query(filters: AuditLogFilters): Promise<AuditEntry[]> {
+    if (!this.initialized) {
+      throw new Error('AuditTrailService not initialized. Call initialize() first.');
+    }
+
+    let content: string;
+    try {
+      content = await fsPromises.readFile(this.logFile, 'utf8');
+    } catch (err) {
+      // File doesn't exist yet — no entries
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      throw err;
+    }
+
+    const lines = content.trim().split('\n').filter(Boolean);
+
+    // Parse from end (most recent first), apply filters
+    let entries: AuditEntry[] = [];
+    const startIdx = Math.max(0, lines.length - MAX_QUERY_LINES);
+    for (let i = lines.length - 1; i >= startIdx && entries.length < filters.limit; i--) {
+      try {
+        const entry: AuditEntry = JSON.parse(lines[i]);
+        if (filters.sensitivity && entry.sensitivity !== filters.sensitivity) continue;
+        if (filters.toolName && entry.toolName !== filters.toolName) continue;
+        entries.push(entry);
+      } catch {
+        // Skip malformed lines
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Get the path to the audit log file.
+   *
+   * @returns Absolute path to the JSONL log file
+   */
+  getLogFilePath(): string {
+    return this.logFile;
+  }
+
+  /**
+   * Check if the service has been initialized.
+   *
+   * @returns True if initialize() has been called successfully
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+}
+
+/**
+ * Sanitize a session name for use as a filename.
+ * Replaces non-alphanumeric characters (except hyphens and underscores) with hyphens.
+ *
+ * @param name - Raw session name
+ * @returns Sanitized filename-safe string
+ */
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, '-');
+}

--- a/packages/crewly-agent/src/runtime/auditor-tools.test.ts
+++ b/packages/crewly-agent/src/runtime/auditor-tools.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked, type MockInstance } from 'vitest';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { createAuditorTools, getAuditorToolNames } from './auditor-tools.js';
+import { CrewlyApiClient } from './api-client.js';
+
+describe('Auditor Tools', () => {
+  let mockClient: Mocked<CrewlyApiClient>;
+  let tools: ReturnType<typeof createAuditorTools>;
+  let readFileSpy: MockInstance<typeof fs.readFile>;
+  let writeFileSpy: MockInstance<typeof fs.writeFile>;
+  let mkdirSpy: MockInstance<typeof fs.mkdir>;
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      get: vi.fn<any>(),
+      post: vi.fn<any>(),
+      put: vi.fn<any>(),
+      delete: vi.fn<any>(),
+    } as any;
+
+    readFileSpy = vi.spyOn(fs, 'readFile') as any;
+    writeFileSpy = vi.spyOn(fs, 'writeFile') as any;
+    mkdirSpy = vi.spyOn(fs, 'mkdir').mockResolvedValue(undefined as any) as any;
+
+    tools = createAuditorTools(mockClient, projectPath);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getAuditorToolNames', () => {
+    it('should return all 11 tool names', () => {
+      const names = getAuditorToolNames();
+      expect(names).toHaveLength(11);
+      expect(names).toContain('get_team_status');
+      expect(names).toContain('get_agent_logs');
+      expect(names).toContain('get_tasks');
+      expect(names).toContain('recall_goals');
+      expect(names).toContain('heartbeat');
+      expect(names).toContain('get_agent_status');
+      expect(names).toContain('subscribe_event');
+      expect(names).toContain('write_audit_report');
+      expect(names).toContain('reply_slack');
+      expect(names).toContain('read_audit_history');
+    });
+  });
+
+  describe('tool definitions', () => {
+    it('should create all 11 tools', () => {
+      expect(Object.keys(tools)).toHaveLength(11);
+    });
+
+    it('should have description and inputSchema on every tool', () => {
+      for (const [name, tool] of Object.entries(tools)) {
+        expect(tool.description).toBeTruthy();
+        expect(tool.inputSchema).toBeDefined();
+        expect(typeof tool.execute).toBe('function');
+      }
+    });
+  });
+
+  describe('get_team_status', () => {
+    it('should return team data on success', async () => {
+      mockClient.get.mockResolvedValue({ success: true, status: 200, data: [{ id: 'team1' }] });
+      const result = await tools.get_team_status.execute({});
+      expect(mockClient.get).toHaveBeenCalledWith('/teams');
+      expect(result).toEqual([{ id: 'team1' }]);
+    });
+
+    it('should return error on failure', async () => {
+      mockClient.get.mockResolvedValue({ success: false, status: 500, error: 'Network error' });
+      const result = await tools.get_team_status.execute({});
+      expect(result).toEqual({ error: 'Network error' });
+    });
+  });
+
+  describe('get_agent_logs', () => {
+    it('should fetch logs with line count', async () => {
+      mockClient.get.mockResolvedValue({ success: true, status: 200, data: { output: 'log data' } });
+      const result = await tools.get_agent_logs.execute({ sessionName: 'agent-1', lines: 30 });
+      expect(mockClient.get).toHaveBeenCalledWith('/terminal/agent-1/output?lines=30');
+      expect(result).toEqual({ output: 'log data' });
+    });
+  });
+
+  describe('get_tasks', () => {
+    it('should fetch tasks with project path', async () => {
+      mockClient.get.mockResolvedValue({ success: true, status: 200, data: [{ id: 'task1' }] });
+      await tools.get_tasks.execute({ projectPath: '/proj', status: 'in_progress' });
+      // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+      expect(mockClient.get).toHaveBeenCalledWith(expect.stringContaining('/task-pool/items'));
+      expect(mockClient.get).toHaveBeenCalledWith(expect.stringContaining('status=in_progress'));
+    });
+
+    it('should fetch all tasks when no status filter', async () => {
+      mockClient.get.mockResolvedValue({ success: true, status: 200, data: [] });
+      await tools.get_tasks.execute({ projectPath: '/proj' });
+      expect(mockClient.get).toHaveBeenCalledWith(expect.not.stringContaining('status='));
+    });
+  });
+
+  describe('recall_goals', () => {
+    it('should call memory recall with project scope', async () => {
+      mockClient.post.mockResolvedValue({ success: true, status: 200, data: { goals: ['OKR1'] } });
+      const result = await tools.recall_goals.execute({ context: 'current goals' });
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/recall', {
+        context: 'current goals',
+        scope: 'project',
+      });
+      expect(result).toEqual({ goals: ['OKR1'] });
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should return combined teams and projects status', async () => {
+      mockClient.get.mockResolvedValueOnce({ success: true, status: 200, data: [{ id: 't1' }] });
+      mockClient.get.mockResolvedValueOnce({ success: true, status: 200, data: [{ id: 'p1' }] });
+      const result = await tools.heartbeat.execute({}) as Record<string, unknown>;
+      expect(result.teams).toEqual([{ id: 't1' }]);
+      expect(result.projects).toEqual([{ id: 'p1' }]);
+      expect(result.timestamp).toBeTruthy();
+    });
+  });
+
+  describe('get_agent_status', () => {
+    it('should find agent by session name across teams', async () => {
+      mockClient.get.mockResolvedValue({
+        success: true,
+        status: 200,
+        data: [
+          { members: [{ sessionName: 'other', name: 'Other' }] },
+          { members: [{ sessionName: 'target', name: 'Target', agentStatus: 'active' }] },
+        ],
+      });
+      const result = await tools.get_agent_status.execute({ sessionName: 'target' });
+      expect(result).toEqual({ sessionName: 'target', name: 'Target', agentStatus: 'active' });
+    });
+
+    it('should return error when agent not found', async () => {
+      mockClient.get.mockResolvedValue({ success: true, status: 200, data: [{ members: [] }] });
+      const result = await tools.get_agent_status.execute({ sessionName: 'missing' }) as { error: string };
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('subscribe_event', () => {
+    it('should subscribe with auditor as target', async () => {
+      mockClient.post.mockResolvedValue({ success: true, status: 200, data: { subscriptionId: 's1' } });
+      await tools.subscribe_event.execute({
+        eventType: 'agent:idle',
+        oneShot: false,
+      });
+      expect(mockClient.post).toHaveBeenCalledWith('/events/subscribe', expect.objectContaining({
+        eventType: 'agent:idle',
+        target: 'crewly-auditor',
+      }));
+    });
+  });
+
+  describe('reply_slack', () => {
+    it('should send message via slack API', async () => {
+      mockClient.post.mockResolvedValue({ success: true, status: 200, data: { ok: true } });
+      const result = await tools.reply_slack.execute({
+        text: 'Here are the audit findings...',
+        channelId: 'C12345',
+        threadTs: '1234567890.123456',
+      }) as { sent: boolean };
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C12345',
+        text: 'Here are the audit findings...',
+        threadTs: '1234567890.123456',
+      });
+      expect(result.sent).toBe(true);
+    });
+
+    it('should return error on failure', async () => {
+      mockClient.post.mockResolvedValue({ success: false, status: 500, error: 'Slack API error' });
+      const result = await tools.reply_slack.execute({
+        text: 'test',
+        channelId: 'C1',
+        threadTs: 't1',
+      }) as { error: string };
+      expect(result.error).toBe('Slack API error');
+    });
+  });
+
+  describe('write_audit_report', () => {
+    it('should create bugs.md with header when file does not exist', async () => {
+      readFileSpy.mockRejectedValue(new Error('ENOENT') as never);
+      writeFileSpy.mockResolvedValue(undefined as never);
+
+      const result = await tools.write_audit_report.execute({
+        severity: 'high',
+        agents: ['agent-sam'],
+        title: 'Agent stuck in loop',
+        description: 'Agent Sam has been retrying the same operation for 30 minutes.',
+        evidence: 'Error: Build failed\nError: Build failed\nError: Build failed',
+        suggestion: 'Investigate build configuration or reset agent.',
+      }) as { success: boolean; severity: string; title: string };
+
+      expect(mkdirSpy).toHaveBeenCalledWith(
+        path.join(projectPath, '.crewly', 'audit'),
+        { recursive: true },
+      );
+      expect(writeFileSpy).toHaveBeenCalled();
+      const written = (writeFileSpy.mock.calls[0] as any[])[1] as string;
+      expect(written).toContain('# Crewly Audit');
+      expect(written).toContain('[HIGH] Agent stuck in loop');
+      expect(written).toContain('agent-sam');
+      expect(written).toContain('Build failed');
+      expect(result.success).toBe(true);
+      expect(result.severity).toBe('high');
+    });
+
+    it('should append to existing bugs.md', async () => {
+      readFileSpy.mockResolvedValue('# Existing content\n\n---\n' as never);
+      writeFileSpy.mockResolvedValue(undefined as never);
+
+      await tools.write_audit_report.execute({
+        severity: 'medium',
+        agents: ['agent-leo'],
+        title: 'Idle agent with pending tasks',
+        description: 'Leo has been idle for 20 minutes with 2 open tasks.',
+        evidence: 'Status: idle. Open tasks: task-123, task-456',
+        suggestion: 'Send a nudge message to Leo.',
+      });
+
+      const written = (writeFileSpy.mock.calls[0] as any[])[1] as string;
+      expect(written).toContain('# Existing content');
+      expect(written).toContain('[MEDIUM] Idle agent');
+    });
+
+    it('should use correct severity icons', async () => {
+      readFileSpy.mockRejectedValue(new Error('ENOENT') as never);
+      writeFileSpy.mockResolvedValue(undefined as never);
+
+      for (const [sev, icon] of [['critical', '🔴'], ['high', '🟠'], ['medium', '🟡'], ['low', '🔵']] as const) {
+        await tools.write_audit_report.execute({
+          severity: sev,
+          agents: ['test'],
+          title: `${sev} issue`,
+          description: 'Test',
+          evidence: 'Test',
+          suggestion: 'Test',
+        });
+      }
+
+      const calls = writeFileSpy.mock.calls;
+      expect((calls[0] as any[])[1]).toContain('🔴');
+      expect((calls[1] as any[])[1]).toContain('🟠');
+      expect((calls[2] as any[])[1]).toContain('🟡');
+      expect((calls[3] as any[])[1]).toContain('🔵');
+    });
+  });
+
+  describe('read_audit_history', () => {
+    it('should return recent findings', async () => {
+      readFileSpy.mockResolvedValue('# Header\n---\nFinding 1\n---\nFinding 2\n---\nFinding 3' as never);
+      const result = await tools.read_audit_history.execute({ lastN: 2 }) as { totalFindings: number };
+      expect(result.totalFindings).toBe(3); // 4 sections - 1 header
+    });
+
+    it('should return empty when no history', async () => {
+      readFileSpy.mockRejectedValue(new Error('ENOENT') as never);
+      const result = await tools.read_audit_history.execute({ lastN: 10 }) as { totalFindings: number; recentFindings: string };
+      expect(result.totalFindings).toBe(0);
+      expect(result.recentFindings).toContain('No audit history');
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/auditor-tools.ts
+++ b/packages/crewly-agent/src/runtime/auditor-tools.ts
@@ -1,0 +1,311 @@
+/**
+ * Crewly Auditor Tool Registry
+ *
+ * Read-only tools for the Auditor agent. These tools allow the auditor
+ * to observe agent activity, read logs, check task alignment, and write
+ * structured bug reports — without any ability to modify system state.
+ *
+ * @module services/agent/crewly-agent/auditor-tools
+ */
+
+import { promises as fsPromises } from 'fs';
+import * as path from 'path';
+import { z } from 'zod';
+import type { CrewlyApiClient } from './api-client.js';
+import type { ToolDefinition } from './types.js';
+import { convertMarkdownToSlackMrkdwn } from './tool-registry.js';
+
+/** Severity levels for audit findings */
+const AUDIT_SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+
+/**
+ * Create the auditor tool set for the Crewly Auditor agent.
+ *
+ * All tools are read-only except `write_audit_report` which appends
+ * to the audit log file.
+ *
+ * @param client - API client for Crewly REST API calls
+ * @param projectPath - Project root path for file operations
+ * @returns Object of named tools for the auditor agent
+ */
+export function createAuditorTools(
+  client: CrewlyApiClient,
+  projectPath: string,
+): Record<string, ToolDefinition> {
+  const auditDir = path.join(projectPath, '.crewly', 'audit');
+  const bugsFile = path.join(auditDir, 'bugs.md');
+
+  return {
+    get_team_status: {
+      description: 'Get status of all teams and their agents. Returns team names, member statuses, and runtime types.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await client.get('/teams');
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    get_agent_logs: {
+      description: 'Get recent terminal output from an agent session. Use to inspect agent activity and detect errors.',
+      inputSchema: z.object({
+        sessionName: z.string().describe('Agent session name'),
+        lines: z.number().default(50).describe('Number of lines to retrieve'),
+      }),
+      execute: async (args) => {
+        const { sessionName, lines } = args as { sessionName: string; lines: number };
+        const result = await client.get(`/terminal/${sessionName}/output?lines=${lines}`);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    get_tasks: {
+      description: 'Get all tracked tasks for a project. Use to detect stale, failed, or orphaned tasks.',
+      inputSchema: z.object({
+        projectPath: z.string().describe('Project path'),
+        status: z.string().optional().describe('Filter by status (open, in_progress, done, failed)'),
+      }),
+      execute: async (args) => {
+        // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+        // The V3 task-pool is global; `projectPath` is no longer a filter.
+        const { status } = args as { projectPath: string; status?: string };
+        const query = status ? `?status=${encodeURIComponent(status)}` : '';
+        const result = await client.get(`/task-pool/items${query}`);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    recall_goals: {
+      description: 'Retrieve current project goals, OKRs, and objectives from memory. Use to check goal alignment.',
+      inputSchema: z.object({
+        context: z.string().default('current project goals OKR objectives priorities').describe('Search context'),
+      }),
+      execute: async (args) => {
+        const { context } = args as { context: string };
+        const result = await client.post('/memory/recall', {
+          context,
+          scope: 'project',
+        });
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    heartbeat: {
+      description: 'System health check. Returns teams, projects, and queue status in one call.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const [teams, projects] = await Promise.all([
+          client.get('/teams'),
+          client.get('/projects'),
+        ]);
+        return {
+          teams: teams.success ? teams.data : { error: teams.error },
+          projects: projects.success ? projects.data : { error: projects.error },
+          timestamp: new Date().toISOString(),
+        };
+      },
+    },
+
+    get_agent_status: {
+      description: 'Get the current status of a specific agent by session name.',
+      inputSchema: z.object({
+        sessionName: z.string().describe('Agent session name to check'),
+      }),
+      execute: async (args) => {
+        const { sessionName } = args as { sessionName: string };
+        const result = await client.get('/teams');
+        if (!result.success) return { error: result.error };
+        const teams = result.data as Array<{ members?: Array<{ sessionName: string }> }>;
+        for (const team of teams) {
+          const member = team.members?.find(m => m.sessionName === sessionName);
+          if (member) return member;
+        }
+        return { error: `Agent '${sessionName}' not found` };
+      },
+    },
+
+    subscribe_event: {
+      description: 'Subscribe to agent lifecycle events for monitoring. Read-only observation.',
+      inputSchema: z.object({
+        eventType: z.string().describe('Event type (e.g., "agent:idle", "agent:busy", "agent:status_changed")'),
+        filter: z.record(z.string()).optional().describe('Event filter criteria'),
+        oneShot: z.boolean().default(false).describe('Auto-unsubscribe after first event'),
+      }),
+      execute: async (args) => {
+        const { eventType, filter, oneShot } = args as { eventType: string; filter?: Record<string, string>; oneShot: boolean };
+        const result = await client.post('/events/subscribe', {
+          eventType,
+          filter,
+          oneShot,
+          target: 'crewly-auditor',
+        });
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    write_audit_report: {
+      description: 'Append a structured audit finding to the bugs.md file. Use when you detect a problem.',
+      inputSchema: z.object({
+        severity: z.enum(AUDIT_SEVERITIES).describe('Problem severity level'),
+        agents: z.array(z.string()).describe('Session names of involved agents'),
+        title: z.string().describe('Short problem title'),
+        description: z.string().describe('Detailed problem description'),
+        evidence: z.string().describe('Log excerpts or data supporting the finding'),
+        suggestion: z.string().describe('Recommended fix or action'),
+      }),
+      execute: async (args) => {
+        const { severity, agents, title, description, evidence, suggestion } =
+          args as { severity: string; agents: string[]; title: string; description: string; evidence: string; suggestion: string };
+
+        const timestamp = new Date().toISOString();
+        const severityIcon = severity === 'critical' ? '🔴' : severity === 'high' ? '🟠' : severity === 'medium' ? '🟡' : '🔵';
+
+        const entry = [
+          '',
+          `### ${severityIcon} [${severity.toUpperCase()}] ${title}`,
+          `**Time:** ${timestamp}`,
+          `**Agents:** ${agents.join(', ')}`,
+          '',
+          description,
+          '',
+          '**Evidence:**',
+          '```',
+          evidence,
+          '```',
+          '',
+          `**Suggestion:** ${suggestion}`,
+          '',
+          '---',
+          '',
+        ].join('\n');
+
+        // Ensure audit directory exists
+        await fsPromises.mkdir(auditDir, { recursive: true });
+
+        // Append to bugs.md (create with header if new)
+        let existing = '';
+        try {
+          existing = await fsPromises.readFile(bugsFile, 'utf8');
+        } catch {
+          existing = '# Crewly Audit — Bug Reports\n\nAutomated findings from the Crewly Auditor agent.\n\n---\n';
+        }
+
+        await fsPromises.writeFile(bugsFile, existing + entry, 'utf8');
+
+        return {
+          success: true,
+          file: bugsFile,
+          severity,
+          title,
+          timestamp,
+        };
+      },
+    },
+
+    reply_slack: {
+      description: 'Send a message directly to a Slack thread. Use this to respond to user questions when SLACK_CONTEXT is present. Supports Slack mrkdwn formatting.',
+      inputSchema: z.object({
+        text: z.string().describe('Message text in Slack mrkdwn format'),
+        channelId: z.string().describe('Slack channel ID from SLACK_CONTEXT'),
+        threadTs: z.string().describe('Slack thread timestamp from SLACK_CONTEXT'),
+      }),
+      execute: async (args) => {
+        const { text, channelId, threadTs } = args as { text: string; channelId: string; threadTs: string };
+        // #181: Convert markdown to Slack mrkdwn format
+        const slackText = convertMarkdownToSlackMrkdwn(text);
+        const result = await client.post('/slack/send', { channelId, text: slackText, threadTs });
+        return result.success ? { sent: true } : { error: result.error };
+      },
+    },
+
+    create_github_issue: {
+      description: 'Create a GitHub issue for a bug or enhancement found during audit (#178). Deduplicates: checks existing open issues before creating. Requires gh CLI to be available.',
+      inputSchema: z.object({
+        title: z.string().describe('Issue title (include severity prefix like [Critical], [High], [Medium])'),
+        body: z.string().describe('Issue body in markdown format'),
+        labels: z.array(z.string()).default(['bug']).describe('GitHub labels (e.g., bug, enhancement)'),
+      }),
+      execute: async (args) => {
+        const { title, body, labels } = args as { title: string; body: string; labels: string[] };
+        const { execSync } = await import('child_process');
+
+        try {
+          // Dedup: search for existing open issues with similar title
+          const searchQuery = title.replace(/\[.*?\]\s*/, '').slice(0, 50);
+          let existingIssues = '';
+          try {
+            existingIssues = execSync(
+              `gh issue list --state open --search "${searchQuery.replace(/"/g, '\\"')}" --json number,title --limit 5`,
+              { encoding: 'utf-8', timeout: 15000 }
+            );
+          } catch { /* gh not available or no repo */ }
+
+          if (existingIssues) {
+            const issues = JSON.parse(existingIssues);
+            const duplicate = issues.find((i: { title: string }) =>
+              i.title.toLowerCase().includes(searchQuery.toLowerCase().slice(0, 30))
+            );
+            if (duplicate) {
+              return {
+                success: true,
+                created: false,
+                duplicate: true,
+                existingIssue: `#${duplicate.number}: ${duplicate.title}`,
+              };
+            }
+          }
+
+          // Create the issue
+          const labelFlag = labels.map(l => `--label "${l}"`).join(' ');
+          const result = execSync(
+            `gh issue create --title "${title.replace(/"/g, '\\"')}" --body "${body.replace(/"/g, '\\"')}" ${labelFlag}`,
+            { encoding: 'utf-8', timeout: 30000 }
+          );
+
+          const issueUrl = result.trim();
+          return { success: true, created: true, url: issueUrl, title };
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+            note: 'GitHub CLI (gh) may not be installed or authenticated',
+          };
+        }
+      },
+    },
+
+    read_audit_history: {
+      description: 'Read previous audit findings from bugs.md. Use to avoid duplicate reports.',
+      inputSchema: z.object({
+        lastN: z.number().default(10).describe('Number of recent findings to return'),
+      }),
+      execute: async (args) => {
+        const { lastN } = args as { lastN: number };
+        try {
+          const content = await fsPromises.readFile(bugsFile, 'utf8');
+          // Split on --- separator, take last N entries
+          const entries = content.split('---').filter(e => e.trim());
+          const recent = entries.slice(-lastN);
+          return {
+            totalFindings: entries.length - 1, // subtract header
+            recentFindings: recent.join('---'),
+          };
+        } catch {
+          return { totalFindings: 0, recentFindings: 'No audit history found.' };
+        }
+      },
+    },
+  };
+}
+
+/**
+ * Get the list of auditor tool names.
+ *
+ * @returns Array of auditor tool name strings
+ */
+export function getAuditorToolNames(): string[] {
+  return [
+    'get_team_status', 'get_agent_logs', 'get_tasks', 'recall_goals',
+    'heartbeat', 'get_agent_status', 'subscribe_event',
+    'write_audit_report', 'reply_slack', 'read_audit_history', 'create_github_issue',
+  ];
+}

--- a/packages/crewly-agent/src/runtime/cloud-config.ts
+++ b/packages/crewly-agent/src/runtime/cloud-config.ts
@@ -1,0 +1,67 @@
+/**
+ * Cloud config helper for tools that need to talk to api.crewlyai.com.
+ *
+ * Reads `~/.crewly/cloud/config.json` (the same file the OSS server writes
+ * during `crewly login`). Each call re-reads from disk so token refreshes are
+ * picked up without process restart.
+ *
+ * @module services/agent/crewly-agent/cloud-config
+ */
+
+import { promises as fs } from 'fs';
+import { homedir } from 'os';
+import * as path from 'path';
+
+export interface CloudConfig {
+  cloudUrl: string;
+  token: string;
+  tier?: string;
+  refreshToken?: string;
+}
+
+export const CLOUD_CONFIG_PATH = path.join(homedir(), '.crewly', 'cloud', 'config.json');
+
+export class CloudNotLoggedInError extends Error {
+  constructor() {
+    super(
+      `Crewly Cloud is not connected. Run \`crewly login\` (or open the Crewly desktop app and sign in) to enable cloud-backed tools.`,
+    );
+    this.name = 'CloudNotLoggedInError';
+  }
+}
+
+export async function loadCloudConfig(filePath: string = CLOUD_CONFIG_PATH): Promise<CloudConfig> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new CloudNotLoggedInError();
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Cloud config at ${filePath} is not valid JSON.`);
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as Record<string, unknown>)['cloudUrl'] !== 'string' ||
+    typeof (parsed as Record<string, unknown>)['token'] !== 'string'
+  ) {
+    throw new CloudNotLoggedInError();
+  }
+
+  const cfg = parsed as Record<string, unknown>;
+  return {
+    cloudUrl: (cfg['cloudUrl'] as string).replace(/\/$/, ''),
+    token: cfg['token'] as string,
+    tier: typeof cfg['tier'] === 'string' ? (cfg['tier'] as string) : undefined,
+    refreshToken: typeof cfg['refreshToken'] === 'string' ? (cfg['refreshToken'] as string) : undefined,
+  };
+}

--- a/packages/crewly-agent/src/runtime/deepseek-sse-transform.test.ts
+++ b/packages/crewly-agent/src/runtime/deepseek-sse-transform.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for DeepSeek SSE Transform.
+ *
+ * Coverage:
+ * - parseSseBlock: well-formed reasoning chunks, plain content (no reasoning),
+ *   `[DONE]` sentinel, malformed JSON resilience, multi-line blocks.
+ * - teeAndParse: passthrough body identical to source, reasoning accumulation
+ *   across chunks, parser error isolation from consumer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSseBlock, teeAndParse } from './deepseek-sse-transform.js';
+
+/**
+ * Helper to build a ReadableStream<Uint8Array> from a list of string chunks.
+ * Each chunk becomes one stream queue entry — useful to simulate SSE arriving
+ * in arbitrary network packet boundaries.
+ */
+function streamOf(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	let i = 0;
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (i >= chunks.length) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(encoder.encode(chunks[i]!));
+			i++;
+		},
+	});
+}
+
+/**
+ * Drain a ReadableStream<Uint8Array> into a single decoded string.
+ */
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let out = '';
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		out += decoder.decode(value, { stream: true });
+	}
+	out += decoder.decode();
+	return out;
+}
+
+describe('parseSseBlock', () => {
+	it('extracts reasoning_content from a single delta chunk', () => {
+		const block = 'data: {"choices":[{"delta":{"reasoning_content":"Let me think..."}}]}';
+		expect(parseSseBlock(block)).toBe('Let me think...');
+	});
+
+	it('returns empty string when delta has only content (no reasoning)', () => {
+		const block = 'data: {"choices":[{"delta":{"content":"answer"}}]}';
+		expect(parseSseBlock(block)).toBe('');
+	});
+
+	it('returns null for [DONE] sentinel', () => {
+		expect(parseSseBlock('data: [DONE]')).toBeNull();
+	});
+
+	it('handles multi-line block with multiple data: lines', () => {
+		const block = [
+			'data: {"choices":[{"delta":{"reasoning_content":"step 1 "}}]}',
+			'data: {"choices":[{"delta":{"reasoning_content":"step 2"}}]}',
+		].join('\n');
+		expect(parseSseBlock(block)).toBe('step 1 step 2');
+	});
+
+	it('skips malformed JSON without throwing', () => {
+		const block = 'data: {not valid json';
+		expect(parseSseBlock(block)).toBe('');
+	});
+
+	it('skips non-data: lines (e.g. event:, id:)', () => {
+		const block = [
+			'id: abc',
+			'event: chunk',
+			'data: {"choices":[{"delta":{"reasoning_content":"x"}}]}',
+		].join('\n');
+		expect(parseSseBlock(block)).toBe('x');
+	});
+
+	it('returns empty string for empty data payload', () => {
+		expect(parseSseBlock('data:')).toBe('');
+		expect(parseSseBlock('data: ')).toBe('');
+	});
+
+	it('handles delta with both content and reasoning_content (returns only reasoning)', () => {
+		const block =
+			'data: {"choices":[{"delta":{"content":"answer","reasoning_content":"thought"}}]}';
+		expect(parseSseBlock(block)).toBe('thought');
+	});
+});
+
+describe('teeAndParse', () => {
+	it('passthroughBody yields exactly the source bytes', async () => {
+		const source = [
+			'data: {"choices":[{"delta":{"reasoning_content":"r1"}}]}\n\n',
+			'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+			'data: [DONE]\n\n',
+		];
+		const expected = source.join('');
+		const stream = streamOf(source);
+		const parsed = teeAndParse(stream);
+		const got = await drain(parsed.passthroughBody);
+		expect(got).toBe(expected);
+	});
+
+	it('accumulates reasoning_content across multiple chunks', async () => {
+		const source = [
+			'data: {"choices":[{"delta":{"reasoning_content":"alpha "}}]}\n\n',
+			'data: {"choices":[{"delta":{"reasoning_content":"beta "}}]}\n\n',
+			'data: {"choices":[{"delta":{"reasoning_content":"gamma"}}]}\n\n',
+			'data: [DONE]\n\n',
+		];
+		const stream = streamOf(source);
+		const parsed = teeAndParse(stream);
+		await drain(parsed.passthroughBody);
+		// Wait one microtask cycle for parser branch to finish draining.
+		// Parser branch runs in the same event loop but completes async; the
+		// consumer drain above ensures backpressure has cleared.
+		await new Promise((r) => setImmediate(r));
+		expect(parsed.getReasoning()).toBe('alpha beta gamma');
+	});
+
+	it('handles SSE chunks split across packet boundaries', async () => {
+		// Simulate a single SSE event arriving in two TCP packets.
+		const source = [
+			'data: {"choices":[{"delta":{"reaso',
+			'ning_content":"split"}}]}\n\n',
+			'data: [DONE]\n\n',
+		];
+		const stream = streamOf(source);
+		const parsed = teeAndParse(stream);
+		await drain(parsed.passthroughBody);
+		await new Promise((r) => setImmediate(r));
+		expect(parsed.getReasoning()).toBe('split');
+	});
+
+	it('isDrained becomes true after [DONE] sentinel is parsed', async () => {
+		const source = ['data: {"choices":[{"delta":{"content":"x"}}]}\n\n', 'data: [DONE]\n\n'];
+		const stream = streamOf(source);
+		const parsed = teeAndParse(stream);
+		expect(parsed.isDrained()).toBe(false);
+		await drain(parsed.passthroughBody);
+		await new Promise((r) => setImmediate(r));
+		expect(parsed.isDrained()).toBe(true);
+	});
+
+	it('returns empty reasoning when stream contains no reasoning_content', async () => {
+		const source = [
+			'data: {"choices":[{"delta":{"content":"plain answer"}}]}\n\n',
+			'data: [DONE]\n\n',
+		];
+		const stream = streamOf(source);
+		const parsed = teeAndParse(stream);
+		await drain(parsed.passthroughBody);
+		await new Promise((r) => setImmediate(r));
+		expect(parsed.getReasoning()).toBe('');
+	});
+});

--- a/packages/crewly-agent/src/runtime/deepseek-sse-transform.ts
+++ b/packages/crewly-agent/src/runtime/deepseek-sse-transform.ts
@@ -1,0 +1,168 @@
+/**
+ * DeepSeek SSE Transform — extracts `reasoning_content` from DeepSeek-R1 streaming responses.
+ *
+ * **Why this exists:**
+ * DeepSeek-R1 (`deepseek-reasoner`) returns chain-of-thought as `delta.reasoning_content`
+ * inside each SSE chunk. The Vercel AI SDK's @ai-sdk/openai chat-completions parser
+ * (3.0.41) accumulates `reasoning_tokens` into `usage.reasoningTokens` (correct billing
+ * surface) but **does not** map `reasoning_content` text to any content-part or
+ * `reasoningText` field. Result: users pay for reasoning tokens but the reasoning
+ * text is silently dropped.
+ *
+ * **What this module does:**
+ * - Pure stream transformer: takes a DeepSeek SSE response body, tees it,
+ *   passes one branch through unchanged (for AI SDK to consume normally),
+ *   and parses the other branch to extract reasoning_content into an
+ *   accumulator string.
+ * - Zero dependency on AI SDK internals — operates only on the raw SSE byte
+ *   stream that AI SDK is about to consume.
+ *
+ * **Architectural note (Sam memo reconciliation):**
+ * Earlier scope memo referenced wrapping a "PR #425 translator output" layer.
+ * Verified: PR #425 is the frontend Settings UI fix; no Crewly-owned translator
+ * exists. The only seam Crewly owns between DeepSeek and the AI SDK is the
+ * `createOpenAI({ fetch })` upstream hook in model-manager.ts. This module is
+ * the body of that hook.
+ *
+ * **DeepClaude pattern reference (read-only):**
+ * Reasoning-content extraction approach borrowed conceptually from public
+ * DeepClaude pattern (HTTP proxy that splits R1 reasoning from final answer).
+ * **No code, no fork, no dependency** — pattern reference only, per Anthropic
+ * ToS guardrail flagged by Arch.
+ *
+ * @module services/agent/crewly-agent/deepseek-sse-transform
+ */
+
+/**
+ * Shape of a single SSE `data:` payload from DeepSeek's chat-completions endpoint.
+ * Only the fields we read are typed; the rest is left open.
+ */
+interface DeepseekSseChunk {
+	choices?: Array<{
+		delta?: {
+			content?: string;
+			reasoning_content?: string;
+		};
+		finish_reason?: string | null;
+	}>;
+}
+
+/**
+ * Result of teeing and parsing a DeepSeek SSE body.
+ *
+ * - `passthroughBody` is the un-tampered byte stream that should be handed
+ *   to the consumer (AI SDK) as the response body.
+ * - `getReasoning()` returns the accumulated reasoning_content text once
+ *   the underlying stream has fully drained. Calling it before drain
+ *   returns whatever has been parsed so far.
+ */
+export interface ParsedDeepseekSse {
+	passthroughBody: ReadableStream<Uint8Array>;
+	getReasoning(): string;
+	/** True once the parser has seen the SSE `[DONE]` sentinel or stream end. */
+	isDrained(): boolean;
+}
+
+/**
+ * Parse a single SSE event-block (one or more `data:` lines + a blank line).
+ *
+ * Returns the accumulated reasoning_content string from this block, or
+ * empty string if the block had no reasoning content. Returns `null` if
+ * the block is the `[DONE]` sentinel.
+ *
+ * @param block - One SSE event block (between blank-line delimiters)
+ * @returns reasoning_content string, or `null` if `[DONE]`
+ */
+export function parseSseBlock(block: string): string | null {
+	const lines = block.split('\n');
+	let reasoning = '';
+	for (const line of lines) {
+		if (!line.startsWith('data:')) continue;
+		const payload = line.slice(5).trim();
+		if (!payload) continue;
+		if (payload === '[DONE]') return null;
+		try {
+			const chunk = JSON.parse(payload) as DeepseekSseChunk;
+			const r = chunk.choices?.[0]?.delta?.reasoning_content;
+			if (typeof r === 'string') {
+				reasoning += r;
+			}
+		} catch {
+			// Malformed JSON — skip silently; AI SDK consumer will surface
+			// any real error itself when it parses the same chunk.
+		}
+	}
+	return reasoning;
+}
+
+/**
+ * Tee a DeepSeek SSE response body and parse one branch for reasoning_content
+ * while passing the other branch through to the AI SDK consumer unchanged.
+ *
+ * The parser runs as a fire-and-forget background reader on the cloned stream.
+ * It accumulates reasoning text into an internal buffer that the caller can
+ * read via `getReasoning()` after the consumer has drained the passthrough.
+ *
+ * **Stream safety:**
+ * - The tee is symmetric: backpressure on the consumer branch does not
+ *   stall the parser branch (and vice versa) thanks to ReadableStream.tee()
+ *   internal buffering.
+ * - Parser errors are caught and logged but never propagated to the consumer.
+ *
+ * @param body - Raw SSE response body from DeepSeek
+ * @returns Object with passthrough body and reasoning accumulator
+ */
+export function teeAndParse(body: ReadableStream<Uint8Array>): ParsedDeepseekSse {
+	const [consumerBranch, parserBranch] = body.tee();
+	let reasoning = '';
+	let drained = false;
+
+	// Background reader: drain parserBranch, parse SSE, accumulate reasoning.
+	// Errors are swallowed — consumer branch is independent and unaffected.
+	void (async () => {
+		const reader = parserBranch.getReader();
+		const decoder = new TextDecoder();
+		let buffer = '';
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				// SSE event blocks are delimited by blank lines (\n\n).
+				let blankIdx: number;
+				while ((blankIdx = buffer.indexOf('\n\n')) >= 0) {
+					const block = buffer.slice(0, blankIdx);
+					buffer = buffer.slice(blankIdx + 2);
+					const result = parseSseBlock(block);
+					if (result === null) {
+						drained = true;
+					} else if (result) {
+						reasoning += result;
+					}
+				}
+			}
+			// Flush trailing partial block (if SSE source ended mid-block — defensive)
+			if (buffer.trim()) {
+				const result = parseSseBlock(buffer);
+				if (result && result !== null) reasoning += result;
+			}
+		} catch (err) {
+			// Parser failures must not break consumer flow — log and exit.
+			// eslint-disable-next-line no-console
+			console.warn('[DeepSeek SSE Transform] parser branch error (consumer unaffected):', err);
+		} finally {
+			drained = true;
+			try {
+				reader.releaseLock();
+			} catch {
+				/* already released */
+			}
+		}
+	})();
+
+	return {
+		passthroughBody: consumerBranch,
+		getReasoning: () => reasoning,
+		isDrained: () => drained,
+	};
+}

--- a/packages/crewly-agent/src/runtime/env-isolation.service.ts
+++ b/packages/crewly-agent/src/runtime/env-isolation.service.ts
@@ -1,0 +1,246 @@
+/**
+ * Environment Isolation Service
+ *
+ * Strips sensitive environment variables (API keys, tokens, secrets) from
+ * child process environments when agents execute bash commands. Maintains
+ * an allowlist of safe variables and provides a mechanism to explicitly
+ * pass specific vars when needed.
+ *
+ * @module services/agent/crewly-agent/env-isolation.service
+ *
+ * @example
+ * ```typescript
+ * const isolation = new EnvIsolationService();
+ * const safeEnv = isolation.createSafeEnv(process.env);
+ * // safeEnv has PATH, HOME, etc. but no ANTHROPIC_API_KEY
+ *
+ * const withOverrides = isolation.createSafeEnv(process.env, ['MY_CUSTOM_VAR']);
+ * // safeEnv + MY_CUSTOM_VAR explicitly included
+ * ```
+ */
+
+/**
+ * Environment variables that are always safe to pass to child processes.
+ * These are essential for basic shell operation and don't contain secrets.
+ */
+export const SAFE_ENV_ALLOWLIST: readonly string[] = [
+  // System essentials
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'TERM',
+  'TERM_PROGRAM',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+
+  // Node.js / runtime
+  'NODE_ENV',
+  'NODE_PATH',
+  'NODE_OPTIONS',
+  'NPM_CONFIG_PREFIX',
+  'NVM_DIR',
+  'NVM_BIN',
+
+  // Build tools
+  'FORCE_COLOR',
+  'NO_COLOR',
+  'CI',
+  'EDITOR',
+  'VISUAL',
+  'PAGER',
+
+  // Git (non-secret)
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+
+  // Platform
+  'HOSTNAME',
+  'PWD',
+  'OLDPWD',
+  'SHLVL',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME',
+  'XDG_CACHE_HOME',
+  'XDG_RUNTIME_DIR',
+
+  // macOS specifics
+  'COMMAND_MODE',
+  '__CF_USER_TEXT_ENCODING',
+
+  // Python
+  'PYTHONPATH',
+  'VIRTUAL_ENV',
+
+  // Rust
+  'CARGO_HOME',
+  'RUSTUP_HOME',
+
+  // Go
+  'GOPATH',
+  'GOROOT',
+
+  // Java
+  'JAVA_HOME',
+
+  // Homebrew
+  'HOMEBREW_PREFIX',
+  'HOMEBREW_CELLAR',
+  'HOMEBREW_REPOSITORY',
+] as const;
+
+/**
+ * Patterns that identify sensitive environment variable names.
+ * Variables matching these patterns are stripped from child processes.
+ */
+export const SENSITIVE_ENV_PATTERNS: readonly RegExp[] = [
+  /api[_-]?key/i,
+  /api[_-]?secret/i,
+  /api[_-]?token/i,
+  /secret[_-]?key/i,
+  /access[_-]?key/i,
+  /access[_-]?token/i,
+  /auth[_-]?token/i,
+  /bearer[_-]?token/i,
+  /private[_-]?key/i,
+  /password/i,
+  /passwd/i,
+  /credential/i,
+  /^AWS_SECRET/i,
+  /^AWS_SESSION/i,
+  /^ANTHROPIC_API/i,
+  /^OPENAI_API/i,
+  /^GOOGLE_API/i,
+  /^GOOGLE_APPLICATION_CREDENTIALS/i,
+  /^STRIPE_SECRET/i,
+  /^SUPABASE_SERVICE_ROLE/i,
+  /^DATABASE_URL$/i,
+  /^REDIS_URL$/i,
+  /^MONGODB_URI$/i,
+  /^GITHUB_TOKEN$/i,
+  /^GH_TOKEN$/i,
+  /^NPM_TOKEN$/i,
+  /^DOCKER_PASSWORD$/i,
+  /^DOCKER_AUTH$/i,
+  /connection[_-]?string/i,
+  /^SENTRY_DSN$/i,
+  /^DATADOG_API_KEY$/i,
+  /^SENDGRID_API_KEY$/i,
+  /^TWILIO_AUTH_TOKEN$/i,
+  /^SLACK_BOT_TOKEN$/i,
+  /^SLACK_TOKEN$/i,
+  /^DISCORD_TOKEN$/i,
+  /^WEBHOOK_SECRET$/i,
+  /^SIGNING_SECRET$/i,
+  /^ENCRYPTION_KEY$/i,
+  /^JWT_SECRET$/i,
+  /^SESSION_SECRET$/i,
+] as const;
+
+/**
+ * Service that creates sanitized environment objects for child processes.
+ */
+export class EnvIsolationService {
+  private readonly allowlist: Set<string>;
+  private readonly sensitivePatterns: readonly RegExp[];
+
+  /**
+   * Creates a new EnvIsolationService.
+   *
+   * @param additionalSafeVars - Extra variable names to always allow
+   * @param additionalSensitivePatterns - Extra patterns to block
+   */
+  constructor(
+    additionalSafeVars?: string[],
+    additionalSensitivePatterns?: RegExp[],
+  ) {
+    this.allowlist = new Set([...SAFE_ENV_ALLOWLIST, ...(additionalSafeVars || [])]);
+    this.sensitivePatterns = additionalSensitivePatterns
+      ? [...SENSITIVE_ENV_PATTERNS, ...additionalSensitivePatterns]
+      : SENSITIVE_ENV_PATTERNS;
+  }
+
+  /**
+   * Creates a safe environment object by filtering out sensitive variables.
+   *
+   * Strategy:
+   * 1. Start with all env vars
+   * 2. Keep vars on the allowlist
+   * 3. Remove vars matching sensitive patterns
+   * 4. Add explicitly requested vars (overrides)
+   *
+   * @param sourceEnv - Source environment (typically process.env)
+   * @param explicitVars - Variable names to explicitly include even if they'd be filtered
+   * @returns Sanitized environment object safe for child processes
+   */
+  createSafeEnv(
+    sourceEnv: Record<string, string | undefined>,
+    explicitVars?: string[],
+  ): Record<string, string> {
+    const safeEnv: Record<string, string> = {};
+    const explicitSet = new Set(explicitVars || []);
+
+    for (const [key, value] of Object.entries(sourceEnv)) {
+      if (value === undefined) continue;
+
+      // Always include explicitly requested vars
+      if (explicitSet.has(key)) {
+        safeEnv[key] = value;
+        continue;
+      }
+
+      // Include if on allowlist
+      if (this.allowlist.has(key)) {
+        safeEnv[key] = value;
+        continue;
+      }
+
+      // Skip if matches a sensitive pattern
+      if (this.isSensitive(key)) {
+        continue;
+      }
+
+      // Default: include non-sensitive vars not on either list
+      safeEnv[key] = value;
+    }
+
+    return safeEnv;
+  }
+
+  /**
+   * Checks if an environment variable name matches any sensitive pattern.
+   *
+   * @param varName - Environment variable name to check
+   * @returns True if the variable is considered sensitive
+   */
+  isSensitive(varName: string): boolean {
+    return this.sensitivePatterns.some((pattern) => pattern.test(varName));
+  }
+
+  /**
+   * Returns the list of sensitive variable names found in the given environment.
+   * Useful for audit logging.
+   *
+   * @param sourceEnv - Environment to scan
+   * @returns Array of sensitive variable names found
+   */
+  findSensitiveVars(sourceEnv: Record<string, string | undefined>): string[] {
+    return Object.keys(sourceEnv).filter((key) => this.isSensitive(key));
+  }
+
+  /**
+   * Returns the current allowlist as an array.
+   * @returns Copy of the safe variable allowlist
+   */
+  getAllowlist(): string[] {
+    return Array.from(this.allowlist);
+  }
+}

--- a/packages/crewly-agent/src/runtime/in-process-log-buffer.test.ts
+++ b/packages/crewly-agent/src/runtime/in-process-log-buffer.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { InProcessLogBuffer } from './in-process-log-buffer.js';
+
+// Constants inlined here too — the standalone runtime owns its own values.
+const CREWLY_CONSTANTS = {
+  PATHS: {
+    CREWLY_HOME: '.crewly',
+    LOGS_DIR: 'logs',
+  },
+} as const;
+
+const LOG_ROTATION_CONSTANTS = {
+  SESSIONS_LOG_DIR: 'sessions',
+} as const;
+
+describe('InProcessLogBuffer', () => {
+  let buffer: InProcessLogBuffer;
+
+  beforeEach(() => {
+    InProcessLogBuffer.resetInstance();
+    buffer = InProcessLogBuffer.getInstance();
+  });
+
+  describe('singleton', () => {
+    it('should return the same instance', () => {
+      const a = InProcessLogBuffer.getInstance();
+      const b = InProcessLogBuffer.getInstance();
+      expect(a).toBe(b);
+    });
+
+    it('should return new instance after reset', () => {
+      const a = InProcessLogBuffer.getInstance();
+      InProcessLogBuffer.resetInstance();
+      const b = InProcessLogBuffer.getInstance();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('append', () => {
+    it('should create session on first append', () => {
+      expect(buffer.hasSession('test')).toBe(false);
+      buffer.append('test', 'info', 'hello');
+      expect(buffer.hasSession('test')).toBe(true);
+    });
+
+    it('should enforce ring buffer limit', () => {
+      for (let i = 0; i < 600; i++) {
+        buffer.append('test', 'info', `line ${i}`);
+      }
+      const output = buffer.capture('test', 600);
+      const lines = output.split('\n');
+      expect(lines.length).toBe(500);
+      expect(lines[lines.length - 1]).toContain('line 599');
+    });
+  });
+
+  describe('capture', () => {
+    it('should return placeholder for empty session', () => {
+      buffer.registerSession('empty');
+      const output = buffer.capture('empty');
+      expect(output).toContain('No output yet');
+    });
+
+    it('should return placeholder for unknown session', () => {
+      const output = buffer.capture('nonexistent');
+      expect(output).toContain('No output yet');
+    });
+
+    it('should format entries with timestamps', () => {
+      buffer.append('test', 'info', 'hello world');
+      const output = buffer.capture('test');
+      expect(output).toMatch(/\[\d{2}:\d{2}:\d{2}\.\d{3}\] hello world/);
+    });
+
+    it('should prefix error and warn levels', () => {
+      buffer.append('test', 'error', 'something broke');
+      buffer.append('test', 'warn', 'be careful');
+      buffer.append('test', 'debug', 'details');
+      const output = buffer.capture('test');
+      expect(output).toContain('ERROR: something broke');
+      expect(output).toContain('WARN: be careful');
+      expect(output).toContain('DEBUG: details');
+    });
+
+    it('should respect lines parameter', () => {
+      buffer.append('test', 'info', 'line 1');
+      buffer.append('test', 'info', 'line 2');
+      buffer.append('test', 'info', 'line 3');
+      const output = buffer.capture('test', 2);
+      const lines = output.split('\n');
+      expect(lines.length).toBe(2);
+      expect(lines[1]).toContain('line 3');
+    });
+  });
+
+  describe('session management', () => {
+    it('should register empty session', () => {
+      buffer.registerSession('new');
+      expect(buffer.hasSession('new')).toBe(true);
+      expect(buffer.capture('new')).toContain('No output yet');
+    });
+
+    it('should remove session', () => {
+      buffer.append('test', 'info', 'data');
+      buffer.removeSession('test');
+      expect(buffer.hasSession('test')).toBe(false);
+    });
+
+    it('should list session names', () => {
+      buffer.registerSession('a');
+      buffer.registerSession('b');
+      buffer.append('c', 'info', 'test');
+      expect(buffer.getSessionNames().sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should clear all sessions', () => {
+      buffer.registerSession('a');
+      buffer.registerSession('b');
+      buffer.clear();
+      expect(buffer.getSessionNames()).toEqual([]);
+    });
+  });
+
+  describe('EventEmitter data events', () => {
+    it('should emit data event on append', () => new Promise<void>((resolve, reject) => {
+      buffer.on('data', (sessionName: string, formattedLine: string) => {
+        try {
+          expect(sessionName).toBe('test-session');
+          expect(formattedLine).toContain('hello world');
+          expect(formattedLine).toMatch(/\[\d{2}:\d{2}:\d{2}\.\d{3}\] hello world/);
+          resolve();
+        } catch (err) { reject(err); }
+      });
+      buffer.append('test-session', 'info', 'hello world');
+    }));
+
+    it('should emit data event with level prefix for errors', () => new Promise<void>((resolve, reject) => {
+      buffer.on('data', (sessionName: string, formattedLine: string) => {
+        try {
+          expect(sessionName).toBe('test-session');
+          expect(formattedLine).toContain('ERROR: something broke');
+          resolve();
+        } catch (err) { reject(err); }
+      });
+      buffer.append('test-session', 'error', 'something broke');
+    }));
+
+    it('should emit data events for each append', () => {
+      const events: string[] = [];
+      buffer.on('data', (_session: string, line: string) => {
+        events.push(line);
+      });
+
+      buffer.append('s1', 'info', 'first');
+      buffer.append('s2', 'warn', 'second');
+
+      expect(events.length).toBe(2);
+      expect(events[0]).toContain('first');
+      expect(events[1]).toContain('WARN: second');
+    });
+
+    it('should include session name in data event', () => {
+      const sessions: string[] = [];
+      buffer.on('data', (session: string) => {
+        sessions.push(session);
+      });
+
+      buffer.append('agent-a', 'info', 'msg1');
+      buffer.append('agent-b', 'info', 'msg2');
+
+      expect(sessions).toEqual(['agent-a', 'agent-b']);
+    });
+
+    it('should clean up listeners on reset', () => {
+      const handler = vi.fn();
+      buffer.on('data', handler);
+
+      InProcessLogBuffer.resetInstance();
+      const newBuffer = InProcessLogBuffer.getInstance();
+      newBuffer.append('test', 'info', 'after reset');
+
+      // Old handler should NOT be called since instance was reset
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('file persistence', () => {
+    const sessionLogsDir = path.join(
+      os.homedir(),
+      CREWLY_CONSTANTS.PATHS.CREWLY_HOME,
+      CREWLY_CONSTANTS.PATHS.LOGS_DIR,
+      LOG_ROTATION_CONSTANTS.SESSIONS_LOG_DIR,
+    );
+
+    const testSessionName = `__test-inprocess-${Date.now()}`;
+
+    afterEach(() => {
+      // Clean up test log file
+      const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+      try { fs.unlinkSync(logPath); } catch { /* may not exist */ }
+    });
+
+    it('should create a log file on registerSession', (done) => {
+      buffer.registerSession(testSessionName);
+      const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+      // WriteStream opens the file lazily — give it a tick to flush the header
+      setTimeout(() => {
+        expect(fs.existsSync(logPath)).toBe(true);
+        done();
+      }, 100);
+    });
+
+    it('should write log entries to disk on append', (done) => {
+      buffer.registerSession(testSessionName);
+      buffer.append(testSessionName, 'info', 'disk test message');
+      buffer.append(testSessionName, 'error', 'disk error message');
+
+      // WriteStream is async — give it a tick to flush
+      setTimeout(() => {
+        const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+        const content = fs.readFileSync(logPath, 'utf8');
+        expect(content).toContain('SESSION STARTED');
+        expect(content).toContain('disk test message');
+        expect(content).toContain('ERROR: disk error message');
+        done();
+      }, 100);
+    });
+
+    it('should write SESSION ENDED marker on removeSession', (done) => {
+      buffer.registerSession(testSessionName);
+      buffer.append(testSessionName, 'info', 'before shutdown');
+      buffer.removeSession(testSessionName);
+
+      setTimeout(() => {
+        const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+        const content = fs.readFileSync(logPath, 'utf8');
+        expect(content).toContain('SESSION ENDED');
+        done();
+      }, 100);
+    });
+
+    it('should write RESTARTED marker when session is re-registered', (done) => {
+      buffer.registerSession(testSessionName);
+      buffer.append(testSessionName, 'info', 'first run');
+      buffer.removeSession(testSessionName);
+
+      // Re-register same session (simulates restart)
+      setTimeout(() => {
+        buffer.registerSession(testSessionName);
+        buffer.append(testSessionName, 'info', 'second run');
+
+        setTimeout(() => {
+          const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+          const content = fs.readFileSync(logPath, 'utf8');
+          expect(content).toContain('SESSION STARTED');
+          expect(content).toContain('first run');
+          expect(content).toContain('SESSION RESTARTED');
+          expect(content).toContain('second run');
+          done();
+        }, 100);
+      }, 100);
+    });
+
+    it('should include full ISO timestamp in file entries', (done) => {
+      buffer.registerSession(testSessionName);
+      buffer.append(testSessionName, 'info', 'timestamp check');
+
+      setTimeout(() => {
+        const logPath = path.join(sessionLogsDir, `${testSessionName}.log`);
+        const content = fs.readFileSync(logPath, 'utf8');
+        // File entries should have full ISO timestamp like "2026-03-18T16:01:00.000Z"
+        expect(content).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z.*timestamp check/);
+        done();
+      }, 100);
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/in-process-log-buffer.ts
+++ b/packages/crewly-agent/src/runtime/in-process-log-buffer.ts
@@ -1,0 +1,317 @@
+/**
+ * In-Process Log Buffer
+ *
+ * Ring buffer that captures structured output from in-process Crewly Agent
+ * runtimes. Provides the same interface as PTY terminal capture so the
+ * frontend Side Terminal panel can display crewly-agent activity.
+ *
+ * Extends EventEmitter to support real-time WebSocket streaming of log entries
+ * to the frontend Side Terminal panel.
+ *
+ * Also persists log entries to disk at ~/.crewly/logs/sessions/{sessionName}.log,
+ * matching the file-based logging that PTY-based agents get via PtySessionBackend.
+ *
+ * @module services/agent/crewly-agent/in-process-log-buffer
+ */
+
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+/**
+ * Local copies of the OSS constants this module relies on — standalone
+ * crewly-agent must not depend on `crewly/backend/src/constants.ts`. Keep
+ * these path fragments in sync with the values OSS writes elsewhere (any
+ * code that reads back the same directory tree on disk).
+ */
+const CREWLY_CONSTANTS = {
+  PATHS: {
+    CREWLY_HOME: '.crewly',
+    LOGS_DIR: 'logs',
+  },
+} as const;
+
+const LOG_ROTATION_CONSTANTS = {
+  SESSIONS_LOG_DIR: 'sessions',
+} as const;
+
+/**
+ * Single log entry from an in-process agent session.
+ */
+export interface LogEntry {
+  /** ISO timestamp */
+  timestamp: string;
+  /** Log level */
+  level: 'info' | 'debug' | 'warn' | 'error';
+  /** Log message */
+  message: string;
+}
+
+/** Maximum number of entries to keep per session */
+const MAX_ENTRIES_PER_SESSION = 500;
+
+/**
+ * Singleton buffer that captures in-process agent output.
+ *
+ * Used by CrewlyAgentRuntimeService to log tool calls, responses,
+ * and errors. The terminal controller reads from this buffer when
+ * the requested session is an in-process agent (no PTY).
+ *
+ * Emits 'data' events with (sessionName, formattedLine) when new entries
+ * are appended, enabling real-time WebSocket streaming via TerminalGateway.
+ *
+ * @example
+ * ```typescript
+ * const buffer = InProcessLogBuffer.getInstance();
+ * buffer.append('crewly-assistant', 'info', 'Calling get_team_status tool...');
+ * const output = buffer.capture('crewly-assistant', 50);
+ *
+ * // Real-time streaming
+ * buffer.on('data', (sessionName, formattedLine) => {
+ *   console.log(`[${sessionName}] ${formattedLine}`);
+ * });
+ * ```
+ */
+export class InProcessLogBuffer extends EventEmitter {
+  private static instance: InProcessLogBuffer | null = null;
+  private sessions = new Map<string, LogEntry[]>();
+  /** File write streams for persisting logs to disk */
+  private logStreams = new Map<string, fs.WriteStream>();
+  /** Resolved path to ~/.crewly/logs/sessions/ */
+  private sessionLogsDir: string;
+
+  constructor() {
+    super();
+    this.sessionLogsDir = path.join(
+      os.homedir(),
+      CREWLY_CONSTANTS.PATHS.CREWLY_HOME,
+      CREWLY_CONSTANTS.PATHS.LOGS_DIR,
+      LOG_ROTATION_CONSTANTS.SESSIONS_LOG_DIR,
+    );
+    // Ensure directory exists (non-fatal if it fails)
+    try {
+      fs.mkdirSync(this.sessionLogsDir, { recursive: true });
+    } catch {
+      // Directory may already exist or be uncreatable — logging will be skipped
+    }
+  }
+
+  /**
+   * Get the singleton instance.
+   *
+   * @returns The shared InProcessLogBuffer instance
+   */
+  static getInstance(): InProcessLogBuffer {
+    if (!InProcessLogBuffer.instance) {
+      InProcessLogBuffer.instance = new InProcessLogBuffer();
+    }
+    return InProcessLogBuffer.instance;
+  }
+
+  /**
+   * Reset the singleton (for testing).
+   */
+  static resetInstance(): void {
+    if (InProcessLogBuffer.instance) {
+      // Close all open file streams
+      for (const stream of InProcessLogBuffer.instance.logStreams.values()) {
+        try { stream.end(); } catch { /* ignore */ }
+      }
+      InProcessLogBuffer.instance.logStreams.clear();
+      InProcessLogBuffer.instance.removeAllListeners();
+    }
+    InProcessLogBuffer.instance = null;
+  }
+
+  /**
+   * Format a log entry into a single display line.
+   *
+   * @param entry - The log entry to format
+   * @returns Formatted string like "[HH:MM:SS.mmm] ERROR: message"
+   */
+  private formatEntry(entry: LogEntry): string {
+    const ts = entry.timestamp.substring(11, 23); // HH:MM:SS.mmm
+    const prefix = entry.level === 'error' ? 'ERROR' : entry.level === 'warn' ? 'WARN' : entry.level === 'debug' ? 'DEBUG' : '';
+    return prefix ? `[${ts}] ${prefix}: ${entry.message}` : `[${ts}] ${entry.message}`;
+  }
+
+  /**
+   * Append a log entry for a session.
+   *
+   * Emits a 'data' event with the session name and formatted line for
+   * real-time WebSocket streaming.
+   *
+   * @param sessionName - In-process agent session name
+   * @param level - Log level
+   * @param message - Log message text
+   */
+  append(sessionName: string, level: LogEntry['level'], message: string): void {
+    if (!this.sessions.has(sessionName)) {
+      this.sessions.set(sessionName, []);
+    }
+    const entries = this.sessions.get(sessionName)!;
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+    };
+    entries.push(entry);
+    // Ring buffer — drop oldest entries
+    if (entries.length > MAX_ENTRIES_PER_SESSION) {
+      entries.splice(0, entries.length - MAX_ENTRIES_PER_SESSION);
+    }
+
+    // Emit for real-time WebSocket streaming
+    const formattedLine = this.formatEntry(entry);
+    this.emit('data', sessionName, formattedLine);
+
+    // Persist to disk (fire-and-forget, non-blocking)
+    this.writeToFile(sessionName, entry, formattedLine);
+  }
+
+  /**
+   * Check if a session has any log entries.
+   *
+   * @param sessionName - Session to check
+   * @returns True if the session has been registered with at least one entry
+   */
+  hasSession(sessionName: string): boolean {
+    return this.sessions.has(sessionName);
+  }
+
+  /**
+   * Capture recent output from an in-process session, formatted like
+   * terminal output for frontend compatibility.
+   *
+   * @param sessionName - Session to capture from
+   * @param lines - Maximum number of lines to return
+   * @returns Formatted output string (one log entry per line)
+   */
+  capture(sessionName: string, lines = 100): string {
+    const entries = this.sessions.get(sessionName);
+    if (!entries || entries.length === 0) {
+      return '[crewly-agent] No output yet';
+    }
+    const slice = entries.slice(-lines);
+    return slice.map(e => this.formatEntry(e)).join('\n');
+  }
+
+  /**
+   * Register a session (creates empty entry list and opens a file log stream).
+   *
+   * @param sessionName - Session to register
+   */
+  registerSession(sessionName: string): void {
+    if (!this.sessions.has(sessionName)) {
+      this.sessions.set(sessionName, []);
+    }
+    this.openLogStream(sessionName);
+  }
+
+  /**
+   * Remove a session's log buffer and close its file stream.
+   * The log file is preserved on disk for post-mortem analysis.
+   *
+   * @param sessionName - Session to remove
+   */
+  removeSession(sessionName: string): void {
+    this.sessions.delete(sessionName);
+    this.closeLogStream(sessionName);
+  }
+
+  /**
+   * Get all registered in-process session names.
+   *
+   * @returns Array of session names
+   */
+  getSessionNames(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+
+  /**
+   * Clear all sessions and close all file streams (for testing).
+   */
+  clear(): void {
+    this.sessions.clear();
+    for (const stream of this.logStreams.values()) {
+      try { stream.end(); } catch { /* ignore */ }
+    }
+    this.logStreams.clear();
+  }
+
+  // ===== Private file I/O helpers =====
+
+  /**
+   * Get the file path for a session's persistent log.
+   *
+   * @param sessionName - Session name
+   * @returns Absolute path to the log file
+   */
+  private getLogPath(sessionName: string): string {
+    return path.join(this.sessionLogsDir, `${sessionName}.log`);
+  }
+
+  /**
+   * Open a writable file stream for a session log.
+   * Appends a session marker so multiple runs are distinguishable.
+   *
+   * @param sessionName - Session name
+   */
+  private openLogStream(sessionName: string): void {
+    // Don't open duplicate streams
+    if (this.logStreams.has(sessionName)) return;
+
+    try {
+      const logPath = this.getLogPath(sessionName);
+      const fileExists = fs.existsSync(logPath);
+
+      const stream = fs.createWriteStream(logPath, { flags: 'a' });
+      stream.on('error', () => {
+        // Silently remove broken streams — disk logging is best-effort
+        this.logStreams.delete(sessionName);
+      });
+
+      const marker = fileExists ? 'RESTARTED' : 'STARTED';
+      stream.write(`\n--- SESSION ${marker} at ${new Date().toISOString()} ---\n\n`);
+
+      this.logStreams.set(sessionName, stream);
+    } catch {
+      // Non-fatal — in-memory buffer and WebSocket streaming still work
+    }
+  }
+
+  /**
+   * Close and remove the file stream for a session.
+   *
+   * @param sessionName - Session name
+   */
+  private closeLogStream(sessionName: string): void {
+    const stream = this.logStreams.get(sessionName);
+    if (stream) {
+      try {
+        stream.write(`\n--- SESSION ENDED at ${new Date().toISOString()} ---\n`);
+        stream.end();
+      } catch { /* ignore */ }
+      this.logStreams.delete(sessionName);
+    }
+  }
+
+  /**
+   * Write a formatted log entry to the session's file stream.
+   * Non-blocking, fire-and-forget — errors are silently ignored.
+   *
+   * @param sessionName - Session name
+   * @param entry - The log entry (for full timestamp in file)
+   * @param formattedLine - Pre-formatted display line
+   */
+  private writeToFile(sessionName: string, entry: LogEntry, formattedLine: string): void {
+    const stream = this.logStreams.get(sessionName);
+    if (!stream) return;
+
+    try {
+      stream.write(`${entry.timestamp} ${formattedLine}\n`);
+    } catch {
+      // Non-fatal — disk logging is best-effort
+    }
+  }
+}

--- a/packages/crewly-agent/src/runtime/index.ts
+++ b/packages/crewly-agent/src/runtime/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Crewly Agent Runtime — Barrel Export
+ *
+ * Standalone runtime module. The OSS-side `CrewlyAgentRuntimeService`
+ * (in-process variant) intentionally does not exist here — this package
+ * IS the process; OSS spawns it as a subprocess and talks via the JSON
+ * protocol implemented in `cli.ts`.
+ *
+ * @module runtime
+ */
+
+export { AgentRunnerService } from './agent-runner.service.js';
+export { CrewlyApiClient } from './api-client.js';
+export { ModelManager } from './model-manager.js';
+export { InProcessLogBuffer, type LogEntry } from './in-process-log-buffer.js';
+export { createTools, getToolNames } from './tool-registry.js';
+export { createAuditorTools, getAuditorToolNames } from './auditor-tools.js';
+export { AuditTrailService } from './audit-trail.service.js';
+export { RateLimiter, RATE_LIMITER_DEFAULTS, type RateLimiterConfig } from './rate-limiter.js';
+export { createWebSearchTool, formatAsMarkdown } from './web-search.tool.js';
+export { loadCloudConfig, CloudNotLoggedInError, type CloudConfig } from './cloud-config.js';
+export {
+  type ModelProvider,
+  type ModelConfig,
+  type ConversationState,
+  type CrewlyAgentConfig,
+  type AgentRunResult,
+  type ToolCallRecord,
+  type ApiCallResult,
+  type AuditEntry,
+  type SecurityPolicy,
+  type AuditLogFilters,
+  MODEL_PROVIDERS,
+  CREWLY_AGENT_DEFAULTS,
+  WRITE_TOOLS,
+  isModelProvider,
+  isModelConfig,
+} from './types.js';

--- a/packages/crewly-agent/src/runtime/mcp-tool-bridge.test.ts
+++ b/packages/crewly-agent/src/runtime/mcp-tool-bridge.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Tests for MCP Tool Bridge
+ *
+ * Validates MCP tool conversion, naming, sensitivity classification,
+ * tool loading, and end-to-end execution via a mock MCP server.
+ */
+
+import { describe, it, expect, vi, type Mocked, type MockInstance } from 'vitest';
+import {
+  MCP_TOOL_PREFIX,
+  MCP_DEFAULT_SENSITIVITY,
+  jsonSchemaToZodPassthrough,
+  buildMcpToolName,
+  resolveSensitivity,
+  convertMcpTool,
+  loadMcpTools,
+  connectAndLoadMcpTools,
+} from './mcp-tool-bridge.js';
+import type { McpClientService, McpToolInfo, McpServerConfig } from '../../mcp-client.js';
+import type { ToolSensitivity } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Mock MCP Client
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock McpClientService with configurable tool lists.
+ */
+function createMockMcpClient(tools: McpToolInfo[] = []): McpClientService {
+  return {
+    connectServer: vi.fn<any>().mockResolvedValue(undefined),
+    disconnectServer: vi.fn<any>().mockResolvedValue(undefined),
+    disconnectAll: vi.fn<any>().mockResolvedValue(undefined),
+    listTools: vi.fn<any>().mockReturnValue(tools),
+    callTool: vi.fn<any>().mockResolvedValue({
+      content: [{ type: 'text', text: 'mock result' }],
+      isError: false,
+    }),
+    refreshTools: vi.fn<any>().mockResolvedValue(undefined),
+    getConnectedServers: vi.fn<any>().mockReturnValue(
+      [...new Set(tools.map(t => t.serverName))],
+    ),
+    isServerConnected: vi.fn<any>().mockReturnValue(true),
+    getServerStatuses: vi.fn<any>().mockReturnValue([]),
+    connectAll: vi.fn<any>().mockResolvedValue(new Map()),
+  } as unknown as McpClientService;
+}
+
+/** Sample MCP tool info for a filesystem read tool */
+const SAMPLE_TOOL: McpToolInfo = {
+  name: 'read_file',
+  description: 'Read the contents of a file',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path to read' },
+    },
+    required: ['path'],
+  },
+  serverName: 'filesystem',
+};
+
+/** Sample MCP tool info without description */
+const TOOL_NO_DESC: McpToolInfo = {
+  name: 'list_dir',
+  inputSchema: { type: 'object', properties: {} },
+  serverName: 'filesystem',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MCP Tool Bridge', () => {
+  describe('Constants', () => {
+    it('should have correct prefix', () => {
+      expect(MCP_TOOL_PREFIX).toBe('mcp_');
+    });
+
+    it('should default to sensitive classification', () => {
+      expect(MCP_DEFAULT_SENSITIVITY).toBe('sensitive');
+    });
+  });
+
+  describe('buildMcpToolName', () => {
+    it('should namespace tool names with server prefix', () => {
+      expect(buildMcpToolName('filesystem', 'read_file')).toBe('mcp_filesystem_read_file');
+    });
+
+    it('should handle different server names', () => {
+      expect(buildMcpToolName('github', 'create_issue')).toBe('mcp_github_create_issue');
+    });
+  });
+
+  describe('jsonSchemaToZodPassthrough', () => {
+    it('should create a schema from JSON Schema with properties', () => {
+      const schema = jsonSchemaToZodPassthrough({
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'File path' },
+          encoding: { type: 'string' },
+        },
+      });
+      // Should parse without errors
+      const result = schema.safeParse({ path: '/tmp/test.txt', encoding: 'utf-8' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept extra properties via passthrough', () => {
+      const schema = jsonSchemaToZodPassthrough({
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'File path' },
+        },
+      });
+      const result = schema.safeParse({ path: '/tmp', extraKey: 'value' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should fall back to record schema when no properties', () => {
+      const schema = jsonSchemaToZodPassthrough({ type: 'object' });
+      const result = schema.safeParse({ anything: 'goes' });
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle empty properties object', () => {
+      const schema = jsonSchemaToZodPassthrough({
+        type: 'object',
+        properties: {},
+      });
+      const result = schema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('resolveSensitivity', () => {
+    it('should return default sensitivity when no overrides', () => {
+      expect(resolveSensitivity('fs', 'read', undefined)).toBe('sensitive');
+    });
+
+    it('should return default sensitivity when no matching override', () => {
+      const overrides = { 'other:tool': 'safe' as ToolSensitivity };
+      expect(resolveSensitivity('fs', 'read', overrides)).toBe('sensitive');
+    });
+
+    it('should match server-specific override', () => {
+      const overrides = { 'fs:read': 'safe' as ToolSensitivity };
+      expect(resolveSensitivity('fs', 'read', overrides)).toBe('safe');
+    });
+
+    it('should match tool-level override', () => {
+      const overrides = { read: 'safe' as ToolSensitivity };
+      expect(resolveSensitivity('fs', 'read', overrides)).toBe('safe');
+    });
+
+    it('should prefer server-specific over tool-level override', () => {
+      const overrides = {
+        'fs:read': 'destructive' as ToolSensitivity,
+        read: 'safe' as ToolSensitivity,
+      };
+      expect(resolveSensitivity('fs', 'read', overrides)).toBe('destructive');
+    });
+  });
+
+  describe('convertMcpTool', () => {
+    it('should convert MCP tool info to ToolDefinition', () => {
+      const mcpClient = createMockMcpClient();
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL);
+
+      expect(tool.description).toContain('[MCP:filesystem]');
+      expect(tool.description).toContain('Read the contents of a file');
+      expect(tool.sensitivity).toBe('sensitive');
+      expect(typeof tool.execute).toBe('function');
+      expect(tool.inputSchema).toBeDefined();
+    });
+
+    it('should use tool name as description fallback', () => {
+      const mcpClient = createMockMcpClient();
+      const tool = convertMcpTool(mcpClient, TOOL_NO_DESC);
+
+      expect(tool.description).toBe('[MCP:filesystem] list_dir');
+    });
+
+    it('should apply sensitivity overrides', () => {
+      const mcpClient = createMockMcpClient();
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL, {
+        'filesystem:read_file': 'safe',
+      });
+
+      expect(tool.sensitivity).toBe('safe');
+    });
+
+    it('should call mcpClient.callTool on execute', async () => {
+      const mcpClient = createMockMcpClient();
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL);
+
+      const result = await tool.execute({ path: '/tmp/test.txt' });
+
+      expect(mcpClient.callTool).toHaveBeenCalledWith(
+        'filesystem',
+        'read_file',
+        { path: '/tmp/test.txt' },
+      );
+      // Single text content should be flattened
+      expect(result).toEqual({ success: true, text: 'mock result' });
+    });
+
+    it('should return full content for multi-block results', async () => {
+      const mcpClient = createMockMcpClient();
+      (mcpClient.callTool as MockedFunction<any>).mockResolvedValue({
+        content: [
+          { type: 'text', text: 'line 1' },
+          { type: 'text', text: 'line 2' },
+        ],
+        isError: false,
+      });
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL);
+
+      const result = await tool.execute({ path: '/tmp/test.txt' }) as Record<string, unknown>;
+
+      expect(result.success).toBe(true);
+      expect(result.content).toHaveLength(2);
+    });
+
+    it('should handle error results from MCP server', async () => {
+      const mcpClient = createMockMcpClient();
+      (mcpClient.callTool as MockedFunction<any>).mockResolvedValue({
+        content: [{ type: 'text', text: 'Permission denied' }],
+        isError: true,
+      });
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL);
+
+      const result = await tool.execute({ path: '/root/secret' }) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('MCP tool returned an error');
+    });
+
+    it('should return error result when callTool throws', async () => {
+      const mcpClient = createMockMcpClient();
+      (mcpClient.callTool as MockedFunction<any>).mockRejectedValue(new Error('Connection lost'));
+      const tool = convertMcpTool(mcpClient, SAMPLE_TOOL);
+
+      const result = await tool.execute({ path: '/tmp' }) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Connection lost');
+    });
+  });
+
+  describe('loadMcpTools', () => {
+    it('should load tools from all connected servers', () => {
+      const tools: McpToolInfo[] = [
+        SAMPLE_TOOL,
+        { name: 'write_file', description: 'Write a file', inputSchema: { type: 'object', properties: {} }, serverName: 'filesystem' },
+        { name: 'create_issue', description: 'Create GitHub issue', inputSchema: { type: 'object', properties: {} }, serverName: 'github' },
+      ];
+      const mcpClient = createMockMcpClient(tools);
+
+      const result = loadMcpTools(mcpClient);
+
+      expect(Object.keys(result)).toEqual([
+        'mcp_filesystem_read_file',
+        'mcp_filesystem_write_file',
+        'mcp_github_create_issue',
+      ]);
+    });
+
+    it('should return empty map when no tools available', () => {
+      const mcpClient = createMockMcpClient([]);
+      const result = loadMcpTools(mcpClient);
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+
+    it('should apply sensitivity overrides to loaded tools', () => {
+      const mcpClient = createMockMcpClient([SAMPLE_TOOL]);
+      const result = loadMcpTools(mcpClient, {
+        'filesystem:read_file': 'safe',
+      });
+
+      expect(result['mcp_filesystem_read_file'].sensitivity).toBe('safe');
+    });
+
+    it('should default all tools to sensitive classification', () => {
+      const mcpClient = createMockMcpClient([SAMPLE_TOOL, TOOL_NO_DESC]);
+      const result = loadMcpTools(mcpClient);
+
+      for (const tool of Object.values(result)) {
+        expect(tool.sensitivity).toBe('sensitive');
+      }
+    });
+  });
+
+  describe('connectAndLoadMcpTools', () => {
+    it('should connect to servers and load tools', async () => {
+      const tools: McpToolInfo[] = [SAMPLE_TOOL];
+      const mcpClient = createMockMcpClient(tools);
+      const configs: Record<string, McpServerConfig> = {
+        filesystem: { command: 'npx', args: ['-y', '@anthropic/mcp-filesystem'] },
+      };
+
+      const { tools: loaded, errors } = await connectAndLoadMcpTools(mcpClient, configs);
+
+      expect(mcpClient.connectAll).toHaveBeenCalledWith(configs);
+      expect(Object.keys(loaded)).toContain('mcp_filesystem_read_file');
+      expect(errors.size).toBe(0);
+    });
+
+    it('should return errors for failed connections', async () => {
+      const mcpClient = createMockMcpClient([]);
+      const failError = new Error('spawn ENOENT');
+      (mcpClient.connectAll as MockedFunction<any>).mockResolvedValue(
+        new Map([['badserver', failError]]),
+      );
+
+      const { errors } = await connectAndLoadMcpTools(mcpClient, {
+        badserver: { command: 'nonexistent' },
+      });
+
+      expect(errors.size).toBe(1);
+      expect(errors.get('badserver')?.message).toBe('spawn ENOENT');
+    });
+
+    it('should still load tools from servers that connected successfully', async () => {
+      const tools: McpToolInfo[] = [SAMPLE_TOOL];
+      const mcpClient = createMockMcpClient(tools);
+      (mcpClient.connectAll as MockedFunction<any>).mockResolvedValue(
+        new Map([['badserver', new Error('fail')]]),
+      );
+
+      const { tools: loaded } = await connectAndLoadMcpTools(mcpClient, {
+        filesystem: { command: 'npx', args: [] },
+        badserver: { command: 'nonexistent' },
+      });
+
+      // filesystem tools should still be loaded
+      expect(Object.keys(loaded)).toContain('mcp_filesystem_read_file');
+    });
+
+    it('should pass sensitivity overrides through', async () => {
+      const mcpClient = createMockMcpClient([SAMPLE_TOOL]);
+      const overrides = { 'filesystem:read_file': 'safe' as ToolSensitivity };
+
+      const { tools: loaded } = await connectAndLoadMcpTools(
+        mcpClient,
+        { filesystem: { command: 'npx' } },
+        overrides,
+      );
+
+      expect(loaded['mcp_filesystem_read_file'].sensitivity).toBe('safe');
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/mcp-tool-bridge.ts
+++ b/packages/crewly-agent/src/runtime/mcp-tool-bridge.ts
@@ -1,0 +1,244 @@
+/**
+ * MCP Tool Bridge
+ *
+ * Converts external MCP server tools into Crewly Agent ToolDefinitions
+ * so they can be used alongside built-in tools during agent execution.
+ * All MCP-sourced tools default to 'sensitive' classification for audit
+ * purposes unless explicitly overridden.
+ *
+ * @module services/agent/crewly-agent/mcp-tool-bridge
+ */
+
+import { z } from 'zod';
+import type {
+  McpClientLike,
+  McpToolInfo,
+  McpServerConfig,
+  ToolDefinition,
+  ToolSensitivity,
+} from './types.js';
+
+/**
+ * Prefix applied to MCP tool names to avoid collisions with built-in tools.
+ */
+export const MCP_TOOL_PREFIX = 'mcp_' as const;
+
+/**
+ * Default sensitivity for MCP-sourced tools.
+ * External tools are classified as 'sensitive' because they interact
+ * with systems outside the agent's direct control.
+ */
+export const MCP_DEFAULT_SENSITIVITY: ToolSensitivity = 'sensitive';
+
+/**
+ * Configuration for MCP tool sensitivity overrides.
+ * Maps `serverName:toolName` or just `toolName` to a sensitivity level.
+ *
+ * @example
+ * ```typescript
+ * const overrides: McpSensitivityOverrides = {
+ *   'filesystem:read_file': 'safe',
+ *   'github:create_issue': 'sensitive',
+ *   'admin:drop_database': 'destructive',
+ * };
+ * ```
+ */
+/**
+ * Convert a JSON Schema object from an MCP tool into a Zod schema.
+ *
+ * MCP tools declare their input using JSON Schema. The AI SDK expects
+ * Zod schemas. This function creates a z.object({}) passthrough schema
+ * that accepts any object — actual validation is done server-side by
+ * the MCP server itself.
+ *
+ * @param inputSchema - JSON Schema from the MCP tool definition
+ * @returns A Zod schema that passes through any object
+ */
+export function jsonSchemaToZodPassthrough(
+  inputSchema: Record<string, unknown>,
+): z.ZodType {
+  // Extract property names from JSON Schema for documentation,
+  // but use a passthrough object since the MCP server validates inputs.
+  const properties = inputSchema.properties as Record<string, unknown> | undefined;
+  if (properties && typeof properties === 'object') {
+    const shape: Record<string, z.ZodType> = {};
+    for (const key of Object.keys(properties)) {
+      shape[key] = z.unknown().optional().describe(
+        String((properties[key] as Record<string, unknown>)?.description || key),
+      );
+    }
+    return z.object(shape).passthrough();
+  }
+  // Fallback: accept any object
+  return z.record(z.unknown());
+}
+
+/**
+ * Build the namespaced tool name for an MCP tool.
+ *
+ * Format: `mcp_{serverName}_{toolName}` to prevent collisions
+ * with built-in Crewly tools and tools from other MCP servers.
+ *
+ * @param serverName - Name of the MCP server
+ * @param toolName - Original tool name from the MCP server
+ * @returns Namespaced tool name
+ */
+export function buildMcpToolName(serverName: string, toolName: string): string {
+  return `${MCP_TOOL_PREFIX}${serverName}_${toolName}`;
+}
+
+/**
+ * Resolve the sensitivity level for an MCP tool.
+ *
+ * Checks overrides in order of specificity:
+ * 1. `serverName:toolName` (most specific)
+ * 2. `toolName` (tool-level default)
+ * 3. Falls back to MCP_DEFAULT_SENSITIVITY ('sensitive')
+ *
+ * @param serverName - Name of the MCP server
+ * @param toolName - Original tool name
+ * @param overrides - Optional sensitivity overrides map
+ * @returns Resolved sensitivity level
+ */
+export function resolveSensitivity(
+  serverName: string,
+  toolName: string,
+  overrides?: McpSensitivityOverrides,
+): ToolSensitivity {
+  if (!overrides) return MCP_DEFAULT_SENSITIVITY;
+
+  // Check server-specific override first
+  const serverSpecific = overrides[`${serverName}:${toolName}`];
+  if (serverSpecific) return serverSpecific;
+
+  // Check tool-level override
+  const toolLevel = overrides[toolName];
+  if (toolLevel) return toolLevel;
+
+  return MCP_DEFAULT_SENSITIVITY;
+}
+
+/**
+ * Convert a single MCP tool into a Crewly ToolDefinition.
+ *
+ * The resulting tool definition:
+ * - Has a namespaced name (`mcp_{server}_{tool}`)
+ * - Uses a passthrough Zod schema for input validation
+ * - Delegates execution to McpClientService.callTool()
+ * - Defaults to 'sensitive' classification for auditing
+ *
+ * @param mcpClient - The MCP client service for executing tool calls
+ * @param toolInfo - Tool metadata from the MCP server
+ * @param overrides - Optional sensitivity overrides
+ * @returns A ToolDefinition compatible with the Crewly Agent runtime
+ */
+export function convertMcpTool(
+  mcpClient: McpClientLike,
+  toolInfo: McpToolInfo,
+  overrides?: McpSensitivityOverrides,
+): ToolDefinition {
+  const sensitivity = resolveSensitivity(
+    toolInfo.serverName,
+    toolInfo.name,
+    overrides,
+  );
+
+  return {
+    description: toolInfo.description
+      ? `[MCP:${toolInfo.serverName}] ${toolInfo.description}`
+      : `[MCP:${toolInfo.serverName}] ${toolInfo.name}`,
+    inputSchema: jsonSchemaToZodPassthrough(toolInfo.inputSchema),
+    sensitivity,
+    execute: async (args: Record<string, unknown>): Promise<unknown> => {
+      try {
+        const result = await mcpClient.callTool(
+          toolInfo.serverName,
+          toolInfo.name,
+          args,
+        );
+
+        // Flatten text content for simpler tool results
+        if (!result.isError && result.content.length === 1
+          && result.content[0].type === 'text' && 'text' in result.content[0]) {
+          return { success: true, text: result.content[0].text };
+        }
+
+        return {
+          success: !result.isError,
+          content: result.content,
+          ...(result.isError && { error: 'MCP tool returned an error' }),
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: `MCP tool call failed: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Load all tools from connected MCP servers and convert them to ToolDefinitions.
+ *
+ * This is the primary entry point for integrating MCP tools into the agent
+ * runtime. It queries all connected MCP servers, converts their tools to
+ * the Crewly ToolDefinition format, and returns a map ready to merge with
+ * the built-in tool registry.
+ *
+ * @param mcpClient - The MCP client service with active server connections
+ * @param overrides - Optional sensitivity overrides
+ * @returns Map of namespaced tool name -> ToolDefinition
+ *
+ * @example
+ * ```typescript
+ * const mcpClient = new McpClientService();
+ * await mcpClient.connectServer('filesystem', config);
+ * const mcpTools = loadMcpTools(mcpClient);
+ * // mcpTools = { mcp_filesystem_read_file: {...}, mcp_filesystem_write_file: {...} }
+ * ```
+ */
+export function loadMcpTools(
+  mcpClient: McpClientLike,
+  overrides?: McpSensitivityOverrides,
+): Record<string, ToolDefinition> {
+  const tools: Record<string, ToolDefinition> = {};
+  const mcpToolInfos = mcpClient.listTools();
+
+  for (const toolInfo of mcpToolInfos) {
+    const toolName = buildMcpToolName(toolInfo.serverName, toolInfo.name);
+    tools[toolName] = convertMcpTool(mcpClient, toolInfo, overrides);
+  }
+
+  return tools;
+}
+
+/**
+ * Connect to MCP servers and load their tools in one step.
+ *
+ * Convenience function that handles the full lifecycle:
+ * 1. Connects to all configured MCP servers (tolerates failures)
+ * 2. Loads and converts all available tools
+ * 3. Returns tools ready to merge into the agent's tool registry
+ *
+ * @param mcpClient - The MCP client service instance
+ * @param serverConfigs - Map of server name -> server configuration
+ * @param overrides - Optional sensitivity overrides
+ * @returns Object with loaded tools and any connection errors
+ *
+ * @example
+ * ```typescript
+ * const { tools, errors } = await connectAndLoadMcpTools(mcpClient, {
+ *   filesystem: { command: 'npx', args: ['-y', '@anthropic/mcp-filesystem'] },
+ * });
+ * ```
+ */
+export async function connectAndLoadMcpTools(
+  mcpClient: McpClientLike,
+  serverConfigs: Record<string, McpServerConfig>,
+  overrides?: McpSensitivityOverrides,
+): Promise<{ tools: Record<string, ToolDefinition>; errors: Map<string, Error> }> {
+  const errors = await mcpClient.connectAll(serverConfigs);
+  const tools = loadMcpTools(mcpClient, overrides);
+  return { tools, errors };
+}

--- a/packages/crewly-agent/src/runtime/model-manager.test.ts
+++ b/packages/crewly-agent/src/runtime/model-manager.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked, type MockInstance } from 'vitest';
+import { ModelManager } from './model-manager.js';
+
+// Mock provider SDKs so we don't make real API calls. vitest's vi.mock is
+// hoisted to the top of the file, so it intercepts ModelManager's imports.
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: vi.fn((modelId: string) => ({ provider: 'anthropic', modelId })),
+}));
+
+vi.mock('@ai-sdk/openai', () => ({
+  openai: vi.fn((modelId: string) => ({ provider: 'openai', modelId })),
+  // DeepSeek wires through createOpenAI({ baseURL }) — return an object with
+  // a .chat factory that mints the same { provider, modelId } stub shape so
+  // tests can assert routing without standing up a real provider.
+  createOpenAI: vi.fn(() => {
+    const chatFactory = (modelId: string) => ({ provider: 'openai.chat', modelId });
+    return Object.assign(chatFactory, { chat: chatFactory });
+  }),
+}));
+
+vi.mock('@ai-sdk/google', () => ({
+  google: vi.fn((modelId: string) => ({ provider: 'google', modelId })),
+}));
+
+vi.mock('ollama-ai-provider', () => ({
+  createOllama: vi.fn(() => {
+    const provider = vi.fn((modelId: string) => ({ provider: 'ollama', modelId }));
+    return provider;
+  }),
+}));
+
+// Note: the standalone ModelManager inlines its own getSettingsService that
+// reads API keys from process.env directly (no settings file). Tests below
+// just set/clear env vars to control key availability — no module mock needed.
+
+describe('ModelManager', () => {
+  let manager: ModelManager;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    manager = new ModelManager();
+  });
+
+  afterEach(() => {
+    manager.clearCache();
+    process.env = { ...originalEnv };
+  });
+
+  describe('getModel', () => {
+    it('should create an Anthropic model', async () => {
+      const model = await manager.getModel({ provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' });
+      expect(model).toBeDefined();
+      expect((model as any).modelId).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('should create an OpenAI model', async () => {
+      const model = await manager.getModel({ provider: 'openai', modelId: 'gpt-4o' });
+      expect(model).toBeDefined();
+      expect((model as any).modelId).toBe('gpt-4o');
+    });
+
+    it('should create a Google model', async () => {
+      const model = await manager.getModel({ provider: 'google', modelId: 'gemini-2.0-flash' });
+      expect(model).toBeDefined();
+      expect((model as any).modelId).toBe('gemini-2.0-flash');
+    });
+
+    it('should create an Ollama model', async () => {
+      const model = await manager.getModel({ provider: 'ollama', modelId: 'llama3.3:70b' });
+      expect(model).toBeDefined();
+      expect((model as any).modelId).toBe('llama3.3:70b');
+    });
+
+    it('should create a DeepSeek model via the OpenAI-compatible API', async () => {
+      process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+      const model = await manager.getModel({ provider: 'deepseek', modelId: 'deepseek-chat' });
+      expect(model).toBeDefined();
+      // The DeepSeek model is built on top of @ai-sdk/openai's createOpenAI
+      // pointed at https://api.deepseek.com/v1; we only assert that the model
+      // instance is produced without throwing — baseURL routing is exercised
+      // implicitly via the createOpenAI factory, which is covered by upstream
+      // tests in @ai-sdk/openai itself.
+      expect((model as any).modelId).toBe('deepseek-chat');
+      // Regression guard: must route via the .chat() factory (chat-completions
+      // path), not the bare function-call form (which @ai-sdk/openai routes to
+      // /responses — unsupported by DeepSeek). See PR #400 review M1 / M2.
+      expect((model as any).provider).toBe('openai.chat');
+    });
+
+    it('should use default config when none provided', async () => {
+      const model = await manager.getModel();
+      expect(model).toBeDefined();
+    });
+
+    it('should throw for unknown provider', async () => {
+      await expect(
+        manager.getModel({ provider: 'azure' as any, modelId: 'test' })
+      ).rejects.toThrow('Unknown model provider: azure');
+    });
+
+    it('should cache provider imports', async () => {
+      await manager.getModel({ provider: 'anthropic', modelId: 'model-1' });
+      await manager.getModel({ provider: 'anthropic', modelId: 'model-2' });
+      // Should only import once — the second call uses cached provider function
+      // We verify by checking the model is still created correctly
+      const model = await manager.getModel({ provider: 'anthropic', modelId: 'model-3' });
+      expect((model as any).modelId).toBe('model-3');
+    });
+  });
+
+  describe('getAvailableProviders', () => {
+    it('should report providers based on environment variables', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+      delete process.env.GEMINI_API_KEY;
+      delete process.env.DEEPSEEK_API_KEY;
+
+      const available = await manager.getAvailableProviders();
+
+      expect(available.anthropic).toBe(false);
+      expect(available.openai).toBe(false);
+      expect(available.google).toBe(false);
+      expect(available.ollama).toBe(true); // Ollama is always available (local)
+      expect(available.deepseek).toBe(false);
+    });
+
+    it('should detect DeepSeek API key from env', async () => {
+      process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+      const available = await manager.getAvailableProviders();
+      expect(available.deepseek).toBe(true);
+    });
+
+    it('should detect Anthropic API key', async () => {
+      process.env.ANTHROPIC_API_KEY = 'test-key';
+      const available = await manager.getAvailableProviders();
+      expect(available.anthropic).toBe(true);
+    });
+
+    it('should detect Google via GEMINI_API_KEY fallback', async () => {
+      delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+      process.env.GEMINI_API_KEY = 'test-key';
+      const available = await manager.getAvailableProviders();
+      expect(available.google).toBe(true);
+    });
+  });
+
+  describe('ensureApiKeyInEnv (settings override)', () => {
+    it('should override existing env var with settings key', async () => {
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY = 'stale-free-key';
+      // getModel calls ensureApiKeyInEnv internally; the mock resolves from process.env
+      // But in production, settings.getApiKey returns the paid key which overwrites env
+      await manager.getModel({ provider: 'google', modelId: 'gemini-2.0-flash' });
+      // The key should now be whatever settings returned (in our mock: the env value itself,
+      // but the important thing is ensureApiKeyInEnv does NOT skip when env already set)
+      expect(process.env.GOOGLE_GENERATIVE_AI_API_KEY).toBeDefined();
+    });
+
+    it('should set env var when settings returns a key and env is empty', async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      process.env.ANTHROPIC_API_KEY = 'paid-key-from-settings';
+      await manager.getModel({ provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' });
+      expect(process.env.ANTHROPIC_API_KEY).toBe('paid-key-from-settings');
+    });
+
+    /**
+     * B1: deepseek now flows through the settings service like every other
+     * cloud provider. This test pins down the new wiring — getModel for
+     * deepseek must trigger ensureApiKeyInEnv, which calls
+     * settingsService.getApiKey('deepseek', ...) and writes the result back
+     * to process.env.DEEPSEEK_API_KEY for the @ai-sdk/openai factory.
+     *
+     * Pre-B1, model-manager.ts short-circuited `if (provider === 'deepseek') return;`
+     * inside ensureApiKeyInEnv, meaning deepseek-via-settings was a dead path.
+     */
+    it('should resolve deepseek key via settings service and write to DEEPSEEK_API_KEY (B1)', async () => {
+      // Mock resolves from the env var, simulating either a settings entry or env fallback.
+      // Either way, the wired flow must end in process.env.DEEPSEEK_API_KEY being set.
+      process.env.DEEPSEEK_API_KEY = 'paid-deepseek-key';
+      await manager.getModel({ provider: 'deepseek', modelId: 'deepseek-chat' });
+      expect(process.env.DEEPSEEK_API_KEY).toBe('paid-deepseek-key');
+    });
+
+    it('should not throw when no deepseek key is configured (B1)', async () => {
+      delete process.env.DEEPSEEK_API_KEY;
+      // ensureApiKeyInEnv should silently no-op when settings returns undefined,
+      // letting the @ai-sdk/openai factory raise its own clear error if the
+      // model is actually invoked.
+      await expect(
+        manager.getModel({ provider: 'deepseek', modelId: 'deepseek-reasoner' })
+      ).resolves.toBeDefined();
+      expect(process.env.DEEPSEEK_API_KEY).toBeUndefined();
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear the provider cache', async () => {
+      await manager.getModel({ provider: 'anthropic', modelId: 'test' });
+      manager.clearCache();
+      // After clear, the next call should re-import
+      const model = await manager.getModel({ provider: 'anthropic', modelId: 'test-2' });
+      expect((model as any).modelId).toBe('test-2');
+    });
+  });
+
+  /**
+   * I2 — DeepSeek-R1 reasoning_content extraction via custom fetch wrapper.
+   *
+   * The wrapper is installed when getModel('deepseek') is called. We exercise
+   * it by stubbing globalThis.fetch, calling the wrapper directly through
+   * an internal accessor, and asserting reasoning is buffered for consume.
+   *
+   * Note: we don't go through the real @ai-sdk/openai SDK here — that would
+   * require simulating the entire chat-completions request lifecycle. Instead
+   * we test the seam where reasoning extraction happens (the custom fetch),
+   * which is the unit boundary we own. Integration with @ai-sdk is exercised
+   * by the Round 3 smoke test (live DeepSeek call).
+   */
+  describe('DeepSeek custom fetch (I2 reasoning_content)', () => {
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      process.env.DEEPSEEK_API_KEY = 'test-deepseek-key';
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('extracts reasoning_content from a streaming SSE response', async () => {
+      // Stub fetch to return a fake DeepSeek SSE response.
+      const sseBody = [
+        'data: {"choices":[{"delta":{"reasoning_content":"chain-of-thought "}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"goes here"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"the answer"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ].join('');
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseBody));
+          controller.close();
+        },
+      });
+      globalThis.fetch = vi.fn<any>().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      );
+
+      // Trigger model creation (installs the custom fetch wrapper inside the provider).
+      await manager.getModel({ provider: 'deepseek', modelId: 'deepseek-reasoner' });
+
+      // Directly invoke the wrapper via the underlying provider invocation path.
+      // We can't easily reach `customFetch` without exporting it, so we instead
+      // call the known wrapper-creator method and exercise it.
+      const customFetch = (manager as any).makeDeepseekFetch();
+      const response: Response = await customFetch('https://api.deepseek.com/v1/chat/completions', {});
+
+      // Drain the consumer side (mimics what AI SDK does)
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let drained = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        drained += decoder.decode(value, { stream: true });
+      }
+      expect(drained).toBe(sseBody); // passthrough must be byte-identical
+
+      const reasoning = await manager.consumeDeepseekReasoning();
+      expect(reasoning).toBe('chain-of-thought goes here');
+    });
+
+    it('returns null from consumeDeepseekReasoning when no fetch happened', async () => {
+      const reasoning = await manager.consumeDeepseekReasoning();
+      expect(reasoning).toBeNull();
+    });
+
+    it('passes through non-SSE responses unchanged', async () => {
+      // 4xx error with JSON body — wrapper must NOT touch it.
+      const errorBody = JSON.stringify({ error: 'bad request' });
+      globalThis.fetch = vi.fn<any>().mockResolvedValue(
+        new Response(errorBody, {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+      const customFetch = (manager as any).makeDeepseekFetch();
+      const response: Response = await customFetch('https://api.deepseek.com/v1/chat/completions', {});
+      expect(response.status).toBe(400);
+      const text = await response.text();
+      expect(text).toBe(errorBody);
+    });
+
+    it('consumes reasoning and resets buffer to null on second call', async () => {
+      const sseBody =
+        'data: {"choices":[{"delta":{"reasoning_content":"first"}}]}\n\ndata: [DONE]\n\n';
+      const encoder = new TextEncoder();
+      globalThis.fetch = vi.fn<any>().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(c) {
+              c.enqueue(encoder.encode(sseBody));
+              c.close();
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        ),
+      );
+
+      const customFetch = (manager as any).makeDeepseekFetch();
+      const r1 = await customFetch('https://api.deepseek.com/v1/chat/completions', {});
+      // Drain to ensure the parser branch sees [DONE]
+      const reader = r1.body!.getReader();
+      while (!(await reader.read()).done) { /* drain */ }
+
+      expect(await manager.consumeDeepseekReasoning()).toBe('first');
+      // Second call: nothing new fetched, buffer was cleared
+      expect(await manager.consumeDeepseekReasoning()).toBeNull();
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/model-manager.ts
+++ b/packages/crewly-agent/src/runtime/model-manager.ts
@@ -1,0 +1,363 @@
+/**
+ * Crewly Agent Model Manager
+ *
+ * Multi-provider model factory that creates AI SDK model instances
+ * from configuration. Supports Anthropic, OpenAI, Google, DeepSeek, and
+ * Ollama providers.
+ *
+ * API keys for cloud providers are resolved through the settings service
+ * (skill → runtime → global → env var) and injected into process.env so the
+ * provider SDKs can pick them up:
+ * - ANTHROPIC_API_KEY
+ * - OPENAI_API_KEY
+ * - GOOGLE_GENERATIVE_AI_API_KEY
+ * - DEEPSEEK_API_KEY (DeepSeek; served via OpenAI-compatible API)
+ *
+ * Ollama runs locally and does not require an API key.
+ * Configure the Ollama base URL via OLLAMA_BASE_URL (default: http://localhost:11434).
+ *
+ * @module services/agent/crewly-agent/model-manager
+ */
+
+import type { LanguageModel } from 'ai';
+import { type ModelConfig, type ModelProvider, CREWLY_AGENT_DEFAULTS } from './types.js';
+/**
+ * Standalone runtime resolves API keys from environment variables only — it
+ * does not depend on OSS's settings service. Anyone running this binary on
+ * a user machine sets keys via env (.env, shell profile, or the harness that
+ * spawns the process), keeping the runtime credential-isolated.
+ *
+ * OSS-side bridging code can still pre-set env vars before spawning the
+ * subprocess, which gives users the same "configure key in UI" experience
+ * without coupling the runtime to OSS internals.
+ */
+type ApiKeyProvider = 'gemini' | 'anthropic' | 'openai' | 'deepseek';
+
+interface SettingsServiceLike {
+  getApiKey(provider: ApiKeyProvider, context: { runtime: string }): Promise<string | null>;
+}
+
+function getSettingsService(): SettingsServiceLike {
+  return {
+    getApiKey: async (provider) => {
+      switch (provider) {
+        case 'gemini':
+          return process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? process.env.GEMINI_API_KEY ?? null;
+        case 'anthropic':
+          return process.env.ANTHROPIC_API_KEY ?? null;
+        case 'openai':
+          return process.env.OPENAI_API_KEY ?? null;
+        case 'deepseek':
+          return process.env.DEEPSEEK_API_KEY ?? null;
+        default:
+          return null;
+      }
+    },
+  };
+}
+import { teeAndParse, type ParsedDeepseekSse } from './deepseek-sse-transform.js';
+
+/**
+ * Base URL for DeepSeek's OpenAI-compatible chat completions endpoint.
+ * DeepSeek implements /chat/completions only — not /responses — so we
+ * must route via the `.chat(modelId)` factory of @ai-sdk/openai's
+ * createOpenAI() return value. Extracted per CLAUDE.md no-hardcoded-values rule.
+ */
+const DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
+
+/**
+ * Factory for creating AI SDK language model instances from configuration.
+ *
+ * Uses dynamic imports to avoid loading provider SDKs that aren't needed,
+ * keeping the startup cost minimal when only one provider is used.
+ *
+ * @example
+ * ```typescript
+ * const manager = new ModelManager();
+ * const model = await manager.getModel({ provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' });
+ * ```
+ */
+export class ModelManager {
+  /** Cached provider module references to avoid re-importing */
+  private providerCache = new Map<ModelProvider, (modelId: string) => LanguageModel>();
+
+  /**
+   * Per-instance buffer of parsed DeepSeek-R1 reasoning_content from in-flight
+   * and recently-completed HTTP calls. Each `streamText` call to a DeepSeek
+   * model triggers one or more fetch calls (one per agentic step); each fetch
+   * appends its parsed reasoning to this buffer. Consumer (agent-runner) reads
+   * via `consumeDeepseekReasoning()` after `await streamResult` and the buffer
+   * resets to `''` on read.
+   *
+   * **Concurrency:** AgentRunner uses one ModelManager per session and calls
+   * streamText serially per session (the rate limiter enforces this).
+   * Cross-session concurrency is not a concern because each AgentRunner gets
+   * its own ModelManager via `new ModelManager()` in the constructor.
+   */
+  private deepseekReasoningBuffer = '';
+
+  /** Tracks in-flight parsed-SSE handles so we can wait for drain on consume. */
+  private deepseekParsedHandles: ParsedDeepseekSse[] = [];
+
+  /**
+   * Get an AI SDK language model instance for the given configuration.
+   *
+   * Resolves API keys from settings (with override chain) and injects them
+   * into the environment before creating the model, so provider SDKs can find them.
+   *
+   * @param config - Model configuration specifying provider and model ID
+   * @returns AI SDK LanguageModel instance ready for use with generateText
+   * @throws Error if the provider is unknown or the SDK is not installed
+   */
+  async getModel(config: ModelConfig = CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL): Promise<LanguageModel> {
+    // Ensure the provider's API key is in the environment from settings
+    await this.ensureApiKeyInEnv(config.provider);
+
+    const providerFn = await this.getProviderFunction(config.provider);
+    return providerFn(config.modelId);
+  }
+
+  /**
+   * Get provider function, using cache for repeated calls.
+   *
+   * @param provider - Provider name
+   * @returns Function that creates a model from a model ID string
+   */
+  private async getProviderFunction(provider: ModelProvider): Promise<(modelId: string) => LanguageModel> {
+    const cached = this.providerCache.get(provider);
+    if (cached) return cached;
+
+    let providerFn: (modelId: string) => LanguageModel;
+
+    try {
+      switch (provider) {
+        case 'anthropic': {
+          const { anthropic } = await import('@ai-sdk/anthropic');
+          providerFn = (modelId: string) => anthropic(modelId);
+          break;
+        }
+        case 'openai': {
+          const { openai } = await import('@ai-sdk/openai');
+          providerFn = (modelId: string) => openai(modelId);
+          break;
+        }
+        case 'google': {
+          const { google } = await import('@ai-sdk/google');
+          providerFn = (modelId: string) => google(modelId);
+          break;
+        }
+        case 'ollama': {
+          const { createOllama } = await import('ollama-ai-provider');
+          const baseURL = process.env.OLLAMA_BASE_URL || CREWLY_AGENT_DEFAULTS.OLLAMA_BASE_URL;
+          const ollamaProvider = createOllama({ baseURL });
+          // ollama-ai-provider exports LanguageModelV1 which is compatible but
+          // doesn't extend the newer LanguageModel union — safe to cast.
+          providerFn = (modelId: string) => ollamaProvider(modelId) as unknown as LanguageModel;
+          break;
+        }
+        case 'deepseek': {
+          // DeepSeek API is OpenAI-compatible — reuse the OpenAI SDK with a custom baseURL.
+          // IMPORTANT: must call deepseekProvider.chat(modelId), NOT deepseekProvider(modelId).
+          // The bare function-call form on @ai-sdk/openai >=3.x routes to /responses, which
+          // DeepSeek does not implement — it only exposes /chat/completions. The .chat factory
+          // forces the chat-completions path. See PR #400 review for full trace.
+          //
+          // **I2 — reasoning_content extraction:**
+          // Pass a custom `fetch` that tees the SSE response body. One branch flows
+          // through to AI SDK unmodified (zero impact on existing behavior); the other
+          // branch is parsed for `delta.reasoning_content` text and accumulated into
+          // `this.deepseekReasoningBuffer`, which agent-runner consumes after
+          // streamResult drains. See deepseek-sse-transform.ts for the parser.
+          const { createOpenAI } = await import('@ai-sdk/openai');
+          const customFetch = this.makeDeepseekFetch();
+          const deepseekProvider = createOpenAI({
+            baseURL: DEEPSEEK_BASE_URL,
+            apiKey: process.env.DEEPSEEK_API_KEY,
+            fetch: customFetch as unknown as typeof globalThis.fetch,
+          });
+          providerFn = (modelId: string) => deepseekProvider.chat(modelId);
+          break;
+        }
+        default:
+          throw new Error(`Unknown model provider: ${provider}`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('Unknown model provider:')) {
+        throw error;
+      }
+      throw new Error(
+        `Failed to load provider SDK for '${provider}'. Is the package installed? ` +
+        `Original error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    this.providerCache.set(provider, providerFn);
+    return providerFn;
+  }
+
+  /**
+   * Check which providers have API keys configured (settings + env vars).
+   *
+   * @returns Object indicating which providers are available
+   */
+  async getAvailableProviders(): Promise<Record<ModelProvider, boolean>> {
+    const settingsService = getSettingsService();
+    const context = { runtime: 'crewly-agent' };
+
+    const [geminiKey, anthropicKey, openaiKey, deepseekKey] = await Promise.all([
+      settingsService.getApiKey('gemini', context),
+      settingsService.getApiKey('anthropic', context),
+      settingsService.getApiKey('openai', context),
+      settingsService.getApiKey('deepseek', context),
+    ]);
+
+    return {
+      anthropic: !!anthropicKey,
+      openai: !!openaiKey,
+      google: !!geminiKey,
+      ollama: true, // Ollama runs locally, always "available" if installed
+      deepseek: !!deepseekKey,
+    };
+  }
+
+  /**
+   * Map model provider name to API key provider name.
+   * Only applicable for cloud providers wired through the settings service
+   * (anthropic, openai, google, deepseek). Ollama runs locally and is
+   * excluded.
+   *
+   * @param provider - Cloud model provider
+   * @returns Corresponding ApiKeyProvider name
+   */
+  private static providerToApiKeyProvider(provider: Exclude<ModelProvider, 'ollama'>): ApiKeyProvider {
+    return provider === 'google' ? 'gemini' : provider;
+  }
+
+  /**
+   * Ensure the API key for a provider is available in process.env
+   * by resolving it from settings if not already present.
+   *
+   * No-op for 'ollama' (runs locally, no key required). All other providers —
+   * including 'deepseek' — flow through the settings service so users can
+   * configure them from the UI without touching env vars.
+   *
+   * @param provider - The model provider
+   */
+  private async ensureApiKeyInEnv(provider: ModelProvider): Promise<void> {
+    if (provider === 'ollama') return; // Ollama is local, no API key needed
+    const apiKeyProvider = ModelManager.providerToApiKeyProvider(provider);
+    const settingsService = getSettingsService();
+    const key = await settingsService.getApiKey(apiKeyProvider, { runtime: 'crewly-agent' });
+
+    if (!key) return;
+
+    // Set env vars so the provider SDKs can find them.
+    // Always override — settings keys take priority over stale env vars.
+    switch (provider) {
+      case 'anthropic':
+        process.env.ANTHROPIC_API_KEY = key;
+        break;
+      case 'openai':
+        process.env.OPENAI_API_KEY = key;
+        break;
+      case 'google':
+        process.env.GOOGLE_GENERATIVE_AI_API_KEY = key;
+        break;
+      case 'deepseek':
+        process.env.DEEPSEEK_API_KEY = key;
+        break;
+    }
+  }
+
+  /**
+   * Clear the provider cache (useful for testing or reconfiguration).
+   * Also clears any buffered DeepSeek reasoning so a fresh test/run starts clean.
+   */
+  clearCache(): void {
+    this.providerCache.clear();
+    this.deepseekReasoningBuffer = '';
+    this.deepseekParsedHandles = [];
+  }
+
+  /**
+   * Build the custom fetch wrapper for the DeepSeek provider.
+   *
+   * Returns a function with the same signature as `globalThis.fetch` that:
+   * 1. Calls native fetch with the supplied input/init.
+   * 2. If the response is a streaming SSE body, tees it and parses one branch
+   *    for `delta.reasoning_content`, accumulating into `this.deepseekReasoningBuffer`.
+   * 3. Returns a new Response wrapping the un-tampered passthrough branch as
+   *    its body, so AI SDK consumes exactly the bytes DeepSeek sent.
+   *
+   * If the response is not an SSE stream (e.g. error JSON, no body), it is
+   * returned unchanged.
+   *
+   * **Why a method, not a free function:** the wrapper closes over `this` to
+   * append to the per-instance reasoning buffer. Each ModelManager instance
+   * has its own buffer (one per AgentRunner per session).
+   */
+  private makeDeepseekFetch(): (input: unknown, init?: unknown) => Promise<Response> {
+    return async (input: unknown, init?: unknown): Promise<Response> => {
+      // Cast through `any` because @ai-sdk/openai's fetch type is the standard
+      // global fetch shape; we re-export native fetch behavior identically.
+      const response: Response = await (globalThis.fetch as any)(input, init);
+
+      // Only intercept successful streaming responses. Non-stream errors
+      // (4xx/5xx with JSON body) and empty bodies pass through untouched.
+      if (!response.ok || !response.body) return response;
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!contentType.includes('text/event-stream')) return response;
+
+      const parsed = teeAndParse(response.body);
+      this.deepseekParsedHandles.push(parsed);
+
+      // Wrap into a new Response with the passthrough branch as body.
+      // Headers, status, and statusText are copied so AI SDK sees an identical
+      // response shape.
+      return new Response(parsed.passthroughBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    };
+  }
+
+  /**
+   * Drain any in-flight DeepSeek SSE parser branches and return the accumulated
+   * `reasoning_content` string. Resets the buffer to `''` on each call (consume
+   * semantics).
+   *
+   * **Caller contract:** call AFTER `await streamResult` resolves in agent-runner.
+   * The AI SDK consumer branch must have been fully drained for the parser branch
+   * (which lags slightly due to tee buffering) to have caught up.
+   *
+   * **Multi-step accumulation:** if a single `streamText` call made multiple HTTP
+   * calls (one per agentic step), reasoning from all steps is concatenated in
+   * call order — not separated by step boundary. This matches the user-facing
+   * mental model of "what was the model's full chain of thought for this turn."
+   *
+   * **Returns `null` if no reasoning was captured.** Empty string means a fetch
+   * happened but produced no reasoning content (e.g. non-R1 DeepSeek model).
+   */
+  async consumeDeepseekReasoning(): Promise<string | null> {
+    const handles = this.deepseekParsedHandles;
+    this.deepseekParsedHandles = [];
+    if (handles.length === 0) {
+      const buffered = this.deepseekReasoningBuffer;
+      this.deepseekReasoningBuffer = '';
+      return buffered || null;
+    }
+    // Wait for all parser branches to finish draining (they should already be
+    // done if AI SDK consumer drained, but allow up to one event-loop tick).
+    for (const h of handles) {
+      if (!h.isDrained()) {
+        // Yield once so the parser background reader can flush.
+        await new Promise((r) => setImmediate(r));
+      }
+      this.deepseekReasoningBuffer += h.getReasoning();
+    }
+    const out = this.deepseekReasoningBuffer;
+    this.deepseekReasoningBuffer = '';
+    return out || null;
+  }
+}

--- a/packages/crewly-agent/src/runtime/output-filter.service.ts
+++ b/packages/crewly-agent/src/runtime/output-filter.service.ts
@@ -1,0 +1,175 @@
+/**
+ * Output Filter Service — API Key Redaction
+ *
+ * Scans all agent text output for API key patterns and replaces them
+ * with [REDACTED] before the output reaches users or logs.
+ *
+ * Detects patterns from major providers (OpenAI, Anthropic, Google, AWS)
+ * as well as generic key/token/secret assignments.
+ *
+ * @module services/agent/crewly-agent/output-filter.service
+ *
+ * @example
+ * ```typescript
+ * const filter = new OutputFilterService();
+ * const safe = filter.redact('My key is sk-abc123xyz');
+ * // => 'My key is [REDACTED]'
+ * ```
+ */
+
+/**
+ * A single API key detection pattern with a label for audit logging.
+ */
+export interface KeyPattern {
+  /** Regex to match the key in text */
+  pattern: RegExp;
+  /** Human-readable label for audit/logging */
+  label: string;
+}
+
+/**
+ * Result of scanning text for API keys.
+ */
+export interface ScanResult {
+  /** Whether any keys were detected */
+  detected: boolean;
+  /** Number of keys found */
+  count: number;
+  /** Labels of the matched patterns */
+  matchedPatterns: string[];
+  /** Redacted text with keys replaced */
+  redactedText: string;
+}
+
+/**
+ * API key patterns for major providers and generic secrets.
+ *
+ * Each pattern uses word boundaries or lookbehind/lookahead to minimize
+ * false positives while catching real key formats.
+ */
+export const API_KEY_PATTERNS: readonly KeyPattern[] = [
+  // OpenAI: sk-<org>-<rest> or sk-<48+ chars>
+  { pattern: /\bsk-[A-Za-z0-9_-]{20,}/g, label: 'OpenAI API Key' },
+  // Anthropic: sk-ant-api03-<rest>
+  { pattern: /\bsk-ant-[A-Za-z0-9_-]{20,}/g, label: 'Anthropic API Key' },
+  // Google AI: AIza<rest>
+  { pattern: /\bAIza[A-Za-z0-9_-]{30,}/g, label: 'Google API Key' },
+  // AWS Access Key: AKIA<16 alphanumeric>
+  { pattern: /\bAKIA[A-Z0-9]{16}\b/g, label: 'AWS Access Key' },
+  // AWS Secret Key (often follows access key)
+  { pattern: /(?<=aws_secret_access_key\s*[=:]\s*)[A-Za-z0-9/+=]{30,}/g, label: 'AWS Secret Key' },
+  // GitHub tokens: ghp_, gho_, ghu_, ghs_, ghr_
+  { pattern: /\bgh[pousr]_[A-Za-z0-9_]{30,}/g, label: 'GitHub Token' },
+  // Stripe: sk_live_ or sk_test_
+  { pattern: /\bsk_(live|test)_[A-Za-z0-9]{20,}/g, label: 'Stripe API Key' },
+  // Supabase anon/service keys (JWT-like, start with eyJ)
+  { pattern: /\beyJ[A-Za-z0-9_-]{50,}\.[A-Za-z0-9_-]{50,}\.[A-Za-z0-9_-]{20,}/g, label: 'JWT Token' },
+  // Generic key=value patterns (key, token, secret, password, api_key, apikey)
+  { pattern: /(?<=(?:api[_-]?key|api[_-]?secret|api[_-]?token|secret[_-]?key|access[_-]?token|auth[_-]?token|password|secret)\s*[=:]\s*["']?)[A-Za-z0-9_/+=.-]{16,}/gi, label: 'Generic Secret' },
+  // Environment variable assignments with sensitive names
+  { pattern: /(?<=(?:ANTHROPIC_API_KEY|OPENAI_API_KEY|GOOGLE_API_KEY|AWS_SECRET_ACCESS_KEY|STRIPE_SECRET_KEY|SUPABASE_SERVICE_ROLE_KEY|DATABASE_URL|REDIS_URL)\s*=\s*["']?)[^\s"']{8,}/g, label: 'Environment Variable Secret' },
+] as const;
+
+/** Replacement text for redacted keys */
+export const REDACTION_PLACEHOLDER = '[REDACTED]';
+
+/**
+ * Service that scans and redacts API keys from agent output text.
+ */
+export class OutputFilterService {
+  private readonly patterns: readonly KeyPattern[];
+
+  /**
+   * Creates a new OutputFilterService.
+   * @param customPatterns - Optional additional patterns to detect (appended to defaults)
+   */
+  constructor(customPatterns?: KeyPattern[]) {
+    this.patterns = customPatterns
+      ? [...API_KEY_PATTERNS, ...customPatterns]
+      : API_KEY_PATTERNS;
+  }
+
+  /**
+   * Scans text for API keys and returns detailed results.
+   *
+   * @param text - Text to scan for API keys
+   * @returns Scan result with detection info and redacted text
+   */
+  scan(text: string): ScanResult {
+    if (!text) {
+      return { detected: false, count: 0, matchedPatterns: [], redactedText: text };
+    }
+
+    let redacted = text;
+    let totalCount = 0;
+    const matchedLabels: Set<string> = new Set();
+
+    for (const { pattern, label } of this.patterns) {
+      // Reset regex lastIndex for global patterns
+      const regex = new RegExp(pattern.source, pattern.flags);
+      const matches = redacted.match(regex);
+      if (matches) {
+        totalCount += matches.length;
+        matchedLabels.add(label);
+        redacted = redacted.replace(regex, REDACTION_PLACEHOLDER);
+      }
+    }
+
+    return {
+      detected: totalCount > 0,
+      count: totalCount,
+      matchedPatterns: Array.from(matchedLabels),
+      redactedText: redacted,
+    };
+  }
+
+  /**
+   * Redacts all API keys in the given text.
+   * Convenience method that returns only the redacted string.
+   *
+   * @param text - Text to redact
+   * @returns Text with all detected API keys replaced with [REDACTED]
+   */
+  redact(text: string): string {
+    return this.scan(text).redactedText;
+  }
+
+  /**
+   * Checks if text contains any API keys without modifying it.
+   *
+   * @param text - Text to check
+   * @returns True if any API key patterns are detected
+   */
+  containsKeys(text: string): boolean {
+    if (!text) return false;
+    for (const { pattern } of this.patterns) {
+      const regex = new RegExp(pattern.source, pattern.flags);
+      if (regex.test(text)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Redacts API keys from a structured object (recursively scans string values).
+   * Useful for sanitizing tool call arguments and results before logging.
+   *
+   * @param obj - Object to scan and redact
+   * @returns Deep copy with all string values redacted
+   */
+  redactObject(obj: unknown): unknown {
+    if (typeof obj === 'string') {
+      return this.redact(obj);
+    }
+    if (Array.isArray(obj)) {
+      return obj.map((item) => this.redactObject(item));
+    }
+    if (typeof obj === 'object' && obj !== null) {
+      const result: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(obj)) {
+        result[key] = this.redactObject(value);
+      }
+      return result;
+    }
+    return obj;
+  }
+}

--- a/packages/crewly-agent/src/runtime/prompt-guard.service.ts
+++ b/packages/crewly-agent/src/runtime/prompt-guard.service.ts
@@ -1,0 +1,303 @@
+/**
+ * Prompt Guard Service — Prompt Injection Protection
+ *
+ * Detects and blocks prompt injection attempts that try to extract API keys,
+ * secrets, or sensitive environment variables through agent commands.
+ *
+ * Integrates with the tool registry to block dangerous bash commands and
+ * logs blocked attempts to the audit trail.
+ *
+ * @module services/agent/crewly-agent/prompt-guard.service
+ *
+ * @example
+ * ```typescript
+ * const guard = new PromptGuardService();
+ * const result = guard.checkCommand('echo $ANTHROPIC_API_KEY');
+ * // { blocked: true, reason: 'Key extraction attempt: echo env var', pattern: '...' }
+ * ```
+ */
+
+import type { AuditEntry, ToolSensitivity } from './types.js';
+
+/**
+ * A pattern that detects key extraction attempts.
+ */
+export interface GuardPattern {
+  /** Regex to match the dangerous command or prompt */
+  pattern: RegExp;
+  /** Human-readable reason for blocking */
+  reason: string;
+  /** Category for audit logging */
+  category: 'env_extraction' | 'key_dump' | 'prompt_injection' | 'file_exfiltration';
+}
+
+/**
+ * Result of a prompt guard check.
+ */
+export interface GuardCheckResult {
+  /** Whether the command/prompt was blocked */
+  blocked: boolean;
+  /** Reason for blocking (empty if not blocked) */
+  reason: string;
+  /** Category of the threat (undefined if not blocked) */
+  category?: GuardPattern['category'];
+  /** The matched pattern source (for audit logging) */
+  matchedPattern?: string;
+}
+
+/**
+ * Patterns that detect attempts to extract API keys or secrets via bash commands.
+ */
+export const KEY_EXTRACTION_PATTERNS: readonly GuardPattern[] = [
+  // Direct env var echo/print
+  {
+    pattern: /\becho\s+\$[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)/i,
+    reason: 'Attempt to echo sensitive environment variable',
+    category: 'env_extraction',
+  },
+  {
+    pattern: /\bprintf\s+.*\$[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|AUTH)/i,
+    reason: 'Attempt to printf sensitive environment variable',
+    category: 'env_extraction',
+  },
+  // env/printenv with grep for secrets
+  {
+    pattern: /\benv\b.*\|\s*grep\s+.*(?:KEY|SECRET|TOKEN|PASSWORD|API|AUTH)/i,
+    reason: 'Attempt to grep env for secrets',
+    category: 'env_extraction',
+  },
+  {
+    pattern: /\bprintenv\b.*(?:KEY|SECRET|TOKEN|PASSWORD|API|AUTH)/i,
+    reason: 'Attempt to printenv sensitive variable',
+    category: 'env_extraction',
+  },
+  // set | grep (bash set command dumps all vars)
+  {
+    pattern: /\bset\b\s*\|\s*grep\s+.*(?:KEY|SECRET|TOKEN|PASSWORD|API|AUTH)/i,
+    reason: 'Attempt to dump shell variables and grep for secrets',
+    category: 'env_extraction',
+  },
+  // Reading sensitive config files (must come before bare env/printenv to avoid early match on "cat .env")
+  {
+    pattern: /\bcat\s+.*\.env\b/i,
+    reason: 'Attempt to read .env file',
+    category: 'file_exfiltration',
+  },
+  {
+    pattern: /\bcat\s+.*(?:credentials|secrets|\.aws\/credentials|\.npmrc|\.netrc|\.pgpass)/i,
+    reason: 'Attempt to read credentials file',
+    category: 'file_exfiltration',
+  },
+  {
+    pattern: /\bcat\s+.*\/etc\/shadow\b/i,
+    reason: 'Attempt to read system password file',
+    category: 'file_exfiltration',
+  },
+  // Direct env dump
+  {
+    pattern: /\benv\s*$/i,
+    reason: 'Attempt to dump all environment variables',
+    category: 'key_dump',
+  },
+  {
+    pattern: /\bprintenv\s*$/i,
+    reason: 'Attempt to dump all environment variables',
+    category: 'key_dump',
+  },
+  // compgen dumps shell vars/functions
+  {
+    pattern: /\bcompgen\s+-[ev]/i,
+    reason: 'Attempt to dump shell variables via compgen',
+    category: 'key_dump',
+  },
+  // base64 encoding secrets for exfiltration
+  {
+    pattern: /\bbase64\b.*\$[A-Z_]*(?:KEY|SECRET|TOKEN)/i,
+    reason: 'Attempt to base64 encode secret for exfiltration',
+    category: 'file_exfiltration',
+  },
+  // curl/wget exfiltration of env vars
+  {
+    pattern: /\b(?:curl|wget)\b.*\$[A-Z_]*(?:KEY|SECRET|TOKEN)/i,
+    reason: 'Attempt to exfiltrate secret via HTTP request',
+    category: 'file_exfiltration',
+  },
+  // Python/Node one-liners to access env
+  {
+    pattern: /\bpython[23]?\s+-c\s+.*os\.environ/i,
+    reason: 'Attempt to access env via Python subprocess',
+    category: 'env_extraction',
+  },
+  {
+    pattern: /\bnode\s+-e\s+.*process\.env/i,
+    reason: 'Attempt to access env via Node subprocess',
+    category: 'env_extraction',
+  },
+  // Specific key variable names in $() or backtick subshells
+  {
+    pattern: /\$\(.*(?:ANTHROPIC_API_KEY|OPENAI_API_KEY|GOOGLE_API_KEY|AWS_SECRET|STRIPE_SECRET)/i,
+    reason: 'Attempt to expand sensitive env var in subshell',
+    category: 'env_extraction',
+  },
+] as const;
+
+/**
+ * Prompt-level injection patterns (detected in natural language prompts, not just commands).
+ */
+export const PROMPT_INJECTION_PATTERNS: readonly GuardPattern[] = [
+  {
+    pattern: /(?:print|show|reveal|tell\s+me|display|output|give\s+me|share)\s+(?:(?:your|the|my|me\s+the)\s+)?(?:api[_ ]?key|secret|token|password|credentials)/i,
+    reason: 'Prompt injection: request to reveal API key/secret',
+    category: 'prompt_injection',
+  },
+  {
+    pattern: /(?:what\s+is|what's)\s+(?:your|the|my)\s+(?:api[_ ]?key|secret[_ ]?key|auth[_ ]?token|password)/i,
+    reason: 'Prompt injection: question about API key/secret',
+    category: 'prompt_injection',
+  },
+  {
+    pattern: /ignore\s+(?:previous|all|your)\s+(?:instructions|rules|safety)/i,
+    reason: 'Prompt injection: instruction override attempt',
+    category: 'prompt_injection',
+  },
+  {
+    pattern: /(?:override|bypass|disable|turn\s+off)\s+(?:security|safety|filter|guardrail|redaction)/i,
+    reason: 'Prompt injection: attempt to disable security filters',
+    category: 'prompt_injection',
+  },
+] as const;
+
+/**
+ * Additional blocked command patterns for tool-registry.ts integration.
+ * These extend the existing BLOCKED_COMMAND_PATTERNS with key extraction blocks.
+ */
+export const KEY_EXTRACTION_BLOCKED_COMMANDS: RegExp[] = [
+  /\benv\s*$/i,
+  /\bprintenv\s*$/i,
+  /\benv\b.*\|\s*grep\s+.*(?:KEY|SECRET|TOKEN|PASSWORD|API)/i,
+  /\bset\b\s*\|\s*grep\s+.*(?:KEY|SECRET|TOKEN|PASSWORD|API)/i,
+  /\bcompgen\s+-[ev]/i,
+  /\bcat\s+.*\.env\b/i,
+  /\bcat\s+.*(?:credentials|secrets|\.aws\/credentials|\.npmrc|\.netrc|\.pgpass)/i,
+];
+
+/**
+ * Service that detects and blocks prompt injection and key extraction attempts.
+ */
+export class PromptGuardService {
+  private readonly commandPatterns: readonly GuardPattern[];
+  private readonly promptPatterns: readonly GuardPattern[];
+
+  /**
+   * Creates a new PromptGuardService.
+   *
+   * @param additionalCommandPatterns - Extra command-level patterns
+   * @param additionalPromptPatterns - Extra prompt-level patterns
+   */
+  constructor(
+    additionalCommandPatterns?: GuardPattern[],
+    additionalPromptPatterns?: GuardPattern[],
+  ) {
+    this.commandPatterns = additionalCommandPatterns
+      ? [...KEY_EXTRACTION_PATTERNS, ...additionalCommandPatterns]
+      : KEY_EXTRACTION_PATTERNS;
+    this.promptPatterns = additionalPromptPatterns
+      ? [...PROMPT_INJECTION_PATTERNS, ...additionalPromptPatterns]
+      : PROMPT_INJECTION_PATTERNS;
+  }
+
+  /**
+   * Checks a bash command for key extraction attempts.
+   *
+   * @param command - Raw bash command string
+   * @returns Guard check result
+   */
+  checkCommand(command: string): GuardCheckResult {
+    if (!command) {
+      return { blocked: false, reason: '' };
+    }
+
+    for (const guard of this.commandPatterns) {
+      if (guard.pattern.test(command)) {
+        return {
+          blocked: true,
+          reason: guard.reason,
+          category: guard.category,
+          matchedPattern: guard.pattern.source,
+        };
+      }
+    }
+
+    return { blocked: false, reason: '' };
+  }
+
+  /**
+   * Checks a user/agent prompt for injection attempts targeting secrets.
+   *
+   * @param prompt - The text prompt or message
+   * @returns Guard check result
+   */
+  checkPrompt(prompt: string): GuardCheckResult {
+    if (!prompt) {
+      return { blocked: false, reason: '' };
+    }
+
+    for (const guard of this.promptPatterns) {
+      if (guard.pattern.test(prompt)) {
+        return {
+          blocked: true,
+          reason: guard.reason,
+          category: guard.category,
+          matchedPattern: guard.pattern.source,
+        };
+      }
+    }
+
+    return { blocked: false, reason: '' };
+  }
+
+  /**
+   * Checks both command and prompt patterns.
+   * Use this for comprehensive scanning of any agent input.
+   *
+   * @param text - Text to check (command or prompt)
+   * @returns Guard check result
+   */
+  check(text: string): GuardCheckResult {
+    const cmdResult = this.checkCommand(text);
+    if (cmdResult.blocked) return cmdResult;
+    return this.checkPrompt(text);
+  }
+
+  /**
+   * Creates an audit entry for a blocked attempt.
+   *
+   * @param sessionName - Agent session that triggered the block
+   * @param toolName - Tool that was used (e.g. 'bash_exec')
+   * @param command - The blocked command
+   * @param guardResult - The guard check result
+   * @returns AuditEntry suitable for the audit log
+   */
+  createAuditEntry(
+    sessionName: string,
+    toolName: string,
+    command: string,
+    guardResult: GuardCheckResult,
+  ): AuditEntry {
+    return {
+      timestamp: new Date().toISOString(),
+      sessionName,
+      toolName,
+      sensitivity: 'destructive' as ToolSensitivity,
+      args: {
+        command,
+        blockedReason: guardResult.reason,
+        category: guardResult.category || 'unknown',
+        matchedPattern: guardResult.matchedPattern || '',
+      },
+      success: false,
+      error: `Blocked by prompt guard: ${guardResult.reason}`,
+      durationMs: 0,
+    };
+  }
+}

--- a/packages/crewly-agent/src/runtime/rate-limiter.test.ts
+++ b/packages/crewly-agent/src/runtime/rate-limiter.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RateLimiter, RATE_LIMITER_DEFAULTS } from './rate-limiter.js';
+
+describe('RateLimiter', () => {
+  let limiter: RateLimiter<string>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    limiter = new RateLimiter<string>({
+      maxRequestsPerWindow: 3,
+      windowMs: 10_000,
+      maxRetries: 2,
+      initialBackoffMs: 100,
+      backoffMultiplier: 2,
+      maxBackoffMs: 1000,
+      coalesceWindowMs: 50,
+    });
+  });
+
+  afterEach(() => {
+    limiter.reset();
+    vi.useRealTimers();
+  });
+
+  describe('defaults', () => {
+    it('should have sensible default config', () => {
+      const defaultLimiter = new RateLimiter<string>();
+      const config = defaultLimiter.getConfig();
+      expect(config.maxRequestsPerWindow).toBe(RATE_LIMITER_DEFAULTS.maxRequestsPerWindow);
+      expect(config.windowMs).toBe(RATE_LIMITER_DEFAULTS.windowMs);
+      expect(config.maxRetries).toBe(RATE_LIMITER_DEFAULTS.maxRetries);
+      defaultLimiter.reset();
+    });
+  });
+
+  describe('basic enqueue', () => {
+    it('should process a single message', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>().mockResolvedValue('ok');
+      const resultP = limiter.enqueue('hello', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      const result = await resultP;
+      expect(result).toBe('ok');
+      expect(handler).toHaveBeenCalledWith('hello', undefined);
+    });
+
+    it('should pass metadata through', async () => {
+      const handler = vi.fn<(msg: string, meta?: Record<string, string>) => Promise<string>>().mockResolvedValue('ok');
+      const meta = { channelId: 'C1' };
+      const resultP = limiter.enqueue('hello', meta, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await resultP;
+      expect(handler).toHaveBeenCalledWith('hello', meta);
+    });
+  });
+
+  describe('message coalescing', () => {
+    it('should coalesce messages arriving within the coalesce window', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>().mockResolvedValue('ok');
+
+      // Enqueue 3 messages rapidly (within 50ms coalesce window)
+      const p1 = limiter.enqueue('msg1', undefined, handler);
+      const p2 = limiter.enqueue('msg2', undefined, handler);
+      const p3 = limiter.enqueue('msg3', undefined, handler);
+
+      // Advance past coalesce window
+      await vi.advanceTimersByTimeAsync(100);
+
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      // All should get the same result
+      expect(r1).toBe('ok');
+      expect(r2).toBe('ok');
+      expect(r3).toBe('ok');
+
+      // Handler called only once (messages coalesced)
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      // The coalesced message should mention all 3
+      const callArg = handler.mock.calls[0][0];
+      expect(callArg).toContain('3 messages received');
+      expect(callArg).toContain('msg1');
+      expect(callArg).toContain('msg2');
+      expect(callArg).toContain('msg3');
+    });
+
+    it('should not coalesce a single message', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>().mockResolvedValue('ok');
+
+      const p = limiter.enqueue('single', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await p;
+
+      expect(handler).toHaveBeenCalledWith('single', undefined);
+    });
+  });
+
+  describe('429 retry', () => {
+    it('should retry on quota exceeded error', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValueOnce(new Error('429 Too Many Requests'))
+        .mockResolvedValueOnce('recovered');
+
+      const resultP = limiter.enqueue('test', undefined, handler);
+      // Advance past coalesce window
+      await vi.advanceTimersByTimeAsync(100);
+      // Advance past backoff (100ms)
+      await vi.advanceTimersByTimeAsync(200);
+      const result = await resultP;
+
+      expect(result).toBe('recovered');
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on quota exceeded message', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValueOnce(new Error('You exceeded your current quota'))
+        .mockResolvedValueOnce('ok');
+
+      const resultP = limiter.enqueue('test', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(200);
+      const result = await resultP;
+
+      expect(result).toBe('ok');
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry on RESOURCE_EXHAUSTED', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValueOnce(new Error('RESOURCE_EXHAUSTED: quota limit reached'))
+        .mockResolvedValueOnce('ok');
+
+      const resultP = limiter.enqueue('test', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(200);
+      const result = await resultP;
+
+      expect(result).toBe('ok');
+    });
+
+    it('should NOT retry on non-quota errors', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValue(new Error('Invalid API key'));
+
+      // Attach catch immediately to prevent unhandled rejection warning
+      let caughtError: Error | null = null;
+      const resultP = limiter.enqueue('test', undefined, handler)
+        .catch((e: Error) => { caughtError = e; return 'caught' as string; });
+
+      for (let i = 0; i < 10; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      await resultP;
+
+      expect(caughtError).not.toBeNull();
+      expect(caughtError!.message).toBe('Invalid API key');
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject after max retries exhausted', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValue(new Error('429 rate limited'));
+
+      let caughtError: Error | null = null;
+      const resultP = limiter.enqueue('test', undefined, handler)
+        .catch((e: Error) => { caughtError = e; return 'caught' as string; });
+
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(200);
+      }
+      await resultP;
+
+      expect(caughtError).not.toBeNull();
+      expect(caughtError!.message).toContain('Rate limit retries exhausted');
+      expect(handler).toHaveBeenCalledTimes(3); // initial + 2 retries
+    });
+
+    it('should reject all coalesced messages on retry exhaustion', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>()
+        .mockRejectedValue(new Error('429'));
+
+      let err1: Error | null = null;
+      let err2: Error | null = null;
+      const p1 = limiter.enqueue('a', undefined, handler)
+        .catch((e: Error) => { err1 = e; return 'caught' as string; });
+      const p2 = limiter.enqueue('b', undefined, handler)
+        .catch((e: Error) => { err2 = e; return 'caught' as string; });
+
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(200);
+      }
+      await Promise.all([p1, p2]);
+
+      expect(err1).not.toBeNull();
+      expect(err1!.message).toContain('Rate limit retries exhausted');
+      expect(err2).not.toBeNull();
+      expect(err2!.message).toContain('Rate limit retries exhausted');
+    });
+  });
+
+  describe('rate limiting (window enforcement)', () => {
+    it('should track requests in window', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>().mockResolvedValue('ok');
+
+      expect(limiter.getRequestCountInWindow()).toBe(0);
+
+      const p1 = limiter.enqueue('a', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await p1;
+      expect(limiter.getRequestCountInWindow()).toBe(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear all state', async () => {
+      const handler = vi.fn<(msg: string) => Promise<string>>().mockResolvedValue('ok');
+
+      const p = limiter.enqueue('test', undefined, handler);
+      await vi.advanceTimersByTimeAsync(100);
+      await p;
+
+      limiter.reset();
+      expect(limiter.getQueueLength()).toBe(0);
+      expect(limiter.isProcessing()).toBe(false);
+      expect(limiter.getRequestCountInWindow()).toBe(0);
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/rate-limiter.ts
+++ b/packages/crewly-agent/src/runtime/rate-limiter.ts
@@ -1,0 +1,353 @@
+/**
+ * Rate Limiter for Crewly Agent API Calls
+ *
+ * Provides token-bucket rate limiting, message coalescing, and 429 retry
+ * logic to prevent Gemini API quota exhaustion when multiple agents are
+ * actively generating messages.
+ *
+ * @module services/agent/crewly-agent/rate-limiter
+ */
+
+/**
+ * Configuration for the rate limiter.
+ */
+export interface RateLimiterConfig {
+  /** Maximum requests allowed per window */
+  maxRequestsPerWindow: number;
+  /** Time window in milliseconds */
+  windowMs: number;
+  /** Maximum retry attempts for 429 errors */
+  maxRetries: number;
+  /** Initial backoff delay in milliseconds for 429 retries */
+  initialBackoffMs: number;
+  /** Backoff multiplier for exponential retry */
+  backoffMultiplier: number;
+  /** Maximum backoff delay in milliseconds */
+  maxBackoffMs: number;
+  /** Coalescing window — how long to wait for additional messages before processing (ms) */
+  coalesceWindowMs: number;
+}
+
+/**
+ * Default rate limiter configuration.
+ */
+export const RATE_LIMITER_DEFAULTS: RateLimiterConfig = {
+  maxRequestsPerWindow: 10,
+  windowMs: 60_000,
+  maxRetries: 3,
+  initialBackoffMs: 5_000,
+  backoffMultiplier: 2,
+  maxBackoffMs: 60_000,
+  coalesceWindowMs: 2_000,
+};
+
+/**
+ * A queued message awaiting processing.
+ */
+interface QueuedMessage<T> {
+  /** The message content */
+  message: string;
+  /** Optional metadata passed through to the handler */
+  metadata?: Record<string, string>;
+  /** Promise resolve callback */
+  resolve: (value: T) => void;
+  /** Promise reject callback */
+  reject: (error: Error) => void;
+  /** Timestamp when the message was enqueued */
+  enqueuedAt: number;
+}
+
+/**
+ * Token-bucket rate limiter with message coalescing and 429 retry.
+ *
+ * Features:
+ * - **Rate limiting**: Enforces max requests per time window using a sliding window.
+ * - **Message coalescing**: Groups messages arriving within a short window into one.
+ * - **429 retry**: Wraps API calls with exponential backoff on quota errors.
+ *
+ * @example
+ * ```typescript
+ * const limiter = new RateLimiter<AgentRunResult>();
+ * const result = await limiter.enqueue('Check status', undefined, async (msg) => {
+ *   return agentRunner.run(msg);
+ * });
+ * ```
+ */
+export class RateLimiter<T> {
+  private config: RateLimiterConfig;
+  private requestTimestamps: number[] = [];
+  private queue: QueuedMessage<T>[] = [];
+  private processing = false;
+  private coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Create a new RateLimiter instance.
+   *
+   * @param config - Optional partial config overrides
+   */
+  constructor(config?: Partial<RateLimiterConfig>) {
+    this.config = { ...RATE_LIMITER_DEFAULTS, ...config };
+  }
+
+  /**
+   * Enqueue a message for rate-limited processing.
+   *
+   * If multiple messages arrive within the coalescing window, they are
+   * merged into a single request to reduce API call count.
+   *
+   * @param message - Message to process
+   * @param metadata - Optional metadata
+   * @param handler - Async function that performs the actual API call
+   * @returns Result from the handler
+   */
+  enqueue(
+    message: string,
+    metadata: Record<string, string> | undefined,
+    handler: (message: string, metadata?: Record<string, string>) => Promise<T>,
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        message,
+        metadata,
+        resolve,
+        reject,
+        enqueuedAt: Date.now(),
+      });
+
+      // Reset coalesce timer — wait for more messages before processing
+      if (this.coalesceTimer) {
+        clearTimeout(this.coalesceTimer);
+      }
+
+      this.coalesceTimer = setTimeout(() => {
+        this.coalesceTimer = null;
+        if (!this.processing) {
+          this.processQueue(handler).catch(() => {
+            // Errors are already routed to individual promise reject callbacks
+          });
+        }
+      }, this.config.coalesceWindowMs);
+    });
+  }
+
+  /**
+   * Get the current number of messages in the queue.
+   *
+   * @returns Queue length
+   */
+  getQueueLength(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Check if the rate limiter is currently processing.
+   *
+   * @returns True if processing
+   */
+  isProcessing(): boolean {
+    return this.processing;
+  }
+
+  /**
+   * Get the number of requests made in the current window.
+   *
+   * @returns Request count in current window
+   */
+  getRequestCountInWindow(): number {
+    this.pruneOldTimestamps();
+    return this.requestTimestamps.length;
+  }
+
+  /**
+   * Get the current configuration.
+   *
+   * @returns Rate limiter configuration
+   */
+  getConfig(): RateLimiterConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Reset internal state (for testing).
+   */
+  reset(): void {
+    this.requestTimestamps = [];
+    this.queue = [];
+    this.processing = false;
+    if (this.coalesceTimer) {
+      clearTimeout(this.coalesceTimer);
+      this.coalesceTimer = null;
+    }
+  }
+
+  /**
+   * Process the queue: coalesce messages, enforce rate limit, execute with retry.
+   *
+   * @param handler - The actual API call handler
+   */
+  private async processQueue(
+    handler: (message: string, metadata?: Record<string, string>) => Promise<T>,
+  ): Promise<void> {
+    this.processing = true;
+
+    try {
+      while (this.queue.length > 0) {
+        // Wait for rate limit window if needed
+        await this.waitForCapacity();
+
+        // Coalesce all pending messages into one
+        const batch = this.queue.splice(0, this.queue.length);
+        const coalesced = this.coalesceMessages(batch);
+
+        // Record this request timestamp
+        this.requestTimestamps.push(Date.now());
+
+        // Execute with 429 retry
+        try {
+          const result = await this.executeWithRetry(
+            coalesced.message,
+            coalesced.metadata,
+            handler,
+          );
+
+          // Resolve all promises in the batch with the same result
+          for (const item of batch) {
+            item.resolve(result);
+          }
+        } catch (error) {
+          // Reject all promises in the batch
+          const err = error instanceof Error ? error : new Error(String(error));
+          for (const item of batch) {
+            item.reject(err);
+          }
+        }
+      }
+    } finally {
+      this.processing = false;
+
+      // Check if more messages arrived while processing
+      if (this.queue.length > 0) {
+        this.processQueue(handler).catch(() => {
+          // Errors are already routed to individual promise reject callbacks
+        });
+      }
+    }
+  }
+
+  /**
+   * Wait until we have capacity in the rate limit window.
+   */
+  private async waitForCapacity(): Promise<void> {
+    this.pruneOldTimestamps();
+
+    while (this.requestTimestamps.length >= this.config.maxRequestsPerWindow) {
+      // Calculate how long to wait until the oldest request falls out of the window
+      const oldestTimestamp = this.requestTimestamps[0];
+      const waitMs = (oldestTimestamp + this.config.windowMs) - Date.now() + 100; // +100ms buffer
+
+      if (waitMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, waitMs));
+      }
+
+      this.pruneOldTimestamps();
+    }
+  }
+
+  /**
+   * Remove timestamps older than the current window.
+   */
+  private pruneOldTimestamps(): void {
+    const cutoff = Date.now() - this.config.windowMs;
+    this.requestTimestamps = this.requestTimestamps.filter((ts) => ts > cutoff);
+  }
+
+  /**
+   * Coalesce multiple queued messages into a single message.
+   *
+   * If there's only one message, it passes through unchanged.
+   * Multiple messages are joined with a separator and a header.
+   *
+   * @param batch - Array of queued messages to coalesce
+   * @returns Single coalesced message and metadata from the most recent item
+   */
+  private coalesceMessages(batch: QueuedMessage<T>[]): { message: string; metadata?: Record<string, string> } {
+    if (batch.length === 1) {
+      return { message: batch[0].message, metadata: batch[0].metadata };
+    }
+
+    // Use metadata from the most recent message
+    const latestMetadata = batch[batch.length - 1].metadata;
+
+    // Coalesce messages with a numbered separator
+    const parts = batch.map((item, index) => {
+      return `[Message ${index + 1}/${batch.length}]\n${item.message}`;
+    });
+
+    const coalesced = `${batch.length} messages received while rate-limited. Process them together:\n\n${parts.join('\n\n---\n\n')}`;
+
+    return { message: coalesced, metadata: latestMetadata };
+  }
+
+  /**
+   * Execute the handler with exponential backoff retry on 429/quota errors.
+   *
+   * @param message - Message to send
+   * @param metadata - Optional metadata
+   * @param handler - The API call handler
+   * @returns Handler result
+   * @throws Error after max retries exhausted
+   */
+  private async executeWithRetry(
+    message: string,
+    metadata: Record<string, string> | undefined,
+    handler: (message: string, metadata?: Record<string, string>) => Promise<T>,
+  ): Promise<T> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        return await handler(message, metadata);
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        // Only retry on 429 / quota errors
+        if (!this.isRetryableError(lastError)) {
+          throw lastError;
+        }
+
+        if (attempt >= this.config.maxRetries) {
+          break;
+        }
+
+        // Exponential backoff
+        const backoffMs = Math.min(
+          this.config.initialBackoffMs * Math.pow(this.config.backoffMultiplier, attempt),
+          this.config.maxBackoffMs,
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+
+    throw new Error(
+      `Rate limit retries exhausted (${this.config.maxRetries} attempts). Last error: ${lastError?.message}`,
+    );
+  }
+
+  /**
+   * Check if an error is retryable (429 or quota-related).
+   *
+   * @param error - The error to check
+   * @returns True if the error should be retried
+   */
+  private isRetryableError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('429') ||
+      message.includes('quota') ||
+      message.includes('rate limit') ||
+      message.includes('resource_exhausted') ||
+      message.includes('too many requests')
+    );
+  }
+}

--- a/packages/crewly-agent/src/runtime/tool-registry.test.ts
+++ b/packages/crewly-agent/src/runtime/tool-registry.test.ts
@@ -1,0 +1,2510 @@
+// Tool registry tests — tools, sensitivity levels, markdown conversion, glob matching
+import { describe, it, expect, beforeEach, vi, afterEach, type Mocked, type MockInstance } from 'vitest';
+import { createTools, getToolNames, TOOL_SENSITIVITY, stripNotifyMarkers, convertMarkdownToSlackMrkdwn, globToRegExp, walkAndMatch, searchFileContents } from './tool-registry.js';
+import { CrewlyApiClient } from './api-client.js';
+import type { AuditEntry, ToolCallbacks, CompactionResult, AuditLogFilters } from './types.js';
+import { WRITE_TOOLS } from './types.js';
+
+describe('Tool Registry', () => {
+  let mockClient: Mocked<CrewlyApiClient>;
+  let tools: ReturnType<typeof createTools>;
+
+  beforeEach(() => {
+    mockClient = {
+      get: vi.fn<any>().mockResolvedValue({ success: false, data: null, status: 404 }),
+      post: vi.fn<any>(),
+      delete: vi.fn<any>(),
+    } as any;
+    tools = createTools(mockClient, 'crewly-orc', '/test/project');
+  });
+
+  describe('getToolNames', () => {
+    it('should return all tool names including glob and grep', () => {
+      const names = getToolNames();
+      // 32 base tools + web_search (cloud-backed; standalone runtime only)
+      expect(names).toHaveLength(33);
+      expect(names).toContain('web_search');
+      expect(names).toContain('delegate_task');
+      expect(names).toContain('send_message');
+      expect(names).toContain('get_agent_status');
+      expect(names).toContain('get_team_status');
+      expect(names).toContain('get_agent_logs');
+      expect(names).toContain('reply_slack');
+      expect(names).toContain('schedule_check');
+      expect(names).toContain('cancel_schedule');
+      expect(names).toContain('get_scheduled_checks');
+      expect(names).toContain('start_agent');
+      expect(names).toContain('stop_agent');
+      expect(names).toContain('subscribe_event');
+      expect(names).toContain('recall_memory');
+      expect(names).toContain('remember');
+      expect(names).toContain('heartbeat');
+      expect(names).toContain('get_tasks');
+      expect(names).toContain('complete_task');
+      expect(names).toContain('broadcast');
+      expect(names).toContain('handle_agent_failure');
+      expect(names).toContain('edit_file');
+      expect(names).toContain('read_file');
+      expect(names).toContain('write_file');
+      expect(names).toContain('register_self');
+      expect(names).toContain('get_project_overview');
+      expect(names).toContain('report_status');
+      expect(names).toContain('compact_memory');
+      expect(names).toContain('get_audit_log');
+      expect(names).toContain('glob');
+      expect(names).toContain('grep');
+    });
+  });
+
+  describe('createTools', () => {
+    it('should create all tools with descriptions and parameters', () => {
+      const toolNames = Object.keys(tools);
+      expect(toolNames.length).toBeGreaterThanOrEqual(30);
+      for (const name of toolNames) {
+        const t = tools[name] as any;
+        expect(t).toBeDefined();
+      }
+    });
+  });
+
+  describe('delegate_task', () => {
+    it('should deliver task message and create tracking entry', async () => {
+      mockClient.post.mockResolvedValueOnce({ success: true, data: {}, status: 200 }); // deliver
+      // V3 task-pool/add response shape: `{ data: { id, ... } }`. The
+      // legacy v1 `taskId` field is gone — see spec
+      // 2026-05-06-task-management-v1-deprecation.md.
+      mockClient.post.mockResolvedValueOnce({ success: true, data: { id: 'task-1' }, status: 201 }); // task create
+      mockClient.post.mockResolvedValueOnce({ success: true, data: { id: 'sub-1' }, status: 201 }); // subscribe
+
+      const result = await (tools.delegate_task as any).execute({
+        to: 'agent-sam',
+        task: 'Build feature X',
+        priority: 'high',
+        projectPath: '/path/to/project',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.delegatedTo).toBe('agent-sam');
+      expect(result.taskId).toBe('task-1');
+      expect(mockClient.post).toHaveBeenCalledTimes(3);
+    });
+
+    it('should fall back to force delivery on initial failure', async () => {
+      mockClient.post
+        .mockResolvedValueOnce({ success: false, error: 'not ready', status: 503 }) // deliver fails
+        .mockResolvedValueOnce({ success: true, data: {}, status: 200 }) // force deliver
+        .mockResolvedValueOnce({ success: true, data: {}, status: 201 }); // subscribe (no projectPath)
+
+      const result = await (tools.delegate_task as any).execute({
+        to: 'agent-sam',
+        task: 'Build feature X',
+        priority: 'normal',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return error if both delivery attempts fail', async () => {
+      mockClient.post
+        .mockResolvedValueOnce({ success: false, error: 'not ready', status: 503 })
+        .mockResolvedValueOnce({ success: false, error: 'session gone', status: 404 });
+
+      const result = await (tools.delegate_task as any).execute({
+        to: 'agent-sam',
+        task: 'Build feature X',
+        priority: 'normal',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('agent-sam');
+    });
+  });
+
+  describe('send_message', () => {
+    it('should deliver message with waitForReady', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.send_message as any).execute({
+        sessionName: 'agent-sam',
+        message: 'Hello',
+        force: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/terminal/agent-sam/deliver',
+        expect.objectContaining({ message: 'Hello', waitForReady: true }),
+      );
+    });
+
+    it('should force deliver when force=true', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.send_message as any).execute({
+        sessionName: 'agent-sam',
+        message: 'Urgent',
+        force: true,
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/terminal/agent-sam/deliver',
+        expect.objectContaining({ message: 'Urgent', force: true }),
+      );
+    });
+  });
+
+  describe('get_agent_status', () => {
+    it('should find agent in team members', async () => {
+      mockClient.get.mockResolvedValue({
+        success: true,
+        data: [
+          { members: [{ sessionName: 'agent-sam', status: 'active' }] },
+        ],
+        status: 200,
+      });
+
+      const result = await (tools.get_agent_status as any).execute({
+        sessionName: 'agent-sam',
+      });
+
+      expect(result.sessionName).toBe('agent-sam');
+      expect(result.status).toBe('active');
+    });
+
+    it('should return error when agent not found', async () => {
+      mockClient.get.mockResolvedValue({
+        success: true,
+        data: [{ members: [] }],
+        status: 200,
+      });
+
+      const result = await (tools.get_agent_status as any).execute({
+        sessionName: 'nonexistent',
+      });
+
+      expect(result.error).toBe('Agent not found');
+    });
+  });
+
+  describe('get_team_status', () => {
+    it('should return all teams', async () => {
+      mockClient.get.mockResolvedValue({ success: true, data: [{ name: 'Team A' }], status: 200 });
+
+      const result = await (tools.get_team_status as any).execute({});
+
+      expect(result).toEqual([{ name: 'Team A' }]);
+    });
+  });
+
+  describe('get_agent_logs', () => {
+    it('should fetch terminal output', async () => {
+      mockClient.get.mockResolvedValue({ success: true, data: 'line 1\nline 2', status: 200 });
+
+      const result = await (tools.get_agent_logs as any).execute({
+        sessionName: 'agent-sam',
+        lines: 20,
+      });
+
+      expect(result).toBe('line 1\nline 2');
+      expect(mockClient.get).toHaveBeenCalledWith('/terminal/agent-sam/output?lines=20');
+    });
+  });
+
+  describe('reply_slack', () => {
+    it('should send slack message with thread', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Hello team',
+        threadTs: '123.456',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C123',
+        text: '[Orc] Hello team',
+        senderSessionName: 'crewly-orc',
+        threadTs: '123.456',
+      });
+    });
+
+    it('should send without threadTs', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Hello',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C123',
+        text: '[Orc] Hello',
+        senderSessionName: 'crewly-orc',
+      });
+    });
+
+    it('should strip [NOTIFY] markers from text before sending (Bug 6)', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: '[NOTIFY]\nconversationId: conv-123\n---\n## Task Done\nAll tasks completed.\n[/NOTIFY]',
+        threadTs: '123.456',
+      });
+
+      // After stripping NOTIFY markers, text starts with "##" not "[", so prefix is added
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C123',
+        text: '[Orc] ## Task Done\nAll tasks completed.',
+        senderSessionName: 'crewly-orc',
+        threadTs: '123.456',
+      });
+    });
+
+    it('should handle text with no NOTIFY markers unchanged', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Plain message without markers',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C123',
+        text: '[Orc] Plain message without markers',
+        senderSessionName: 'crewly-orc',
+      });
+    });
+
+    it('should not double-prefix text already starting with [', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: '[Sam] Already prefixed message',
+        senderSessionName: 'crewly-orc',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/send', {
+        channelId: 'C123',
+        text: '[Sam] Already prefixed message',
+        senderSessionName: 'crewly-orc',
+      });
+    });
+
+    it('should upload image when imagePath is provided', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { fileId: 'F123' }, status: 200 });
+
+      const result = await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Here is the screenshot',
+        imagePath: '/tmp/screenshot.png',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(true);
+      expect(result.filePath).toBe('/tmp/screenshot.png');
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/upload-image', {
+        channelId: 'C123',
+        filePath: '/tmp/screenshot.png',
+        initialComment: '[Orc] Here is the screenshot',
+      });
+    });
+
+    it('should upload image with threadTs', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { fileId: 'F123' }, status: 200 });
+
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Screenshot',
+        threadTs: '123.456',
+        imagePath: '/tmp/shot.png',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/upload-image', {
+        channelId: 'C123',
+        filePath: '/tmp/shot.png',
+        initialComment: '[Orc] Screenshot',
+        threadTs: '123.456',
+      });
+    });
+
+    it('should return error when image upload fails', async () => {
+      mockClient.post.mockResolvedValue({ success: false, data: null, status: 404, error: 'File not found: /tmp/missing.png' });
+
+      const result = await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Missing image',
+        imagePath: '/tmp/missing.png',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('File not found: /tmp/missing.png');
+    });
+
+    it('should use Slack context channelId for image upload when channelId omitted', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { fileId: 'F456' }, status: 200 });
+
+      const toolsWithContext = createTools(mockClient, 'crewly-orc', '/test/project', undefined, undefined, { channelId: 'C-FROM-CONTEXT', threadTs: '999.888' });
+
+      const result = await (toolsWithContext.reply_slack as any).execute({
+        text: 'Image from context',
+        imagePath: '/tmp/ctx.png',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/upload-image', {
+        channelId: 'C-FROM-CONTEXT',
+        filePath: '/tmp/ctx.png',
+        initialComment: '[Orc] Image from context',
+        threadTs: '999.888',
+      });
+    });
+
+    it('should return error when no channelId for image upload', async () => {
+      const toolsNoContext = createTools(mockClient, 'crewly-orc', '/test/project');
+
+      const result = await (toolsNoContext.reply_slack as any).execute({
+        text: 'Image without channel',
+        imagePath: '/tmp/no-channel.png',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No channelId');
+    });
+
+    it('should skip dedup and throttle for image uploads', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      // Send a text message first to populate dedup and throttle state
+      await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Duplicate text',
+      });
+
+      // Image upload with same text should NOT be deduped or throttled
+      const result = await (tools.reply_slack as any).execute({
+        channelId: 'C123',
+        text: 'Duplicate text',
+        imagePath: '/tmp/image.png',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.uploaded).toBe(true);
+      // Should have called upload-image, not been throttled/deduped
+      expect(mockClient.post).toHaveBeenCalledWith('/slack/upload-image', expect.objectContaining({
+        filePath: '/tmp/image.png',
+      }));
+    });
+  });
+
+  describe('stripNotifyMarkers', () => {
+    it('should extract body after --- separator', () => {
+      const input = '[NOTIFY]\nconversationId: conv-123\ntype: task_completed\n---\n## Done\nTask finished.\n[/NOTIFY]';
+      expect(stripNotifyMarkers(input)).toBe('## Done\nTask finished.');
+    });
+
+    it('should return inner content when no --- separator', () => {
+      const input = '[NOTIFY]\nHello world\n[/NOTIFY]';
+      expect(stripNotifyMarkers(input)).toBe('Hello world');
+    });
+
+    it('should handle text mixed with NOTIFY blocks', () => {
+      const input = 'Before [NOTIFY]\n---\nExtracted\n[/NOTIFY] After';
+      expect(stripNotifyMarkers(input)).toBe('Before Extracted After');
+    });
+
+    it('should handle multiple NOTIFY blocks', () => {
+      const input = '[NOTIFY]\n---\nFirst\n[/NOTIFY] and [NOTIFY]\n---\nSecond\n[/NOTIFY]';
+      expect(stripNotifyMarkers(input)).toBe('First and Second');
+    });
+
+    it('should return text unchanged when no markers present', () => {
+      expect(stripNotifyMarkers('No markers here')).toBe('No markers here');
+    });
+
+    it('should be case-insensitive', () => {
+      const input = '[notify]\n---\nContent\n[/notify]';
+      expect(stripNotifyMarkers(input)).toBe('Content');
+    });
+  });
+
+  describe('#181: convertMarkdownToSlackMrkdwn', () => {
+    it('should convert **bold** to *bold*', () => {
+      expect(convertMarkdownToSlackMrkdwn('This is **bold** text')).toBe('This is *bold* text');
+    });
+
+    it('should convert multiple **bold** segments', () => {
+      expect(convertMarkdownToSlackMrkdwn('**one** and **two**')).toBe('*one* and *two*');
+    });
+
+    it('should convert [text](url) to <url|text>', () => {
+      expect(convertMarkdownToSlackMrkdwn('Visit [Google](https://google.com) now'))
+        .toBe('Visit <https://google.com|Google> now');
+    });
+
+    it('should escape & < > to HTML entities', () => {
+      expect(convertMarkdownToSlackMrkdwn('A & B < C > D'))
+        .toBe('A &amp; B &lt; C &gt; D');
+    });
+
+    it('should strip language hints from fenced code blocks', () => {
+      const input = '```typescript\nconst x = 1;\n```';
+      const expected = '```\nconst x = 1;\n```';
+      expect(convertMarkdownToSlackMrkdwn(input)).toBe(expected);
+    });
+
+    it('should preserve plain code blocks without language hint', () => {
+      const input = '```\ncode here\n```';
+      expect(convertMarkdownToSlackMrkdwn(input)).toBe('```\ncode here\n```');
+    });
+
+    it('should handle combined formatting', () => {
+      const input = '**Important**: See [docs](https://docs.io) for A & B';
+      const result = convertMarkdownToSlackMrkdwn(input);
+      expect(result).toContain('*Important*');
+      expect(result).toContain('<https://docs.io|docs>');
+      expect(result).toContain('A &amp; B');
+    });
+
+    it('should not touch single asterisks (italic)', () => {
+      expect(convertMarkdownToSlackMrkdwn('This is *italic* text')).toBe('This is *italic* text');
+    });
+
+    it('should return empty string unchanged', () => {
+      expect(convertMarkdownToSlackMrkdwn('')).toBe('');
+    });
+
+    it('should handle text with no markdown', () => {
+      expect(convertMarkdownToSlackMrkdwn('Plain text')).toBe('Plain text');
+    });
+  });
+
+  describe('schedule_check', () => {
+    it('should schedule a one-time check', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { checkId: 'sched-1' }, status: 201 });
+
+      const result = await (tools.schedule_check as any).execute({
+        minutes: 10,
+        message: 'Check progress',
+        recurring: false,
+      });
+
+      expect(result.checkId).toBe('sched-1');
+      expect(mockClient.post).toHaveBeenCalledWith('/schedule', expect.objectContaining({
+        targetSession: 'crewly-orc',
+        minutes: 10,
+        message: 'Check progress',
+      }));
+    });
+
+    it('should schedule a recurring check', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { checkId: 'sched-2' }, status: 201 });
+
+      await (tools.schedule_check as any).execute({
+        minutes: 5,
+        message: 'Recurring check',
+        recurring: true,
+        maxOccurrences: 3,
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/schedule', expect.objectContaining({
+        isRecurring: true,
+        intervalMinutes: 5,
+        maxOccurrences: 3,
+      }));
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should fetch teams, projects, and queue in parallel', async () => {
+      mockClient.get
+        .mockResolvedValueOnce({ success: true, data: [{ name: 'Team A' }], status: 200 })
+        .mockResolvedValueOnce({ success: true, data: [{ name: 'Project 1' }], status: 200 })
+        .mockResolvedValueOnce({ success: true, data: { pending: 0 }, status: 200 });
+
+      const result = await (tools.heartbeat as any).execute({});
+
+      expect(result.status).toBe('ok');
+      expect(result.teams).toEqual([{ name: 'Team A' }]);
+      expect(result.projects).toEqual([{ name: 'Project 1' }]);
+      expect(result.queue).toEqual({ pending: 0 });
+    });
+
+    it('should handle partial failures gracefully', async () => {
+      mockClient.get
+        .mockResolvedValueOnce({ success: true, data: [], status: 200 })
+        .mockResolvedValueOnce({ success: false, error: 'unavailable', status: 500 })
+        .mockResolvedValueOnce({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.heartbeat as any).execute({});
+
+      expect(result.status).toBe('ok');
+      expect(result.projects).toBe('unavailable');
+    });
+  });
+
+  describe('start_agent', () => {
+    it('should start agent via API when not already active', async () => {
+      // Pre-check returns team with inactive member
+      mockClient.get.mockResolvedValueOnce({
+        success: true,
+        data: { members: [{ id: 'member-1', agentStatus: 'inactive', sessionName: '' }] },
+        status: 200,
+      });
+      mockClient.post.mockResolvedValue({ success: true, data: { started: true }, status: 200 });
+
+      const result = await (tools.start_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.started).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledWith('/teams/team-1/members/member-1/start', {});
+    });
+
+    it('should return already_active without calling start if agent is active', async () => {
+      mockClient.get.mockResolvedValueOnce({
+        success: true,
+        data: { members: [{ id: 'member-1', agentStatus: 'active', sessionName: 'session-1', name: 'Sam' }] },
+        status: 200,
+      });
+
+      const result = await (tools.start_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.status).toBe('already_active');
+      expect(result.sessionName).toBe('session-1');
+      expect(mockClient.post).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with start if pre-check fails', async () => {
+      mockClient.get.mockResolvedValueOnce({ success: false, error: 'not found', status: 404 });
+      mockClient.post.mockResolvedValue({ success: true, data: { started: true }, status: 200 });
+
+      const result = await (tools.start_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.started).toBe(true);
+    });
+  });
+
+  describe('stop_agent', () => {
+    it('should stop agent via API', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { stopped: true }, status: 200 });
+
+      const result = await (tools.stop_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.stopped).toBe(true);
+    });
+  });
+
+  describe('handle_agent_failure', () => {
+    it('should restart agent by stopping then starting', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.handle_agent_failure as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+        sessionName: 'agent-sam',
+        action: 'restart',
+      });
+
+      expect(result.action).toBe('restarted');
+      expect(result.success).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledTimes(2); // stop + start
+    });
+
+    it('should handle escalation', async () => {
+      const result = await (tools.handle_agent_failure as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+        sessionName: 'agent-sam',
+        action: 'escalate',
+        reason: 'Agent stuck',
+      });
+
+      expect(result.action).toBe('escalated');
+      expect(result.reason).toBe('Agent stuck');
+    });
+  });
+
+  describe('recall_memory', () => {
+    it('should call memory recall API with auto-injected projectPath', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { memories: [] }, status: 200 });
+
+      const result = await (tools.recall_memory as any).execute({
+        context: 'deployment process',
+        scope: 'project',
+      });
+
+      expect(result.memories).toEqual([]);
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/recall', {
+        agentId: 'crewly-orc',
+        context: 'deployment process',
+        scope: 'project',
+        projectPath: '/test/project',
+      });
+    });
+
+    it('should auto-inject projectPath for scope=both', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { memories: [] }, status: 200 });
+
+      await (tools.recall_memory as any).execute({
+        context: 'OKR goals',
+        scope: 'both',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/recall', expect.objectContaining({
+        projectPath: '/test/project',
+        scope: 'both',
+      }));
+    });
+
+    it('should not inject projectPath for scope=agent', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { memories: [] }, status: 200 });
+
+      await (tools.recall_memory as any).execute({
+        context: 'my preferences',
+        scope: 'agent',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/recall', {
+        agentId: 'crewly-orc',
+        context: 'my preferences',
+        scope: 'agent',
+      });
+    });
+
+    it('should prefer explicit projectPath over auto-injected', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      await (tools.recall_memory as any).execute({
+        context: 'test',
+        scope: 'project',
+        projectPath: '/explicit/path',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/recall', expect.objectContaining({
+        projectPath: '/explicit/path',
+      }));
+    });
+  });
+
+  describe('remember', () => {
+    it('should store knowledge via API with auto-injected projectPath', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { id: 'mem-1' }, status: 201 });
+
+      const result = await (tools.remember as any).execute({
+        content: 'Always use async/await',
+        category: 'pattern',
+        scope: 'project',
+      });
+
+      expect(result.id).toBe('mem-1');
+      expect(mockClient.post).toHaveBeenCalledWith('/memory/remember', expect.objectContaining({
+        projectPath: '/test/project',
+      }));
+    });
+  });
+
+  describe('get_tasks', () => {
+    it('should fetch tasks with project path', async () => {
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+
+      await (tools.get_tasks as any).execute({
+        projectPath: '/path/to/project',
+        status: 'in_progress',
+      });
+
+      // V3-only: pool is global, projectPath is no longer a filter. See
+      // spec/2026-05-06-task-management-v1-deprecation.md.
+      expect(mockClient.get).toHaveBeenCalledWith('/task-pool/items?status=in_progress');
+    });
+  });
+
+  describe('broadcast', () => {
+    it('should send message to all sessions except self', async () => {
+      mockClient.get.mockResolvedValue({
+        success: true,
+        data: [{ name: 'agent-sam' }, { name: 'agent-leo' }, { name: 'crewly-orc' }],
+        status: 200,
+      });
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.broadcast as any).execute({ message: 'Hello all' });
+
+      expect(result.sent).toBe(2); // sam + leo, skip crewly-orc (self)
+      expect(result.failed).toBe(0);
+    });
+  });
+
+  describe('edit_file', () => {
+    let mockReadFile: MockInstance<typeof import('fs').promises.readFile>;
+    let mockWriteFile: MockInstance<typeof import('fs').promises.writeFile>;
+
+    beforeEach(async () => {
+      const fs = await import('fs');
+      mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+      mockWriteFile = vi.spyOn(fs.promises, 'writeFile') as any;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should replace unique string in file', async () => {
+      mockReadFile.mockResolvedValue('Hello World\nGoodbye World' as any);
+      mockWriteFile.mockResolvedValue(undefined as any);
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'Hello World',
+        new_string: 'Hi World',
+        replace_all: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.replacements).toBe(1);
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        '/test/file.ts',
+        'Hi World\nGoodbye World',
+        'utf8',
+      );
+    });
+
+    it('should fail when old_string not found', async () => {
+      mockReadFile.mockResolvedValue('Hello World' as any);
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'Not Found',
+        new_string: 'Replacement',
+        replace_all: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('should fail when old_string has multiple matches and replace_all is false', async () => {
+      mockReadFile.mockResolvedValue('foo bar foo baz foo' as any);
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'foo',
+        new_string: 'qux',
+        replace_all: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('3 times');
+      expect(result.occurrences).toBe(3);
+    });
+
+    it('should replace all occurrences when replace_all is true', async () => {
+      mockReadFile.mockResolvedValue('foo bar foo baz foo' as any);
+      mockWriteFile.mockResolvedValue(undefined as any);
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'foo',
+        new_string: 'qux',
+        replace_all: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.replacements).toBe(3);
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        '/test/file.ts',
+        'qux bar qux baz qux',
+        'utf8',
+      );
+    });
+
+    it('should handle single occurrence with replace_all true', async () => {
+      mockReadFile.mockResolvedValue('Hello World\nGoodbye World' as any);
+      mockWriteFile.mockResolvedValue(undefined as any);
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'Hello World',
+        new_string: 'Hi World',
+        replace_all: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.replacements).toBe(1);
+    });
+
+    it('should handle file not found error', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+      const result = await (tools.edit_file as any).execute({
+        file_path: '/nonexistent/file.ts',
+        old_string: 'foo',
+        new_string: 'bar',
+        replace_all: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('read_file', () => {
+    let mockReadFile: MockInstance<typeof import('fs').promises.readFile>;
+
+    beforeEach(async () => {
+      const fs = await import('fs');
+      mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should read entire file with line numbers', async () => {
+      mockReadFile.mockResolvedValue('line 1\nline 2\nline 3' as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/file.ts',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.totalLines).toBe(3);
+      expect(result.content).toContain('1\tline 1');
+      expect(result.content).toContain('3\tline 3');
+    });
+
+    it('should support offset and limit', async () => {
+      mockReadFile.mockResolvedValue('a\nb\nc\nd\ne' as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/file.ts',
+        offset: 2,
+        limit: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain('2\tb');
+      expect(result.content).toContain('3\tc');
+      expect(result.content).not.toContain('4\td');
+    });
+
+    it('should handle file not found', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/nonexistent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('should return base64 image data for PNG files', async () => {
+      const fakeImageBuffer = Buffer.from('fake-png-data');
+      mockReadFile.mockResolvedValue(fakeImageBuffer as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/screenshot.png',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('image');
+      expect(result.mimeType).toBe('image/png');
+      expect(result.data).toBe(fakeImageBuffer.toString('base64'));
+      expect(result.sizeBytes).toBe(fakeImageBuffer.length);
+      expect(result.file).toBe('/test/screenshot.png');
+    });
+
+    it('should return base64 image data for JPEG files', async () => {
+      const fakeImageBuffer = Buffer.from('fake-jpg-data');
+      mockReadFile.mockResolvedValue(fakeImageBuffer as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/photo.jpg',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('image');
+      expect(result.mimeType).toBe('image/jpeg');
+    });
+
+    it('should return base64 image data for WebP files', async () => {
+      const fakeImageBuffer = Buffer.from('fake-webp-data');
+      mockReadFile.mockResolvedValue(fakeImageBuffer as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/image.webp',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('image');
+      expect(result.mimeType).toBe('image/webp');
+    });
+
+    it('should return base64 image data for SVG files', async () => {
+      const fakeSvgBuffer = Buffer.from('<svg></svg>');
+      mockReadFile.mockResolvedValue(fakeSvgBuffer as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/icon.svg',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('image');
+      expect(result.mimeType).toBe('image/svg+xml');
+    });
+
+    it('should read text files normally even with image-like names', async () => {
+      mockReadFile.mockResolvedValue('text content' as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/data.json',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBeUndefined();
+      expect(result.content).toContain('text content');
+    });
+
+    it('should handle image file not found', async () => {
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/nonexistent/image.png',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('should truncate files exceeding 2000 lines when no limit specified', async () => {
+      // Generate a file with 3000 lines
+      const lines = Array.from({ length: 3000 }, (_, i) => `Line ${i + 1} content here`);
+      const largeContent = lines.join('\n');
+      mockReadFile.mockResolvedValue(largeContent as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/large-file.ts',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.totalLines).toBe(3000);
+      expect(result.truncated).toBe(true);
+      expect(result.shownLines).toBe(2000);
+      // Should only contain first 2000 lines
+      const outputLines = result.content.split('\n');
+      expect(outputLines.length).toBeLessThanOrEqual(2001); // 2000 lines + possible truncation msg
+    });
+
+    it('should not truncate small files', async () => {
+      const smallContent = 'line1\nline2\nline3';
+      mockReadFile.mockResolvedValue(smallContent as any);
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/test/small-file.ts',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.totalLines).toBe(3);
+      expect(result.truncated).toBeUndefined();
+    });
+  });
+
+  describe('write_file', () => {
+    let mockWriteFile: MockInstance<typeof import('fs').promises.writeFile>;
+    let mockMkdir: MockInstance<typeof import('fs').promises.mkdir>;
+
+    beforeEach(async () => {
+      const fs = await import('fs');
+      mockWriteFile = vi.spyOn(fs.promises, 'writeFile') as any;
+      mockMkdir = vi.spyOn(fs.promises, 'mkdir') as any;
+      mockWriteFile.mockResolvedValue(undefined as any);
+      mockMkdir.mockResolvedValue(undefined as any);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should write file and return byte count', async () => {
+      const result = await (tools.write_file as any).execute({
+        file_path: '/test/new-file.ts',
+        content: 'export const x = 1;\n',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.file).toBe('/test/new-file.ts');
+      expect(result.bytes).toBeGreaterThan(0);
+      expect(mockMkdir).toHaveBeenCalledWith('/test', { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith('/test/new-file.ts', 'export const x = 1;\n', 'utf8');
+    });
+
+    it('should handle write errors', async () => {
+      mockWriteFile.mockRejectedValue(new Error('EACCES'));
+
+      const result = await (tools.write_file as any).execute({
+        file_path: '/protected/file.ts',
+        content: 'test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('EACCES');
+    });
+  });
+
+  describe('read_file bash fallback', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const os = require('os') as typeof import('os');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs') as typeof import('fs');
+    const tmpDir: string = os.tmpdir();
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return error when fs.readFile fails with non-ENOENT error', async () => {
+      const tmpFile = `${tmpDir}/crewly-test-read-fallback-${Date.now()}.txt`;
+      fs.writeFileSync(tmpFile, 'line one\nline two\n');
+
+      // Mock fs.promises.readFile to fail with EPERM (not ENOENT)
+      const mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+      mockReadFile.mockRejectedValue(new Error('EPERM: operation not permitted'));
+
+      try {
+        const result = await (tools.read_file as any).execute({
+          file_path: tmpFile,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('EPERM');
+      } finally {
+        fs.unlinkSync(tmpFile);
+      }
+    });
+
+    it('should not fallback for ENOENT errors', async () => {
+      const result = await (tools.read_file as any).execute({
+        file_path: '/nonexistent/crewly-test-no-such-file.ts',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+      expect(result.fallback).toBeUndefined();
+    });
+
+    it('should return original error when both fs and bash fail', async () => {
+      // Mock readFile to fail with EPERM, use a non-existent file so bash cat also fails
+      const mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+      mockReadFile.mockRejectedValue(new Error('EPERM'));
+
+      const result = await (tools.read_file as any).execute({
+        file_path: '/nonexistent/crewly-test-both-fail.ts',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('EPERM');
+    });
+  });
+
+  describe('write_file bash fallback', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const os = require('os') as typeof import('os');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('fs') as typeof import('fs');
+    const tmpDir: string = os.tmpdir();
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return error when fs.writeFile fails', async () => {
+      const tmpFile = `${tmpDir}/crewly-test-write-fallback-${Date.now()}.txt`;
+      const content = 'export const x = 1;\n';
+
+      // Mock writeFile to fail
+      const mockWriteFile = vi.spyOn(fs.promises, 'writeFile') as any;
+      mockWriteFile.mockRejectedValue(new Error('EPERM: operation not permitted'));
+
+      try {
+        const result = await (tools.write_file as any).execute({
+          file_path: tmpFile,
+          content,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('EPERM');
+      } finally {
+        try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
+      }
+    });
+
+    it('should return original error when both fs and bash fail', async () => {
+      // Mock writeFile to fail; use an invalid path so bash cat > also fails
+      const mockWriteFile = vi.spyOn(fs.promises, 'writeFile') as any;
+      const mockMkdir = vi.spyOn(fs.promises, 'mkdir') as any;
+      mockWriteFile.mockRejectedValue(new Error('EACCES'));
+      mockMkdir.mockResolvedValue(undefined as any);
+
+      const result = await (tools.write_file as any).execute({
+        file_path: '/proc/nonexistent/crewly-test-both-fail.ts',
+        content: 'test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('EACCES');
+    });
+  });
+
+  // ===== Bug 1: Tilde path expansion tests =====
+
+  describe('read_file tilde expansion', () => {
+    let mockReadFile: MockInstance<typeof import('fs').promises.readFile>;
+
+    beforeEach(async () => {
+      const fs = await import('fs');
+      mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should expand ~ to home directory', async () => {
+      mockReadFile.mockResolvedValue('file content' as any);
+
+      await (tools.read_file as any).execute({
+        file_path: '~/.crewly/skills/SKILLS_CATALOG.md',
+      });
+
+      const calledPath = mockReadFile.mock.calls[0][0] as string;
+      expect(calledPath).not.toContain('~');
+      expect(calledPath).toMatch(/^\//); // absolute path
+      expect(calledPath).toContain('.crewly/skills/SKILLS_CATALOG.md');
+    });
+
+    it('should expand $HOME to home directory', async () => {
+      mockReadFile.mockResolvedValue('file content' as any);
+
+      await (tools.read_file as any).execute({
+        file_path: '$HOME/.config/test.json',
+      });
+
+      const calledPath = mockReadFile.mock.calls[0][0] as string;
+      expect(calledPath).not.toContain('$HOME');
+      expect(calledPath).toMatch(/^\//);
+      expect(calledPath).toContain('.config/test.json');
+    });
+
+    it('should not modify absolute paths', async () => {
+      mockReadFile.mockResolvedValue('file content' as any);
+
+      await (tools.read_file as any).execute({
+        file_path: '/usr/local/test.txt',
+      });
+
+      expect(mockReadFile).toHaveBeenCalledWith('/usr/local/test.txt', 'utf8');
+    });
+  });
+
+  describe('edit_file tilde expansion', () => {
+    let mockReadFile: MockInstance<typeof import('fs').promises.readFile>;
+    let mockWriteFile: MockInstance<typeof import('fs').promises.writeFile>;
+
+    beforeEach(async () => {
+      const fs = await import('fs');
+      mockReadFile = vi.spyOn(fs.promises, 'readFile') as any;
+      mockWriteFile = vi.spyOn(fs.promises, 'writeFile') as any;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should expand ~ in edit_file path', async () => {
+      mockReadFile.mockResolvedValue('old content' as any);
+      mockWriteFile.mockResolvedValue(undefined as any);
+
+      await (tools.edit_file as any).execute({
+        file_path: '~/test.ts',
+        old_string: 'old content',
+        new_string: 'new content',
+        replace_all: false,
+      });
+
+      const readPath = mockReadFile.mock.calls[0][0] as string;
+      expect(readPath).not.toContain('~');
+      expect(readPath).toMatch(/^\//);
+    });
+  });
+
+  // ===== Bug 3: New tool tests =====
+
+  describe('register_self', () => {
+    it('should register agent with the backend', async () => {
+      mockClient.post.mockResolvedValue({
+        success: true,
+        data: { sessionName: 'crewly-orc', status: 'active' },
+        status: 200,
+      });
+
+      const result = await (tools.register_self as any).execute({
+        role: 'developer',
+      });
+
+      expect(result.sessionName).toBe('crewly-orc');
+      expect(result.status).toBe('active');
+      expect(mockClient.post).toHaveBeenCalledWith('/teams/members/register', {
+        role: 'developer',
+        sessionName: 'crewly-orc',
+      });
+    });
+
+    it('should return error on failure', async () => {
+      mockClient.post.mockResolvedValue({
+        success: false,
+        error: 'Agent not found',
+        status: 404,
+      });
+
+      const result = await (tools.register_self as any).execute({
+        role: 'developer',
+      });
+
+      expect(result.error).toBe('Agent not found');
+    });
+  });
+
+  describe('get_project_overview', () => {
+    it('should return all projects', async () => {
+      const projects = [{ name: 'crewly', path: '/path' }];
+      mockClient.get.mockResolvedValue({ success: true, data: projects, status: 200 });
+
+      const result = await (tools.get_project_overview as any).execute({});
+
+      expect(result).toEqual(projects);
+      expect(mockClient.get).toHaveBeenCalledWith('/projects');
+    });
+
+    it('should return error on failure', async () => {
+      mockClient.get.mockResolvedValue({ success: false, error: 'Server error', status: 500 });
+
+      const result = await (tools.get_project_overview as any).execute({});
+
+      expect(result.error).toBe('Server error');
+    });
+  });
+
+  describe('report_status', () => {
+    it('should send status via chat API with formatted message', async () => {
+      mockClient.post.mockResolvedValue({
+        success: true,
+        data: { acknowledged: true },
+        status: 200,
+      });
+
+      const result = await (tools.report_status as any).execute({
+        status: 'done',
+        summary: 'Task completed',
+      });
+
+      expect(result.acknowledged).toBe(true);
+      expect(mockClient.post).toHaveBeenCalledWith('/chat/agent-response', {
+        content: '[DONE] Agent crewly-orc: Task completed',
+        senderName: 'crewly-orc',
+        senderType: 'agent',
+      });
+    });
+
+    // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+    // Auto-complete now resolves the agent's running WI from the pool and
+    // calls `/task-pool/complete/:id`. Replaces v1 `/task-management/complete-by-session`.
+    //
+    // Hygiene #4 (2026-05-09): the body shape is the canonical
+    // `{agentId, result:{summary}}` required by task-pool.controller.ts
+    // `completeItem`. `agentId` here is the session whose status=done
+    // message triggered this auto-complete path.
+    it('should auto-complete the running WorkItem when status is done — canonical body shape', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { acknowledged: true }, status: 200 });
+      mockClient.get.mockResolvedValueOnce({
+        success: true,
+        data: { workItems: [{ id: 'wi-running-1' }] },
+        status: 200,
+      });
+
+      await (tools.report_status as any).execute({
+        status: 'done',
+        summary: 'Feature implemented',
+      });
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/task-pool\/items\?status=running&target=/),
+      );
+      // Canonical body shape per Hygiene #4 — `{agentId, result:{summary}}`.
+      // The `crewly-orc` literal here is the createTools sessionName arg
+      // used in the test fixture (see top-of-file `createTools(mockClient, 'crewly-orc', ...)`).
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/task-pool/complete/wi-running-1',
+        { agentId: 'crewly-orc', result: { summary: 'Feature implemented' } },
+      );
+    });
+
+    it('should not auto-complete tasks when status is in_progress', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { acknowledged: true }, status: 200 });
+
+      await (tools.report_status as any).execute({
+        status: 'in_progress',
+        summary: 'Working on it',
+      });
+
+      expect(mockClient.post).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^\/task-pool\/complete\//),
+        expect.anything(),
+      );
+    });
+  });
+
+  // ===== F13: Autonomous Context Compaction =====
+
+  describe('compact_memory', () => {
+    it('should call onCompactMemory callback when available', async () => {
+      const mockCompact = vi.fn<() => Promise<CompactionResult>>().mockResolvedValue({
+        compacted: true,
+        messagesBefore: 50,
+        messagesAfter: 11,
+      });
+      const callbacks: ToolCallbacks = { onCompactMemory: mockCompact };
+      const toolsWithCallbacks = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithCallbacks.compact_memory as any).execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(result.messagesBefore).toBe(50);
+      expect(result.messagesAfter).toBe(11);
+      expect(mockCompact).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return error when no callback configured', async () => {
+      const result = await (tools.compact_memory as any).execute({});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not available');
+    });
+
+    it('should pass through skipped compaction result', async () => {
+      const mockCompact = vi.fn<() => Promise<CompactionResult>>().mockResolvedValue({
+        compacted: false,
+        messagesBefore: 5,
+        messagesAfter: 5,
+        reason: 'Too few messages to compact',
+      });
+      const callbacks: ToolCallbacks = { onCompactMemory: mockCompact };
+      const toolsWithCallbacks = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithCallbacks.compact_memory as any).execute({});
+
+      expect(result.success).toBe(false);
+      expect(result.reason).toContain('Too few');
+    });
+  });
+
+  describe('get_context_budget', () => {
+    it('should return budget status when callback is configured', async () => {
+      const mockBudget = vi.fn<any>().mockReturnValue({
+        totalTokensUsed: 50000,
+        contextWindowSize: 200000,
+        usagePercent: 0.25,
+        level: 'normal',
+        messageCount: 20,
+        compactionPending: false,
+        summary: '25.0% of context budget used (50,000/200,000 tokens, 20 messages)',
+      });
+      const callbacks: ToolCallbacks = { onGetContextBudget: mockBudget };
+      const toolsWithCallbacks = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithCallbacks.get_context_budget as any).execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.totalTokensUsed).toBe(50000);
+      expect(result.contextWindowSize).toBe(200000);
+      expect(result.usagePercent).toBe(0.25);
+      expect(result.level).toBe('normal');
+      expect(mockBudget).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return error when no callback configured', async () => {
+      const result = await (tools.get_context_budget as any).execute({});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not available');
+    });
+
+    it('should return warning level when approaching threshold', async () => {
+      const mockBudget = vi.fn<any>().mockReturnValue({
+        totalTokensUsed: 140000,
+        contextWindowSize: 200000,
+        usagePercent: 0.7,
+        level: 'warning',
+        messageCount: 80,
+        compactionPending: false,
+        summary: '70.0% of context budget used — WARNING: approaching compaction threshold',
+      });
+      const callbacks: ToolCallbacks = { onGetContextBudget: mockBudget };
+      const toolsWithCallbacks = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithCallbacks.get_context_budget as any).execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.level).toBe('warning');
+      expect(result.summary).toContain('WARNING');
+    });
+
+    it('should be classified as safe', () => {
+      expect(TOOL_SENSITIVITY.get_context_budget).toBe('safe');
+    });
+  });
+
+  // ===== F27: Security Audit Trail & Hardening =====
+
+  describe('get_audit_log', () => {
+    it('should return error when no callback configured', async () => {
+      const result = await (tools.get_audit_log as any).execute({
+        limit: 20,
+        sensitivity: 'destructive',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not available');
+    });
+
+    it('should return actual audit entries via onGetAuditLog callback', async () => {
+      const mockEntries: AuditEntry[] = [
+        { timestamp: '2026-01-01T00:00:00Z', toolName: 'edit_file', sensitivity: 'destructive', args: {}, success: true, durationMs: 10 },
+        { timestamp: '2026-01-01T00:01:00Z', toolName: 'get_team_status', sensitivity: 'safe', args: {}, success: true, durationMs: 5 },
+      ];
+      const callbacks: ToolCallbacks = {
+        onGetAuditLog: (filters: AuditLogFilters) => {
+          let entries = [...mockEntries];
+          if (filters.sensitivity) entries = entries.filter(e => e.sensitivity === filters.sensitivity);
+          if (filters.toolName) entries = entries.filter(e => e.toolName === filters.toolName);
+          return entries.slice(0, filters.limit);
+        },
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithAudit.get_audit_log as any).execute({
+        limit: 20,
+        sensitivity: 'destructive',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.totalEntries).toBe(1);
+      expect(result.entries[0].toolName).toBe('edit_file');
+      expect(result.filters.limit).toBe(20);
+      expect(result.filters.sensitivity).toBe('destructive');
+    });
+
+    it('should use defaults when no filters provided', async () => {
+      const callbacks: ToolCallbacks = {
+        onGetAuditLog: () => [],
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithAudit.get_audit_log as any).execute({});
+
+      expect(result.success).toBe(true);
+      expect(result.filters.limit).toBe(50);
+      expect(result.filters.sensitivity).toBe('all');
+      expect(result.filters.toolName).toBe('all');
+    });
+  });
+
+  describe('TOOL_SENSITIVITY', () => {
+    it('should classify read-only tools as safe', () => {
+      expect(TOOL_SENSITIVITY.get_agent_status).toBe('safe');
+      expect(TOOL_SENSITIVITY.get_team_status).toBe('safe');
+      expect(TOOL_SENSITIVITY.get_agent_logs).toBe('safe');
+      expect(TOOL_SENSITIVITY.heartbeat).toBe('safe');
+      expect(TOOL_SENSITIVITY.get_tasks).toBe('safe');
+      expect(TOOL_SENSITIVITY.read_file).toBe('safe');
+      expect(TOOL_SENSITIVITY.recall_memory).toBe('safe');
+      expect(TOOL_SENSITIVITY.get_project_overview).toBe('safe');
+      expect(TOOL_SENSITIVITY.get_scheduled_checks).toBe('safe');
+    });
+
+    it('should classify communication tools as sensitive', () => {
+      expect(TOOL_SENSITIVITY.delegate_task).toBe('sensitive');
+      expect(TOOL_SENSITIVITY.send_message).toBe('sensitive');
+      expect(TOOL_SENSITIVITY.reply_slack).toBe('sensitive');
+      expect(TOOL_SENSITIVITY.broadcast).toBe('sensitive');
+      expect(TOOL_SENSITIVITY.report_status).toBe('sensitive');
+      expect(TOOL_SENSITIVITY.remember).toBe('sensitive');
+    });
+
+    it('should classify high-impact tools as destructive', () => {
+      expect(TOOL_SENSITIVITY.start_agent).toBe('destructive');
+      expect(TOOL_SENSITIVITY.stop_agent).toBe('destructive');
+      expect(TOOL_SENSITIVITY.handle_agent_failure).toBe('destructive');
+      expect(TOOL_SENSITIVITY.edit_file).toBe('destructive');
+      expect(TOOL_SENSITIVITY.write_file).toBe('destructive');
+    });
+
+    it('should have classifications for all tool names', () => {
+      const allToolNames = getToolNames();
+      for (const name of allToolNames) {
+        expect(TOOL_SENSITIVITY[name]).toBeDefined();
+      }
+    });
+  });
+
+  describe('audit wrapping', () => {
+    it('should call onAuditLog for each tool invocation', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+      await (toolsWithAudit.get_team_status as any).execute({});
+
+      expect(auditEntries).toHaveLength(1);
+      expect(auditEntries[0].toolName).toBe('get_team_status');
+      expect(auditEntries[0].sensitivity).toBe('safe');
+      expect(auditEntries[0].success).toBe(true);
+      expect(auditEntries[0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should record failure in audit log', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.post.mockResolvedValue({ success: false, error: 'Not found', status: 404 });
+      await (toolsWithAudit.send_message as any).execute({
+        sessionName: 'agent-sam',
+        message: 'Hello',
+        force: false,
+      });
+
+      expect(auditEntries).toHaveLength(1);
+      expect(auditEntries[0].toolName).toBe('send_message');
+      expect(auditEntries[0].success).toBe(false);
+      expect(auditEntries[0].error).toContain('Not found');
+    });
+
+    it('should record audit on tool exception', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.get.mockRejectedValue(new Error('Network failure'));
+
+      await expect(
+        (toolsWithAudit.get_team_status as any).execute({}),
+      ).rejects.toThrow('Network failure');
+
+      expect(auditEntries).toHaveLength(1);
+      expect(auditEntries[0].success).toBe(false);
+      expect(auditEntries[0].error).toBe('Network failure');
+    });
+
+    it('should redact sensitive fields in audit args', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      // Use send_message which has simple fields; inject args that include a sensitive-named key
+      // The audit wrapper sanitizes the raw args object before logging
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+      await (toolsWithAudit.send_message as any).execute({
+        sessionName: 'agent-sam',
+        message: 'Hello',
+        force: false,
+        authorization_token: 'bearer-secret-123',
+      });
+
+      expect(auditEntries).toHaveLength(1);
+      // authorization_token contains 'token' which is a sensitive key
+      expect(auditEntries[0].args.authorization_token).toBe('[REDACTED]');
+      expect(auditEntries[0].args.message).toBe('Hello');
+    });
+
+    it('should truncate long argument values', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+      await (toolsWithAudit.remember as any).execute({
+        content: 'x'.repeat(1000),
+        category: 'pattern',
+        scope: 'project',
+      });
+
+      expect(auditEntries).toHaveLength(1);
+      const contentArg = auditEntries[0].args.content as string;
+      // sanitizeArgs truncates at 2000 chars, so 1000-char input should NOT be truncated
+      expect(contentArg).toBe('x'.repeat(1000));
+    });
+
+    it('should truncate argument values exceeding 2000 chars', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+      };
+      const toolsWithAudit = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.post.mockResolvedValue({ success: true, data: {}, status: 200 });
+      await (toolsWithAudit.remember as any).execute({
+        content: 'x'.repeat(3000),
+        category: 'pattern',
+        scope: 'project',
+      });
+
+      expect(auditEntries).toHaveLength(1);
+      const contentArg = auditEntries[0].args.content as string;
+      expect(contentArg.length).toBeLessThan(2100);
+      expect(contentArg).toContain('[truncated]');
+    });
+
+    it('should assign sensitivity to all created tools', () => {
+      for (const [name, tool] of Object.entries(tools)) {
+        expect((tool as any).sensitivity).toBeDefined();
+        expect(['safe', 'sensitive', 'destructive']).toContain((tool as any).sensitivity);
+      }
+    });
+  });
+
+  // ===== F27: Approval Mode & Blocked Tools Enforcement =====
+
+  describe('approval mode enforcement', () => {
+    it('should block tool when onCheckApproval returns not allowed (blocked)', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+        onCheckApproval: (toolName) => {
+          if (toolName === 'stop_agent') {
+            return { allowed: false, blocked: true, reason: "Tool 'stop_agent' is blocked by security policy" };
+          }
+          return { allowed: true };
+        },
+      };
+      const toolsWithApproval = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithApproval.stop_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.blocked).toBe(true);
+      expect(result.error).toContain('blocked');
+      // Should NOT have called the API
+      expect(mockClient.post).not.toHaveBeenCalled();
+      // Should still log the blocked attempt
+      expect(auditEntries).toHaveLength(1);
+      expect(auditEntries[0].success).toBe(false);
+      expect(auditEntries[0].error).toContain('blocked');
+    });
+
+    it('should block tool when sensitivity requires approval', async () => {
+      const auditEntries: AuditEntry[] = [];
+      const callbacks: ToolCallbacks = {
+        onAuditLog: (entry) => auditEntries.push(entry),
+        onCheckApproval: (_toolName, sensitivity) => {
+          if (sensitivity === 'destructive') {
+            return { allowed: false, blocked: false, reason: 'Destructive tools require approval' };
+          }
+          return { allowed: true };
+        },
+      };
+      const toolsWithApproval = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsWithApproval.edit_file as any).execute({
+        file_path: '/test/file.ts',
+        old_string: 'foo',
+        new_string: 'bar',
+        replace_all: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.requiresApproval).toBe(true);
+      expect(result.blocked).toBe(false);
+      expect(result.error).toContain('approval');
+    });
+
+    it('should allow safe tools when only destructive requires approval', async () => {
+      const callbacks: ToolCallbacks = {
+        onCheckApproval: (_toolName, sensitivity) => {
+          if (sensitivity === 'destructive') {
+            return { allowed: false, blocked: false, reason: 'Requires approval' };
+          }
+          return { allowed: true };
+        },
+      };
+      const toolsWithApproval = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+      const result = await (toolsWithApproval.get_team_status as any).execute({});
+
+      expect(result).toEqual([]);
+      expect(mockClient.get).toHaveBeenCalled();
+    });
+
+    it('should work without onCheckApproval callback (no enforcement)', async () => {
+      const callbacks: ToolCallbacks = {
+        onAuditLog: () => {},
+      };
+      const toolsNoApproval = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      mockClient.post.mockResolvedValue({ success: true, data: { stopped: true }, status: 200 });
+      const result = await (toolsNoApproval.stop_agent as any).execute({
+        teamId: 'team-1',
+        memberId: 'member-1',
+      });
+
+      expect(result.stopped).toBe(true);
+    });
+
+    it('should enforce approval without audit logger', async () => {
+      const callbacks: ToolCallbacks = {
+        onCheckApproval: (toolName) => {
+          if (toolName === 'write_file') {
+            return { allowed: false, blocked: true, reason: 'Blocked' };
+          }
+          return { allowed: true };
+        },
+      };
+      const toolsApprovalOnly = createTools(mockClient, 'crewly-orc', '/test/project', callbacks);
+
+      const result = await (toolsApprovalOnly.write_file as any).execute({
+        file_path: '/test/file.ts',
+        content: 'hello',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.blocked).toBe(true);
+    });
+  });
+
+  describe('get_scheduled_checks', () => {
+    it('should fetch all scheduled checks', async () => {
+      mockClient.get.mockResolvedValue({ success: true, data: [{ id: 'chk-1', isRecurring: true }], status: 200 });
+
+      const result = await (tools.get_scheduled_checks as any).execute({});
+
+      expect(mockClient.get).toHaveBeenCalledWith('/schedule');
+      expect(result).toEqual([{ id: 'chk-1', isRecurring: true }]);
+    });
+
+    it('should filter by session when provided', async () => {
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+
+      await (tools.get_scheduled_checks as any).execute({ session: 'agent-sam' });
+
+      expect(mockClient.get).toHaveBeenCalledWith('/schedule?session=agent-sam');
+    });
+
+    it('should return error on failure', async () => {
+      mockClient.get.mockResolvedValue({ success: false, error: 'Server error', status: 500 });
+
+      const result = await (tools.get_scheduled_checks as any).execute({});
+
+      expect(result).toEqual({ error: 'Server error' });
+    });
+  });
+
+  describe('schedule_check with taskId', () => {
+    it('should pass taskId to the schedule API', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { checkId: 'sched-3' }, status: 201 });
+
+      await (tools.schedule_check as any).execute({
+        minutes: 5,
+        message: 'Check Sam progress',
+        recurring: true,
+        taskId: 'task-42',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith('/schedule', expect.objectContaining({
+        taskId: 'task-42',
+        isRecurring: true,
+        intervalMinutes: 5,
+      }));
+    });
+
+    it('should not include taskId when not provided', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { checkId: 'sched-4' }, status: 201 });
+
+      await (tools.schedule_check as any).execute({
+        minutes: 10,
+        message: 'Check progress',
+        recurring: false,
+      });
+
+      const postArgs = mockClient.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(postArgs.taskId).toBeUndefined();
+    });
+  });
+
+  describe('complete_task with check cleanup', () => {
+    it('should cancel recurring checks for the completing agent', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { completed: true }, status: 200 });
+      mockClient.get.mockResolvedValue({
+        success: true,
+        data: [
+          { id: 'chk-1', isRecurring: true },
+          { id: 'chk-2', isRecurring: false },
+          { id: 'chk-3', isRecurring: true },
+        ],
+        status: 200,
+      });
+      mockClient.delete.mockResolvedValue({ success: true, data: {}, status: 200 });
+
+      const result = await (tools.complete_task as any).execute({
+        workItemId: 'wi-1',
+        sessionName: 'agent-sam',
+        summary: 'Done',
+      });
+
+      expect(result.completed).toBe(true);
+      expect(result.cancelledChecks).toBe(2); // Only recurring checks
+      expect(mockClient.delete).toHaveBeenCalledWith('/schedule/chk-1');
+      expect(mockClient.delete).toHaveBeenCalledWith('/schedule/chk-3');
+      expect(mockClient.delete).not.toHaveBeenCalledWith('/schedule/chk-2');
+    });
+
+    // Hygiene #4 (2026-05-09): assert the canonical body shape on the
+    // /task-pool/complete POST. Prior shape `{summary}` 400'd because the
+    // controller looks at `result.summary` and requires non-empty `agentId`.
+    it('emits canonical body shape `{agentId, result:{summary}}`', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { completed: true }, status: 200 });
+      mockClient.get.mockResolvedValue({ success: true, data: [], status: 200 });
+
+      await (tools.complete_task as any).execute({
+        workItemId: 'wi-shape-1',
+        sessionName: 'agent-quinn',
+        summary: 'Implemented hygiene #4',
+      });
+
+      expect(mockClient.post).toHaveBeenCalledWith(
+        '/task-pool/complete/wi-shape-1',
+        { agentId: 'agent-quinn', result: { summary: 'Implemented hygiene #4' } },
+      );
+    });
+
+    it('should still complete task even if check cleanup fails', async () => {
+      mockClient.post.mockResolvedValue({ success: true, data: { completed: true }, status: 200 });
+      mockClient.get.mockRejectedValue(new Error('Network error'));
+
+      const result = await (tools.complete_task as any).execute({
+        absoluteTaskPath: '/tasks/task-1.md',
+        sessionName: 'agent-sam',
+        summary: 'Done',
+      });
+
+      expect(result.completed).toBe(true);
+      expect(result.cancelledChecks).toBe(0);
+    });
+  });
+
+  describe('WRITE_TOOLS', () => {
+    it('should include all destructive and sensitive tools that modify state', () => {
+      expect(WRITE_TOOLS).toContain('edit_file');
+      expect(WRITE_TOOLS).toContain('write_file');
+      expect(WRITE_TOOLS).toContain('start_agent');
+      expect(WRITE_TOOLS).toContain('stop_agent');
+      expect(WRITE_TOOLS).toContain('delegate_task');
+      expect(WRITE_TOOLS).toContain('send_message');
+      expect(WRITE_TOOLS).toContain('reply_slack');
+      expect(WRITE_TOOLS).toContain('broadcast');
+    });
+
+    it('should not include read-only tools', () => {
+      expect(WRITE_TOOLS).not.toContain('get_agent_status');
+      expect(WRITE_TOOLS).not.toContain('get_team_status');
+      expect(WRITE_TOOLS).not.toContain('read_file');
+      expect(WRITE_TOOLS).not.toContain('recall_memory');
+      expect(WRITE_TOOLS).not.toContain('heartbeat');
+      expect(WRITE_TOOLS).not.toContain('get_audit_log');
+      expect(WRITE_TOOLS).not.toContain('compact_memory');
+    });
+
+    it('should only contain valid tool names from the registry', () => {
+      const validNames = getToolNames();
+      for (const writeTool of WRITE_TOOLS) {
+        expect(validNames).toContain(writeTool);
+      }
+    });
+  });
+
+  describe('git_status', () => {
+    it.skip('should parse git status output correctly (CJS require, ESM-incompatible)', async () => {
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        const callback = args[args.length - 1] as Function;
+        if (cmd.includes('rev-parse')) { callback(null, 'main\n', ''); return; }
+        if (cmd.includes('status --porcelain')) { callback(null, 'M  staged.ts\n M unstaged.ts\n?? new.ts\n', ''); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_status as any).execute({ projectPath: '/test/project' });
+
+      expect(result.success).toBe(true);
+      expect(result.branch).toBe('main');
+      expect(result.staged).toContain('staged.ts');
+      expect(result.unstaged).toContain('unstaged.ts');
+      expect(result.untracked).toContain('new.ts');
+
+      vi.restoreAllMocks();
+    });
+
+    it.skip('should handle errors gracefully (CJS require)', async () => {
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const callback = args[args.length - 1] as Function;
+        callback(new Error('not a git repository'));
+      });
+
+      const result = await (tools.git_status as any).execute({ projectPath: '/not/a/repo' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not a git repository');
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe('git_diff', () => {
+    it.skip('should return unstaged diff by default (CJS require)', async () => {
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        const callback = args[args.length - 1] as Function;
+        if (cmd === 'git diff') { callback(null, 'diff --git a/file.ts\n+added line\n', ''); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_diff as any).execute({ projectPath: '/test/project', staged: false });
+
+      expect(result.success).toBe(true);
+      expect(result.diff).toContain('+added line');
+      expect(result.truncated).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+
+    it.skip('should return staged diff when staged=true (CJS require)', async () => {
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        const callback = args[args.length - 1] as Function;
+        if (cmd === 'git diff --cached') { callback(null, 'staged diff output\n', ''); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_diff as any).execute({ projectPath: '/test/project', staged: true });
+
+      expect(result.success).toBe(true);
+      expect(result.diff).toContain('staged diff output');
+
+      vi.restoreAllMocks();
+    });
+
+    it.skip('should truncate long diffs to 5000 chars (CJS require)', async () => {
+      const longDiff = 'x'.repeat(6000);
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const callback = args[args.length - 1] as Function;
+        callback(null, longDiff, '');
+      });
+
+      const result = await (tools.git_diff as any).execute({ projectPath: '/test/project', staged: false });
+
+      expect(result.success).toBe(true);
+      expect(result.truncated).toBe(true);
+      expect(result.diff.length).toBeLessThanOrEqual(5020);
+      expect(result.totalLength).toBe(6000);
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe('git_commit', () => {
+    it.skip('should stage all and commit when no files specified (CJS require)', async () => {
+      const calls: string[] = [];
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        calls.push(cmd);
+        const callback = args[args.length - 1] as Function;
+        if (cmd.includes('rev-parse HEAD')) { callback(null, 'abc123def\n', ''); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_commit as any).execute({
+        projectPath: '/test/project',
+        message: 'feat: add feature',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.commitHash).toBe('abc123def');
+      expect(calls).toContain('git add -A');
+      expect(calls.some((c: string) => c.includes('git commit'))).toBe(true);
+
+      vi.restoreAllMocks();
+    });
+
+    it.skip('should stage specific files when provided (CJS require)', async () => {
+      const calls: string[] = [];
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        calls.push(cmd);
+        const callback = args[args.length - 1] as Function;
+        if (cmd.includes('rev-parse HEAD')) { callback(null, 'def456\n', ''); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_commit as any).execute({
+        projectPath: '/test/project',
+        message: 'fix: bug',
+        files: ['src/a.ts', 'src/b.ts'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.commitHash).toBe('def456');
+      expect(calls.some((c: string) => c.includes('git add') && c.includes('src/a.ts'))).toBe(true);
+      expect(calls.some((c: string) => c.includes('git add') && c.includes('src/b.ts'))).toBe(true);
+      expect(calls).not.toContain('git add -A');
+
+      vi.restoreAllMocks();
+    });
+
+    it.skip('should handle commit errors gracefully (CJS require)', async () => {
+      vi.spyOn(require('child_process'), 'exec').mockImplementation((...args: unknown[]) => {
+        const cmd = String(args[0]);
+        const callback = args[args.length - 1] as Function;
+        if (cmd.includes('git commit')) { callback(new Error('nothing to commit')); return; }
+        callback(null, '', '');
+      });
+
+      const result = await (tools.git_commit as any).execute({
+        projectPath: '/test/project',
+        message: 'empty commit',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('nothing to commit');
+
+      vi.restoreAllMocks();
+    });
+
+    it('should have sensitive classification', () => {
+      expect(TOOL_SENSITIVITY.git_commit).toBe('sensitive');
+    });
+  });
+
+  describe('git tool sensitivity', () => {
+    it('should classify git_status as safe', () => {
+      expect(TOOL_SENSITIVITY.git_status).toBe('safe');
+    });
+
+    it('should classify git_diff as safe', () => {
+      expect(TOOL_SENSITIVITY.git_diff).toBe('safe');
+    });
+
+    it('should classify git_commit as sensitive', () => {
+      expect(TOOL_SENSITIVITY.git_commit).toBe('sensitive');
+    });
+  });
+
+  describe('getToolNames includes git tools', () => {
+    it('should include all 3 git tools', () => {
+      const names = getToolNames();
+      expect(names).toContain('git_status');
+      expect(names).toContain('git_diff');
+      expect(names).toContain('git_commit');
+    });
+  });
+
+  describe('validateBashCommand', () => {
+    let validateFn: typeof import('./tool-registry.js')['validateBashCommand'];
+
+    beforeEach(async () => {
+      const mod = await import('./tool-registry.js');
+      validateFn = mod.validateBashCommand;
+    });
+
+    it('should allow safe commands', () => {
+      expect(validateFn('ls -la')).toBeNull();
+      expect(validateFn('npm run build')).toBeNull();
+      expect(validateFn('git status')).toBeNull();
+      expect(validateFn('cat package.json')).toBeNull();
+      expect(validateFn('echo "hello world"')).toBeNull();
+      expect(validateFn('node -e "console.log(1)"')).toBeNull();
+    });
+
+    it('should block kill commands', () => {
+      expect(validateFn('kill 1234')).not.toBeNull();
+      expect(validateFn('kill -9 $$')).not.toBeNull();
+      expect(validateFn('killall node')).not.toBeNull();
+      expect(validateFn('pkill -f crewly')).not.toBeNull();
+    });
+
+    it('should block system commands', () => {
+      expect(validateFn('shutdown -h now')).not.toBeNull();
+      expect(validateFn('reboot')).not.toBeNull();
+      expect(validateFn('launchctl unload com.crewly')).not.toBeNull();
+      expect(validateFn('systemctl stop crewly')).not.toBeNull();
+    });
+
+    it('should block destructive disk commands', () => {
+      expect(validateFn('mkfs /dev/sda1')).not.toBeNull();
+      expect(validateFn('dd if=/dev/zero of=/dev/sda')).not.toBeNull();
+    });
+
+    it('should allow rm for specific files (not root wipe)', () => {
+      expect(validateFn('rm file.txt')).toBeNull();
+      expect(validateFn('rm -rf ./dist')).toBeNull();
+      expect(validateFn('rm -rf node_modules')).toBeNull();
+    });
+  });
+
+  describe('bash_exec tool', () => {
+    let bashTools: ReturnType<typeof createTools>;
+
+    beforeEach(() => {
+      // Use a real directory so spawnSync can set cwd
+      bashTools = createTools(mockClient, 'crewly-orc', '/tmp');
+    });
+
+    it('should execute simple commands successfully', async () => {
+      const result = await bashTools.bash_exec.execute({ command: 'echo "hello"' }) as any;
+      expect(result.success).toBe(true);
+      expect(result.stdout).toContain('hello');
+    });
+
+    it('should block dangerous commands', async () => {
+      const result = await bashTools.bash_exec.execute({ command: 'kill 1234' }) as any;
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(126);
+      expect(result.error).toContain('blocked');
+    });
+
+    it('should handle command failure gracefully', async () => {
+      const result = await bashTools.bash_exec.execute({ command: 'false' }) as any;
+      expect(result.success).toBe(false);
+      expect(result.exitCode).not.toBe(0);
+    });
+
+    it('should respect timeout', async () => {
+      const result = await bashTools.bash_exec.execute({ command: 'sleep 30', timeout: 1000 }) as any;
+      expect(result.success).toBe(false);
+    }, 10000);
+
+    it('should use process isolation (spawnSync, not execSync)', async () => {
+      const result = await bashTools.bash_exec.execute({ command: 'echo $$' }) as any;
+      expect(result.success).toBe(true);
+      const childPid = parseInt(result.stdout.trim(), 10);
+      expect(childPid).not.toBe(process.pid);
+    });
+  });
+
+  // ===== globToRegExp unit tests =====
+
+  describe('globToRegExp', () => {
+    it('should match simple wildcards', () => {
+      const re = globToRegExp('*.ts');
+      expect(re.test('foo.ts')).toBe(true);
+      expect(re.test('bar.js')).toBe(false);
+      expect(re.test('src/foo.ts')).toBe(false); // * should not match /
+    });
+
+    it('should match ** for recursive paths', () => {
+      const re = globToRegExp('**/*.ts');
+      expect(re.test('foo.ts')).toBe(true);
+      expect(re.test('src/foo.ts')).toBe(true);
+      expect(re.test('src/deep/nested/foo.ts')).toBe(true);
+      expect(re.test('foo.js')).toBe(false);
+    });
+
+    it('should match ? for single characters', () => {
+      const re = globToRegExp('?.ts');
+      expect(re.test('a.ts')).toBe(true);
+      expect(re.test('ab.ts')).toBe(false);
+    });
+
+    it('should match brace alternatives', () => {
+      const re = globToRegExp('*.{ts,tsx}');
+      expect(re.test('foo.ts')).toBe(true);
+      expect(re.test('foo.tsx')).toBe(true);
+      expect(re.test('foo.js')).toBe(false);
+    });
+
+    it('should match character classes', () => {
+      const re = globToRegExp('[abc].ts');
+      expect(re.test('a.ts')).toBe(true);
+      expect(re.test('d.ts')).toBe(false);
+    });
+
+    it('should escape regex special characters in literal parts', () => {
+      const re = globToRegExp('file.test.ts');
+      expect(re.test('file.test.ts')).toBe(true);
+      expect(re.test('filextest.ts')).toBe(false); // dot should be literal
+    });
+
+    it('should handle src/**/*.test.ts pattern', () => {
+      const re = globToRegExp('src/**/*.test.ts');
+      expect(re.test('src/foo.test.ts')).toBe(true);
+      expect(re.test('src/deep/bar.test.ts')).toBe(true);
+      expect(re.test('lib/foo.test.ts')).toBe(false);
+    });
+  });
+
+  // ===== walkAndMatch unit tests =====
+
+  describe('walkAndMatch', () => {
+    const fs = require('fs').promises;
+    const os = require('os');
+    const path = require('path');
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-glob-test-'));
+      // Create test file structure
+      await fs.mkdir(path.join(tmpDir, 'src'), { recursive: true });
+      await fs.mkdir(path.join(tmpDir, 'src', 'utils'), { recursive: true });
+      await fs.mkdir(path.join(tmpDir, 'node_modules', 'pkg'), { recursive: true });
+      await fs.writeFile(path.join(tmpDir, 'index.ts'), 'export {};');
+      await fs.writeFile(path.join(tmpDir, 'src', 'app.ts'), 'const app = 1;');
+      await fs.writeFile(path.join(tmpDir, 'src', 'app.test.ts'), 'test("app", () => {});');
+      await fs.writeFile(path.join(tmpDir, 'src', 'utils', 'helper.ts'), 'export function help() {}');
+      await fs.writeFile(path.join(tmpDir, 'src', 'style.css'), 'body {}');
+      await fs.writeFile(path.join(tmpDir, 'node_modules', 'pkg', 'index.js'), 'module.exports = {};');
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should find all .ts files recursively', async () => {
+      const re = globToRegExp('**/*.ts');
+      const results = await walkAndMatch(tmpDir, re, new Set(['node_modules', '.git']), 100);
+      expect(results.length).toBe(4);
+      expect(results.some(f => f.endsWith('index.ts'))).toBe(true);
+      expect(results.some(f => f.endsWith('app.ts'))).toBe(true);
+      expect(results.some(f => f.endsWith('app.test.ts'))).toBe(true);
+      expect(results.some(f => f.endsWith('helper.ts'))).toBe(true);
+    });
+
+    it('should ignore node_modules by default', async () => {
+      const re = globToRegExp('**/*.js');
+      const results = await walkAndMatch(tmpDir, re, new Set(['node_modules']), 100);
+      expect(results.length).toBe(0); // Only .js is in node_modules
+    });
+
+    it('should respect maxResults limit', async () => {
+      const re = globToRegExp('**/*');
+      const results = await walkAndMatch(tmpDir, re, new Set(['node_modules']), 2);
+      expect(results.length).toBe(2);
+    });
+
+    it('should match specific subdirectory patterns', async () => {
+      const re = globToRegExp('src/**/*.ts');
+      const results = await walkAndMatch(tmpDir, re, new Set(['node_modules']), 100);
+      expect(results.length).toBe(3); // app.ts, app.test.ts, helper.ts
+      expect(results.every(f => f.includes('/src/'))).toBe(true);
+    });
+  });
+
+  // ===== searchFileContents unit tests =====
+
+  describe('searchFileContents', () => {
+    const fs = require('fs').promises;
+    const os = require('os');
+    const path = require('path');
+    let tmpFile: string;
+
+    beforeEach(async () => {
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'crewly-grep-test-'));
+      tmpFile = path.join(tmpDir, 'test.ts');
+      await fs.writeFile(tmpFile, [
+        'import { foo } from "./foo";',
+        'import { bar } from "./bar";',
+        '',
+        'export function hello() {',
+        '  return "hello world";',
+        '}',
+        '',
+        'export function goodbye() {',
+        '  return "goodbye world";',
+        '}',
+      ].join('\n'));
+    });
+
+    it('should find matching lines with line numbers', async () => {
+      const matches = await searchFileContents(tmpFile, /export function/, 0);
+      expect(matches.length).toBe(2);
+      expect(matches[0].line).toBe(4);
+      expect(matches[0].content).toContain('hello');
+      expect(matches[1].line).toBe(8);
+      expect(matches[1].content).toContain('goodbye');
+    });
+
+    it('should return context lines when requested', async () => {
+      const matches = await searchFileContents(tmpFile, /hello\(\)/, 1);
+      expect(matches.length).toBe(1);
+      expect(matches[0].line).toBe(4);
+      expect(matches[0].context).toBeDefined();
+      expect(matches[0].context!.length).toBe(3); // 1 before + match + 1 after
+    });
+
+    it('should return empty array when no matches', async () => {
+      const matches = await searchFileContents(tmpFile, /nonexistent/, 0);
+      expect(matches.length).toBe(0);
+    });
+
+    it('should handle regex special characters in content', async () => {
+      const matches = await searchFileContents(tmpFile, /from "\.\/foo"/, 0);
+      expect(matches.length).toBe(1);
+      expect(matches[0].line).toBe(1);
+    });
+  });
+
+  // ===== glob tool integration tests =====
+
+  describe('glob tool', () => {
+    it('should exist in createTools output', () => {
+      expect(tools.glob).toBeDefined();
+      expect((tools.glob as any).description).toContain('file pattern matching');
+    });
+
+    it('should find files in the project directory', async () => {
+      const result = await (tools.glob as any).execute({
+        pattern: '**/*.ts',
+        path: __dirname,
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBeGreaterThan(0);
+      expect(result.files.some((f: string) => f.endsWith('tool-registry.ts'))).toBe(true);
+    });
+
+    it('should return error for non-existent directory', async () => {
+      const result = await (tools.glob as any).execute({
+        pattern: '**/*.ts',
+        path: '/nonexistent/path/xyz',
+      }) as any;
+      expect(result.success).toBe(false);
+    });
+
+    it('should respect custom ignore patterns', async () => {
+      const result = await (tools.glob as any).execute({
+        pattern: '**/*.ts',
+        path: __dirname,
+        ignore: ['__snapshots__'],
+      }) as any;
+      expect(result.success).toBe(true);
+    });
+
+    it('should have safe sensitivity', () => {
+      expect(TOOL_SENSITIVITY.glob).toBe('safe');
+    });
+  });
+
+  // ===== grep tool integration tests =====
+
+  describe('grep tool', () => {
+    it('should exist in createTools output', () => {
+      expect(tools.grep).toBeDefined();
+      expect((tools.grep as any).description).toContain('Search file contents');
+    });
+
+    it('should find pattern matches in files', async () => {
+      const result = await (tools.grep as any).execute({
+        pattern: 'export function createTools',
+        path: __dirname,
+        file_pattern: '**/*.ts',
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBeGreaterThan(0);
+      // Match may come from source or test file — both contain the string
+      expect(result.matches.some((m: any) => m.file.includes('tool-registry'))).toBe(true);
+    });
+
+    it('should support case insensitive search', async () => {
+      const result = await (tools.grep as any).execute({
+        pattern: 'EXPORT FUNCTION CREATETOOLS',
+        path: __dirname,
+        file_pattern: 'tool-registry.ts',
+        case_insensitive: true,
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBeGreaterThan(0);
+    });
+
+    it('should return context lines when requested', async () => {
+      const result = await (tools.grep as any).execute({
+        pattern: 'export function createTools',
+        path: __dirname,
+        file_pattern: 'tool-registry.ts',
+        context_lines: 2,
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matches[0].context).toBeDefined();
+      expect(result.matches[0].context.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should return error for invalid regex', async () => {
+      const result = await (tools.grep as any).execute({
+        pattern: '[invalid',
+        path: __dirname,
+      }) as any;
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid regex');
+    });
+
+    it('should search a single file when path is a file', async () => {
+      const filePath = require('path').join(__dirname, 'tool-registry.ts');
+      const result = await (tools.grep as any).execute({
+        pattern: 'glob:',
+        path: filePath,
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBeGreaterThan(0);
+    });
+
+    it('should have safe sensitivity', () => {
+      expect(TOOL_SENSITIVITY.grep).toBe('safe');
+    });
+
+    it('should respect max_matches limit', async () => {
+      const result = await (tools.grep as any).execute({
+        pattern: 'const|let|var',
+        path: __dirname,
+        file_pattern: '**/*.ts',
+        max_matches: 3,
+      }) as any;
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBeLessThanOrEqual(3);
+      expect(result.truncated).toBe(true);
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/tool-registry.ts
+++ b/packages/crewly-agent/src/runtime/tool-registry.ts
@@ -1,0 +1,2104 @@
+/**
+ * Crewly Agent Tool Registry
+ *
+ * Defines all AI SDK tools available to the Crewly Agent runtime.
+ * Each tool maps to a Crewly REST API endpoint, replacing the bash
+ * skill scripts used by PTY-based runtimes.
+ *
+ * @module services/agent/crewly-agent/tool-registry
+ */
+
+import { promises as fsPromises } from 'fs';
+import * as childProcess from 'child_process';
+import { homedir } from 'os';
+import * as path from 'path';
+import { z } from 'zod';
+import type { CrewlyApiClient } from './api-client.js';
+import type { ToolDefinition, ToolCallbacks, ToolSensitivity, AuditEntry, ApprovalCheckResult, AuditLogFilters } from './types.js';
+import { KEY_EXTRACTION_BLOCKED_COMMANDS, PromptGuardService } from './prompt-guard.service.js';
+import { EnvIsolationService } from './env-isolation.service.js';
+import { OutputFilterService } from './output-filter.service.js';
+import { createWebSearchTool } from './web-search.tool.js';
+
+/** TTL for delegation idle event subscriptions (minutes) */
+const DELEGATION_SUBSCRIPTION_TTL_MINUTES = 120;
+
+/** Maximum characters for git diff output */
+const GIT_DIFF_MAX_CHARS = 5000;
+
+/** Maximum characters for read_file output to prevent context overflow */
+const READ_FILE_MAX_CHARS = 50_000;
+
+/** Maximum lines to return from read_file when no limit is specified */
+const READ_FILE_MAX_LINES = 2000;
+
+/**
+ * Commands that could kill/signal the parent Crewly server process or
+ * cause irreversible system damage.  Checked against the raw command
+ * string (case-insensitive, word-boundary match via regex).
+ */
+const BLOCKED_COMMAND_PATTERNS: RegExp[] = [
+  /\bkill\b/i,
+  /\bkillall\b/i,
+  /\bpkill\b/i,
+  /\bshutdown\b/i,
+  /\breboot\b/i,
+  /\brm\s+-[^\s]*r[^\s]*\s+\/(?!\S)/i,     // rm -rf / (root wipe)
+  /\bmkfs\b/i,
+  /\bdd\s+.*of=\/dev\//i,                    // dd of=/dev/...
+  /\blaunchctl\b/i,
+  /\bsystemctl\b/i,
+  // Key extraction protection (from prompt-guard.service.ts)
+  ...KEY_EXTRACTION_BLOCKED_COMMANDS,
+];
+
+/**
+ * Bash commands that require explicit approval before execution.
+ * These are dangerous but not catastrophic — they modify remote state,
+ * delete files, or interact with container/network infrastructure.
+ *
+ * Matched against the raw command string (case-insensitive, word-boundary).
+ */
+export const APPROVAL_REQUIRED_BASH_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /\bgit\s+push\b/i, label: 'git push (modifies remote repository)' },
+  { pattern: /\bgit\s+push\s+.*--force\b/i, label: 'git push --force (destructive remote rewrite)' },
+  { pattern: /\brm\s+/i, label: 'rm (file deletion)' },
+  { pattern: /\bdocker\s+(rm|rmi|stop|kill|exec|run|build|push|pull)\b/i, label: 'docker operation (container/image management)' },
+  { pattern: /\bcurl\b/i, label: 'curl (network request)' },
+  { pattern: /\bwget\b/i, label: 'wget (network download)' },
+  { pattern: /\bnpm\s+publish\b/i, label: 'npm publish (package registry push)' },
+  { pattern: /\bgit\s+reset\s+--hard\b/i, label: 'git reset --hard (destructive history rewrite)' },
+];
+
+/**
+ * Validate a shell command against the blocklist.
+ *
+ * @param command - Raw shell command string
+ * @returns Error message if blocked, or null if allowed
+ */
+export function validateBashCommand(command: string): string | null {
+  for (const pattern of BLOCKED_COMMAND_PATTERNS) {
+    if (pattern.test(command)) {
+      return `Command blocked by security policy: matches forbidden pattern ${pattern}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a bash command matches any approval-required pattern.
+ *
+ * @param command - Raw shell command string
+ * @returns Matching label if approval is required, or null if safe to proceed
+ */
+export function checkBashApprovalRequired(command: string): string | null {
+  for (const { pattern, label } of APPROVAL_REQUIRED_BASH_PATTERNS) {
+    if (pattern.test(command)) {
+      return label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Execute a shell command asynchronously in an isolated process group so that
+ * signals (SIGTERM, SIGINT) from the child cannot propagate to the Crewly server.
+ *
+ * Uses spawn (async) to avoid blocking the Node.js event loop. The child
+ * process runs in a detached process group so its signals don't reach the parent.
+ *
+ * @param cmd - Shell command to run
+ * @param workDir - Working directory
+ * @param timeoutMs - Timeout in milliseconds
+ * @returns Object with stdout, stderr, exitCode
+ */
+function execIsolatedAsync(cmd: string, workDir: string, timeoutMs: number): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}> {
+  return new Promise((resolve) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutLen = 0;
+    let stderrLen = 0;
+    const maxBuffer = 1024 * 1024;
+    let finished = false;
+
+    // Apply environment isolation — strip sensitive vars from child process
+    const envIsolation = new EnvIsolationService();
+    const safeEnv = envIsolation.createSafeEnv(process.env as Record<string, string>);
+    safeEnv.FORCE_COLOR = '0';
+
+    const child = childProcess.spawn('/bin/sh', ['-c', cmd], {
+      cwd: workDir,
+      env: safeEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+    });
+
+    const timer = setTimeout(() => {
+      if (!finished) {
+        finished = true;
+        // Kill the entire process group
+        try { process.kill(-child.pid!, 'SIGTERM'); } catch { /* ignore */ }
+        try { child.kill('SIGTERM'); } catch { /* ignore */ }
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf-8')
+            + `\n[crewly] Process killed by signal: SIGTERM (timeout: ${timeoutMs}ms)`,
+          exitCode: 128,
+        });
+      }
+    }, timeoutMs);
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      if (stdoutLen < maxBuffer) {
+        stdoutChunks.push(chunk);
+        stdoutLen += chunk.length;
+      }
+    });
+
+    child.stderr!.on('data', (chunk: Buffer) => {
+      if (stderrLen < maxBuffer) {
+        stderrChunks.push(chunk);
+        stderrLen += chunk.length;
+      }
+    });
+
+    child.on('close', (code, signal) => {
+      if (!finished) {
+        finished = true;
+        clearTimeout(timer);
+        const exitCode = code ?? (signal ? 128 : 1);
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+        const signalInfo = signal
+          ? `\n[crewly] Process killed by signal: ${signal} (timeout: ${timeoutMs}ms)`
+          : '';
+        resolve({
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: stderr + signalInfo,
+          exitCode,
+        });
+      }
+    });
+
+    child.on('error', (err) => {
+      if (!finished) {
+        finished = true;
+        clearTimeout(timer);
+        resolve({
+          stdout: '',
+          stderr: err.message,
+          exitCode: 1,
+        });
+      }
+    });
+
+    // Unref so the child doesn't keep the process alive
+    child.unref();
+  });
+}
+
+/**
+ * Execute a git command asynchronously without blocking the event loop.
+ *
+ * @param cmd - Git command to run
+ * @param cwd - Working directory
+ * @returns stdout string trimmed
+ * @throws Error if the command fails
+ */
+async function execGitAsync(cmd: string, cwd: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    childProcess.exec(cmd, {
+      cwd,
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+    }, (error, stdout) => {
+      if (error) { reject(error); return; }
+      resolve(stdout as string);
+    });
+  });
+}
+
+/**
+ * Expand ~ and $HOME in a file path to the user's home directory.
+ * If the path is relative and a baseDir is provided, resolve against it.
+ *
+ * @param filePath - Path that may contain ~ or $HOME, or be relative
+ * @param baseDir  - Optional base directory to resolve relative paths against
+ * @returns Resolved absolute path
+ */
+function expandPath(filePath: string, baseDir?: string): string {
+  const home = homedir();
+  if (filePath === '~' || filePath.startsWith('~/')) {
+    return home + filePath.slice(1);
+  }
+  if (filePath.startsWith('$HOME/') || filePath === '$HOME') {
+    return home + filePath.slice(5);
+  }
+  // Resolve relative paths against baseDir (e.g. projectPath)
+  if (baseDir && !path.isAbsolute(filePath)) {
+    return path.resolve(baseDir, filePath);
+  }
+  return filePath;
+}
+
+/** File extensions recognized as images for multimodal read_file support */
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg']);
+
+/** MIME type mapping for image extensions */
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+};
+
+// ── Glob / Grep Native Helpers ──────────────────────────────────────────────
+
+/** Maximum number of files returned by glob to prevent runaway results */
+const GLOB_MAX_RESULTS = 1000;
+
+/** Maximum number of matching lines returned by grep */
+const GREP_MAX_MATCHES = 500;
+
+/** Default directories/patterns to ignore during glob/grep traversal */
+const DEFAULT_IGNORE_PATTERNS = [
+  'node_modules', '.git', 'dist', 'build', '.next', '__pycache__',
+  '.cache', 'coverage', '.nyc_output', '.turbo', '.parcel-cache',
+];
+
+/**
+ * Convert a glob pattern to a RegExp.
+ *
+ * Supports:
+ * - `*` matches any characters except `/`
+ * - `**` matches any characters including `/` (recursive)
+ * - `?` matches a single character except `/`
+ * - `{a,b}` matches either a or b
+ * - Character classes `[abc]`
+ *
+ * @param pattern - Glob pattern string (e.g., "src/**\/*.ts")
+ * @returns Compiled RegExp
+ */
+export function globToRegExp(pattern: string): RegExp {
+  let regexStr = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*' && pattern[i + 1] === '*') {
+      // ** — match everything including path separators
+      if (pattern[i + 2] === '/') {
+        regexStr += '(?:.*/)?';
+        i += 3;
+      } else {
+        regexStr += '.*';
+        i += 2;
+      }
+    } else if (ch === '*') {
+      regexStr += '[^/]*';
+      i++;
+    } else if (ch === '?') {
+      regexStr += '[^/]';
+      i++;
+    } else if (ch === '{') {
+      const closeBrace = pattern.indexOf('}', i);
+      if (closeBrace === -1) {
+        regexStr += '\\{';
+        i++;
+      } else {
+        const alternatives = pattern.slice(i + 1, closeBrace).split(',');
+        regexStr += '(?:' + alternatives.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|') + ')';
+        i = closeBrace + 1;
+      }
+    } else if (ch === '[') {
+      const closeBracket = pattern.indexOf(']', i);
+      if (closeBracket === -1) {
+        regexStr += '\\[';
+        i++;
+      } else {
+        regexStr += pattern.slice(i, closeBracket + 1);
+        i = closeBracket + 1;
+      }
+    } else if ('.+^${}()|[]\\'.includes(ch)) {
+      regexStr += '\\' + ch;
+      i++;
+    } else {
+      regexStr += ch;
+      i++;
+    }
+  }
+  return new RegExp('^' + regexStr + '$');
+}
+
+/**
+ * Recursively walk a directory tree, yielding file paths that match
+ * the given glob pattern while respecting ignore patterns.
+ *
+ * Uses a stack-based iterative approach to avoid stack overflow on deep trees.
+ * Respects DEFAULT_IGNORE_PATTERNS and user-supplied ignore patterns.
+ *
+ * @param rootDir - Root directory to start traversal
+ * @param patternRegex - Compiled glob regex to test relative paths against
+ * @param ignoreSet - Set of directory base names to skip
+ * @param maxResults - Maximum number of results to return
+ * @returns Array of matching absolute file paths
+ */
+export async function walkAndMatch(
+  rootDir: string,
+  patternRegex: RegExp,
+  ignoreSet: Set<string>,
+  maxResults: number,
+): Promise<string[]> {
+  const results: string[] = [];
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0 && results.length < maxResults) {
+    const dir = stack.pop()!;
+    let entries;
+    try {
+      entries = await fsPromises.readdir(dir, { withFileTypes: true });
+    } catch {
+      // Permission denied or not a directory — skip
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (results.length >= maxResults) break;
+      if (ignoreSet.has(entry.name)) continue;
+
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = path.relative(rootDir, fullPath);
+
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        if (patternRegex.test(relativePath)) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Search file contents for lines matching a regular expression.
+ *
+ * Reads the file once, splits into lines, and tests each against the pattern.
+ * Returns matching lines with line numbers and optional context lines.
+ *
+ * @param filePath - Absolute path to the file to search
+ * @param regex - Compiled RegExp to test each line
+ * @param contextLines - Number of lines before and after each match to include
+ * @returns Array of match objects with line number, content, and context
+ */
+export async function searchFileContents(
+  filePath: string,
+  regex: RegExp,
+  contextLines: number,
+): Promise<Array<{ line: number; content: string; context?: string[] }>> {
+  const content = await fsPromises.readFile(filePath, 'utf8');
+  const lines = content.split('\n');
+  const matches: Array<{ line: number; content: string; context?: string[] }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (regex.test(lines[i])) {
+      const match: { line: number; content: string; context?: string[] } = {
+        line: i + 1,
+        content: lines[i],
+      };
+      if (contextLines > 0) {
+        const start = Math.max(0, i - contextLines);
+        const end = Math.min(lines.length, i + contextLines + 1);
+        match.context = lines.slice(start, end).map((l, idx) => `${start + idx + 1}\t${l}`);
+      }
+      matches.push(match);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Determine if a file is likely binary by reading its first 8KB and
+ * checking for null bytes.
+ *
+ * @param filePath - Absolute path to the file
+ * @returns True if the file appears to be binary
+ */
+async function isBinaryFile(filePath: string): Promise<boolean> {
+  const fd = await fsPromises.open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(8192);
+    const { bytesRead } = await fd.read(buffer, 0, 8192, 0);
+    for (let i = 0; i < bytesRead; i++) {
+      if (buffer[i] === 0) return true;
+    }
+    return false;
+  } finally {
+    await fd.close();
+  }
+}
+
+/**
+ * Strip [NOTIFY]...[/NOTIFY] markers from text.
+ *
+ * The crewly-agent model sometimes wraps tool arguments in NOTIFY markers
+ * intended for the terminal gateway routing layer. When this leaks into
+ * reply_slack or other outward-facing tools, the raw markers appear in
+ * the Slack message. This function extracts the body content (after the
+ * --- separator if present) or the full block content.
+ *
+ * @param text - Text that may contain NOTIFY markers
+ * @returns Clean text with markers stripped and body content extracted
+ */
+export function stripNotifyMarkers(text: string): string {
+  // Replace each [NOTIFY]...[/NOTIFY] block with its body content
+  const cleaned = text.replace(/\[NOTIFY\]([\s\S]*?)\[\/NOTIFY\]/gi, (_match, inner: string) => {
+    const trimmed = inner.trim();
+    // If there's a --- separator, extract only the body after it
+    const separatorIdx = trimmed.indexOf('---');
+    if (separatorIdx !== -1) {
+      return trimmed.slice(separatorIdx + 3).trim();
+    }
+    // No separator — return the full inner content
+    return trimmed;
+  });
+  return cleaned.trim();
+}
+
+/**
+ * Convert GitHub-flavored Markdown to Slack mrkdwn format (#181).
+ *
+ * Transformations applied (in order):
+ * 1. Escape &, <, > to HTML entities (Slack requirement)
+ * 2. Convert fenced code blocks (```lang\n...\n```) to Slack code blocks
+ * 3. Convert **bold** to *bold* (Slack uses single asterisks)
+ * 4. Convert [text](url) links to <url|text> (Slack link format)
+ *
+ * @param text - Markdown-formatted text
+ * @returns Text formatted for Slack mrkdwn
+ */
+export function convertMarkdownToSlackMrkdwn(text: string): string {
+  // 1. Escape special Slack characters (must happen first, before adding <> for links)
+  let result = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+  // 2. Convert fenced code blocks: ```lang\n...\n``` → ```\n...\n```
+  // Slack doesn't support language hints in code blocks, so strip them
+  result = result.replace(/```\w*\n/g, '```\n');
+
+  // 3. Convert **bold** to *bold* (Slack bold is single asterisk)
+  // Must not touch single * (already italic in both formats)
+  result = result.replace(/\*\*(.+?)\*\*/g, '*$1*');
+
+  // 4. Convert [text](url) links to <url|text>
+  // The url may contain escaped &gt; from step 1, but real URLs won't have those
+  result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<$2|$1>');
+
+  return result;
+}
+
+/**
+ * Sensitivity classification for each tool.
+ * Used by the audit trail to classify tool invocations.
+ */
+export const TOOL_SENSITIVITY: Record<string, ToolSensitivity> = {
+  // Safe: read-only, informational
+  get_agent_status: 'safe',
+  get_team_status: 'safe',
+  get_agent_logs: 'safe',
+  heartbeat: 'safe',
+  get_tasks: 'safe',
+  get_project_overview: 'safe',
+  read_file: 'safe',
+  glob: 'safe',
+  grep: 'safe',
+  recall_memory: 'safe',
+  subscribe_event: 'safe',
+  get_audit_log: 'safe',
+  get_scheduled_checks: 'safe',
+  compact_memory: 'safe',
+  get_context_budget: 'safe',
+  // Sensitive: modify state, communicate externally
+  delegate_task: 'sensitive',
+  send_message: 'sensitive',
+  reply_slack: 'sensitive',
+  schedule_check: 'sensitive',
+  cancel_schedule: 'sensitive',
+  register_self: 'sensitive',
+  report_status: 'sensitive',
+  remember: 'sensitive',
+  complete_task: 'sensitive',
+  broadcast: 'sensitive',
+  // Destructive: irreversible or high-impact operations
+  start_agent: 'destructive',
+  stop_agent: 'destructive',
+  handle_agent_failure: 'destructive',
+  edit_file: 'destructive',
+  write_file: 'destructive',
+  // Git tools (#176)
+  git_status: 'safe',
+  git_diff: 'safe',
+  git_commit: 'sensitive',
+  // Shell execution (#176)
+  bash_exec: 'destructive',
+  // Task handoff (F12)
+  handoff_task: 'sensitive',
+  // Cloud-backed web search
+  web_search: 'safe',
+};
+
+/**
+ * Wrap a tool's execute function with audit logging.
+ *
+ * Records tool name, sensitivity, args, result status, and duration.
+ * Sanitizes arguments to avoid logging secrets.
+ *
+ * @param toolName - Name of the tool being wrapped
+ * @param executeFn - Original execute function
+ * @param callbacks - Callbacks object with onAuditLog handler
+ * @returns Wrapped execute function
+ */
+/**
+ * Wrap a tool's execute function with security policy enforcement and audit logging.
+ *
+ * Checks blocked tools and approval requirements before execution.
+ * Records tool name, sensitivity, args, result status, and duration.
+ * Sanitizes arguments to avoid logging secrets.
+ *
+ * @param toolName - Name of the tool being wrapped
+ * @param executeFn - Original execute function
+ * @param callbacks - Callbacks object with onAuditLog and onCheckApproval handlers
+ * @returns Wrapped execute function
+ */
+function wrapWithAudit(
+  toolName: string,
+  executeFn: (args: Record<string, unknown>) => Promise<unknown>,
+  callbacks?: ToolCallbacks,
+): (args: Record<string, unknown>) => Promise<unknown> {
+  if (!callbacks?.onAuditLog && !callbacks?.onCheckApproval) return executeFn;
+
+  return async (args: Record<string, unknown>): Promise<unknown> => {
+    const start = Date.now();
+    const sensitivity = TOOL_SENSITIVITY[toolName] || 'safe';
+
+    // Sanitize args: redact potential secrets
+    const sanitizedArgs = sanitizeArgs(args);
+
+    // Check security policy before execution
+    if (callbacks?.onCheckApproval) {
+      const approvalResult: ApprovalCheckResult = callbacks.onCheckApproval(toolName, sensitivity);
+      if (!approvalResult.allowed) {
+        const entry: AuditEntry = {
+          timestamp: new Date().toISOString(),
+          toolName,
+          sensitivity,
+          args: sanitizedArgs,
+          success: false,
+          error: approvalResult.reason || 'Blocked by security policy',
+          durationMs: Date.now() - start,
+        };
+        if (callbacks?.onAuditLog) callbacks.onAuditLog(entry);
+        // Enqueue for approval if not hard-blocked
+        let approvalId: string | undefined;
+        if (!approvalResult.blocked && callbacks?.onEnqueueApproval) {
+          const enqueued = callbacks.onEnqueueApproval(toolName, sensitivity, sanitizedArgs);
+          approvalId = enqueued.approvalId;
+        }
+
+        return {
+          success: false,
+          blocked: approvalResult.blocked ?? false,
+          requiresApproval: !approvalResult.blocked,
+          approvalId,
+          error: approvalResult.reason || 'Tool execution denied by security policy',
+        };
+      }
+    }
+
+    // No audit logger — just execute
+    if (!callbacks?.onAuditLog) return executeFn(args);
+
+    try {
+      const result = await executeFn(args);
+      const success = result != null && typeof result === 'object'
+        ? (result as Record<string, unknown>).success !== false
+        : true;
+
+      const entry: AuditEntry = {
+        timestamp: new Date().toISOString(),
+        toolName,
+        sensitivity,
+        args: sanitizedArgs,
+        success,
+        durationMs: Date.now() - start,
+      };
+      if (!success && typeof result === 'object' && result !== null) {
+        entry.error = String((result as Record<string, unknown>).error || 'unknown');
+      }
+      callbacks.onAuditLog!(entry);
+      return result;
+    } catch (error) {
+      const entry: AuditEntry = {
+        timestamp: new Date().toISOString(),
+        toolName,
+        sensitivity,
+        args: sanitizedArgs,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - start,
+      };
+      callbacks.onAuditLog!(entry);
+      throw error;
+    }
+  };
+}
+
+/**
+ * Sanitize tool arguments for audit logging.
+ * Redacts values for keys that may contain secrets.
+ *
+ * @param args - Raw tool arguments
+ * @returns Sanitized copy safe for logging
+ */
+function sanitizeArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const sensitiveKeys = ['password', 'secret', 'token', 'apiKey', 'api_key', 'authorization'];
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (sensitiveKeys.some(sk => key.toLowerCase().includes(sk))) {
+      result[key] = '[REDACTED]';
+    } else if (typeof value === 'string' && value.length > 2000) {
+      result[key] = value.substring(0, 2000) + '...[truncated]';
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Create the complete set of AI SDK tools for the Crewly Agent.
+ *
+ * Each tool's execute function calls the Crewly REST API directly
+ * via the provided API client, bypassing the bash script layer.
+ * Tools are wrapped with audit logging when callbacks are provided.
+ *
+ * @param client - API client instance for making REST calls
+ * @param sessionName - Agent session name for identity context
+ * @param projectPath - Optional project path for auto-injection
+ * @param callbacks - Optional callbacks for compaction and audit logging
+ * @returns Object of named tools ready to pass to generateText
+ */
+export function createTools(client: CrewlyApiClient, sessionName: string, projectPath?: string, callbacks?: ToolCallbacks, conversationId?: string, slackContext?: { channelId: string; threadTs?: string }, mcpTools?: Record<string, ToolDefinition>): Record<string, ToolDefinition> {
+  // Slack rate-limiting state: throttle messages within a 3-second window
+  let lastSlackSendMs = 0;
+  const SLACK_THROTTLE_MS = 3000;
+
+  // Slack dedup: ring buffer of recent messages to prevent duplicate sends
+  const recentSlackMessages: string[] = [];
+  const SLACK_DEDUP_WINDOW = 10;
+
+  const rawTools: Record<string, ToolDefinition> = {
+    // ===== Core Orchestration Tools =====
+
+    delegate_task: {
+      description: 'Delegate a task to a worker agent. Sends the task message and creates a task tracking file. Enforces TL hierarchy — if target has a parent TL, routes through TL instead.',
+      inputSchema: z.object({
+        to: z.string().describe('Target agent session name'),
+        task: z.string().describe('Task description and instructions'),
+        priority: z.enum(['low', 'normal', 'high', 'critical']).default('normal'),
+        context: z.string().optional().describe('Additional context for the task'),
+        projectPath: z.string().optional().describe('Project path for task tracking'),
+      }),
+      execute: async ({ to, task, priority, context, projectPath }) => {
+        // #164: TL hierarchy validation — enforce that the caller has delegation authority
+        const teamsResult = await client.get('/teams').catch(() => null);
+        if (teamsResult?.success && Array.isArray(teamsResult.data)) {
+          type MemberInfo = { id: string; sessionName: string; parentMemberId?: string; canDelegate?: boolean; subordinateIds?: string[]; agentStatus?: string; workingStatus?: string };
+          type TeamInfo = { members?: MemberInfo[] };
+          for (const team of teamsResult.data as TeamInfo[]) {
+            const targetMember = team.members?.find(m => m.sessionName === (to as string));
+            const callerMember = team.members?.find(m => m.sessionName === sessionName);
+
+            if (targetMember?.parentMemberId) {
+              const tlMember = team.members?.find(m => m.id === targetMember.parentMemberId);
+              // If the caller is NOT the TL, redirect through TL
+              if (tlMember && tlMember.sessionName !== sessionName) {
+                return {
+                  success: false,
+                  error: `Hierarchy violation: ${to} reports to TL ${tlMember.sessionName} (${tlMember.id}). You must delegate through the TL, not directly. Use send_message to ask ${tlMember.sessionName} to delegate this task to ${to}.`,
+                  redirectTo: tlMember.sessionName,
+                  hint: 'Use send_message to the TL with the task details, and ask them to delegate to the worker.',
+                };
+              }
+            }
+
+            // Verify caller has canDelegate permission when delegating to a subordinate
+            if (callerMember && targetMember && callerMember.canDelegate === false) {
+              return {
+                success: false,
+                error: `You (${sessionName}) do not have delegation permission (canDelegate: false). Ask your TL to delegate this task.`,
+              };
+            }
+
+            // Task stacking prevention — check if target already has in-progress tasks
+            if (targetMember && targetMember.workingStatus === 'in_progress') {
+              return {
+                success: false,
+                error: `Agent ${to} is already working on a task (workingStatus: in_progress). Wait for current task to complete before delegating a new one.`,
+                agentStatus: targetMember.agentStatus,
+                workingStatus: targetMember.workingStatus,
+              };
+            }
+          }
+        }
+
+        const taskMessage = buildTaskMessage(to as string, task as string, priority as string, context as string | undefined, projectPath as string | undefined);
+
+        // Deliver the task message
+        const deliverResult = await client.post(`/terminal/${to}/deliver`, {
+          message: taskMessage,
+          waitForReady: true,
+          waitTimeout: 15000,
+        });
+
+        if (!deliverResult.success) {
+          // Fallback: force delivery
+          const forceResult = await client.post(`/terminal/${to}/deliver`, {
+            message: taskMessage,
+            force: true,
+          });
+          if (!forceResult.success) {
+            return { success: false, error: `Failed to deliver task to ${to}: ${forceResult.error}` };
+          }
+        }
+
+        // Create task tracking entry as a V3 WorkItem.
+        // Migrated from v1 `/task-management/create` per spec
+        // 2026-05-06-task-management-v1-deprecation.md.
+        let taskId: string | undefined;
+        if (projectPath) {
+          const priorityNum =
+            priority === 'critical' ? 1 :
+            priority === 'high'     ? 2 :
+            priority === 'low'      ? 4 :
+            3;
+          const wiId = `task-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+          const createResult = await client.post('/task-pool/add', {
+            workItem: {
+              id: wiId,
+              title: typeof task === 'string' ? task.slice(0, 200) : 'Delegated task',
+              type: 'delegate',
+              owner: typeof to === 'string' ? to : 'system',
+              priority: priorityNum,
+              status: 'queued',
+              target: to,
+              briefMarkdown: typeof task === 'string' ? task : undefined,
+              metadata: { projectPath, milestone: 'delegated' },
+            },
+          });
+          if (createResult.success && createResult.data) {
+            const data = createResult.data as Record<string, unknown>;
+            taskId = (data.id as string | undefined) ?? wiId;
+          }
+        }
+
+        // Subscribe to idle event for monitoring (with dedup check)
+        const existingSubs = await client.get(`/events/subscriptions?subscriberSession=${encodeURIComponent(sessionName)}`).catch(() => null);
+        const alreadySubscribed = existingSubs?.success && Array.isArray(existingSubs.data) &&
+          (existingSubs.data as Array<{ eventType: string; filter?: Record<string, string> }>).some(
+            sub => sub.eventType === 'agent:idle' && sub.filter?.sessionName === (to as string),
+          );
+        if (!alreadySubscribed) {
+          await client.post('/events/subscribe', {
+            eventType: 'agent:idle',
+            filter: { sessionName: to },
+            subscriberSession: sessionName,
+            oneShot: true,
+            ttlMinutes: DELEGATION_SUBSCRIPTION_TTL_MINUTES,
+          });
+        }
+
+        return { success: true, delegatedTo: to, taskId, conversationId: conversationId || undefined };
+      },
+    },
+
+    send_message: {
+      description: 'Send a message to an agent terminal session.',
+      inputSchema: z.object({
+        sessionName: z.string().describe('Target agent session name'),
+        message: z.string().describe('Message content'),
+        force: z.boolean().default(false).describe('Force send without waiting for ready state'),
+      }),
+      execute: async ({ sessionName: target, message, force }) => {
+        const body = force
+          ? { message, force: true }
+          : { message, waitForReady: true, waitTimeout: 120000 };
+        const result = await client.post(`/terminal/${target}/deliver`, body);
+        return result.success
+          ? { success: true, delivered: true }
+          : { success: false, error: result.error };
+      },
+    },
+
+    get_agent_status: {
+      description: 'Get the current status of a specific agent by session name.',
+      inputSchema: z.object({
+        sessionName: z.string().describe('Agent session name to check'),
+      }),
+      execute: async ({ sessionName: target }) => {
+        // Record manual check so redundant scheduled checks are suppressed (fire-and-forget)
+        Promise.resolve(client.post('/schedule/manual-check', { agentSession: target })).catch(() => {});
+
+        const result = await client.get('/teams');
+        if (!result.success) return { error: result.error };
+
+        const teams = result.data as Record<string, unknown>[];
+        const teamArray = Array.isArray(teams) ? teams : [teams];
+        for (const team of teamArray) {
+          const members = (team as Record<string, unknown>).members as Array<Record<string, unknown>> | undefined;
+          if (!members) continue;
+          const agent = members.find(m => m.sessionName === target || m.name === target);
+          if (agent) return agent;
+        }
+        return { error: 'Agent not found', sessionName: target };
+      },
+    },
+
+    get_team_status: {
+      description: 'Get status of all teams and their agents.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await client.get('/teams');
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    get_agent_logs: {
+      description: 'Get recent terminal output from an agent session.',
+      inputSchema: z.object({
+        sessionName: z.string().describe('Agent session name'),
+        lines: z.number().default(50).describe('Number of lines to retrieve'),
+      }),
+      execute: async ({ sessionName: target, lines }) => {
+        // Record manual check so redundant scheduled checks are suppressed (fire-and-forget)
+        Promise.resolve(client.post('/schedule/manual-check', { agentSession: target })).catch(() => {});
+
+        const result = await client.get(`/terminal/${target}/output?lines=${lines}`);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    reply_slack: {
+      description: 'Send a text reply or upload an image to a Slack channel or thread. If channelId is omitted, uses the current Slack thread context. For images, provide imagePath (absolute path on disk) — the image is uploaded via Slack file upload API. Messages sent within 3 seconds are batched to avoid spam.',
+      inputSchema: z.object({
+        channelId: z.string().optional().describe('Slack channel ID (auto-filled from current thread context if omitted)'),
+        text: z.string().describe('Message text (used as comment when uploading an image)'),
+        threadTs: z.string().optional().describe('Thread timestamp for replies (auto-filled from current thread context if omitted)'),
+        imagePath: z.string().optional().describe('Absolute path to an image file to upload (png, jpg, gif, webp). When provided, uploads the image instead of sending a text message.'),
+      }),
+      execute: async ({ channelId, text, threadTs, imagePath }) => {
+        let cleanText = stripNotifyMarkers(text as string);
+        // #181: Convert markdown to Slack mrkdwn format
+        cleanText = convertMarkdownToSlackMrkdwn(cleanText);
+
+        // Auto-prefix with agent display name so Slack messages are attributable
+        // Session format: "crewly-{team}-{name}-{uuid}" → extract {name}
+        // Fallback: "crewly-orc" → "orc"
+        if (sessionName && !cleanText.startsWith('[')) {
+          const parts = sessionName.split('-');
+          // For "crewly-product-sam-217bfbbf": parts[2] = "sam"
+          // For "crewly-orc": parts[1] = "orc"
+          const namePart = parts.length >= 3 ? parts[2] : parts[parts.length - 1];
+          const capitalized = namePart.charAt(0).toUpperCase() + namePart.slice(1);
+          cleanText = `[${capitalized}] ${cleanText}`;
+        }
+        const resolvedChannelId = (channelId as string | undefined) || slackContext?.channelId;
+        const resolvedThreadTs = (threadTs as string | undefined) || slackContext?.threadTs;
+        if (!resolvedChannelId) {
+          return { success: false, error: 'No channelId provided and no Slack thread context available. Use reply_slack with an explicit channelId.' };
+        }
+
+        // ── Image upload path ──
+        if (imagePath) {
+          const uploadBody: Record<string, string> = {
+            channelId: resolvedChannelId,
+            filePath: imagePath as string,
+            initialComment: cleanText,
+          };
+          if (resolvedThreadTs) uploadBody.threadTs = resolvedThreadTs;
+          const result = await client.post('/slack/upload-image', uploadBody);
+          if (result.success) {
+            lastSlackSendMs = Date.now();
+          }
+          return result.success
+            ? { success: true, sent: true, uploaded: true, filePath: imagePath }
+            : { success: false, error: result.error };
+        }
+
+        // ── Text message path ──
+        // Dedup: skip if this exact message was recently sent
+        if (recentSlackMessages.includes(cleanText)) {
+          return { success: true, sent: false, deduplicated: true, reason: 'Message already sent recently' };
+        }
+
+        // Issue 3: Rate-limit Slack messages — throttle within a 3s window
+        const now = Date.now();
+        if (now - lastSlackSendMs < SLACK_THROTTLE_MS) {
+          return { success: true, sent: false, throttled: true, retryAfterMs: SLACK_THROTTLE_MS - (now - lastSlackSendMs) };
+        }
+
+        const body: Record<string, string> = { channelId: resolvedChannelId, text: cleanText };
+        if (resolvedThreadTs) body.threadTs = resolvedThreadTs;
+        if (conversationId) body.conversationId = conversationId;
+        if (sessionName) body.senderSessionName = sessionName;
+        const result = await client.post('/slack/send', body);
+        if (result.success) {
+          lastSlackSendMs = Date.now();
+          // Track for dedup
+          recentSlackMessages.push(cleanText);
+          if (recentSlackMessages.length > SLACK_DEDUP_WINDOW) {
+            recentSlackMessages.shift();
+          }
+        }
+        return result.success
+          ? { success: true, sent: true }
+          : { success: false, error: result.error };
+      },
+    },
+
+    // ===== Scheduling Tools =====
+
+    schedule_check: {
+      description: 'Schedule a future check-in reminder. Include taskId to auto-cancel when the linked task completes. Deduplicates: skips if a similar check already exists for the same target.',
+      inputSchema: z.object({
+        minutes: z.number().describe('Minutes from now'),
+        message: z.string().describe('Reminder message'),
+        target: z.string().optional().describe('Target session (defaults to self)'),
+        recurring: z.boolean().default(false),
+        maxOccurrences: z.number().optional(),
+        taskId: z.string().optional().describe('Link to a task ID — recurring check auto-cancels when this task completes'),
+      }),
+      execute: async ({ minutes, message, target, recurring, maxOccurrences, taskId }) => {
+        const targetSession = target || sessionName;
+
+        // Issue 2: Dedup check — list existing scheduled checks for this target
+        const existingResult = await client.get(`/schedule?session=${encodeURIComponent(targetSession as string)}`).catch(() => null);
+        if (existingResult?.success && Array.isArray(existingResult.data)) {
+          type CheckInfo = { targetSession: string; message: string; taskId?: string };
+          const msgPrefix = (message as string).slice(0, 50); // Match on message prefix
+          const isDuplicate = (existingResult.data as CheckInfo[]).some(check =>
+            check.targetSession === targetSession &&
+            (check.message?.startsWith(msgPrefix) || (taskId && check.taskId === taskId))
+          );
+          if (isDuplicate) {
+            return { success: true, status: 'already_scheduled', targetSession, message };
+          }
+        }
+
+        const body: Record<string, unknown> = {
+          targetSession,
+          minutes,
+          message,
+        };
+        if (recurring) {
+          body.isRecurring = true;
+          body.intervalMinutes = minutes;
+        }
+        if (maxOccurrences) body.maxOccurrences = maxOccurrences;
+        if (taskId) body.taskId = taskId;
+        const result = await client.post('/schedule', body);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    cancel_schedule: {
+      description: 'Cancel a scheduled check-in by ID.',
+      inputSchema: z.object({
+        checkId: z.string().describe('Schedule ID to cancel'),
+      }),
+      execute: async ({ checkId }) => {
+        const result = await client.delete(`/schedule/${checkId}`);
+        return result.success ? { success: true } : { error: result.error };
+      },
+    },
+
+    get_scheduled_checks: {
+      description: 'List all active scheduled checks. Use to identify stale or completed checks that should be cancelled.',
+      inputSchema: z.object({
+        session: z.string().optional().describe('Filter by target session name'),
+      }),
+      execute: async ({ session }) => {
+        const endpoint = session
+          ? `/schedule?session=${encodeURIComponent(session as string)}`
+          : '/schedule';
+        const result = await client.get(endpoint);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    // ===== Agent Lifecycle Tools =====
+
+    start_agent: {
+      description: 'Start a specific agent within a team. Safely skips if the agent is already active.',
+      inputSchema: z.object({
+        teamId: z.string().describe('Team UUID'),
+        memberId: z.string().describe('Member UUID'),
+      }),
+      execute: async ({ teamId, memberId }) => {
+        // Pre-check: if the agent is already active, return immediately to avoid
+        // timeout and session interruption from redundant start calls
+        const teamResult = await client.get(`/teams/${teamId}`).catch(() => null);
+        if (teamResult?.success && teamResult.data) {
+          const team = teamResult.data as { members?: Array<{ id: string; agentStatus?: string; sessionName?: string; name?: string }> };
+          const member = team.members?.find(m => m.id === memberId);
+          if (member && member.agentStatus === 'active' && member.sessionName) {
+            return {
+              success: true,
+              memberName: member.name,
+              memberId: member.id,
+              sessionName: member.sessionName,
+              status: 'already_active',
+            };
+          }
+        }
+
+        const result = await client.post(`/teams/${teamId}/members/${memberId}/start`, {});
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    stop_agent: {
+      description: 'Stop a specific agent within a team.',
+      inputSchema: z.object({
+        teamId: z.string().describe('Team UUID'),
+        memberId: z.string().describe('Member UUID'),
+      }),
+      execute: async ({ teamId, memberId }) => {
+        const result = await client.post(`/teams/${teamId}/members/${memberId}/stop`, {});
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    // ===== Event Tools =====
+
+    subscribe_event: {
+      description: 'Subscribe to agent lifecycle events (e.g., agent:idle, agent:busy). Deduplicates: skips if an identical subscription already exists.',
+      inputSchema: z.object({
+        eventType: z.string().describe('Event type (e.g., "agent:idle")'),
+        filter: z.record(z.string()).optional().describe('Event filter criteria'),
+        oneShot: z.boolean().default(true),
+      }),
+      execute: async ({ eventType, filter, oneShot }) => {
+        // Issue 2: Dedup check — list existing subscriptions and skip if duplicate
+        const existingResult = await client.get(`/events/subscriptions?subscriberSession=${encodeURIComponent(sessionName)}`).catch(() => null);
+        if (existingResult?.success && Array.isArray(existingResult.data)) {
+          type SubInfo = { eventType: string; filter?: Record<string, string>; subscriberSession: string };
+          const filterStr = JSON.stringify(filter || {});
+          const isDuplicate = (existingResult.data as SubInfo[]).some(sub =>
+            sub.eventType === eventType &&
+            sub.subscriberSession === sessionName &&
+            JSON.stringify(sub.filter || {}) === filterStr
+          );
+          if (isDuplicate) {
+            return { success: true, status: 'already_subscribed', eventType, filter };
+          }
+        }
+
+        const result = await client.post('/events/subscribe', {
+          eventType,
+          filter: filter || {},
+          subscriberSession: sessionName,
+          oneShot,
+        });
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    // ===== Memory Tools =====
+
+    recall_memory: {
+      description: 'Retrieve relevant knowledge from agent/project memory.',
+      inputSchema: z.object({
+        context: z.string().describe('What to search for'),
+        scope: z.enum(['agent', 'project', 'both']).default('both'),
+        projectPath: z.string().optional().describe('Project path (auto-injected if omitted)'),
+      }),
+      execute: async ({ context, scope, projectPath: pp }) => {
+        const body: Record<string, unknown> = {
+          agentId: sessionName,
+          context,
+          scope,
+        };
+        // Auto-inject projectPath when scope requires it
+        const resolvedProjectPath = (pp as string | undefined) || projectPath;
+        if (resolvedProjectPath && (scope === 'project' || scope === 'both')) {
+          body.projectPath = resolvedProjectPath;
+        }
+        const result = await client.post('/memory/recall', body);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    remember: {
+      description: 'Store knowledge for future reference.',
+      inputSchema: z.object({
+        content: z.string().describe('Knowledge to store'),
+        category: z.enum(['pattern', 'decision', 'gotcha', 'fact', 'preference']),
+        scope: z.enum(['agent', 'project']).default('project'),
+        projectPath: z.string().optional().describe('Project path (auto-injected if omitted)'),
+      }),
+      execute: async ({ content, category, scope, projectPath: pp }) => {
+        const body: Record<string, unknown> = {
+          agentId: sessionName,
+          content,
+          category,
+          scope,
+        };
+        const resolvedProjectPath = (pp as string | undefined) || projectPath;
+        if (resolvedProjectPath) {
+          body.projectPath = resolvedProjectPath;
+        }
+        const result = await client.post('/memory/remember', body);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    // ===== System Tools =====
+
+    heartbeat: {
+      description: 'System health check. Returns teams, projects, and message queue status.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const [teams, projects, queue] = await Promise.all([
+          client.get('/teams'),
+          client.get('/projects'),
+          client.get('/messaging/queue/status'),
+        ]);
+        return {
+          status: 'ok',
+          timestamp: new Date().toISOString(),
+          teams: teams.success ? teams.data : 'unavailable',
+          projects: projects.success ? projects.data : 'unavailable',
+          queue: queue.success ? queue.data : 'unavailable',
+        };
+      },
+    },
+
+    get_tasks: {
+      description: 'Get all tracked tasks for a project.',
+      inputSchema: z.object({
+        projectPath: z.string().describe('Project path'),
+        status: z.string().optional().describe('Filter by status (e.g., "in_progress", "done")'),
+      }),
+      execute: async ({ projectPath: _projectPath, status }) => {
+        // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+        // The V3 task-pool is a single global file; `projectPath` is no
+        // longer a filter. Status filter still applies.
+        let endpoint = '/task-pool/items';
+        if (status) endpoint += `?status=${encodeURIComponent(status as string)}`;
+        const result = await client.get(endpoint);
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    complete_task: {
+      description: 'Mark a WorkItem as complete. Also cancels any scheduled checks targeting the completing agent session.',
+      inputSchema: z.object({
+        workItemId: z.string().describe('WorkItem id to complete'),
+        sessionName: z.string().describe('Agent session that completed it'),
+        summary: z.string().describe('Completion summary'),
+      }),
+      execute: async ({ workItemId, sessionName: agent, summary }) => {
+        // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md.
+        // Replaces v1 `/task-management/complete`. Note: the legacy
+        // `absoluteTaskPath` parameter is removed; callers must now pass
+        // `workItemId` (returned from `start_agent_with_task` /
+        // `delegate_task`).
+        //
+        // Hygiene #4: emit canonical body shape `{agentId, result:{summary}}`
+        // required by task-pool.controller.ts `completeItem`. Prior shape
+        // `{summary}` 400'd because the controller looks at `result.summary`
+        // and requires non-empty `agentId`. Cf. fix-paired changes in:
+        //   - config/skills/agent/core/{report-status,complete-task}/execute.sh
+        //   - config/skills/orchestrator/complete-task/execute.sh
+        //   - tool-registry.ts §report_status auto-complete path (below)
+        const result = await client.post(`/task-pool/complete/${workItemId}`, {
+          agentId: agent,
+          result: { summary },
+        });
+
+        // Auto-cancel scheduled checks targeting the completing agent
+        // to prevent stale recurring checks from firing after task completion
+        let cancelledChecks = 0;
+        try {
+          const checksResult = await client.get(`/schedule?session=${encodeURIComponent(agent as string)}`);
+          if (checksResult.success && Array.isArray(checksResult.data)) {
+            for (const check of checksResult.data as Array<{ id: string; isRecurring?: boolean }>) {
+              if (check.isRecurring) {
+                await client.delete(`/schedule/${check.id}`);
+                cancelledChecks++;
+              }
+            }
+          }
+        } catch {
+          // Non-fatal: task completion succeeded even if check cleanup fails
+        }
+
+        if (result.success) {
+          return { ...result.data as Record<string, unknown>, cancelledChecks };
+        }
+        return { error: result.error };
+      },
+    },
+
+    broadcast: {
+      description: 'Broadcast a message to all active agent sessions.',
+      inputSchema: z.object({
+        message: z.string().describe('Message to broadcast'),
+      }),
+      execute: async ({ message }) => {
+        const sessionsResult = await client.get('/terminal/sessions');
+        if (!sessionsResult.success) return { error: sessionsResult.error };
+
+        const sessions = sessionsResult.data as Record<string, unknown>[] | { data: Record<string, unknown>[] };
+        const sessionList = Array.isArray(sessions) ? sessions : (sessions as Record<string, unknown>).data as Record<string, unknown>[] || [];
+
+        let sent = 0;
+        let failed = 0;
+        for (const session of sessionList) {
+          const name = (session as Record<string, string>).name;
+          if (!name || name === sessionName) continue;
+          const result = await client.post(`/terminal/${name}/deliver`, { message });
+          if (result.success) sent++;
+          else failed++;
+        }
+        return { sent, failed };
+      },
+    },
+
+    handle_agent_failure: {
+      description: 'Handle agent failure: restart the agent session.',
+      inputSchema: z.object({
+        teamId: z.string(),
+        memberId: z.string(),
+        sessionName: z.string().describe('Agent session name'),
+        action: z.enum(['restart', 'retry', 'escalate']),
+        reason: z.string().optional(),
+      }),
+      execute: async ({ teamId, memberId, sessionName: agent, action, reason }) => {
+        if (action === 'restart') {
+          await client.post(`/teams/${teamId}/members/${memberId}/stop`, {});
+          const result = await client.post(`/teams/${teamId}/members/${memberId}/start`, {});
+          return { action: 'restarted', sessionName: agent, success: result.success };
+        }
+        if (action === 'escalate') {
+          return { action: 'escalated', sessionName: agent, reason: reason || 'unknown' };
+        }
+        return { action, sessionName: agent, note: 'Action acknowledged' };
+      },
+    },
+
+    // ===== File Editing Tools =====
+
+    edit_file: {
+      description: 'Surgical file edit: replace an exact substring in a file with new content. Uses precise string matching (not regex) to find the old text and replace it. The old_string must appear exactly once in the file for the edit to succeed. This is safer than full file rewrites — only the targeted section changes.',
+      inputSchema: z.object({
+        file_path: z.string().describe('Absolute path to the file to edit'),
+        old_string: z.string().describe('Exact string to find and replace (must be unique in the file)'),
+        new_string: z.string().describe('Replacement string'),
+        replace_all: z.boolean().default(false).describe('Replace all occurrences instead of requiring uniqueness'),
+      }),
+      execute: async ({ file_path, old_string, new_string, replace_all }) => {
+        const fp = expandPath(file_path as string, projectPath), os = old_string as string, ns = new_string as string;
+        try {
+          // Read the file
+          const content = await fsPromises.readFile(fp, 'utf8');
+
+          // Count occurrences
+          const occurrences = content.split(os).length - 1;
+
+          if (occurrences === 0) {
+            return {
+              success: false,
+              error: `old_string not found in ${fp}. Make sure the string matches exactly (including whitespace and indentation).`,
+            };
+          }
+
+          // When replace_all is true, replace all occurrences
+          if (replace_all && occurrences > 1) {
+            const newContent = content.replaceAll(os, ns);
+            await fsPromises.writeFile(fp, newContent, 'utf8');
+            return {
+              success: true,
+              file: fp,
+              replacements: occurrences,
+            };
+          }
+
+          // Default behavior: require unique match for safety
+          if (occurrences > 1) {
+            return {
+              success: false,
+              error: `old_string found ${occurrences} times in ${fp}. Provide a larger unique string with more surrounding context, or set replace_all=true.`,
+              occurrences,
+            };
+          }
+
+          // Perform the replacement (single occurrence)
+          const newContent = content.replace(os, ns);
+
+          // Write back
+          await fsPromises.writeFile(fp, newContent, 'utf8');
+
+          return {
+            success: true,
+            file: fp,
+            replacements: 1,
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (msg.includes('ENOENT')) {
+            return { success: false, error: `File not found: ${fp}` };
+          }
+          if (msg.includes('EACCES')) {
+            return { success: false, error: `Permission denied: ${fp}` };
+          }
+          return { success: false, error: msg };
+        }
+      },
+    },
+
+    read_file: {
+      description: 'Read the contents of a file. Returns text content with line numbers, or base64-encoded image data for image files (png/jpg/gif/webp/svg). Image files are returned as multimodal content parts for AI SDK.',
+      inputSchema: z.object({
+        file_path: z.string().describe('Absolute path to the file to read'),
+        offset: z.number().optional().describe('Line number to start reading from (1-based, text files only)'),
+        limit: z.number().optional().describe('Maximum number of lines to read (text files only)'),
+      }),
+      execute: async ({ file_path, offset, limit }) => {
+        const fp = expandPath(file_path as string, projectPath);
+        try {
+          // Check if this is an image file
+          const ext = fp.split('.').pop()?.toLowerCase() || '';
+          if (IMAGE_EXTENSIONS.has(ext)) {
+            const buffer = await fsPromises.readFile(fp);
+            const base64 = buffer.toString('base64');
+            const mimeType = IMAGE_MIME_TYPES[ext] || 'application/octet-stream';
+            return {
+              success: true,
+              type: 'image',
+              mimeType,
+              data: base64,
+              file: fp,
+              sizeBytes: buffer.length,
+            };
+          }
+
+          const content = await fsPromises.readFile(fp, 'utf8');
+          const lines = content.split('\n');
+
+          if (offset || limit) {
+            const start = ((offset as number) || 1) - 1;
+            const end = limit ? start + (limit as number) : lines.length;
+            const sliced = lines.slice(start, end);
+            return {
+              success: true,
+              content: sliced.map((line, i) => `${start + i + 1}\t${line}`).join('\n'),
+              totalLines: lines.length,
+            };
+          }
+
+          // Auto-limit large files to prevent context overflow
+          const effectiveLines = lines.length > READ_FILE_MAX_LINES
+            ? lines.slice(0, READ_FILE_MAX_LINES)
+            : lines;
+          let output = effectiveLines.map((line, i) => `${i + 1}\t${line}`).join('\n');
+          const wasTruncated = lines.length > READ_FILE_MAX_LINES;
+          if (output.length > READ_FILE_MAX_CHARS) {
+            output = output.slice(0, READ_FILE_MAX_CHARS) + '\n...[truncated — use offset/limit to read specific sections]';
+          }
+          return {
+            success: true,
+            content: output,
+            totalLines: lines.length,
+            ...(wasTruncated && { truncated: true, shownLines: READ_FILE_MAX_LINES }),
+          };
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          if (msg.includes('ENOENT')) {
+            return { success: false, error: `File not found: ${fp}` };
+          }
+          return { success: false, error: msg };
+        }
+      },
+    },
+
+    write_file: {
+      description: 'Write content to a file, creating it if it does not exist. Overwrites existing content. Use edit_file for surgical modifications to existing files.',
+      inputSchema: z.object({
+        file_path: z.string().describe('Absolute path to the file to write'),
+        content: z.string().describe('Full file content to write'),
+      }),
+      execute: async ({ file_path, content }) => {
+        const fp = expandPath(file_path as string, projectPath), ct = content as string;
+        try {
+          // Ensure parent directory exists
+          const dir = fp.substring(0, fp.lastIndexOf('/'));
+          if (dir) {
+            await fsPromises.mkdir(dir, { recursive: true });
+          }
+          await fsPromises.writeFile(fp, ct, 'utf8');
+          return { success: true, file: fp, bytes: Buffer.byteLength(ct, 'utf8') };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    // ===== Native File Search Tools (O7.KR1 — Claude Code parity) =====
+
+    glob: {
+      description: 'Fast file pattern matching. Recursively find files matching a glob pattern (e.g., "**/*.ts", "src/**/*.test.tsx"). Returns matching file paths sorted alphabetically. Use this instead of bash find.',
+      inputSchema: z.object({
+        pattern: z.string().describe('Glob pattern to match files (e.g., "**/*.ts", "src/components/**/*.tsx")'),
+        path: z.string().optional().describe('Root directory to search in. Defaults to projectPath or cwd.'),
+        ignore: z.array(z.string()).optional().describe('Additional directory names to ignore (node_modules, .git, dist are always ignored)'),
+      }),
+      execute: async ({ pattern, path: searchPath, ignore }) => {
+        try {
+          const rootDir = expandPath((searchPath as string | undefined) || projectPath || process.cwd());
+          const stat = await fsPromises.stat(rootDir);
+          if (!stat.isDirectory()) {
+            return { success: false, error: `Not a directory: ${rootDir}` };
+          }
+
+          const patternStr = pattern as string;
+          const patternRegex = globToRegExp(patternStr);
+
+          const ignoreNames = new Set(DEFAULT_IGNORE_PATTERNS);
+          if (Array.isArray(ignore)) {
+            for (const ig of ignore) {
+              ignoreNames.add(ig as string);
+            }
+          }
+
+          const results = await walkAndMatch(rootDir, patternRegex, ignoreNames, GLOB_MAX_RESULTS);
+          results.sort();
+
+          return {
+            success: true,
+            pattern: patternStr,
+            root: rootDir,
+            matchCount: results.length,
+            files: results,
+            truncated: results.length >= GLOB_MAX_RESULTS,
+          };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    grep: {
+      description: 'Search file contents for a regex pattern. Returns matching lines with line numbers and optional context. Searches recursively through files matching an optional file glob filter. Use this instead of bash grep/rg.',
+      inputSchema: z.object({
+        pattern: z.string().describe('Regular expression pattern to search for in file contents'),
+        path: z.string().optional().describe('File or directory to search in. Defaults to projectPath or cwd.'),
+        file_pattern: z.string().optional().describe('Glob pattern to filter which files to search (e.g., "*.ts", "**/*.tsx")'),
+        context_lines: z.number().optional().describe('Number of lines before and after each match to include (default: 0)'),
+        case_insensitive: z.boolean().optional().describe('Case insensitive search (default: false)'),
+        max_matches: z.number().optional().describe('Maximum total matches to return (default: 500)'),
+        ignore: z.array(z.string()).optional().describe('Additional directory names to ignore'),
+      }),
+      execute: async ({ pattern: searchPattern, path: searchPath, file_pattern, context_lines, case_insensitive, max_matches, ignore }) => {
+        try {
+          const patternStr = searchPattern as string;
+          const flags = (case_insensitive as boolean) ? 'gi' : 'g';
+          let regex: RegExp;
+          try {
+            regex = new RegExp(patternStr, flags);
+          } catch (e) {
+            return { success: false, error: `Invalid regex: ${patternStr} — ${e instanceof Error ? e.message : String(e)}` };
+          }
+
+          // Also create a non-global version for line testing
+          const testRegex = new RegExp(patternStr, (case_insensitive as boolean) ? 'i' : '');
+          const ctxLines = (context_lines as number | undefined) || 0;
+          const maxTotal = (max_matches as number | undefined) || GREP_MAX_MATCHES;
+
+          const rootDir = expandPath((searchPath as string | undefined) || projectPath || process.cwd());
+          let filesToSearch: string[];
+
+          // Check if rootDir is a file or directory
+          const stat = await fsPromises.stat(rootDir);
+          if (stat.isFile()) {
+            filesToSearch = [rootDir];
+          } else {
+            // Determine file pattern for filtering
+            const filePatternStr = (file_pattern as string | undefined) || '**/*';
+            const fileRegex = globToRegExp(filePatternStr);
+
+            const ignoreNames = new Set(DEFAULT_IGNORE_PATTERNS);
+            if (Array.isArray(ignore)) {
+              for (const ig of ignore) {
+                ignoreNames.add(ig as string);
+              }
+            }
+
+            filesToSearch = await walkAndMatch(rootDir, fileRegex, ignoreNames, GLOB_MAX_RESULTS);
+          }
+
+          const allMatches: Array<{
+            file: string;
+            line: number;
+            content: string;
+            context?: string[];
+          }> = [];
+          let totalMatches = 0;
+
+          for (const filePath of filesToSearch) {
+            if (totalMatches >= maxTotal) break;
+
+            // Skip binary files
+            try {
+              if (await isBinaryFile(filePath)) continue;
+            } catch {
+              continue;
+            }
+
+            try {
+              const fileMatches = await searchFileContents(filePath, testRegex, ctxLines);
+              for (const m of fileMatches) {
+                if (totalMatches >= maxTotal) break;
+                allMatches.push({
+                  file: filePath,
+                  line: m.line,
+                  content: m.content,
+                  ...(m.context ? { context: m.context } : {}),
+                });
+                totalMatches++;
+              }
+            } catch {
+              // Permission denied, encoding error, etc. — skip file
+              continue;
+            }
+          }
+
+          return {
+            success: true,
+            pattern: patternStr,
+            root: rootDir,
+            matchCount: allMatches.length,
+            filesSearched: filesToSearch.length,
+            matches: allMatches,
+            truncated: totalMatches >= maxTotal,
+          };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    // ===== Agent Lifecycle Self-Registration Tools =====
+
+    register_self: {
+      description: 'Register this agent as active with the Crewly backend. Call this immediately on startup.',
+      inputSchema: z.object({
+        role: z.string().describe('Agent role (e.g., "developer", "orchestrator")'),
+      }),
+      execute: async ({ role }) => {
+        const result = await client.post('/teams/members/register', {
+          role,
+          sessionName,
+        });
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    get_project_overview: {
+      description: 'Get an overview of all configured projects.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const result = await client.get('/projects');
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    report_status: {
+      description: 'Report task status to the orchestrator. sessionName and role are auto-injected from the current session context.',
+      inputSchema: z.object({
+        status: z.enum(['in_progress', 'done', 'blocked', 'error']).describe('Current status'),
+        summary: z.string().describe('Brief status summary'),
+      }),
+      execute: async ({ status, summary }) => {
+        // Build status message matching the bash report-status format
+        const statusUpper = (status as string).toUpperCase();
+        const message = `[${statusUpper}] Agent ${sessionName}: ${summary}`;
+
+        // Send to orchestrator via chat API (matches bash skill behavior)
+        const chatBody: Record<string, string> = {
+          content: message,
+          senderName: sessionName,
+          senderType: 'agent',
+        };
+        if (conversationId) {
+          chatBody.conversationId = conversationId;
+        }
+        const result = await client.post('/chat/agent-response', chatBody);
+
+        // Auto-complete the agent's currently-running WorkItem when done.
+        // V3-only as of spec 2026-05-06-task-management-v1-deprecation.md:
+        // resolve the running claim from the pool, then call
+        // `/task-pool/complete/:id`. Replaces v1 `/task-management/complete-by-session`.
+        if (status === 'done') {
+          try {
+            const poolResp = await client.get(
+              `/task-pool/items?status=running&target=${encodeURIComponent(sessionName)}`,
+            );
+            const items = (poolResp.data as Record<string, unknown> | undefined);
+            const list = (
+              (items?.workItems as Array<{ id: string }> | undefined) ??
+              (items?.data as Array<{ id: string }> | undefined) ??
+              (Array.isArray(items) ? items as Array<{ id: string }> : [])
+            );
+            const wiId = list[0]?.id;
+            if (wiId) {
+              // Hygiene #4: canonical body shape `{agentId, result:{summary}}`.
+              // `agentId` here is `sessionName` because that's the runtime
+              // identity of the completing agent (the session whose
+              // status=done message triggered this auto-complete path).
+              await client
+                .post(`/task-pool/complete/${wiId}`, {
+                  agentId: sessionName,
+                  result: { summary },
+                })
+                .catch(() => {});
+            }
+          } catch {
+            // Non-fatal: status report still succeeded.
+          }
+        }
+
+        // Auto-persist key findings as project knowledge when done (#127)
+        if (status === 'done' && summary && projectPath) {
+          await client.post('/memory/remember', {
+            agentId: sessionName,
+            content: `Task completed by ${sessionName}: ${summary}`,
+            category: 'pattern',
+            scope: 'project',
+            projectPath,
+          }).catch(() => {});
+        }
+
+        return result.success ? result.data : { error: result.error };
+      },
+    },
+
+    // ===== Context Compaction Tool =====
+
+    compact_memory: {
+      description: 'Proactively compact conversation context to preserve critical state while freeing token budget. Use when context is growing large or before starting a new phase of work. Generates an AI-powered structured summary of older messages preserving: active tasks, decisions, findings, blockers, and current context.',
+      inputSchema: z.object({}),
+      sensitivity: 'safe',
+      execute: async () => {
+        if (!callbacks?.onCompactMemory) {
+          return { success: false, error: 'Compaction not available — no runner callback configured' };
+        }
+        const result = await callbacks.onCompactMemory();
+        return {
+          success: result.compacted,
+          ...result,
+        };
+      },
+    },
+
+    get_context_budget: {
+      description: 'Check current context window token budget usage. Returns total tokens used, context window size, usage percentage, and warning level (normal/warning/critical). Use proactively to decide when to compact or wrap up work.',
+      inputSchema: z.object({}),
+      sensitivity: 'safe',
+      execute: async () => {
+        if (!callbacks?.onGetContextBudget) {
+          return { success: false, error: 'Context budget tracking not available — no runner callback configured' };
+        }
+        const budget = callbacks.onGetContextBudget();
+        return { success: true, ...budget };
+      },
+    },
+
+    // ===== Security Audit Tool =====
+
+    get_audit_log: {
+      description: 'Retrieve the security audit trail of recent tool invocations. Shows tool name, sensitivity classification, success/failure, duration, and sanitized arguments. Use for security review, debugging, or compliance.',
+      inputSchema: z.object({
+        limit: z.number().default(50).describe('Maximum entries to return (most recent first)'),
+        sensitivity: z.enum(['safe', 'sensitive', 'destructive']).optional().describe('Filter by sensitivity level'),
+        toolName: z.string().optional().describe('Filter by specific tool name'),
+      }),
+      sensitivity: 'safe',
+      execute: async ({ limit, sensitivity: filterSensitivity, toolName: filterTool }) => {
+        if (!callbacks?.onGetAuditLog) {
+          return {
+            success: false,
+            error: 'Audit log not available — no runner callback configured',
+          };
+        }
+
+        const filters: AuditLogFilters = {
+          limit: (limit as number) || 50,
+          sensitivity: filterSensitivity as ToolSensitivity | undefined,
+          toolName: filterTool as string | undefined,
+        };
+        const entries = callbacks.onGetAuditLog(filters);
+
+        return {
+          success: true,
+          totalEntries: entries.length,
+          filters: {
+            limit: filters.limit,
+            sensitivity: filters.sensitivity || 'all',
+            toolName: filters.toolName || 'all',
+          },
+          entries,
+        };
+      },
+    },
+
+    // ===================================================================
+    // Shell Execution (#176)
+    // ===================================================================
+
+    bash_exec: {
+      description: 'Execute a shell command and return stdout/stderr. Commands run with a timeout (default 60s, max 300s). Use for build, test, lint, system operations, and skill scripts. Some commands (kill, reboot, rm -rf /, etc.) are blocked by security policy.',
+      inputSchema: z.object({
+        command: z.string().describe('Shell command to execute'),
+        cwd: z.string().optional().describe('Working directory (defaults to project path)'),
+        timeout: z.number().optional().describe('Timeout in milliseconds (default: 60000, max: 300000)'),
+      }),
+      sensitivity: 'destructive' as ToolSensitivity,
+      execute: async ({ command, cwd, timeout }) => {
+        const cmd = command as string;
+
+        // Check command against blocklist before execution
+        const blockReason = validateBashCommand(cmd);
+        if (blockReason) {
+          return {
+            success: false,
+            exitCode: 126,
+            stdout: '',
+            stderr: blockReason,
+            error: blockReason,
+          };
+        }
+
+        // Check if command requires explicit approval (git push, rm, docker, network, etc.)
+        // Only enforce if the security policy's requireApproval includes 'destructive'.
+        const approvalLabel = checkBashApprovalRequired(cmd);
+        if (approvalLabel && callbacks?.onEnqueueApproval && callbacks?.onCheckApproval) {
+          const policyCheck = callbacks.onCheckApproval('bash_exec', 'destructive');
+          if (!policyCheck.allowed && !policyCheck.blocked) {
+            const sanitizedArgs = sanitizeArgs({ command: cmd, cwd, timeout });
+            const enqueued = callbacks.onEnqueueApproval('bash_exec', 'destructive', sanitizedArgs);
+            return {
+              success: false,
+              requiresApproval: true,
+              approvalId: enqueued.approvalId,
+              reason: `Command requires approval: ${approvalLabel}`,
+              error: `Approval required for: ${approvalLabel}. Approval ID: ${enqueued.approvalId}`,
+            };
+          }
+        }
+
+        const workDir = expandPath((cwd as string | undefined) || projectPath || process.cwd());
+        const timeoutMs = Math.min((timeout as number | undefined) || 60000, 300000);
+
+        // Validate working directory exists — spawn gives cryptic "ENOENT" if cwd is missing
+        try { await fsPromises.stat(workDir); } catch {
+          return {
+            success: false,
+            exitCode: 1,
+            stdout: '',
+            stderr: `Working directory does not exist: ${workDir}`,
+            error: `Working directory does not exist: ${workDir}`,
+          };
+        }
+
+        // Run in isolated process group to prevent signal propagation (async, non-blocking)
+        const result = await execIsolatedAsync(cmd, workDir, timeoutMs);
+
+        if (result.exitCode === 0) {
+          const truncated = result.stdout.length > 10000;
+          return {
+            success: true,
+            exitCode: 0,
+            stdout: truncated ? result.stdout.slice(-10000) + '\n...(truncated)' : result.stdout,
+            truncated,
+          };
+        }
+
+        return {
+          success: false,
+          exitCode: result.exitCode,
+          stdout: (result.stdout || '').slice(-5000),
+          stderr: (result.stderr || '').slice(-5000),
+          error: result.stderr ? result.stderr.slice(0, 500) : `Process exited with code ${result.exitCode}`,
+        };
+      },
+    },
+
+    // ===================================================================
+    // Git Tools (#176)
+    // ===================================================================
+
+    git_status: {
+      description: 'Get the git status of a project directory. Returns current branch, staged files, unstaged changes, and untracked files.',
+      inputSchema: z.object({
+        projectPath: z.string().describe('Absolute path to the git repository'),
+      }),
+      execute: async ({ projectPath }) => {
+        const cwd = expandPath(projectPath as string);
+        try {
+          const branch = (await execGitAsync('git rev-parse --abbrev-ref HEAD', cwd)).trim();
+          const statusOutput = await execGitAsync('git status --porcelain', cwd);
+
+          const staged: string[] = [];
+          const unstaged: string[] = [];
+          const untracked: string[] = [];
+
+          for (const line of statusOutput.split('\n')) {
+            if (!line.trim()) continue;
+            const x = line[0]; // index status
+            const y = line[1]; // working tree status
+            const file = line.slice(3);
+            if (x === '?' && y === '?') {
+              untracked.push(file);
+            } else {
+              if (x !== ' ' && x !== '?') staged.push(file);
+              if (y !== ' ' && y !== '?') unstaged.push(file);
+            }
+          }
+
+          return { success: true, branch, staged, unstaged, untracked };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    git_diff: {
+      description: 'Get the git diff output for a project directory. Shows unstaged changes by default, or staged changes when staged=true. Output truncated to 5000 characters.',
+      inputSchema: z.object({
+        projectPath: z.string().describe('Absolute path to the git repository'),
+        staged: z.boolean().default(false).describe('Show staged (cached) changes instead of unstaged'),
+      }),
+      execute: async ({ projectPath, staged }) => {
+        const cwd = expandPath(projectPath as string);
+        try {
+          const cmd = staged ? 'git diff --cached' : 'git diff';
+          const diff = await execGitAsync(cmd, cwd);
+
+          const truncated = diff.length > GIT_DIFF_MAX_CHARS;
+          const output = truncated ? diff.slice(0, GIT_DIFF_MAX_CHARS) + '\n... (truncated)' : diff;
+
+          return { success: true, diff: output, truncated, totalLength: diff.length };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    git_commit: {
+      description: 'Stage files and create a git commit. If files are provided, stages only those files. Otherwise stages all changes (git add -A). Returns the new commit hash.',
+      inputSchema: z.object({
+        projectPath: z.string().describe('Absolute path to the git repository'),
+        message: z.string().describe('Commit message'),
+        files: z.array(z.string()).optional().describe('Specific files to stage (omit for git add -A)'),
+      }),
+      sensitivity: 'sensitive' as ToolSensitivity,
+      execute: async ({ projectPath, message, files }) => {
+        const cwd = expandPath(projectPath as string);
+        try {
+          // Stage files
+          if (files && (files as string[]).length > 0) {
+            for (const file of files as string[]) {
+              await execGitAsync(`git add -- ${JSON.stringify(file)}`, cwd);
+            }
+          } else {
+            await execGitAsync('git add -A', cwd);
+          }
+
+          // Commit
+          await execGitAsync(`git commit -m ${JSON.stringify(message as string)}`, cwd);
+
+          // Get the commit hash
+          const hash = (await execGitAsync('git rev-parse HEAD', cwd)).trim();
+
+          return { success: true, commitHash: hash, message: message as string };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
+    // ===================================================================
+    // Task Handoff (F12)
+    // ===================================================================
+
+    handoff_task: {
+      description: 'Hand off an in-progress task to another agent with full context (progress, findings, blockers). Unlike delegate_task which assigns NEW work, handoff transfers ONGOING work so the receiving agent can continue where you left off.',
+      inputSchema: z.object({
+        to: z.string().describe('Target agent session name to hand off to'),
+        reason: z.string().describe('Why you are handing off (blocked, expertise needed, etc.)'),
+        progress: z.string().optional().describe('Current progress summary (what is done so far)'),
+        findings: z.string().optional().describe('Key findings and decisions made'),
+        blockers: z.string().optional().describe('Current blockers or notes for the receiving agent'),
+        workItemId: z.string().optional().describe('WorkItem id being handed off (resolved from running claim if omitted)'),
+      }),
+      sensitivity: 'sensitive' as ToolSensitivity,
+      execute: async ({ to, reason, progress, findings, blockers, workItemId }) => {
+        const target = to as string;
+        const handoffReason = reason as string;
+
+        // Build handoff context message
+        let message = `[TASK HANDOFF] from ${sessionName}\n\n## Reason\n${handoffReason}\n`;
+        if (progress) message += `\n## Progress\n${progress}\n`;
+        if (findings) message += `\n## Key Findings\n${findings}\n`;
+        if (blockers) message += `\n## Blockers / Notes\n${blockers}\n`;
+
+        if (projectPath) {
+          message += `\n---\nWhen done, report back using: bash config/skills/agent/core/report-status/execute.sh '{"sessionName":"${target}","status":"done","summary":"<brief summary>","projectPath":"${projectPath}"}'`;
+        }
+
+        // Deliver to target agent
+        const deliverResult = await client.post(`/terminal/${target}/deliver`, {
+          message,
+          waitForReady: true,
+          waitTimeout: 15000,
+        }).catch(async () => {
+          // Retry with force
+          return client.post(`/terminal/${target}/deliver`, { message, force: true });
+        });
+
+        // Record handoff via V3 task-pool (spec
+        // 2026-05-06-task-management-v1-deprecation.md). Replaces
+        // v1 `/task-management/handoff`. Resolves the source WI from
+        // the running claim if `workItemId` was not supplied.
+        let resolvedWiId = workItemId as string | undefined;
+        if (!resolvedWiId) {
+          try {
+            const poolResp = await client.get(
+              `/task-pool/items?status=running&target=${encodeURIComponent(sessionName)}`,
+            );
+            const data = poolResp.data as Record<string, unknown> | undefined;
+            const list = (
+              (data?.workItems as Array<{ id: string }> | undefined) ??
+              (data?.data as Array<{ id: string }> | undefined) ??
+              []
+            );
+            resolvedWiId = list[0]?.id;
+          } catch {
+            // fall through — handoff tracking will be marked unavailable
+          }
+        }
+        const handoffRecord = resolvedWiId
+          ? await client.post(`/task-pool/items/${resolvedWiId}/handoff`, {
+              newTarget: target,
+              fromAgent: sessionName,
+              reason: handoffReason,
+            }).catch(() => ({ success: false, error: 'handoff API unavailable' }))
+          : { success: false, error: 'no active WorkItem to hand off' };
+
+        return {
+          success: deliverResult?.success ?? false,
+          handoff: {
+            from: sessionName,
+            to: target,
+            reason: handoffReason,
+            timestamp: new Date().toISOString(),
+          },
+          delivery: deliverResult?.success ? 'delivered' : (deliverResult?.error || 'failed'),
+          tracking: handoffRecord?.success ? 'tracked' : 'not tracked',
+        };
+      },
+    },
+
+    // ===== Cloud-Backed Web Search =====
+
+    web_search: createWebSearchTool(),
+  };
+
+  // Apply sensitivity classifications and audit wrapping
+  const tools: Record<string, ToolDefinition> = {};
+  for (const [name, tool] of Object.entries(rawTools)) {
+    tools[name] = {
+      ...tool,
+      sensitivity: tool.sensitivity || TOOL_SENSITIVITY[name] || 'safe',
+      execute: wrapWithAudit(name, tool.execute, callbacks),
+    };
+  }
+
+  // Merge MCP-sourced tools with audit wrapping
+  if (mcpTools) {
+    for (const [name, tool] of Object.entries(mcpTools)) {
+      tools[name] = {
+        ...tool,
+        execute: wrapWithAudit(name, tool.execute, callbacks),
+      };
+    }
+  }
+
+  return tools;
+}
+
+/**
+ * Build a structured task message matching the delegate-task skill format.
+ *
+ * @param to - Target agent session
+ * @param task - Task instructions
+ * @param priority - Task priority
+ * @param context - Optional additional context
+ * @param projectPath - Optional project path
+ * @returns Formatted task message string
+ */
+function buildTaskMessage(
+  to: string,
+  task: string,
+  priority: string,
+  context?: string,
+  projectPath?: string,
+): string {
+  let message = `New task from orchestrator (priority: ${priority}):\n\n${task}`;
+  if (context) message += `\n\nContext: ${context}`;
+  if (projectPath) {
+    message += `\n\nWhen done, report back using: bash config/skills/agent/core/report-status/execute.sh '{"sessionName":"${to}","status":"done","summary":"<brief summary>","projectPath":"${projectPath}"}'`;
+  }
+  return message;
+}
+
+/**
+ * Get the list of tool names available in the registry.
+ *
+ * @returns Array of tool name strings
+ */
+export function getToolNames(): string[] {
+  return [
+    'delegate_task', 'send_message', 'get_agent_status', 'get_team_status',
+    'get_agent_logs', 'reply_slack', 'schedule_check', 'cancel_schedule',
+    'get_scheduled_checks', 'start_agent', 'stop_agent', 'subscribe_event',
+    'recall_memory', 'remember', 'heartbeat', 'get_tasks', 'complete_task',
+    'broadcast', 'handle_agent_failure', 'edit_file', 'read_file', 'write_file',
+    'glob', 'grep',
+    'register_self', 'get_project_overview', 'report_status',
+    'compact_memory', 'get_audit_log',
+    'git_status', 'git_diff', 'git_commit',
+    'web_search',
+  ];
+}

--- a/packages/crewly-agent/src/runtime/types.test.ts
+++ b/packages/crewly-agent/src/runtime/types.test.ts
@@ -1,0 +1,519 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isModelProvider,
+  isModelConfig,
+  MODEL_PROVIDERS,
+  CREWLY_AGENT_DEFAULTS,
+  WRITE_TOOLS,
+  MODEL_CONTEXT_WINDOWS,
+  MODEL_OUTPUT_TOKEN_FLOORS,
+  SUPPORTED_MODELS,
+  resolveMaxOutputTokens,
+} from './types.js';
+import type {
+  ToolDefinition,
+  ToolSensitivity,
+  AuditEntry,
+  SecurityPolicy,
+  CompactionResult,
+  ContextBudgetStatus,
+  ToolCallbacks,
+  ApprovalCheckResult,
+  AuditLogFilters,
+  AgentRunResult,
+} from './types.js';
+
+describe('Crewly Agent Types', () => {
+  describe('MODEL_PROVIDERS', () => {
+    it('should contain all supported providers', () => {
+      expect(MODEL_PROVIDERS).toContain('anthropic');
+      expect(MODEL_PROVIDERS).toContain('openai');
+      expect(MODEL_PROVIDERS).toContain('google');
+      expect(MODEL_PROVIDERS).toContain('ollama');
+      expect(MODEL_PROVIDERS).toContain('deepseek');
+      expect(MODEL_PROVIDERS).toHaveLength(5);
+    });
+  });
+
+  describe('CREWLY_AGENT_DEFAULTS', () => {
+    it('should have sensible default values', () => {
+      expect(CREWLY_AGENT_DEFAULTS.MAX_STEPS).toBe(500);
+      expect(CREWLY_AGENT_DEFAULTS.API_BASE_URL).toBe('http://localhost:8787');
+      expect(CREWLY_AGENT_DEFAULTS.MAX_HISTORY_MESSAGES).toBe(100);
+      expect(CREWLY_AGENT_DEFAULTS.COMPACTION_THRESHOLD).toBe(0.8);
+      expect(CREWLY_AGENT_DEFAULTS.API_TIMEOUT_MS).toBe(30000);
+    });
+
+    it('should have a valid default model config', () => {
+      expect(CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.provider).toBe('google');
+      expect(CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.modelId).toBeTruthy();
+      expect(typeof CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.temperature).toBe('number');
+      expect(typeof CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens).toBe('number');
+    });
+
+    it('should have a valid default security policy', () => {
+      const policy = CREWLY_AGENT_DEFAULTS.SECURITY_POLICY;
+      expect(policy.auditEnabled).toBe(true);
+      expect(policy.requireApproval).toEqual([]);
+      expect(policy.blockedTools).toEqual([]);
+      expect(policy.maxAuditEntries).toBe(500);
+      expect(policy.readOnlyMode).toBe(false);
+    });
+
+    it('should have valid default security guardrails', () => {
+      const guardrails = CREWLY_AGENT_DEFAULTS.SECURITY_GUARDRAILS;
+      expect(guardrails.outputFilterEnabled).toBe(true);
+      expect(guardrails.envIsolationEnabled).toBe(true);
+      expect(guardrails.promptGuardEnabled).toBe(true);
+      expect(guardrails.explicitEnvVars).toEqual([]);
+    });
+
+    /**
+     * P3 #7 — defensive guard: MODEL_TIMEOUT_MS must be Object.frozen at module
+     * load. `as const` is compile-time only and the `Record<string, number>` cast
+     * widens it back to mutable; without freeze, runtime writes like
+     * `MODEL_TIMEOUT_MS['x'] = 999` silently mutate global config table.
+     * Catches future regressions if anyone removes the freeze wrapper.
+     */
+    it('MODEL_TIMEOUT_MS is Object.frozen (defensive guard against runtime mutation)', () => {
+      expect(Object.isFrozen(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS)).toBe(true);
+      // In strict mode (which Node ESM modules use by default) writes to a
+      // frozen object throw TypeError. Without strict mode they would fail
+      // silently. Jest runs with strict mode under Node ESM.
+      expect(() => {
+        (CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS as Record<string, number>)['test-mutation'] = 999;
+      }).toThrow(TypeError);
+      // And the existing entry is untouched.
+      expect(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['deepseek-reasoner']).toBe(600_000);
+      expect(CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['test-mutation']).toBeUndefined();
+    });
+  });
+
+  describe('isModelProvider', () => {
+    it('should return true for valid providers', () => {
+      expect(isModelProvider('anthropic')).toBe(true);
+      expect(isModelProvider('openai')).toBe(true);
+      expect(isModelProvider('google')).toBe(true);
+      expect(isModelProvider('ollama')).toBe(true);
+    });
+
+    it('should return false for invalid providers', () => {
+      expect(isModelProvider('azure')).toBe(false);
+      expect(isModelProvider('')).toBe(false);
+      expect(isModelProvider('ANTHROPIC')).toBe(false);
+    });
+  });
+
+  describe('isModelConfig', () => {
+    it('should return true for valid configs', () => {
+      expect(isModelConfig({ provider: 'anthropic', modelId: 'claude-sonnet-4-20250514' })).toBe(true);
+      expect(isModelConfig({ provider: 'openai', modelId: 'gpt-4o', temperature: 0.5 })).toBe(true);
+      expect(isModelConfig({ provider: 'google', modelId: 'gemini-2.0-flash', maxTokens: 4096 })).toBe(true);
+      expect(isModelConfig({ provider: 'ollama', modelId: 'llama3.3:70b' })).toBe(true);
+    });
+
+    it('should return false for invalid configs', () => {
+      expect(isModelConfig(null)).toBe(false);
+      expect(isModelConfig(undefined)).toBe(false);
+      expect(isModelConfig(42)).toBe(false);
+      expect(isModelConfig('string')).toBe(false);
+      expect(isModelConfig({})).toBe(false);
+      expect(isModelConfig({ provider: 'anthropic' })).toBe(false);
+      expect(isModelConfig({ modelId: 'gpt-4o' })).toBe(false);
+      expect(isModelConfig({ provider: 'invalid', modelId: 'test' })).toBe(false);
+      expect(isModelConfig({ provider: 'anthropic', modelId: '' })).toBe(false);
+    });
+  });
+
+  describe('ToolDefinition', () => {
+    it('should be usable as a type for tool objects', () => {
+      const tool: ToolDefinition = {
+        description: 'A test tool',
+        inputSchema: { parse: () => ({}) } as any,
+        execute: async () => ({ result: 'ok' }),
+      };
+      expect(tool.description).toBe('A test tool');
+      expect(typeof tool.execute).toBe('function');
+    });
+
+    it('should support optional sensitivity field', () => {
+      const tool: ToolDefinition = {
+        description: 'A sensitive tool',
+        inputSchema: { parse: () => ({}) } as any,
+        execute: async () => ({ result: 'ok' }),
+        sensitivity: 'destructive',
+      };
+      expect(tool.sensitivity).toBe('destructive');
+    });
+  });
+
+  describe('ToolSensitivity', () => {
+    it('should accept valid sensitivity values', () => {
+      const safe: ToolSensitivity = 'safe';
+      const sensitive: ToolSensitivity = 'sensitive';
+      const destructive: ToolSensitivity = 'destructive';
+      expect(safe).toBe('safe');
+      expect(sensitive).toBe('sensitive');
+      expect(destructive).toBe('destructive');
+    });
+  });
+
+  describe('AuditEntry', () => {
+    it('should be constructible with required fields', () => {
+      const entry: AuditEntry = {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        toolName: 'edit_file',
+        sensitivity: 'destructive',
+        args: { file_path: '/test.ts' },
+        success: true,
+        durationMs: 42,
+      };
+      expect(entry.toolName).toBe('edit_file');
+      expect(entry.sensitivity).toBe('destructive');
+      expect(entry.error).toBeUndefined();
+      expect(entry.sessionName).toBeUndefined();
+    });
+
+    it('should support optional error field', () => {
+      const entry: AuditEntry = {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        toolName: 'write_file',
+        sensitivity: 'destructive',
+        args: {},
+        success: false,
+        error: 'EACCES',
+        durationMs: 5,
+      };
+      expect(entry.error).toBe('EACCES');
+    });
+
+    it('should support optional sessionName field', () => {
+      const entry: AuditEntry = {
+        timestamp: '2026-03-12T00:00:00.000Z',
+        sessionName: 'agent-session-abc',
+        toolName: 'delegate_task',
+        sensitivity: 'sensitive',
+        args: {},
+        success: true,
+        durationMs: 100,
+      };
+      expect(entry.sessionName).toBe('agent-session-abc');
+    });
+  });
+
+  describe('SecurityPolicy', () => {
+    it('should be constructible with all fields', () => {
+      const policy: SecurityPolicy = {
+        auditEnabled: true,
+        requireApproval: ['destructive'],
+        blockedTools: ['stop_agent'],
+        maxAuditEntries: 100,
+        readOnlyMode: false,
+      };
+      expect(policy.auditEnabled).toBe(true);
+      expect(policy.requireApproval).toContain('destructive');
+      expect(policy.blockedTools).toContain('stop_agent');
+      expect(policy.readOnlyMode).toBe(false);
+    });
+
+    it('should support readOnlyMode', () => {
+      const policy: SecurityPolicy = {
+        auditEnabled: true,
+        requireApproval: [],
+        blockedTools: [],
+        maxAuditEntries: 500,
+        readOnlyMode: true,
+      };
+      expect(policy.readOnlyMode).toBe(true);
+    });
+  });
+
+  describe('CompactionResult', () => {
+    it('should represent a successful compaction', () => {
+      const result: CompactionResult = {
+        compacted: true,
+        messagesBefore: 50,
+        messagesAfter: 11,
+      };
+      expect(result.compacted).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should represent a skipped compaction with reason', () => {
+      const result: CompactionResult = {
+        compacted: false,
+        messagesBefore: 5,
+        messagesAfter: 5,
+        reason: 'Too few messages to compact',
+      };
+      expect(result.compacted).toBe(false);
+      expect(result.reason).toBeTruthy();
+    });
+  });
+
+  describe('ToolCallbacks', () => {
+    it('should be constructible with optional fields', () => {
+      const callbacks: ToolCallbacks = {};
+      expect(callbacks.onCompactMemory).toBeUndefined();
+      expect(callbacks.onAuditLog).toBeUndefined();
+      expect(callbacks.onCheckApproval).toBeUndefined();
+      expect(callbacks.onGetAuditLog).toBeUndefined();
+    });
+
+    it('should accept callback functions', () => {
+      const callbacks: ToolCallbacks = {
+        onCompactMemory: async () => ({ compacted: true, messagesBefore: 50, messagesAfter: 11 }),
+        onAuditLog: () => {},
+        onCheckApproval: () => ({ allowed: true }),
+        onGetAuditLog: () => [],
+      };
+      expect(typeof callbacks.onCompactMemory).toBe('function');
+      expect(typeof callbacks.onAuditLog).toBe('function');
+      expect(typeof callbacks.onCheckApproval).toBe('function');
+      expect(typeof callbacks.onGetAuditLog).toBe('function');
+    });
+  });
+
+  describe('ApprovalCheckResult', () => {
+    it('should represent an allowed result', () => {
+      const result: ApprovalCheckResult = { allowed: true };
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toBeUndefined();
+      expect(result.blocked).toBeUndefined();
+    });
+
+    it('should represent a blocked tool', () => {
+      const result: ApprovalCheckResult = {
+        allowed: false,
+        blocked: true,
+        reason: 'Tool is blocked by security policy',
+      };
+      expect(result.allowed).toBe(false);
+      expect(result.blocked).toBe(true);
+      expect(result.reason).toBeTruthy();
+    });
+
+    it('should represent a tool requiring approval', () => {
+      const result: ApprovalCheckResult = {
+        allowed: false,
+        blocked: false,
+        reason: 'Tool requires approval for destructive operations',
+      };
+      expect(result.allowed).toBe(false);
+      expect(result.blocked).toBe(false);
+      expect(result.reason).toContain('approval');
+    });
+  });
+
+  describe('AuditLogFilters', () => {
+    it('should be constructible with required limit', () => {
+      const filters: AuditLogFilters = { limit: 50 };
+      expect(filters.limit).toBe(50);
+      expect(filters.sensitivity).toBeUndefined();
+      expect(filters.toolName).toBeUndefined();
+    });
+
+    it('should support optional filters', () => {
+      const filters: AuditLogFilters = {
+        limit: 10,
+        sensitivity: 'destructive',
+        toolName: 'edit_file',
+      };
+      expect(filters.sensitivity).toBe('destructive');
+      expect(filters.toolName).toBe('edit_file');
+    });
+  });
+
+  describe('WRITE_TOOLS', () => {
+    it('should be a non-empty readonly array', () => {
+      expect(WRITE_TOOLS.length).toBeGreaterThan(0);
+      expect(Array.isArray(WRITE_TOOLS)).toBe(true);
+    });
+
+    it('should contain all file-modifying tools', () => {
+      expect(WRITE_TOOLS).toContain('edit_file');
+      expect(WRITE_TOOLS).toContain('write_file');
+    });
+
+    it('should contain agent lifecycle tools', () => {
+      expect(WRITE_TOOLS).toContain('start_agent');
+      expect(WRITE_TOOLS).toContain('stop_agent');
+      expect(WRITE_TOOLS).toContain('handle_agent_failure');
+    });
+
+    it('should not contain read-only tools', () => {
+      expect(WRITE_TOOLS).not.toContain('read_file');
+      expect(WRITE_TOOLS).not.toContain('get_team_status');
+      expect(WRITE_TOOLS).not.toContain('recall_memory');
+    });
+  });
+
+  describe('MODEL_CONTEXT_WINDOWS', () => {
+    it('should have a default entry', () => {
+      expect(MODEL_CONTEXT_WINDOWS.default).toBeDefined();
+      expect(MODEL_CONTEXT_WINDOWS.default).toBeGreaterThan(0);
+    });
+
+    it('should include known Anthropic models', () => {
+      expect(MODEL_CONTEXT_WINDOWS['claude-opus-4-20250514']).toBe(200_000);
+      expect(MODEL_CONTEXT_WINDOWS['claude-sonnet-4-20250514']).toBe(200_000);
+    });
+
+    it('should include known Google models', () => {
+      expect(MODEL_CONTEXT_WINDOWS['gemini-2.0-flash']).toBe(1_000_000);
+    });
+
+    it('should include known OpenAI models', () => {
+      expect(MODEL_CONTEXT_WINDOWS['gpt-4o']).toBe(128_000);
+    });
+
+    it('should include DeepSeek models with the real 64k window (B3)', () => {
+      // Without these entries the lookup falls back to `default: 128_000`,
+      // which would let Crewly's compaction trigger (0.8 × budget) skip past
+      // DeepSeek's real 64k cap and let the API 4xx with context_length_exceeded.
+      expect(MODEL_CONTEXT_WINDOWS['deepseek-chat']).toBe(64_000);
+      expect(MODEL_CONTEXT_WINDOWS['deepseek-reasoner']).toBe(64_000);
+    });
+  });
+
+  describe('SUPPORTED_MODELS (B2)', () => {
+    it('should include both DeepSeek model variants for the model picker', () => {
+      const ids = SUPPORTED_MODELS.map((m) => m.id);
+      expect(ids).toContain('deepseek/deepseek-chat');
+      expect(ids).toContain('deepseek/deepseek-reasoner');
+    });
+
+    it('should tag DeepSeek entries with the deepseek provider', () => {
+      const chat = SUPPORTED_MODELS.find((m) => m.id === 'deepseek/deepseek-chat');
+      const reasoner = SUPPORTED_MODELS.find((m) => m.id === 'deepseek/deepseek-reasoner');
+      expect(chat?.provider).toBe('deepseek');
+      expect(reasoner?.provider).toBe('deepseek');
+      expect(chat?.label).toBeTruthy();
+      expect(reasoner?.label).toBeTruthy();
+    });
+  });
+
+  describe('MODEL_OUTPUT_TOKEN_FLOORS / resolveMaxOutputTokens (N5)', () => {
+    it('should declare a 1024-token floor only for deepseek-reasoner', () => {
+      // R1 mixes reasoning_tokens into the same max_tokens budget as
+      // completion_tokens, so a low limit silently produces empty content.
+      // See live smoke test D in the gap-list spec (2026-05-03).
+      expect(MODEL_OUTPUT_TOKEN_FLOORS['deepseek-reasoner']).toBe(1024);
+      expect(MODEL_OUTPUT_TOKEN_FLOORS['deepseek-chat']).toBeUndefined();
+      expect(MODEL_OUTPUT_TOKEN_FLOORS['gpt-4o']).toBeUndefined();
+    });
+
+    it('should clamp deepseek-reasoner maxTokens up to the 1024 floor', () => {
+      expect(
+        resolveMaxOutputTokens({ provider: 'deepseek', modelId: 'deepseek-reasoner', maxTokens: 30 })
+      ).toBe(1024);
+      expect(
+        resolveMaxOutputTokens({ provider: 'deepseek', modelId: 'deepseek-reasoner', maxTokens: 500 })
+      ).toBe(1024);
+    });
+
+    it('should pass through user-set maxTokens when above the floor', () => {
+      expect(
+        resolveMaxOutputTokens({ provider: 'deepseek', modelId: 'deepseek-reasoner', maxTokens: 8192 })
+      ).toBe(8192);
+    });
+
+    it('should not clamp models without a floor', () => {
+      expect(
+        resolveMaxOutputTokens({ provider: 'deepseek', modelId: 'deepseek-chat', maxTokens: 30 })
+      ).toBe(30);
+      expect(
+        resolveMaxOutputTokens({ provider: 'openai', modelId: 'gpt-4o', maxTokens: 100 })
+      ).toBe(100);
+    });
+
+    it('should fall back to the runtime default when maxTokens is undefined', () => {
+      const fallback = CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens ?? 0;
+      expect(
+        resolveMaxOutputTokens({ provider: 'openai', modelId: 'gpt-4o' })
+      ).toBe(fallback);
+    });
+
+    it('should still apply the floor when maxTokens is undefined for deepseek-reasoner', () => {
+      // CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens=8192 already clears the
+      // 1024 floor, so the result is the default itself — but the contract
+      // remains: `result >= floor`.
+      const result = resolveMaxOutputTokens({ provider: 'deepseek', modelId: 'deepseek-reasoner' });
+      expect(result).toBeGreaterThanOrEqual(1024);
+    });
+  });
+
+  describe('ContextBudgetStatus type', () => {
+    it('should accept valid normal status', () => {
+      const status: ContextBudgetStatus = {
+        totalTokensUsed: 5000,
+        contextWindowSize: 200000,
+        usagePercent: 0.025,
+        level: 'normal',
+        messageCount: 10,
+        compactionPending: false,
+        summary: '2.5% of context budget used',
+      };
+      expect(status.level).toBe('normal');
+      expect(status.compactionPending).toBe(false);
+    });
+
+    it('should accept valid critical status', () => {
+      const status: ContextBudgetStatus = {
+        totalTokensUsed: 180000,
+        contextWindowSize: 200000,
+        usagePercent: 0.9,
+        level: 'critical',
+        messageCount: 95,
+        compactionPending: true,
+        summary: '90.0% — CRITICAL',
+      };
+      expect(status.level).toBe('critical');
+      expect(status.compactionPending).toBe(true);
+    });
+  });
+
+  describe('AgentRunResult budgetWarning', () => {
+    it('should accept result with budgetWarning', () => {
+      const result: AgentRunResult = {
+        text: 'Done',
+        steps: 1,
+        usage: { input: 100, output: 50 },
+        toolCalls: [],
+        finishReason: 'stop',
+        budgetWarning: 'WARNING: approaching compaction threshold',
+      };
+      expect(result.budgetWarning).toContain('WARNING');
+    });
+
+    it('should accept result without budgetWarning', () => {
+      const result: AgentRunResult = {
+        text: 'Done',
+        steps: 1,
+        usage: { input: 100, output: 50 },
+        toolCalls: [],
+        finishReason: 'stop',
+      };
+      expect(result.budgetWarning).toBeUndefined();
+    });
+  });
+
+  describe('ToolCallbacks onGetContextBudget', () => {
+    it('should accept callbacks with onGetContextBudget', () => {
+      const callbacks: ToolCallbacks = {
+        onGetContextBudget: () => ({
+          totalTokensUsed: 0,
+          contextWindowSize: 200000,
+          usagePercent: 0,
+          level: 'normal',
+          messageCount: 0,
+          compactionPending: false,
+          summary: '0%',
+        }),
+      };
+      expect(callbacks.onGetContextBudget).toBeDefined();
+      const result = callbacks.onGetContextBudget!();
+      expect(result.level).toBe('normal');
+    });
+  });
+});

--- a/packages/crewly-agent/src/runtime/types.ts
+++ b/packages/crewly-agent/src/runtime/types.ts
@@ -1,0 +1,637 @@
+/**
+ * Crewly Agent Runtime Type Definitions
+ *
+ * Types for the in-process Crewly Agent runtime powered by Vercel AI SDK.
+ * Covers model configuration, conversation state, and agent lifecycle.
+ *
+ * @module services/agent/crewly-agent/types
+ */
+
+import type { ModelMessage } from 'ai';
+import type { z } from 'zod';
+
+/**
+ * Minimal MCP server configuration used by the standalone runtime.
+ * Mirrors OSS `McpServerConfig` from `services/mcp-client.ts` — kept
+ * field-compatible so the bridge can pass JSON payloads unchanged.
+ */
+export interface McpServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
+/** MCP tool metadata used by the standalone tool bridge. */
+export interface McpToolInfo {
+  serverName: string;
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** MCP call result shape. */
+export interface McpCallResult {
+  isError: boolean;
+  content: Array<Record<string, unknown>>;
+}
+
+/**
+ * Interface a caller can use to inject an MCP client implementation.
+ * Standalone has no concrete implementation by default; OSS bridges via
+ * the JSON protocol if MCP is needed in cloud-resident agents.
+ */
+export interface McpClientLike {
+  connectAll(serverConfigs: Record<string, McpServerConfig>): Promise<Map<string, Error>>;
+  listTools(): McpToolInfo[];
+  callTool(serverName: string, toolName: string, args: Record<string, unknown>): Promise<McpCallResult>;
+  disconnectAll(): Promise<void>;
+  getConnectedServers(): string[];
+}
+
+/**
+ * Sensitivity overrides for MCP tools, keyed by 'serverName:toolName' or
+ * just 'toolName'. Mirrors the OSS `McpSensitivityOverrides` type formerly
+ * imported from `./mcp-tool-bridge.js`.
+ */
+export type McpSensitivityOverrides = Record<string, 'safe' | 'sensitive' | 'destructive'>;
+
+/**
+ * Supported model providers for Crewly Agent.
+ *
+ * Note: 'deepseek' is served through the OpenAI-compatible API at
+ * https://api.deepseek.com/v1, but is exposed as a distinct provider
+ * so users can select it explicitly. Its API key (DEEPSEEK_API_KEY) is
+ * read from the environment, not from the settings service — see
+ * model-manager.ts for details.
+ */
+export type ModelProvider = 'anthropic' | 'openai' | 'google' | 'ollama' | 'deepseek';
+
+/**
+ * All valid model providers
+ */
+export const MODEL_PROVIDERS: readonly ModelProvider[] = [
+  'anthropic',
+  'openai',
+  'google',
+  'ollama',
+  'deepseek',
+] as const;
+
+/**
+ * Configuration for a specific model instance
+ */
+export interface ModelConfig {
+  /** Model provider (e.g., 'anthropic', 'openai', 'google', 'ollama') */
+  provider: ModelProvider;
+  /** Model identifier (e.g., 'claude-sonnet-4-20250514', 'gpt-4o', 'gemini-2.0-flash') */
+  modelId: string;
+  /** Optional temperature override (0-1) */
+  temperature?: number;
+  /** Optional max tokens per response */
+  maxTokens?: number;
+}
+
+/**
+ * Conversation state maintained by the AgentRunner
+ */
+export interface ConversationState {
+  /** AI SDK ModelMessage array — the full conversation history */
+  messages: ModelMessage[];
+  /** System prompt loaded from prompt.md */
+  systemPrompt: string;
+  /** Cumulative token usage across all generateText calls */
+  totalTokens: { input: number; output: number };
+  /** Conversation creation time */
+  createdAt: Date;
+  /** Last activity timestamp */
+  lastActivityAt: Date;
+}
+
+/**
+ * Configuration for the Crewly Agent runtime
+ */
+export interface CrewlyAgentConfig {
+  /** Model configuration for the agent */
+  model: ModelConfig;
+  /** Maximum reasoning steps per generateText call */
+  maxSteps: number;
+  /** Session name for this agent instance */
+  sessionName: string;
+  /** Agent role (e.g. developer, product-manager) */
+  role?: string;
+  /** Base URL for the Crewly REST API */
+  apiBaseUrl: string;
+  /** System prompt content (loaded from prompt.md) */
+  systemPrompt: string;
+  /** Maximum conversation history messages before compaction triggers */
+  maxHistoryMessages: number;
+  /** Token budget threshold (percentage of context window) for compaction */
+  compactionThreshold: number;
+  /** Project path for memory and task tools (auto-injected) */
+  projectPath?: string;
+  /** Team member ID for heartbeat tracking (used as key in teamAgentStatus.json) */
+  memberId?: string;
+  /** MCP server configurations for external tool integration */
+  mcpServers?: Record<string, McpServerConfig>;
+  /** Sensitivity overrides for MCP tools (key: 'serverName:toolName' or 'toolName') */
+  mcpSensitivityOverrides?: McpSensitivityOverrides;
+  /**
+   * Eval mode flag. When true:
+   * - Strips TL delegation-first instructions from system prompt
+   * - Agent implements directly instead of delegating to workers
+   * - Enables post-execution deliverable self-check (Stop Hook)
+   */
+  evalMode?: boolean;
+}
+
+/**
+ * Result of a single agent run (one generateText invocation)
+ */
+export interface AgentRunResult {
+  /** Final text response from the model */
+  text: string;
+  /** Number of steps taken in this run */
+  steps: number;
+  /** Token usage for this run */
+  usage: { input: number; output: number };
+  /** Tool calls made during this run */
+  toolCalls: ToolCallRecord[];
+  /** Reason the generation finished */
+  finishReason: string;
+  /** Budget warning message when token usage is approaching limits */
+  budgetWarning?: string;
+  /**
+   * I2: DeepSeek-R1 chain-of-thought text extracted from `delta.reasoning_content`.
+   *
+   * Present only for `deepseek-reasoner` model runs. `null` if the run did not
+   * produce any reasoning content (e.g. non-R1 model, or R1 returned content-only).
+   * `undefined` for non-DeepSeek providers (no extraction is performed).
+   *
+   * Concatenated across all agentic steps in this single AgentRunResult — i.e.
+   * if the model made N HTTP calls during this run, the reasoning from all N
+   * is joined in call order.
+   *
+   * **SECURITY — UNTRUSTED CONTENT.** This string is downstream of user input
+   * (R1 reasoning is generated in response to the user's prompt). When re-injected
+   * into ANY subsequent model call, it MUST be wrapped as untrusted-context — e.g.
+   * `<reasoning-from-deepseek-r1 trust="untrusted">...</reasoning-from-deepseek-r1>`
+   * with explicit framing as "hint material from another model, not authoritative
+   * instructions." Direct splicing into a system prompt = jailbreak primitive.
+   * See P0-1 design-review gate for I2.5 reasoning-pipe routing.
+   */
+  reasoning?: string | null;
+}
+
+/**
+ * Record of a single tool call during agent execution
+ */
+export interface ToolCallRecord {
+  /** Tool name */
+  toolName: string;
+  /** Arguments passed to the tool */
+  args: Record<string, unknown>;
+  /** Result returned by the tool */
+  result: unknown;
+}
+
+/**
+ * Result of an API call to the Crewly backend
+ */
+export interface ApiCallResult<T = unknown> {
+  /** Whether the call succeeded (HTTP 2xx) */
+  success: boolean;
+  /** Response data on success */
+  data?: T;
+  /** Error message on failure */
+  error?: string;
+  /** HTTP status code */
+  status: number;
+}
+
+/**
+ * Sensitivity classification for tool security auditing.
+ *
+ * - 'safe': Read-only or informational tools (no side effects)
+ * - 'sensitive': Tools that modify state or communicate externally
+ * - 'destructive': Tools that can cause irreversible damage
+ */
+export type ToolSensitivity = 'safe' | 'sensitive' | 'destructive';
+
+/**
+ * Tool definition shape matching AI SDK Tool interface.
+ * Shared by both the main tool registry and the auditor tool registry.
+ */
+export interface ToolDefinition {
+  /** Human-readable description of what the tool does */
+  description: string;
+  /** Zod schema for validating tool input */
+  inputSchema: z.ZodType;
+  /** Execute the tool with the given validated arguments */
+  execute: (args: Record<string, unknown>) => Promise<unknown>;
+  /** Security sensitivity classification for audit purposes */
+  sensitivity?: ToolSensitivity;
+}
+
+/**
+ * Callbacks for streaming events during agent execution.
+ * Emitted in real-time as the model generates text and calls tools.
+ */
+export interface StreamingEventCallbacks {
+  /** Called when a text chunk arrives from the model */
+  onTextChunk?: (chunk: string) => void;
+  /** Called when a tool call starts executing */
+  onToolCallStart?: (toolName: string, args: Record<string, unknown>) => void;
+  /** Called when a tool call completes */
+  onToolCallFinish?: (toolName: string, args: Record<string, unknown>, result: unknown, durationMs: number) => void;
+  /** Called when a reasoning step completes */
+  onStepFinish?: (stepIndex: number, hasToolCalls: boolean) => void;
+}
+
+/**
+ * A single entry in the security audit trail.
+ * Records every tool invocation with timing, classification, and result status.
+ */
+export interface AuditEntry {
+  /** ISO timestamp of the tool invocation */
+  timestamp: string;
+  /** Agent session name that invoked the tool */
+  sessionName?: string;
+  /** Name of the tool that was called */
+  toolName: string;
+  /** Sensitivity classification of the tool */
+  sensitivity: ToolSensitivity;
+  /** Arguments passed to the tool (sanitized — no secrets) */
+  args: Record<string, unknown>;
+  /** Whether the tool call succeeded */
+  success: boolean;
+  /** Error message if the call failed */
+  error?: string;
+  /** Execution duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Security policy configuration for the agent runtime.
+ * Controls which tool sensitivity levels require approval or are blocked.
+ */
+export interface SecurityPolicy {
+  /** Whether audit logging is enabled */
+  auditEnabled: boolean;
+  /** Tool sensitivity levels that require explicit approval */
+  requireApproval: ToolSensitivity[];
+  /** Tool names that are completely blocked */
+  blockedTools: string[];
+  /** Maximum audit log entries to retain in memory */
+  maxAuditEntries: number;
+  /**
+   * Read-only audit mode. When enabled, all tools classified as
+   * 'sensitive' or 'destructive' are blocked — only 'safe' (read-only)
+   * tools can execute. Tool invocations are still logged to the audit trail.
+   */
+  readOnlyMode: boolean;
+}
+
+/**
+ * Tools that perform write/modify operations.
+ * Used by readOnlyMode to determine which tools to block.
+ */
+export const WRITE_TOOLS: readonly string[] = [
+  'edit_file',
+  'write_file',
+  'start_agent',
+  'stop_agent',
+  'handle_agent_failure',
+  'delegate_task',
+  'send_message',
+  'reply_slack',
+  'broadcast',
+  'schedule_check',
+  'cancel_schedule',
+  'register_self',
+  'report_status',
+  'remember',
+  'complete_task',
+] as const;
+
+/**
+ * Context budget status for the current conversation.
+ * Tracks token usage against the model's context window limit.
+ */
+export interface ContextBudgetStatus {
+  /** Total tokens used so far (input + output) */
+  totalTokensUsed: number;
+  /** Estimated context window size for the current model */
+  contextWindowSize: number;
+  /** Usage as a fraction (0.0 - 1.0) */
+  usagePercent: number;
+  /** Current threshold level based on compactionThreshold */
+  level: 'normal' | 'warning' | 'critical';
+  /** Number of messages in conversation history */
+  messageCount: number;
+  /** Whether auto-compaction will trigger on next message */
+  compactionPending: boolean;
+  /** Human-readable summary */
+  summary: string;
+}
+
+/**
+ * Estimated context window sizes (in tokens) for known models.
+ * Used for budget tracking when the model doesn't report its own limit.
+ */
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  // Anthropic
+  'claude-opus-4-20250514': 200_000,
+  'claude-sonnet-4-20250514': 200_000,
+  'claude-haiku-4-20250506': 200_000,
+  // Google
+  'gemini-2.0-flash': 1_000_000,
+  'gemini-2.5-flash-preview-05-20': 1_000_000,
+  'gemini-3-flash-preview': 1_000_000,
+  // OpenAI
+  'gpt-4o': 128_000,
+  'gpt-4o-mini': 128_000,
+  'gpt-4-turbo': 128_000,
+  // DeepSeek — V3 chat and R1 reasoner both ship with a 64k context window.
+  // Without these entries the manager falls back to `default: 128_000`, which
+  // would let Crewly's compaction trigger (0.8 × budget) skip past the real
+  // 64k cap and let DeepSeek 4xx with context_length_exceeded.
+  'deepseek-chat': 64_000,
+  'deepseek-reasoner': 64_000,
+  // Fallback
+  default: 128_000,
+} as const;
+
+/**
+ * Per-model floor on `maxOutputTokens` (the AI SDK's name for the
+ * `max_tokens` request param). Used to defend against a class of bugs where
+ * a low user-configured limit silently produces an empty response.
+ *
+ * Currently only `deepseek-reasoner` has a real floor: R1 mixes
+ * `reasoning_tokens` into the same `max_tokens` budget as `completion_tokens`,
+ * so a user value < ~200 can be entirely consumed by the reasoning trace,
+ * leaving `message.content = ""` (200 OK, no error).
+ *
+ * Models not listed here resolve to a floor of 0 (no clamp).
+ *
+ * Discovered 2026-05-03 via live smoke test D — see
+ * `.crewly/specs/2026-05-03-crewly-agent-deepseek-gap-list.md` (finding N5).
+ */
+export const MODEL_OUTPUT_TOKEN_FLOORS: Record<string, number> = {
+  'deepseek-reasoner': 1024,
+} as const;
+
+/**
+ * Resolve the effective `maxOutputTokens` for a given model configuration,
+ * applying any per-model floor from `MODEL_OUTPUT_TOKEN_FLOORS`.
+ *
+ * If `config.maxTokens` is unset, falls back to the runtime default
+ * (`CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens`). The result is always
+ * `>= floor` for the model, where `floor` defaults to 0.
+ *
+ * @param config - Model configuration (may have `maxTokens` undefined)
+ * @returns Effective max output tokens to pass to generateText/streamText
+ */
+export function resolveMaxOutputTokens(config: ModelConfig): number {
+  const requested = config.maxTokens ?? CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens ?? 0;
+  const floor = MODEL_OUTPUT_TOKEN_FLOORS[config.modelId] ?? 0;
+  return Math.max(requested, floor);
+}
+
+/**
+ * Result of an autonomous context compaction operation.
+ * Returned by the compact_memory tool and requestCompaction().
+ */
+export interface CompactionResult {
+  /** Whether compaction was performed */
+  compacted: boolean;
+  /** Number of messages before compaction */
+  messagesBefore: number;
+  /** Number of messages after compaction */
+  messagesAfter: number;
+  /** Reason if compaction was skipped */
+  reason?: string;
+}
+
+/**
+ * Result of a tool approval check.
+ * Returned by the onCheckApproval callback to determine if a tool can execute.
+ */
+export interface ApprovalCheckResult {
+  /** Whether the tool is allowed to execute */
+  allowed: boolean;
+  /** Reason if the tool is blocked or requires approval */
+  reason?: string;
+  /** Whether the tool was blocked (vs requiring approval) */
+  blocked?: boolean;
+}
+
+/**
+ * Callbacks from tool registry to the agent runner.
+ * Allows tools to trigger runner-level operations like compaction and security checks.
+ */
+export interface ToolCallbacks {
+  /** Trigger intelligent context compaction */
+  onCompactMemory?: () => Promise<CompactionResult>;
+  /** Get current context budget status */
+  onGetContextBudget?: () => ContextBudgetStatus;
+  /** Record an audit entry for a tool call */
+  onAuditLog?: (entry: AuditEntry) => void;
+  /** Check if a tool is allowed to execute given current security policy */
+  onCheckApproval?: (toolName: string, sensitivity: ToolSensitivity) => ApprovalCheckResult;
+  /** Retrieve audit log entries with optional filters */
+  onGetAuditLog?: (filters: AuditLogFilters) => AuditEntry[];
+  /** Enqueue a tool call for approval when it requires explicit approval */
+  onEnqueueApproval?: (toolName: string, sensitivity: ToolSensitivity, args: Record<string, unknown>) => { approvalId: string };
+}
+
+/**
+ * Filters for querying the audit log.
+ */
+export interface AuditLogFilters {
+  /** Maximum entries to return (most recent first) */
+  limit: number;
+  /** Filter by sensitivity level */
+  sensitivity?: ToolSensitivity;
+  /** Filter by specific tool name */
+  toolName?: string;
+}
+
+/**
+ * Configuration for API key security guardrails.
+ * Controls output filtering, environment isolation, and prompt protection.
+ */
+export interface SecurityGuardrailConfig {
+  /** Enable output filtering (redact API keys from agent responses) */
+  outputFilterEnabled: boolean;
+  /** Enable environment isolation (strip secrets from bash child processes) */
+  envIsolationEnabled: boolean;
+  /** Enable prompt guard (block key extraction commands and prompt injections) */
+  promptGuardEnabled: boolean;
+  /** Additional env vars to explicitly allow in child processes */
+  explicitEnvVars: string[];
+}
+
+/**
+ * Default configuration values for Crewly Agent
+ */
+export const CREWLY_AGENT_DEFAULTS = {
+  /** Default max reasoning steps per generateText call (high to mimic unlimited like Claude Code) */
+  MAX_STEPS: 500,
+  /** Maximum tool calls allowed per single response to prevent polling dead-loops */
+  MAX_TOOL_CALLS_PER_RESPONSE: 15,
+  /** Consecutive identical tool calls before aborting (loop detection) */
+  LOOP_DETECTION_THRESHOLD: 3,
+  /** Consecutive error responses (404, 4xx, 5xx) from the same tool before aborting */
+  ERROR_LOOP_THRESHOLD: 3,
+  /** Default API base URL */
+  API_BASE_URL: 'http://localhost:8787',
+  /** Default max history messages before compaction */
+  MAX_HISTORY_MESSAGES: 100,
+  /** Default compaction threshold (80% of context window) */
+  COMPACTION_THRESHOLD: 0.8,
+  /** Default model configuration */
+  DEFAULT_MODEL: {
+    provider: 'google' as ModelProvider,
+    modelId: 'gemini-3-flash-preview',
+    temperature: 0.3,
+    maxTokens: 8192,
+  } satisfies ModelConfig,
+  /** HTTP request timeout in milliseconds */
+  API_TIMEOUT_MS: 30_000,
+  /** Heartbeat interval in milliseconds for keeping in-process agent active between messages */
+  HEARTBEAT_INTERVAL_MS: 30_000,
+  /** Maximum time in milliseconds for a single message processing (generateText call) — hard abort.
+   *  Override via CREWLY_AGENT_MESSAGE_TIMEOUT_MS env var.
+   *
+   *  This is the **default** timeout used when the model has no entry in
+   *  `MODEL_TIMEOUT_MS`. Per-model overrides take precedence — see below. */
+  MESSAGE_TIMEOUT_MS: Number(process.env.CREWLY_AGENT_MESSAGE_TIMEOUT_MS) || 300_000,
+  /** I4 — Per-model hard-timeout overrides. Looked up by `modelId`.
+   *
+   *  When the runtime service is about to run a message, it checks
+   *  `MODEL_TIMEOUT_MS[config.model.modelId]` first; falls back to
+   *  `MESSAGE_TIMEOUT_MS` if no entry exists.
+   *
+   *  **Why per-model:** different models have radically different latency
+   *  characteristics. DeepSeek-R1 (`deepseek-reasoner`) emits chain-of-thought
+   *  reasoning_tokens which are slower to generate than plain content tokens.
+   *  Live smoke (2026-05-03) measured R1 single-step at avg 2.8s/max 4.8s, but
+   *  long-context (>32k) latency rises sharply per vendor docs, and multi-step
+   *  agentic loops can accumulate 30+ steps. 5min default is tight; 10min gives
+   *  safety margin without inviting runaway loops. See gap-list spec §I4 for
+   *  measurement evidence. */
+  /**
+   * Frozen at module load via `Object.freeze` — defensive guard against
+   * runtime mutation. `as const` is compile-time only and the
+   * `Record<string, number>` cast widens it back to mutable, so freeze
+   * is the only line of defense against accidental writes like
+   * `CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['x'] = 999` from elsewhere
+   * in the codebase. Per-model overrides should be added by editing this
+   * file (treat as a config table, not runtime state).
+   */
+  MODEL_TIMEOUT_MS: Object.freeze({
+    /** DeepSeek-R1: 2× default — reasoning chain-of-thought is slower per token. */
+    'deepseek-reasoner': 600_000,
+  }) as Readonly<Record<string, number>>,
+  /** Soft warning threshold in milliseconds — logs a warning but does not kill the request.
+   *  Override via CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS env var. */
+  MESSAGE_SOFT_WARNING_MS: Number(process.env.CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS) || 240_000,
+  /** Cooldown period in milliseconds after rate limit retries are exhausted */
+  RATE_LIMIT_COOLDOWN_MS: 300_000,
+  /** Maximum number of automatic retries for recoverable errors (429, 5xx, network) */
+  MAX_RETRIES: 3,
+  /** Base delay in milliseconds for exponential backoff between retries */
+  RETRY_BASE_DELAY_MS: 1_000,
+  /** Default Ollama API base URL for local LLM provider */
+  OLLAMA_BASE_URL: 'http://localhost:11434/api',
+  /** Default security policy */
+  SECURITY_POLICY: {
+    auditEnabled: true,
+    requireApproval: [] as ToolSensitivity[],
+    blockedTools: [] as string[],
+    maxAuditEntries: 500,
+    readOnlyMode: false,
+  } satisfies SecurityPolicy,
+  /** Default security guardrail configuration */
+  SECURITY_GUARDRAILS: {
+    outputFilterEnabled: true,
+    envIsolationEnabled: true,
+    promptGuardEnabled: true,
+    explicitEnvVars: [],
+  } satisfies SecurityGuardrailConfig,
+} as const;
+
+/**
+ * Type guard to check if a string is a valid ModelProvider
+ *
+ * @param value - String to check
+ * @returns True if the value is a valid ModelProvider
+ */
+export function isModelProvider(value: string): value is ModelProvider {
+  return MODEL_PROVIDERS.includes(value as ModelProvider);
+}
+
+/**
+ * Supported models for the UI dropdown.
+ * Format: provider/modelId → display label
+ */
+export const SUPPORTED_MODELS: Array<{ id: string; label: string; provider: ModelProvider }> = [
+  { id: 'google/gemini-3-flash-preview', label: 'Gemini 3 Flash (Preview)', provider: 'google' },
+  { id: 'google/gemini-2.5-flash-preview-05-20', label: 'Gemini 2.5 Flash', provider: 'google' },
+  { id: 'anthropic/claude-sonnet-4-20250514', label: 'Claude Sonnet 4', provider: 'anthropic' },
+  { id: 'anthropic/claude-haiku-4-20250514', label: 'Claude Haiku 4', provider: 'anthropic' },
+  { id: 'openai/gpt-4o', label: 'GPT-4o', provider: 'openai' },
+  { id: 'openai/gpt-4o-mini', label: 'GPT-4o Mini', provider: 'openai' },
+  { id: 'deepseek/deepseek-chat', label: 'DeepSeek V3', provider: 'deepseek' },
+  { id: 'deepseek/deepseek-reasoner', label: 'DeepSeek R1', provider: 'deepseek' },
+  { id: 'ollama/llama3', label: 'Llama 3 (Ollama)', provider: 'ollama' },
+];
+
+/**
+ * Parse a modelId string (provider/modelId) into a ModelConfig.
+ * Falls back to DEFAULT_MODEL if the input is invalid.
+ *
+ * @param modelId - Format: "provider/modelId" (e.g. "google/gemini-3-flash-preview")
+ * @returns Parsed ModelConfig
+ */
+export function parseModelId(modelId: string | undefined): ModelConfig {
+  if (!modelId || !modelId.includes('/')) {
+    return CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL;
+  }
+
+  const slashIdx = modelId.indexOf('/');
+  const provider = modelId.substring(0, slashIdx);
+  const model = modelId.substring(slashIdx + 1);
+
+  if (!isModelProvider(provider) || !model) {
+    return CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL;
+  }
+
+  return {
+    provider,
+    modelId: model,
+    temperature: CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.temperature,
+    maxTokens: CREWLY_AGENT_DEFAULTS.DEFAULT_MODEL.maxTokens,
+  };
+}
+
+/**
+ * Type guard to check if an object is a valid ModelConfig
+ *
+ * @param obj - Object to validate
+ * @returns True if the object has all required ModelConfig fields
+ */
+export function isModelConfig(obj: unknown): obj is ModelConfig {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const candidate = obj as Record<string, unknown>;
+  return (
+    typeof candidate.provider === 'string' &&
+    isModelProvider(candidate.provider) &&
+    typeof candidate.modelId === 'string' &&
+    candidate.modelId.length > 0
+  );
+}

--- a/packages/crewly-agent/src/runtime/web-search.tool.test.ts
+++ b/packages/crewly-agent/src/runtime/web-search.tool.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the web_search tool.
+ *
+ * @module services/agent/crewly-agent/web-search.tool.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createWebSearchTool, formatAsMarkdown } from './web-search.tool.js';
+import { CloudNotLoggedInError, type CloudConfig } from './cloud-config.js';
+
+const config: CloudConfig = {
+  cloudUrl: 'https://api.crewlyai.com',
+  token: 'fake-jwt',
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('formatAsMarkdown', () => {
+  it('returns just the answer when there are no sources', () => {
+    expect(formatAsMarkdown('hello\n', [])).toBe('hello');
+  });
+
+  it('appends a numbered Sources list', () => {
+    const out = formatAsMarkdown('Some answer.', [
+      { title: 'Title A', url: 'https://a.com', snippet: '' },
+      { title: 'Title B', url: 'https://b.com', snippet: '' },
+    ]);
+    expect(out).toBe(
+      'Some answer.\n\nSources:\n[1] Title A — https://a.com\n[2] Title B — https://b.com',
+    );
+  });
+
+  it('falls back to url when title is missing', () => {
+    const out = formatAsMarkdown('a', [{ title: '', url: 'https://x.com', snippet: '' }]);
+    expect(out.endsWith('[1] https://x.com — https://x.com')).toBe(true);
+  });
+});
+
+describe('createWebSearchTool', () => {
+  it('returns CloudNotLoggedInError as a structured failure (does not throw)', async () => {
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.reject(new CloudNotLoggedInError()),
+    });
+    const result = (await tool.execute({ query: 'hi' })) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Crewly Cloud is not connected/);
+  });
+
+  it('sends the query + bearer token to the configured endpoint', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({
+        success: true,
+        answer: 'answer text',
+        sources: [{ title: 'A', url: 'https://a.com', snippet: '' }],
+      }),
+    );
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.resolve(config),
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+
+    const result = (await tool.execute({ query: 'what is X', max_results: 3 })) as {
+      success: boolean;
+      result?: string;
+    };
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://api.crewlyai.com/api/v1/search');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer fake-jwt');
+    expect(JSON.parse(init.body)).toEqual({ query: 'what is X', max_results: 3 });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('answer text');
+    expect(result.result).toContain('[1] A — https://a.com');
+  });
+
+  it('omits max_results from body when not provided', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({ success: true, answer: 'ok', sources: [] }),
+    );
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.resolve(config),
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    await tool.execute({ query: 'hi' });
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1].body)).toEqual({ query: 'hi' });
+  });
+
+  it('returns a structured error on non-2xx response', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({ success: false, error: 'bad query' }, 400),
+    );
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.resolve(config),
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const result = (await tool.execute({ query: 'hi' })) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Search backend returned 400.*bad query/);
+  });
+
+  it('returns a structured error on fetch failure', async () => {
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.resolve(config),
+      fetchImpl: (() => Promise.reject(new Error('network down'))) as unknown as typeof fetch,
+    });
+    const result = (await tool.execute({ query: 'hi' })) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/network down/);
+  });
+
+  it('reports when the backend returns success:false', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({ success: false, error: 'quota exhausted' }, 200),
+    );
+    const tool = createWebSearchTool({
+      loadConfig: () => Promise.resolve(config),
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    const result = (await tool.execute({ query: 'hi' })) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/quota exhausted/);
+  });
+});

--- a/packages/crewly-agent/src/runtime/web-search.tool.ts
+++ b/packages/crewly-agent/src/runtime/web-search.tool.ts
@@ -1,0 +1,140 @@
+/**
+ * `web_search` tool — Crewly cloud-backed web search.
+ *
+ * Models like DeepSeek that lack a built-in search capability call this tool
+ * to delegate the search to the Crewly cloud service, which hits Gemini +
+ * Google Search and returns a synthesized answer with cited sources. The
+ * tool formats the response as markdown with a numbered Sources footer so
+ * the model can naturally inline citations like [1][2].
+ *
+ * Claude Code / Gemini CLI / Codex runtimes have their own search and won't
+ * be wired through this — this tool only ships in the Crewly agent runtime.
+ *
+ * @module services/agent/crewly-agent/web-search.tool
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition } from './types.js';
+import { loadCloudConfig, CloudNotLoggedInError, type CloudConfig } from './cloud-config.js';
+
+const SEARCH_PATH = '/api/v1/search';
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface SearchSource {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+interface SearchResponse {
+  success: boolean;
+  answer?: string;
+  sources?: SearchSource[];
+  error?: string;
+}
+
+/** Injectable IO for tests. */
+export interface WebSearchDeps {
+  loadConfig?: () => Promise<CloudConfig>;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export function createWebSearchTool(deps: WebSearchDeps = {}): ToolDefinition {
+  const loadConfig = deps.loadConfig ?? (() => loadCloudConfig());
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    description:
+      'Search the web. Returns a synthesized answer plus a numbered list of cited sources. Use it whenever the user asks about current events, third-party documentation, package versions, or anything that may have changed since training. Inline-cite sources as [1][2] in your reply.',
+    inputSchema: z.object({
+      query: z.string().min(1).describe('The search query in natural language.'),
+      max_results: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .optional()
+        .describe('Maximum number of cited sources to return (1-10, default 5).'),
+    }),
+    execute: async (args) => {
+      const { query, max_results } = args as { query: string; max_results?: number };
+
+      let config: CloudConfig;
+      try {
+        config = await loadConfig();
+      } catch (err) {
+        if (err instanceof CloudNotLoggedInError) {
+          return { success: false, error: err.message };
+        }
+        throw err;
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let resp: Response;
+      try {
+        resp = await fetchImpl(`${config.cloudUrl}${SEARCH_PATH}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.token}`,
+          },
+          body: JSON.stringify(
+            max_results !== undefined ? { query, max_results } : { query },
+          ),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: `Search request failed: ${message}` };
+      }
+      clearTimeout(timer);
+
+      if (!resp.ok) {
+        let body: SearchResponse | null = null;
+        try {
+          body = (await resp.json()) as SearchResponse;
+        } catch {
+          /* not JSON — fall through */
+        }
+        const detail = body?.error || resp.statusText;
+        return { success: false, error: `Search backend returned ${resp.status}: ${detail}` };
+      }
+
+      const body = (await resp.json()) as SearchResponse;
+      if (!body.success || typeof body.answer !== 'string') {
+        return { success: false, error: body.error || 'Search returned no answer.' };
+      }
+
+      const sources = Array.isArray(body.sources) ? body.sources : [];
+      return {
+        success: true,
+        result: formatAsMarkdown(body.answer, sources),
+        sourceCount: sources.length,
+      };
+    },
+  };
+}
+
+/**
+ * Format `answer` + `sources` as a single markdown block ready to drop into
+ * the model's context: synthesized answer followed by a numbered Sources
+ * section. The model can inline [1][2] back-references.
+ *
+ * Exported for unit testing.
+ */
+export function formatAsMarkdown(answer: string, sources: readonly SearchSource[]): string {
+  if (sources.length === 0) return answer.trim();
+
+  const numbered = sources
+    .map((s, i) => {
+      const title = s.title?.trim() || s.url;
+      return `[${i + 1}] ${title} — ${s.url}`;
+    })
+    .join('\n');
+
+  return `${answer.trim()}\n\nSources:\n${numbered}`;
+}


### PR DESCRIPTION
## What

Moves the in-process **`crewly-agent`** runtime — the AI-SDK-based agent reasoning loop crewly spawns as a subprocess (NDJSON over stdio) — out of its separate private repo (`crewly-agent.git#v0.1.1`) and **into this monorepo** at `packages/crewly-agent/`.

## Why

It was pinned only as a `crewly-pro` dependency, which made the runtime invisible/unverifiable from OSS and unavailable to OSS users out of the box. Vendoring it puts the code where it belongs and ships it with OSS.

## Key finding

The runtime **already has a complete coding tool set** — `bash_exec`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`, `git_status/diff/commit` (35 tools), plus a security blocklist (`rm -rf /`, `kill`, `shutdown`…) and an approval-gate system (`git push`, `rm`, `docker`, `curl`…), all handed to the model unfiltered. **No tools needed adding.** (The earlier "its tools are unverified" gap was purely because the source lived in another repo.)

## Changes

- **`packages/crewly-agent/`** — vendored workspace package (private). Self-contained (only non-dep import is `vitest`); runs from source via `tsx`. **528/528 own tests pass.**
- **Shippable in the published tarball** — added `packages/crewly-agent/{bin,src}` to `files`, and `tsx` + `zod` to root `dependencies` (ai/@ai-sdk/*/better-sqlite3/ollama already present) so the spawned subprocess resolves them from an installed crewly.
- **Spawn resolution** (`crewly-agent-external-runtime.service.ts`) now resolves the **vendored binary by absolute path** (`packages/crewly-agent/bin/crewly-agent` under the install dir), so the in-process runtime works whether launched via npm script or `node dist/...`, from a checkout or an installed package — PATH fallback for legacy global installs.

## Tests
`packages/crewly-agent` 528/528 · `crewly-agent-external-runtime` service 33/33 · backend typecheck clean.

## Pairs with
stevehuang0115/crewly-pro#NN (drops the now-redundant git dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)