### PR TITLE
feat(v3): P2 — Request-level acceptance gate (no premature completion)

### DIFF
--- a/backend/src/services/v3/cascade-request-status.test.ts
+++ b/backend/src/services/v3/cascade-request-status.test.ts
@@ -107,14 +107,14 @@ describe('cascadeRequestStatus', () => {
     expect(updates).toEqual([]);
   });
 
-  it('cascades to done when every child landed on a success terminal', async () => {
+  it('cascades to done when every child landed on a verified terminal', async () => {
     const r = makeRequest({ status: 'running' });
     const { deps, updates, notified } = makeDeps({
       request: r,
       pool: [
         makeWI({ id: 'a', status: 'done' }),
         makeWI({ id: 'b', status: 'verified' }),
-        makeWI({ id: 'c', status: 'done_by_worker' }),
+        makeWI({ id: 'c', status: 'verified' }),
       ],
     });
     await cascadeRequestStatus(r.id, deps);
@@ -122,6 +122,24 @@ describe('cascadeRequestStatus', () => {
     expect(notified).toEqual([
       { event: 'v3:request_updated', payload: { requestId: 'req-1', status: 'done', previousStatus: 'running' } },
     ]);
+  });
+
+  it('P2 acceptance gate: a done_by_worker (unverified) child keeps the Request running, not done', async () => {
+    // The deliverable must NOT be marked done while a child still awaits a TL
+    // verdict — that would be the Request-level silent-pass. It stays running;
+    // P1's verify-enforcement escalates the unverified child for a verdict,
+    // after which a later cascade completes the Request.
+    const r = makeRequest({ status: 'running' });
+    const { deps, updates } = makeDeps({
+      request: r,
+      pool: [
+        makeWI({ id: 'a', status: 'verified' }),
+        makeWI({ id: 'b', status: 'done_by_worker' }),
+      ],
+    });
+    await cascadeRequestStatus(r.id, deps);
+    // running → running is a no-op write OR a running update; either way NOT done.
+    expect(updates.some(([, u]) => u.status === 'done')).toBe(false);
   });
 
   it('cascades to cancelled when every child is cancelled or failed', async () => {

--- a/backend/src/services/v3/cascade-request-status.ts
+++ b/backend/src/services/v3/cascade-request-status.ts
@@ -113,7 +113,9 @@ function isSlaResolvedByVerifiedReply(metadata: Record<string, unknown> | undefi
  * Cascade rules — match the original V3DataService implementation so
  * behaviour is unchanged for paths that already cascade correctly:
  *
- *   - All children done/verified/done_by_worker → done
+ *   - All children done/verified                 → done
+ *     (P2: `done_by_worker` does NOT count — see the acceptance-gate note
+ *      at the rule below; unverified children keep the Request `running`)
  *   - Any child running                          → running
  *   - All children queued/scheduled              → no change
  *     (work delegated, not started — Request keeps current status)
@@ -181,7 +183,15 @@ export async function cascadeRequestStatus(
 
     let newStatus: RequestStatus;
     const allQueued = statuses.every((s) => s === 'queued' || s === 'scheduled');
-    if (statuses.every((s) => s === 'done' || s === 'verified' || s === 'done_by_worker')) {
+    // P2 acceptance gate: a Request is only `done` when its children are
+    // actually VERIFIED (or `done`), NOT merely `done_by_worker`. A
+    // `done_by_worker` child is awaiting a TL/orc verdict — counting it as
+    // complete would mark the deliverable done before it was ever accepted
+    // (the Request-level silent-pass). Such children keep the Request
+    // `running` (pending verification); P1's verify-enforcement escalates them
+    // to the orc for a verdict (→ verified, or rejected → rework), after which
+    // this cascade completes the Request honestly.
+    if (statuses.every((s) => s === 'done' || s === 'verified')) {
       newStatus = 'done';
     } else if (statuses.some((s) => s === 'running')) {
       newStatus = 'running';

--- a/backend/src/services/v3/request-cascade.subscriber.test.ts
+++ b/backend/src/services/v3/request-cascade.subscriber.test.ts
@@ -192,14 +192,38 @@ describe('RequestCascadeSubscriber', () => {
     expect(services.updates).toEqual([['req-1', { status: 'cancelled' }]]);
   });
 
-  it('cascades on task:done_by_worker (closes Request when all children done)', async () => {
-    // Live wiring of the success path — proves the subscriber doesn't
-    // ONLY handle cancellation. After the last child reports done,
-    // the Request closes automatically.
+  it('cascades on task:done_by_worker but does NOT close the Request (P2 acceptance gate)', async () => {
+    // Live wiring of the success path — proves the subscriber handles the
+    // done_by_worker event. But per the P2 acceptance gate, a done_by_worker
+    // (unverified) child must NOT mark the deliverable done; the Request stays
+    // running pending a TL/orc verdict (which P1 escalates for).
     const r = makeRequest({ status: 'running' });
     const wis = [
       makeWI({ id: 'a', status: 'done' }),
       makeWI({ id: 'b', status: 'done_by_worker' }),
+    ];
+    const services = makeFakeServices({ request: r, pool: wis });
+    const bus = makeFakeBus();
+    const sub = new RequestCascadeSubscriber({
+      eventBus: bus as never,
+      ...services,
+      logger: SILENT_LOGGER as never,
+    });
+    sub.start();
+
+    bus.publish(makeEvent({ type: 'task:done_by_worker', workItemId: 'b', requestId: 'req-1' }));
+    await sub.flushPending();
+
+    expect(services.updates.some(([, u]) => u.status === 'done')).toBe(false);
+  });
+
+  it('cascades to done on task:verified once all children are verified', async () => {
+    // The real completion path: when the last child is verified, the Request
+    // closes automatically.
+    const r = makeRequest({ status: 'running' });
+    const wis = [
+      makeWI({ id: 'a', status: 'verified' }),
+      makeWI({ id: 'b', status: 'verified' }),
     ];
     const services = makeFakeServices({ request: r, pool: wis });
     const bus = makeFakeBus();


### PR DESCRIPTION
## Autonomy roadmap — P2 of P0→P1→P2 (core)

**Before:** the Request-completion cascade marked a Request `done` when its children were merely `done_by_worker` — the deliverable was reported complete while its work still awaited a TL/orc verdict (the Request-level silent-pass). "Top TL judges the deliverable" was never enforced.

**Now:** in `cascadeRequestStatus`, a Request reaches `done` **only** when its children are actually `done`/`verified` — `done_by_worker` no longer counts. An unverified child keeps the Request `running` (pending verification); P1's verify-enforcement escalates that child to the orc for a verdict, after which a later cascade completes the Request honestly. No permanent stall (P1 escalates at ~2h; 24h TTL auto-verify remains the backstop).

**Validated:** `cascade-request-status` (17 tests, incl. a new acceptance-gate case) + `request-cascade.subscriber` (updated to the new semantics + a verified→done case); **26/26** in touched suites; full tsc clean.

**Follow-up (remaining P2):** emit an aggregated pass/partial/fail deliverable verdict to the orc by wiring `hierarchy-reporting.aggregateAndReportUp` (currently unwired) — needs a WorkItem→InProgressTask adapter.

Pairs with #724 (P0) and the P1 verify-enforcement PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)