### PR TITLE
feat(cloud): mobile-app support — LAN pairing endpoint + relay API passthrough

### DIFF
--- a/backend/src/controllers/cloud/cloud.controller.ts
+++ b/backend/src/controllers/cloud/cloud.controller.ts
@@ -632,3 +632,63 @@ export async function getDevicesFromSync(req: Request, res: Response, _next: Nex
     });
   }
 }
+
+/**
+ * POST /api/cloud/mobile-pair
+ *
+ * LAN pairing bootstrap for the Crewly mobile app. The phone, on the SAME
+ * network as this OSS, calls this once to ADOPT the OSS's cloud session:
+ * it receives the cloud URL + the access token + this device's identity, and
+ * can then register on the Cloud relay under the same account (pairing code =
+ * sha256("crewly-pair-" + userId) — same derivation as the web Portal) so the
+ * app keeps working OFF the LAN via the relay.
+ *
+ * Trust model: single-user OSS — anyone who can reach this HTTP port already
+ * has unauthenticated access to the full REST API (requireAuth dev-fallback),
+ * so returning the cloud token to a LAN caller does not widen the boundary.
+ * When the OSS is not logged into Cloud, returns `cloud: null` — the app then
+ * runs in LAN-only mode against this host.
+ *
+ * @param _req - Request (no body).
+ * @param res - JSON: `{ success, data: { deviceId, deviceName, cloud } }`
+ *   where `cloud` is `{ cloudUrl, accessToken, userId }` or null.
+ * @param next - Error handler.
+ */
+export async function mobilePair(_req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const identityService = DeviceIdentityService.getInstance();
+    const identity = await identityService.getOrCreateIdentity();
+
+    const client = CloudClientService.getInstance();
+    const token = client.getToken();
+    const cloudUrl = client.getCloudUrl();
+
+    let cloud: { cloudUrl: string; accessToken: string; userId: string | null } | null = null;
+    if (token && cloudUrl) {
+      // Best-effort sub extraction (the relay pairing code derives from it).
+      let userId: string | null = null;
+      try {
+        const mid = token.split('.')[1];
+        const claims = JSON.parse(Buffer.from(mid, 'base64url').toString('utf8')) as { sub?: string };
+        userId = typeof claims.sub === 'string' ? claims.sub : null;
+      } catch {
+        userId = null;
+      }
+      cloud = { cloudUrl, accessToken: token, userId };
+    }
+
+    res.json({
+      success: true,
+      data: {
+        deviceId: identity.deviceId,
+        deviceName: identity.deviceName,
+        cloud,
+      },
+    });
+  } catch (error) {
+    logger.error('mobile-pair failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    next(error);
+  }
+}

--- a/backend/src/controllers/cloud/cloud.routes.ts
+++ b/backend/src/controllers/cloud/cloud.routes.ts
@@ -33,6 +33,7 @@ import {
   getDeviceId,
   getDevicesFromSync,
   verifyLicense,
+  mobilePair,
 } from './cloud.controller.js';
 import {
   cloudGoogleStart,
@@ -59,6 +60,8 @@ export function createCloudRouter(): Router {
   router.post('/send', sendCloudMessage);
   router.get('/templates', getCloudTemplates);
   router.get('/license/verify', verifyLicense);
+  // Mobile-app LAN pairing — adopt this OSS's cloud session (see mobilePair).
+  router.post('/mobile-pair', mobilePair);
 
   // Google OAuth login flow — browser-redirect (GET)
   router.get('/google/start', cloudGoogleStart);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1625,6 +1625,23 @@ void (async () => {
 						});
 						chatRelayAdapter.start();
 						this.logger.info('ChatV2RelayAdapter started — Cloud Portal can now drive chat-v2 via relay');
+
+						// Mobile app: generic allowlisted REST passthrough over the same
+						// relay (api_request → local HTTP → api_response). Non-fatal.
+						try {
+							const { MobileApiRelayService } = await import(
+								'./services/cloud/mobile-api-relay.service.js'
+							);
+							const mobileRelay = new MobileApiRelayService({
+								cloudSync: sync,
+								webPort: this.config.webPort,
+							});
+							mobileRelay.start();
+						} catch (mobileErr) {
+							this.logger.warn('MobileApiRelayService wiring skipped', {
+								error: mobileErr instanceof Error ? mobileErr.message : String(mobileErr),
+							});
+						}
 					}
 				} catch (err) {
 					// Adapter wiring failure is non-fatal — local OSS UI still works.

--- a/backend/src/services/cloud/mobile-api-relay.service.test.ts
+++ b/backend/src/services/cloud/mobile-api-relay.service.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for MobileApiRelayService — allowlist, proxying, reply round-trip,
+ * and resilience (never hangs the phone).
+ *
+ * @module services/cloud/mobile-api-relay.service.test
+ */
+
+import {
+  MobileApiRelayService,
+  isAllowedMobileApiCall,
+  type MobileRelayIncomingMessage,
+  type IMobileRelayCloudSync,
+} from './mobile-api-relay.service.js';
+
+const SILENT = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+} as unknown as ConstructorParameters<typeof MobileApiRelayService>[0]['logger'];
+
+/** In-memory cloud-sync stub that captures replies + lets tests inject messages. */
+function makeSync() {
+  const handlers: Array<(msg: MobileRelayIncomingMessage) => void> = [];
+  const sent: Array<{ to: string; type: string; payload: unknown }> = [];
+  const sync: IMobileRelayCloudSync = {
+    on: (_e, h) => { handlers.push(h); },
+    off: (_e, h) => { const i = handlers.indexOf(h); if (i >= 0) handlers.splice(i, 1); },
+    sendMessage: async (to, type, payload) => { sent.push({ to, type, payload }); },
+  };
+  const emit = (msg: MobileRelayIncomingMessage) => { for (const h of [...handlers]) h(msg); };
+  return { sync, sent, emit, handlers };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('isAllowedMobileApiCall', () => {
+  it('allows the read surface', () => {
+    expect(isAllowedMobileApiCall('GET', '/teams')).toBe(true);
+    expect(isAllowedMobileApiCall('GET', '/escalations')).toBe(true);
+    expect(isAllowedMobileApiCall('GET', '/task-pool/items')).toBe(true);
+    expect(isAllowedMobileApiCall('GET', '/requests?status=running')).toBe(true);
+  });
+
+  it('allows only the human-in-the-loop mutations', () => {
+    expect(isAllowedMobileApiCall('POST', '/escalations/abc/resolve')).toBe(true);
+    expect(isAllowedMobileApiCall('POST', '/approvals/xyz/approve')).toBe(true);
+    expect(isAllowedMobileApiCall('POST', '/teams')).toBe(false);
+    expect(isAllowedMobileApiCall('POST', '/task-pool/add')).toBe(false);
+  });
+
+  it('rejects traversal, non-rooted, and odd methods', () => {
+    expect(isAllowedMobileApiCall('GET', '/teams/../settings')).toBe(false);
+    expect(isAllowedMobileApiCall('GET', 'teams')).toBe(false);
+    expect(isAllowedMobileApiCall('GET', '//evil')).toBe(false);
+    expect(isAllowedMobileApiCall('DELETE', '/teams')).toBe(false);
+  });
+});
+
+describe('MobileApiRelayService', () => {
+  it('proxies an allowed GET to the local API and replies api_response', async () => {
+    const { sync, sent, emit } = makeSync();
+    const fetchImpl = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: [{ id: 't1' }] }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+
+    emit({ type: 'api_request', from: 'phone-1', payload: { id: 'r1', method: 'GET', path: '/teams' } });
+    await flush();
+
+    expect(fetchImpl).toHaveBeenCalledWith('http://127.0.0.1:8787/api/teams', expect.objectContaining({ method: 'GET' }));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ to: 'phone-1', type: 'api_response' });
+    const payload = sent[0].payload as { id: string; status: number; body: { success: boolean } };
+    expect(payload.id).toBe('r1');
+    expect(payload.status).toBe(200);
+    expect(payload.body.success).toBe(true);
+  });
+
+  it('forwards POST bodies for allowed mutations', async () => {
+    const { sync, sent, emit } = makeSync();
+    const fetchImpl = jest.fn().mockResolvedValue(new Response('{"success":true}', { status: 200 })) as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+
+    emit({
+      type: 'api_request',
+      from: 'phone-1',
+      payload: { id: 'r2', method: 'POST', path: '/escalations/e1/resolve', body: { resolution: 'approve' } },
+    });
+    await flush();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:8787/api/escalations/e1/resolve',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ resolution: 'approve' }) }),
+    );
+    expect((sent[0].payload as { status: number }).status).toBe(200);
+  });
+
+  it('replies 403 (never silent-drops) for a blocked path', async () => {
+    const { sync, sent, emit } = makeSync();
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+
+    emit({ type: 'api_request', from: 'phone-1', payload: { id: 'r3', method: 'POST', path: '/settings' } });
+    await flush();
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect((sent[0].payload as { status: number }).status).toBe(403);
+  });
+
+  it('replies 502 when the local API is unreachable', async () => {
+    const { sync, sent, emit } = makeSync();
+    const fetchImpl = jest.fn().mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+
+    emit({ type: 'api_request', from: 'phone-1', payload: { id: 'r4', method: 'GET', path: '/teams' } });
+    await flush();
+
+    expect((sent[0].payload as { status: number; body: { error: string } }).status).toBe(502);
+  });
+
+  it('ignores non-api_request messages and missing sender', async () => {
+    const { sync, sent, emit } = makeSync();
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+
+    emit({ type: 'chat_request', from: 'phone-1', payload: { id: 'x' } });
+    emit({ type: 'api_request', payload: { id: 'r5', method: 'GET', path: '/teams' } }); // no sender
+    await flush();
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it('start is idempotent and stop detaches', async () => {
+    const { sync, emit, sent, handlers } = makeSync();
+    const fetchImpl = jest.fn().mockResolvedValue(new Response('{}', { status: 200 })) as unknown as typeof fetch;
+    const svc = new MobileApiRelayService({ cloudSync: sync, webPort: 8787, fetchImpl, logger: SILENT });
+    svc.start();
+    svc.start();
+    expect(handlers).toHaveLength(1);
+    svc.stop();
+    emit({ type: 'api_request', from: 'p', payload: { id: 'r6', method: 'GET', path: '/teams' } });
+    await flush();
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/backend/src/services/cloud/mobile-api-relay.service.ts
+++ b/backend/src/services/cloud/mobile-api-relay.service.ts
@@ -1,0 +1,218 @@
+/**
+ * Mobile API Relay — generic REST passthrough over the Cloud relay queue.
+ *
+ * The Cloud relay's chat adapter (`ChatV2RelayAdapter`) services a CLOSED set
+ * of chat RPCs. The mobile app needs more than chat — approvals, escalations,
+ * teams, requests, task-pool, backups — and adding each as a bespoke RPC would
+ * never keep up with the REST surface. Instead this service forwards a SMALL,
+ * ALLOWLISTED subset of the local REST API over the relay:
+ *
+ *   phone →(relay queue)→ `api_request {id, method, path, body}`
+ *     → allowlist check → local HTTP `http://127.0.0.1:<webPort>/api<path>`
+ *     → `api_response {id, status, body}` →(relay queue)→ phone
+ *
+ * Security model: the relay only pairs devices under the SAME cloud account
+ * (sha256 pairing code derived from the JWT sub — see RelayContext/PWA), so the
+ * caller is the account owner. The allowlist below still constrains the surface
+ * to read endpoints + a few explicitly-safe mutations (approve/resolve/send),
+ * so a compromised phone session cannot, e.g., rewrite settings or run skills.
+ *
+ * @module services/cloud/mobile-api-relay.service
+ */
+
+import { LoggerService, type ComponentLogger } from '../core/logger.service.js';
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/** Inbound request payload (mirrors the chat_request envelope shape). */
+export interface ApiRequestPayload {
+  id: string;
+  method: 'GET' | 'POST';
+  /** Path under `/api`, e.g. `/escalations` or `/task-pool/items`. */
+  path: string;
+  body?: unknown;
+}
+
+/** Outbound response payload. */
+export interface ApiResponsePayload {
+  id: string;
+  status: number;
+  body: unknown;
+}
+
+/** Minimal cloud-sync surface (mirrors ChatV2RelayAdapter's ICloudSyncLike). */
+export interface IMobileRelayCloudSync {
+  on(event: 'message', handler: (msg: MobileRelayIncomingMessage) => void): void;
+  off(event: 'message', handler: (msg: MobileRelayIncomingMessage) => void): void;
+  sendMessage(toDeviceId: string, type: string, payload: unknown): Promise<unknown>;
+}
+
+/** Minimal incoming-message shape from CloudSyncService. */
+export interface MobileRelayIncomingMessage {
+  type: string;
+  payload: unknown;
+  from?: string;
+  fromDeviceName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * Allowed `method path-prefix` pairs. A request passes when its method matches
+ * and its path starts with one of the prefixes for that method. Keep this
+ * tight: reads broadly, mutations only where the mobile UX needs them.
+ */
+export const MOBILE_API_ALLOWLIST: ReadonlyArray<{ method: 'GET' | 'POST'; prefix: string }> = [
+  // Reads — status surfaces.
+  { method: 'GET', prefix: '/teams' },
+  { method: 'GET', prefix: '/requests' },
+  { method: 'GET', prefix: '/task-pool' },
+  { method: 'GET', prefix: '/escalations' },
+  { method: 'GET', prefix: '/approvals' },
+  { method: 'GET', prefix: '/health' },
+  { method: 'GET', prefix: '/cloud/status' },
+  { method: 'GET', prefix: '/cloud/devices' },
+  { method: 'GET', prefix: '/team-health' },
+  // Mutations — human-in-the-loop actions only.
+  { method: 'POST', prefix: '/escalations/' }, // …/:id/resolve
+  { method: 'POST', prefix: '/approvals/' },   // …/:id/approve|reject
+];
+
+/**
+ * Check a request against {@link MOBILE_API_ALLOWLIST}. Also rejects path
+ * traversal (`..`), protocol-relative tricks, and non-`/`-rooted paths.
+ *
+ * @param method - HTTP method of the proxied request.
+ * @param path - Path under `/api`.
+ * @returns true when the request may be proxied.
+ */
+export function isAllowedMobileApiCall(method: string, path: string): boolean {
+  if (method !== 'GET' && method !== 'POST') return false;
+  if (!path.startsWith('/') || path.includes('..') || path.startsWith('//')) return false;
+  return MOBILE_API_ALLOWLIST.some((e) => e.method === method && path.startsWith(e.prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/** Constructor options. */
+export interface MobileApiRelayOptions {
+  cloudSync: IMobileRelayCloudSync;
+  /** Local web port the REST API listens on (e.g. 8787). */
+  webPort: number;
+  logger?: ComponentLogger;
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Listens for `api_request` messages on the relay and proxies allowlisted
+ * calls to the local REST API, replying with `api_response`. Lifecycle
+ * mirrors ChatV2RelayAdapter (start/stop, idempotent).
+ */
+export class MobileApiRelayService {
+  private readonly cloudSync: IMobileRelayCloudSync;
+  private readonly webPort: number;
+  private readonly logger: ComponentLogger;
+  private readonly fetchImpl: typeof fetch;
+  private handler: ((msg: MobileRelayIncomingMessage) => void) | null = null;
+
+  constructor(options: MobileApiRelayOptions) {
+    this.cloudSync = options.cloudSync;
+    this.webPort = options.webPort;
+    this.logger =
+      options.logger ?? LoggerService.getInstance().createComponentLogger('MobileApiRelay');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  /** Attach the relay listener. Idempotent. */
+  start(): void {
+    if (this.handler) {
+      this.logger.warn('MobileApiRelayService.start called twice — ignoring');
+      return;
+    }
+    this.handler = (msg: MobileRelayIncomingMessage): void => {
+      if (msg.type !== 'api_request') return;
+      void this.handleRequest(msg);
+    };
+    this.cloudSync.on('message', this.handler);
+    this.logger.info('MobileApiRelayService started — mobile app can call allowlisted REST over relay');
+  }
+
+  /** Detach the relay listener. Safe during shutdown. */
+  stop(): void {
+    if (this.handler) {
+      this.cloudSync.off('message', this.handler);
+      this.handler = null;
+    }
+  }
+
+  /**
+   * Validate, proxy, and reply to one `api_request`. Never throws — every
+   * outcome (including allowlist rejection and local fetch failure) is
+   * reported to the caller as an `api_response` so the phone never hangs.
+   *
+   * @param msg - The incoming relay message (payload: {@link ApiRequestPayload}).
+   */
+  private async handleRequest(msg: MobileRelayIncomingMessage): Promise<void> {
+    const fromDevice = msg.from || msg.fromDeviceName || '';
+    const payload = msg.payload as Partial<ApiRequestPayload> | undefined;
+    if (!fromDevice || !payload || typeof payload.id !== 'string') {
+      this.logger.warn('api_request missing sender or id — dropping');
+      return;
+    }
+
+    const reply = async (status: number, body: unknown): Promise<void> => {
+      const response: ApiResponsePayload = { id: payload.id as string, status, body };
+      try {
+        await this.cloudSync.sendMessage(fromDevice, 'api_response', response);
+      } catch (err) {
+        this.logger.warn('Failed to send api_response (phone will retry)', {
+          id: payload.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
+
+    const method = String(payload.method ?? '');
+    const path = String(payload.path ?? '');
+    if (!isAllowedMobileApiCall(method, path)) {
+      this.logger.warn('api_request blocked by allowlist', { method, path });
+      await reply(403, { success: false, error: `not allowed: ${method} ${path}` });
+      return;
+    }
+
+    try {
+      const url = `http://127.0.0.1:${this.webPort}/api${path}`;
+      const res = await this.fetchImpl(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        ...(method === 'POST' && payload.body !== undefined
+          ? { body: JSON.stringify(payload.body) }
+          : {}),
+      });
+      let body: unknown = null;
+      try {
+        body = await res.json();
+      } catch {
+        body = null;
+      }
+      await reply(res.status, body);
+    } catch (err) {
+      this.logger.warn('api_request local proxy failed', {
+        method,
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      await reply(502, {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}


### PR DESCRIPTION
## What

Two small, additive OSS endpoints that back the new **Crewly Mobile** app (iOS + Android, in `crewly-projects/mobile`). No core logic changes — both are opaque to the Cloud relay and gated behind the existing single-user trust model.

### 1. `POST /api/cloud/mobile-pair`
LAN pairing bootstrap. A phone on the same network adopts this OSS's cloud session (cloudUrl + access token + device identity + JWT `sub` for the relay pairing-code derivation), so the app keeps working **off-LAN** through the Cloud relay. Returns `cloud: null` when the OSS isn't logged into Cloud (app falls back to LAN-only mode).

### 2. `MobileApiRelayService` — allowlisted REST passthrough over the relay
The chat adapter's closed RPC set only covers chat. This service forwards an **allowlisted** subset of the local REST API over the relay (`api_request {id,method,path,body}` → local `127.0.0.1` HTTP → `api_response`):
- **Reads**: teams, requests, task-pool, escalations, approvals, health, cloud status/devices, team-health
- **Mutations (human-in-the-loop only)**: escalation resolve, approval approve/reject

Path-traversal guarded; every outcome (incl. 403/502) is replied so the phone never hangs. Wired next to `ChatV2RelayAdapter` in `index.ts` (non-fatal).

## Why
The mobile app needs more than chat (approvals inbox, team/request status). Adding each as a bespoke relay RPC wouldn't keep up with the REST surface; a tight allowlist passthrough does, without widening the security boundary (a LAN caller already has the full unauthenticated REST API under the dev-fallback).

## Validation
- 9/9 `mobile-api-relay.service.test` (allowlist, proxy, POST body, 403, 502, idempotent start/stop)
- Full backend `tsc` clean
- **Live e2e in iOS simulator** against an isolated OSS: auto-pair → agent directory → chat thread (history + send→persist) → approvals (live escalation → Approve → `POST /escalations/:id/resolve 200` → resolved + badge clear) → overview (live P3 nested hierarchy) → settings (relay devices on account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)