### PR TITLE
fix(reconciler): stop the TTL rule and its sibling rules from emitting illegal and unearned corrections

### DIFF
--- a/backend/src/controllers/chat/chat.controller.test.ts
+++ b/backend/src/controllers/chat/chat.controller.test.ts
@@ -12,6 +12,15 @@ jest.mock('node-pty', () => ({
   spawn: jest.fn(),
 }));
 
+// Delivery enforcer is lazily imported by the agent-response handler; stub it
+// so the #731 tests can assert exactly when a thread gets tracked.
+const mockMarkPendingDelivery = jest.fn();
+jest.mock('../../services/orc/orc-delivery-enforcer.service.js', () => ({
+  OrcDeliveryEnforcerService: {
+    getInstance: () => ({ markPendingDelivery: mockMarkPendingDelivery }),
+  },
+}));
+
 // Phase 6c migration note — chat.controller still calls the legacy
 // ChatService façade (14 sites). The façade now delegates to chat-v2
 // under the hood, so existing fixtures continue to work without
@@ -639,6 +648,52 @@ describe('Chat Controller', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('Message content is required');
+    });
+
+    /**
+     * Issue #731 — a cron-driven daily task reports completion with no
+     * conversationId, so the handler fell back to the globally-current
+     * conversation and tracked a delivery against whatever thread happened to
+     * be current: a long-resolved one. The watchdog then demanded a deliverable
+     * in that unrelated thread every single day.
+     */
+    describe('delivery tracking only for a named thread (#731)', () => {
+      beforeEach(() => {
+        mockMarkPendingDelivery.mockClear();
+      });
+
+      it('tracks the delivery when the agent names the conversation', async () => {
+        const conversation = await chatService.createNewConversation('Slack thread');
+
+        const response = await request(app)
+          .post('/api/chat/agent-response')
+          .send({
+            content: '[DONE] Agent ella: research finished',
+            senderName: 'ella',
+            senderType: 'agent',
+            conversationId: conversation.id,
+          });
+
+        expect(response.status).toBe(201);
+        expect(mockMarkPendingDelivery).toHaveBeenCalledWith(
+          expect.objectContaining({ conversationId: conversation.id, agentSender: 'ella' }),
+        );
+      });
+
+      it('does NOT track when the conversation was inferred, not named', async () => {
+        const response = await request(app)
+          .post('/api/chat/agent-response')
+          .send({
+            content: '[COMPLETED] Agent ella: daily tech briefing posted',
+            senderName: 'ella',
+            senderType: 'agent',
+          });
+
+        // Still accepted and routed to the orchestrator — only the delivery
+        // watchdog association is suppressed.
+        expect(response.status).toBe(201);
+        expect(mockMarkPendingDelivery).not.toHaveBeenCalled();
+      });
     });
 
     it('should return 400 for missing senderName', async () => {

--- a/backend/src/controllers/chat/chat.controller.ts
+++ b/backend/src/controllers/chat/chat.controller.ts
@@ -369,7 +369,13 @@ export async function agentResponse(
 
     const chatService = getChatService();
 
-    // Resolve conversation: use provided ID or get/create the current one
+    // Resolve conversation: use provided ID or get/create the current one.
+    //
+    // Whether the caller NAMED the conversation matters downstream: the
+    // fallback below picks the globally-current conversation, which is a fine
+    // default for storing a message but is NOT evidence that this message
+    // belongs to that thread (issue #731).
+    const conversationIdWasExplicit = Boolean(conversationId);
     let resolvedConversationId = conversationId;
     if (!resolvedConversationId) {
       const current = await chatService.getCurrentConversation();
@@ -429,15 +435,30 @@ export async function agentResponse(
       // within the cadence, the enforcer will nudge it with
       // [DELIVER_REQUIRED]. The service no-ops on non-slack conversations
       // and on non-delivery markers (e.g. [IN_PROGRESS]).
+      //
+      // Only when the caller NAMED the thread (issue #731): a cron-driven
+      // daily task reports completion with no conversationId, so the fallback
+      // above hands back whatever thread happens to be globally current —
+      // typically some long-resolved thread. Tracking that as a pending
+      // delivery made the watchdog demand a deliverable in an unrelated thread
+      // every single day, and because markPendingDelivery re-arms the reminder
+      // counter, the nudges never aged out.
       try {
-        const { OrcDeliveryEnforcerService } = await import(
-          '../../services/orc/orc-delivery-enforcer.service.js'
-        );
-        OrcDeliveryEnforcerService.getInstance()?.markPendingDelivery({
-          conversationId: resolvedConversationId,
-          agentSender: senderName,
-          text: content,
-        });
+        if (conversationIdWasExplicit) {
+          const { OrcDeliveryEnforcerService } = await import(
+            '../../services/orc/orc-delivery-enforcer.service.js'
+          );
+          OrcDeliveryEnforcerService.getInstance()?.markPendingDelivery({
+            conversationId: resolvedConversationId,
+            agentSender: senderName,
+            text: content,
+          });
+        } else {
+          logger.debug('Skipping delivery tracking — conversation was inferred, not named', {
+            senderName,
+            conversationId: resolvedConversationId,
+          });
+        }
       } catch (enforcerErr) {
         logger.warn('OrcDeliveryEnforcer.markPendingDelivery threw (swallowed)', {
           error: enforcerErr instanceof Error ? enforcerErr.message : String(enforcerErr),

--- a/backend/src/controllers/cloud/cloud.controller.ts
+++ b/backend/src/controllers/cloud/cloud.controller.ts
@@ -663,7 +663,12 @@ export async function mobilePair(_req: Request, res: Response, next: NextFunctio
     const token = client.getToken();
     const cloudUrl = client.getCloudUrl();
 
-    let cloud: { cloudUrl: string; accessToken: string; userId: string | null } | null = null;
+    let cloud: {
+      cloudUrl: string;
+      accessToken: string;
+      refreshToken: string | null;
+      userId: string | null;
+    } | null = null;
     if (token && cloudUrl) {
       // Best-effort sub extraction (the relay pairing code derives from it).
       let userId: string | null = null;
@@ -674,7 +679,7 @@ export async function mobilePair(_req: Request, res: Response, next: NextFunctio
       } catch {
         userId = null;
       }
-      cloud = { cloudUrl, accessToken: token, userId };
+      cloud = { cloudUrl, accessToken: token, refreshToken: client.getRefreshToken(), userId };
     }
 
     res.json({

--- a/backend/src/services/agent/agent-registration.service.ts
+++ b/backend/src/services/agent/agent-registration.service.ts
@@ -357,11 +357,17 @@ export class AgentRegistrationService {
 					});
 					return;
 				}
+				// No metadata override here: processNotifyMessage already tags the
+				// turn `source: 'in-process-runtime'` — the canonical member of the
+				// closed RECORD_TURN_SOURCES enum for exactly this path. The old
+				// `'crewly-agent'` value was spread OVER that correct default and
+				// then failed enum validation, so every in-process reply to a web
+				// conversation was rejected with "unknown metadata.source" and
+				// silently dropped after the agent had already done the work.
 				return chatGateway.processNotifyMessage(
 					sessionName,
 					text,
 					conversationId,
-					{ source: 'crewly-agent' },
 				);
 			})
 			.then((chatMessage) => {

--- a/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.test.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../settings/settings.service.js', () => ({
 
 import { CrewlyAgentExternalRuntimeService } from './crewly-agent-external-runtime.service.js';
 import { CREWLY_AGENT_MANAGED_COMMAND } from '../../../constants.js';
+import { CREWLY_AGENT_DEFAULTS } from './types.js';
 
 // Pull the private allow-list regex via a typed escape hatch so we
 // can pin its behavior. Keeping it private on the class is the right
@@ -207,5 +208,281 @@ describe('CrewlyAgentExternalRuntimeService — public API contract', () => {
     expect(typeof proto['handleMessage']).toBe('function');
     expect(typeof proto['isReady']).toBe('function');
     expect(typeof proto['shutdown']).toBe('function');
+  });
+});
+
+/**
+ * IPC deadline + recycle — the 假死 (silent-catatonia) backstop.
+ *
+ * Regression cover for the production incident: `handleMessage` settled only
+ * on child IPC, so a child that stopped replying left the promise pending
+ * forever. Delivery is fire-and-forget, so the caller's .catch never ran
+ * either — the orchestrator sat silent for 12 days with no log line and no
+ * status reset. These tests pin that the parent now gives up and rebuilds the
+ * runtime.
+ */
+describe('CrewlyAgentExternalRuntimeService — IPC deadline and recycle', () => {
+  /** Escape hatch onto the private fields the deadline path touches. */
+  type Internals = {
+    initialized: boolean;
+    ready: boolean;
+    child: unknown;
+    pendingRuns: Map<string, unknown>;
+    handleWorkerMessage: (msg: unknown) => void;
+    currentSessionName: string | null;
+    storedConfig: unknown;
+    recycling: boolean;
+    resolveIpcTimeoutMs: () => number;
+    spawnAgentProcess: (config: unknown) => Promise<void>;
+    handleExit: (child: unknown, code: number | null, signal: string | null) => void;
+    startHeartbeat: (session: string) => void;
+  };
+
+  /** A child stub that accepts writes but never answers — the wedged shape. */
+  function makeSilentChild(): { killed: boolean; kill: jest.Mock; stdin: { writable: boolean; write: jest.Mock } } {
+    return {
+      killed: false,
+      kill: jest.fn(),
+      stdin: { writable: true, write: jest.fn() },
+    };
+  }
+
+  function makeService(modelId = 'deepseek-chat'): {
+    svc: CrewlyAgentExternalRuntimeService;
+    inner: Internals;
+  } {
+    const svc = new CrewlyAgentExternalRuntimeService({} as never, '/tmp/project');
+    const inner = svc as unknown as Internals;
+    inner.initialized = true;
+    inner.ready = true;
+    inner.currentSessionName = 'crewly-orc';
+    inner.storedConfig = { model: { provider: 'deepseek', modelId }, sessionName: 'crewly-orc' };
+    inner.child = makeSilentChild();
+    inner.startHeartbeat = jest.fn();
+    return { svc, inner };
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockGetSettings.mockResolvedValue(settingsWithCrewlyAgentCommand(undefined));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('waits longer than the child budget so the child reports its own timeout first', () => {
+    const { inner } = makeService('deepseek-chat');
+    expect(inner.resolveIpcTimeoutMs()).toBe(
+      CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS + CREWLY_AGENT_DEFAULTS.IPC_RUN_TIMEOUT_GRACE_MS,
+    );
+  });
+
+  it('applies the per-model budget when resolving the deadline', () => {
+    const { inner } = makeService('deepseek-reasoner');
+    expect(inner.resolveIpcTimeoutMs()).toBe(
+      CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['deepseek-reasoner']
+        + CREWLY_AGENT_DEFAULTS.IPC_RUN_TIMEOUT_GRACE_MS,
+    );
+  });
+
+  it('rejects instead of hanging forever when the child never replies', async () => {
+    const { svc, inner } = makeService();
+    inner.spawnAgentProcess = jest.fn().mockResolvedValue(undefined);
+
+    const pending = svc.handleMessage('are you alive?');
+    const assertion = expect(pending).rejects.toThrow(/did not reply within/);
+
+    await jest.advanceTimersByTimeAsync(inner.resolveIpcTimeoutMs() + 1);
+
+    await assertion;
+  });
+
+  it('recycles the wedged child so the session is usable again', async () => {
+    const { svc, inner } = makeService();
+    const spawn = jest.fn().mockResolvedValue(undefined);
+    inner.spawnAgentProcess = spawn;
+    const wedged = inner.child as ReturnType<typeof makeSilentChild>;
+
+    const pending = svc.handleMessage('are you alive?');
+    const assertion = expect(pending).rejects.toThrow(/Recycling it/);
+    await jest.advanceTimersByTimeAsync(inner.resolveIpcTimeoutMs() + 1);
+    await assertion;
+
+    expect(wedged.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(svc.isReady()).toBe(false); // spawn stubbed — no real child attached
+    expect(inner.initialized).toBe(true);
+  });
+
+  it('fails fast when the child stdin is already gone', async () => {
+    const { svc, inner } = makeService();
+    inner.spawnAgentProcess = jest.fn().mockResolvedValue(undefined);
+    (inner.child as ReturnType<typeof makeSilentChild>).stdin.writable = false;
+
+    // Rejects immediately — no timer advance needed.
+    await expect(svc.handleMessage('hello')).rejects.toThrow(/stdin is not writable/);
+  });
+
+  it('ignores the exit of a superseded child so it cannot kill its replacement', () => {
+    const { svc, inner } = makeService();
+    const oldChild = inner.child;
+    const replacement = makeSilentChild();
+    inner.child = replacement;
+
+    inner.handleExit(oldChild, 0, null);
+
+    // The replacement survives — before the identity guard, this late event
+    // nulled the healthy child and left the session permanently dead.
+    expect(inner.child).toBe(replacement);
+    expect(inner.initialized).toBe(true);
+  });
+});
+
+/**
+ * Run correlation — the crossed-wires bug.
+ *
+ * The runtime used to hold ONE resolve/reject pair. Delivery is
+ * fire-and-forget, so two messages dispatched milliseconds apart both wrote
+ * that pair: run A's handlers were overwritten (its promise orphaned forever)
+ * and run B was settled with run A's result. Seen live on 2026-08-07 — a Slack
+ * reply was booked against the wrong thread, the orphan later tripped the IPC
+ * deadline and recycled a healthy child, and the second message's real answer
+ * hit an already-cleared slot and was swallowed by `?.`.
+ */
+describe('CrewlyAgentExternalRuntimeService — concurrent run correlation', () => {
+  type Internals = {
+    initialized: boolean;
+    ready: boolean;
+    child: unknown;
+    currentSessionName: string | null;
+    storedConfig: unknown;
+    pendingRuns: Map<string, unknown>;
+    spawnAgentProcess: (config: unknown) => Promise<void>;
+    handleWorkerMessage: (msg: unknown) => void;
+    handleExit: (child: unknown, code: number | null, signal: string | null) => void;
+    startHeartbeat: (session: string) => void;
+  };
+
+  let svc: CrewlyAgentExternalRuntimeService;
+  let inner: Internals;
+  let writes: string[];
+
+  /** Reads the runIds the parent actually put on the wire, in order. */
+  function dispatchedRunIds(): string[] {
+    return writes
+      .map((w) => JSON.parse(w) as { type: string; runId?: string })
+      .filter((m) => m.type === 'run')
+      .map((m) => m.runId as string);
+  }
+
+  function result(text: string) {
+    return { text, steps: 1, toolCalls: [], usage: { input: 1, output: 1 } };
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockGetSettings.mockResolvedValue(settingsWithCrewlyAgentCommand(undefined));
+
+    writes = [];
+    svc = new CrewlyAgentExternalRuntimeService({} as never, '/tmp/project');
+    inner = svc as unknown as Internals;
+    inner.initialized = true;
+    inner.ready = true;
+    inner.currentSessionName = 'crewly-orc';
+    inner.storedConfig = { model: { provider: 'deepseek', modelId: 'deepseek-chat' }, sessionName: 'crewly-orc' };
+    inner.child = {
+      killed: false,
+      kill: jest.fn(),
+      stdin: { writable: true, write: jest.fn((chunk: string) => { writes.push(chunk); return true; }) },
+    };
+    inner.startHeartbeat = jest.fn();
+    inner.spawnAgentProcess = jest.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('settles each concurrent run with ITS OWN result', async () => {
+    const runA = svc.handleMessage('[CHAT:thread-a] question A');
+    const runB = svc.handleMessage('[CHAT:thread-b] question B');
+
+    const [idA, idB] = dispatchedRunIds();
+    expect(idA).toBeDefined();
+    expect(idB).toBeDefined();
+    expect(idA).not.toBe(idB);
+
+    // The child answers B first (it finished quicker) — correlation must not
+    // care about arrival order.
+    inner.handleWorkerMessage({ type: 'result', runId: idB, data: result('answer B') });
+    inner.handleWorkerMessage({ type: 'result', runId: idA, data: result('answer A') });
+
+    await expect(runA).resolves.toMatchObject({ text: 'answer A' });
+    await expect(runB).resolves.toMatchObject({ text: 'answer B' });
+  });
+
+  it('does not orphan the first run when a second is dispatched', async () => {
+    const runA = svc.handleMessage('first');
+    svc.handleMessage('second').catch(() => { /* settled by teardown below */ });
+
+    expect(inner.pendingRuns.size).toBe(2);
+
+    const [idA] = dispatchedRunIds();
+    inner.handleWorkerMessage({ type: 'result', runId: idA, data: result('A survived') });
+
+    await expect(runA).resolves.toMatchObject({ text: 'A survived' });
+  });
+
+  it('routes an error to the run it belongs to', async () => {
+    const runA = svc.handleMessage('will succeed');
+    const runB = svc.handleMessage('will fail');
+    const [idA, idB] = dispatchedRunIds();
+
+    inner.handleWorkerMessage({ type: 'error', runId: idB, error: 'boom' });
+    inner.handleWorkerMessage({ type: 'result', runId: idA, data: result('fine') });
+
+    await expect(runB).rejects.toThrow('boom');
+    await expect(runA).resolves.toMatchObject({ text: 'fine' });
+  });
+
+  it('falls back to the oldest run when the child echoes no runId', async () => {
+    // Back-compat: an older crewly-agent binary that does not know about
+    // correlation ids. The child is serial, so oldest-first is correct.
+    const runA = svc.handleMessage('older');
+    const runB = svc.handleMessage('newer');
+
+    inner.handleWorkerMessage({ type: 'result', data: result('for older') });
+    inner.handleWorkerMessage({ type: 'result', data: result('for newer') });
+
+    await expect(runA).resolves.toMatchObject({ text: 'for older' });
+    await expect(runB).resolves.toMatchObject({ text: 'for newer' });
+  });
+
+  it('fails EVERY in-flight run when the child process exits', async () => {
+    const runA = svc.handleMessage('one');
+    const runB = svc.handleMessage('two');
+    const assertions = Promise.all([
+      expect(runA).rejects.toThrow(/process exited/),
+      expect(runB).rejects.toThrow(/process exited/),
+    ]);
+
+    inner.handleExit(inner.child, 0, null);
+
+    await assertions;
+    expect(inner.pendingRuns.size).toBe(0);
+  });
+
+  it('reports a result that matches no pending run instead of dropping it', async () => {
+    const run = svc.handleMessage('only run');
+    const [id] = dispatchedRunIds();
+    inner.handleWorkerMessage({ type: 'result', runId: id, data: result('done') });
+    await expect(run).resolves.toMatchObject({ text: 'done' });
+
+    // A late/duplicate result with nothing waiting: must not throw, and must
+    // not vanish without a trace.
+    expect(() =>
+      inner.handleWorkerMessage({ type: 'result', runId: 'ghost', data: result('orphan') }),
+    ).not.toThrow();
   });
 });

--- a/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
+++ b/backend/src/services/agent/crewly-agent/crewly-agent-external-runtime.service.ts
@@ -34,17 +34,23 @@ import {
   type RuntimeType,
 } from '../../../constants.js';
 
+/** Handlers for one in-flight run, awaiting the child's reply. */
+interface PendingRun {
+  resolve: (result: AgentRunResult) => void;
+  reject: (error: Error) => void;
+}
+
 type ParentMessage =
   | { type: 'init'; config: CrewlyAgentConfig }
-  | { type: 'run'; message: string; conversationId?: string; metadata?: Record<string, string> }
+  | { type: 'run'; runId: string; message: string; conversationId?: string; metadata?: Record<string, string> }
   | { type: 'abort' }
   | { type: 'get-state' }
   | { type: 'shutdown' };
 
 type WorkerMessage =
   | { type: 'ready' }
-  | { type: 'result'; data: AgentRunResult }
-  | { type: 'error'; error: string; code?: string }
+  | { type: 'result'; runId?: string; data: AgentRunResult }
+  | { type: 'error'; runId?: string; error: string; code?: string }
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
   | { type: 'stream'; event: 'text'; data: { chunk: string } }
   | { type: 'stream'; event: 'toolStart'; data: { toolName: string; args: Record<string, unknown> } }
@@ -63,11 +69,26 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
   private logBuffer: InProcessLogBuffer;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private stdoutBuffer = '';
-  private pendingRunResolve: ((result: AgentRunResult) => void) | null = null;
-  private pendingRunReject: ((error: Error) => void) | null = null;
+  /**
+   * In-flight runs keyed by correlation id, in dispatch order.
+   *
+   * A single resolve/reject pair used to live here instead. Delivery is
+   * fire-and-forget, so two messages dispatched milliseconds apart both wrote
+   * that pair: the first run's handlers were overwritten and its promise was
+   * orphaned forever, while the second promise got settled with the FIRST
+   * run's result. Observed live — a reply meant for one Slack thread was
+   * booked against another, the orphan later tripped the IPC deadline and
+   * recycled a perfectly healthy child, and the second message's real answer
+   * was swallowed by the `?.` on an already-cleared slot.
+   */
+  private readonly pendingRuns = new Map<string, PendingRun>();
+  /** Monotonic source for run correlation ids. */
+  private runCounter = 0;
   private pendingInitResolve: (() => void) | null = null;
   private pendingInitReject: ((error: Error) => void) | null = null;
   private storedConfig: CrewlyAgentConfig | null = null;
+  /** Guard against overlapping {@link recycleChild} calls. */
+  private recycling = false;
   /**
    * Bound signal forwarder so we can register it on parent SIGINT/
    * SIGTERM/SIGHUP and detach the same identity on shutdown. Null
@@ -148,32 +169,162 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
 
     this.logBuffer.append(session, 'info', `← Message received (${cleanMessage.length} chars): ${cleanMessage.substring(0, 150)}`);
 
+    // Backstop deadline on the child's IPC reply.
+    //
+    // This promise settles ONLY when the child writes `result` or `error` to
+    // stdout. A child that can no longer write — blocked event loop, broken
+    // pipe, SIGSTOP — leaves it pending forever, and because delivery is
+    // fire-and-forget the caller's .then/.catch never run either: no log, no
+    // status reset, no alert. That is exactly how the orchestrator went
+    // silently catatonic for 12 days. The child enforces its own (shorter) run
+    // budget, so reaching this deadline means the child itself is gone-but-
+    // breathing — hence the recycle.
+    const timeoutMs = this.resolveIpcTimeoutMs();
+    const runId = `run-${++this.runCounter}-${Date.now().toString(36)}`;
+
     return await new Promise<AgentRunResult>((resolve, reject) => {
-      this.pendingRunResolve = async (result) => {
-        this.pendingRunResolve = null;
-        this.pendingRunReject = null;
+      const timer = setTimeout(() => {
+        this.pendingRuns.delete(runId);
+        const message =
+          `Crewly Agent did not reply within ${timeoutMs}ms — the runtime process is `
+          + `alive but unresponsive. Recycling it.`;
+        this.logBuffer.append(session, 'error', message);
+        this.logger.error('Crewly Agent IPC timeout — recycling wedged runtime', {
+          sessionName: session,
+          runId,
+          timeoutMs,
+        });
+        // Respawn before rejecting so the session is usable again by the time
+        // the caller handles the failure.
+        void this.recycleChild();
+        reject(new Error(message));
+      }, timeoutMs);
 
-        const textPreview = result.text ? result.text.substring(0, 150) : '(no text)';
-        this.logBuffer.append(session, 'info', `→ Response (${result.steps} steps, ${result.toolCalls.length} tools): ${textPreview}`);
-        this.logBuffer.append(session, 'debug', `  Tokens: ${result.usage.input}in/${result.usage.output}out`);
-        this.recordTokenUsageIfEnabled(session, result).catch(() => {});
-        resolve(result);
-      };
+      this.pendingRuns.set(runId, {
+        resolve: (result) => {
+          clearTimeout(timer);
+          this.pendingRuns.delete(runId);
 
-      this.pendingRunReject = (error) => {
-        this.pendingRunResolve = null;
-        this.pendingRunReject = null;
-        this.logBuffer.append(session, 'error', `Agent error: ${error.message}`);
-        reject(error);
-      };
-
-      this.sendMessage({
-        type: 'run',
-        message: cleanMessage,
-        conversationId,
-        metadata,
+          const textPreview = result.text ? result.text.substring(0, 150) : '(no text)';
+          this.logBuffer.append(session, 'info', `→ Response (${result.steps} steps, ${result.toolCalls.length} tools): ${textPreview}`);
+          this.logBuffer.append(session, 'debug', `  Tokens: ${result.usage.input}in/${result.usage.output}out`);
+          this.recordTokenUsageIfEnabled(session, result).catch(() => {});
+          resolve(result);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          this.pendingRuns.delete(runId);
+          this.logBuffer.append(session, 'error', `Agent error: ${error.message}`);
+          reject(error);
+        },
       });
+
+      try {
+        this.sendMessage({
+          type: 'run',
+          runId,
+          message: cleanMessage,
+          conversationId,
+          metadata,
+        });
+      } catch (sendError) {
+        // stdin already gone — fail now rather than idling until the deadline.
+        clearTimeout(timer);
+        this.pendingRuns.delete(runId);
+        reject(sendError instanceof Error ? sendError : new Error(String(sendError)));
+      }
     });
+  }
+
+  /**
+   * Settle the pending run a worker message belongs to.
+   *
+   * Correlates on `runId` when the child echoes one. Falls back to the OLDEST
+   * pending run when it does not — the child processes runs strictly serially
+   * (its own queue is FIFO), so the oldest outstanding request is the one being
+   * answered. The fallback keeps an older `crewly-agent` binary working.
+   *
+   * @param runId - Correlation id echoed by the child, if any
+   * @param settle - Applied to the matched run's handlers
+   * @returns True when a pending run was matched and settled
+   */
+  private settlePendingRun(
+    runId: string | undefined,
+    settle: (handlers: PendingRun) => void,
+  ): boolean {
+    let key = runId;
+    if (key === undefined || !this.pendingRuns.has(key)) {
+      // Map preserves insertion order — first key is the oldest run.
+      key = this.pendingRuns.keys().next().value;
+    }
+    if (key === undefined) return false;
+    const handlers = this.pendingRuns.get(key);
+    if (!handlers) return false;
+    settle(handlers);
+    return true;
+  }
+
+  /**
+   * Resolve how long the parent waits for the child's IPC reply.
+   *
+   * Deliberately the child's own run budget plus a grace window, so the child
+   * always gets to report its own timeout with proper context first; the parent
+   * timer only fires when the child has stopped reporting altogether.
+   *
+   * @returns Deadline in milliseconds
+   */
+  private resolveIpcTimeoutMs(): number {
+    const modelId = this.storedConfig?.model.modelId ?? '';
+    const childBudget =
+      CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS[modelId]
+      ?? CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS;
+    return childBudget + CREWLY_AGENT_DEFAULTS.IPC_RUN_TIMEOUT_GRACE_MS;
+  }
+
+  /**
+   * Replace a wedged child process with a fresh one.
+   *
+   * Without this, a single unresponsive child left the session permanently
+   * dead: `handleExit` nulls the child and clears `initialized`, and nothing
+   * ever spawned a replacement, so every later message failed the `isReady()`
+   * check for the lifetime of the backend process.
+   *
+   * Concurrent calls are collapsed — the delivery mutex serializes sends, but
+   * a process 'error' event can race the IPC deadline.
+   *
+   * @returns Resolves once the replacement is ready, or after logging a failure
+   */
+  private async recycleChild(): Promise<void> {
+    if (this.recycling) return;
+    const config = this.storedConfig;
+    const session = this.currentSessionName;
+    if (!config || !session) return;
+
+    this.recycling = true;
+    try {
+      const doomed = this.child;
+      // Drop the reference FIRST so the imminent 'exit' event is recognized as
+      // belonging to a superseded child and does not clobber the new one.
+      this.child = null;
+      this.ready = false;
+      this.stdoutBuffer = '';
+      if (doomed && !doomed.killed) {
+        try { doomed.kill('SIGKILL'); } catch { /* already gone */ }
+      }
+
+      await this.spawnAgentProcess(config);
+      this.initialized = true;
+      this.ready = true;
+      this.logBuffer.append(session, 'info', 'Crewly Agent runtime recycled after timeout');
+      this.logger.info('Crewly Agent runtime recycled', { sessionName: session });
+      this.startHeartbeat(session);
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      this.logBuffer.append(session, 'error', `Runtime recycle failed: ${errMsg}`);
+      this.logger.error('Crewly Agent runtime recycle failed', { sessionName: session, error: errMsg });
+    } finally {
+      this.recycling = false;
+    }
   }
 
   isReady(): boolean {
@@ -220,10 +371,31 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
     this.stdoutBuffer = '';
     this.pendingInitResolve = null;
     this.pendingInitReject = null;
-    this.pendingRunResolve = null;
-    this.pendingRunReject = null;
+    this.rejectAllPendingRuns(new Error('Crewly Agent runtime shut down'));
     this.currentSessionName = null;
     this.storedConfig = null;
+  }
+
+  /**
+   * Fail every in-flight run with the same cause.
+   *
+   * Used on teardown paths where the child is gone: leaving any pending run
+   * unsettled would strand its caller forever, which is precisely the silent
+   * hang this runtime has been hardened against.
+   *
+   * @param error - Cause reported to every waiting caller
+   */
+  private rejectAllPendingRuns(error: Error): void {
+    // Snapshot first — each reject() deletes its own entry from the map.
+    const handlers = [...this.pendingRuns.values()];
+    this.pendingRuns.clear();
+    for (const h of handlers) {
+      try {
+        h.reject(error);
+      } catch {
+        // A caller's rejection handler must not block the rest.
+      }
+    }
   }
 
   private async spawnAgentProcess(config: CrewlyAgentConfig): Promise<void> {
@@ -281,10 +453,15 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
 
     this.child.stdout.setEncoding('utf8');
     this.child.stderr.setEncoding('utf8');
-    this.child.stdout.on('data', (chunk: string) => this.handleStdout(chunk));
-    this.child.stderr.on('data', (chunk: string) => this.handleStderr(chunk));
-    this.child.on('exit', (code, signal) => this.handleExit(code, signal));
-    this.child.on('error', (error) => this.handleProcessError(error));
+    // Bind handlers to THIS child instance. A recycled runtime has an old
+    // process whose 'exit' fires after the replacement is already installed;
+    // without the identity check in the handlers, that late event would tear
+    // down the healthy new child.
+    const spawned = this.child;
+    spawned.stdout.on('data', (chunk: string) => this.handleStdout(chunk));
+    spawned.stderr.on('data', (chunk: string) => this.handleStderr(chunk));
+    spawned.on('exit', (code, signal) => this.handleExit(spawned, code, signal));
+    spawned.on('error', (error) => this.handleProcessError(spawned, error));
 
     // Forward parent termination signals to the child so PM2 restarts /
     // SIGINT / SIGTERM don't leave the agent process orphaned and
@@ -494,18 +671,34 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
           this.pendingInitReject = null;
         }
         break;
-      case 'result':
-        this.pendingRunResolve?.(message.data);
+      case 'result': {
+        const matched = this.settlePendingRun(message.runId, (h) => h.resolve(message.data));
+        if (!matched && session) {
+          // A result nobody is waiting for. Previously `?.` swallowed this
+          // silently; say so, because it means an answer was computed and
+          // then thrown away.
+          this.logBuffer.append(
+            session,
+            'warn',
+            `Discarded a result with no matching pending run (runId=${message.runId ?? 'none'})`,
+          );
+          this.logger.warn('Crewly Agent result had no matching pending run', {
+            sessionName: session,
+            runId: message.runId ?? null,
+          });
+        }
         break;
+      }
       case 'error': {
         const error = new Error(message.error);
         if (this.pendingInitReject) {
           this.pendingInitReject(error);
           this.pendingInitResolve = null;
           this.pendingInitReject = null;
-        } else if (this.pendingRunReject) {
-          this.pendingRunReject(error);
-        } else if (session) {
+          break;
+        }
+        const matched = this.settlePendingRun(message.runId, (h) => h.reject(error));
+        if (!matched && session) {
           this.logBuffer.append(session, 'error', message.error);
         }
         break;
@@ -542,7 +735,24 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
     }
   }
 
-  private handleExit(code: number | null, signal: NodeJS.Signals | null): void {
+  /**
+   * Handle child process exit.
+   *
+   * @param child - The process that exited; ignored when it is not the current
+   *   one (a superseded child from a recycle)
+   * @param code - Exit code, if any
+   * @param signal - Terminating signal, if any
+   */
+  private handleExit(
+    child: ChildProcessWithoutNullStreams,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    if (this.child !== child) {
+      // Superseded child finishing its death throes — its replacement owns the
+      // runtime state now.
+      return;
+    }
     // Clear initialized + detach signal handlers — the child is gone,
     // any tick-aligned work (heartbeat, signal forwarding) referring
     // to it would be writing to a corpse.
@@ -552,25 +762,29 @@ export class CrewlyAgentExternalRuntimeService extends RuntimeAgentService {
     this.detachSignalForwarders();
     const error = new Error(`Crewly Agent process exited (${code ?? 'null'}${signal ? `, ${signal}` : ''})`);
     if (this.pendingInitReject) this.pendingInitReject(error);
-    if (this.pendingRunReject) this.pendingRunReject(error);
     this.pendingInitResolve = null;
     this.pendingInitReject = null;
-    this.pendingRunResolve = null;
-    this.pendingRunReject = null;
+    // EVERY in-flight run dies with the process, not just the newest one.
+    this.rejectAllPendingRuns(error);
     if (this.currentSessionName) {
       this.logBuffer.append(this.currentSessionName, 'warn', error.message);
     }
     this.child = null;
   }
 
-  private handleProcessError(error: Error): void {
+  /**
+   * Handle a child process-level error (spawn failure, EPIPE, …).
+   *
+   * @param child - The process that errored; ignored when superseded
+   * @param error - The emitted error
+   */
+  private handleProcessError(child: ChildProcessWithoutNullStreams, error: Error): void {
+    if (this.child !== child) return;
     this.ready = false;
     if (this.pendingInitReject) this.pendingInitReject(error);
-    if (this.pendingRunReject) this.pendingRunReject(error);
     this.pendingInitResolve = null;
     this.pendingInitReject = null;
-    this.pendingRunResolve = null;
-    this.pendingRunReject = null;
+    this.rejectAllPendingRuns(error);
     if (this.currentSessionName) {
       this.logBuffer.append(this.currentSessionName, 'error', `Process error: ${error.message}`);
     }

--- a/backend/src/services/agent/crewly-agent/types.ts
+++ b/backend/src/services/agent/crewly-agent/types.ts
@@ -500,6 +500,15 @@ export const CREWLY_AGENT_DEFAULTS = {
   /** Soft warning threshold in milliseconds — logs a warning but does not kill the request.
    *  Override via CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS env var. */
   MESSAGE_SOFT_WARNING_MS: Number(process.env.CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS) || 240_000,
+  /** Grace period added on top of the agent's own run budget before the PARENT
+   *  gives up waiting on the child's IPC reply.
+   *
+   *  The child enforces the run budget itself and reports a clean error, so in
+   *  normal operation the parent timer never fires. It exists for the case the
+   *  child can no longer report at all — blocked event loop, broken stdout pipe,
+   *  SIGSTOP. The grace keeps the parent from racing the child and mislabelling
+   *  a normal in-budget timeout as a wedged runtime. */
+  IPC_RUN_TIMEOUT_GRACE_MS: 30_000,
   /** Cooldown period in milliseconds after rate limit retries are exhausted */
   RATE_LIMIT_COOLDOWN_MS: 300_000,
   /** Maximum number of automatic retries for recoverable errors (429, 5xx, network) */

--- a/backend/src/services/cloud/cloud-client.service.test.ts
+++ b/backend/src/services/cloud/cloud-client.service.test.ts
@@ -954,4 +954,13 @@ describe('CloudClientService', () => {
       expect(service.getRelayToken()).toBe('relay-original');
     });
   });
+
+  describe('getRefreshToken', () => {
+    it('returns the refresh token set via connectLocal and null after disconnect', async () => {
+      service.connectLocal(CLOUD_URL, TOKEN, 'pro' as any, 'rt-12345');
+      expect(service.getRefreshToken()).toBe('rt-12345');
+      await service.disconnect();
+      expect(service.getRefreshToken()).toBeNull();
+    });
+  });
 });

--- a/backend/src/services/cloud/cloud-client.service.ts
+++ b/backend/src/services/cloud/cloud-client.service.ts
@@ -642,6 +642,14 @@ export class CloudClientService {
   }
 
   /**
+   * Get the persisted refresh token (long-lived), or null when absent.
+   * Used by mobile-pair so the phone can auto-renew its adopted session.
+   */
+  getRefreshToken(): string | null {
+    return this.refreshToken;
+  }
+
+  /**
    * Register a callback to be invoked whenever the access token is refreshed.
    * Used by BrowserProxyService to update its relay auth token in real-time.
    *

--- a/backend/src/services/orchestrator/commitment-approval-guard.test.ts
+++ b/backend/src/services/orchestrator/commitment-approval-guard.test.ts
@@ -99,6 +99,30 @@ describe('evaluateColdLaunch', () => {
     const d = evaluateColdLaunch({ team: active, recentOwnerMessages: [] });
     expect(d.allowed).toBe(true);
   });
+
+  /**
+   * Issue #730 — an owner on a session that never persists chat messages
+   * cannot satisfy this gate with ANY wording. The old reason text blamed the
+   * phrasing, so orc and owner burned retry cycles hunting for a magic word.
+   */
+  describe('diagnosis when the channel records nothing (#730)', () => {
+    it('names the channel as the cause when zero owner messages were recorded', () => {
+      const d = evaluateColdLaunch({ team: dormant, recentOwnerMessages: [] });
+      expect(d.allowed).toBe(false);
+      expect(d.reason).toContain('channel problem, not a wording problem');
+      expect(d.reason).toMatch(/Slack.*Chat UI/s);
+    });
+
+    it('still blames wording when owner messages exist but none approve', () => {
+      const d = evaluateColdLaunch({
+        team: dormant,
+        recentOwnerMessages: ['要不要启动?', 'hold off for now'],
+      });
+      expect(d.allowed).toBe(false);
+      expect(d.reason).not.toContain('channel problem');
+      expect(d.reason).toContain('No such owner message was found');
+    });
+  });
 });
 
 describe('extractScheduleClaim', () => {

--- a/backend/src/services/orchestrator/commitment-approval-guard.ts
+++ b/backend/src/services/orchestrator/commitment-approval-guard.ts
@@ -169,6 +169,34 @@ export function evaluateColdLaunch(args: {
     return { allowed: true, evidence: approving };
   }
 
+  // Distinguish "wrong wording" from "this channel records nothing" (issue
+  // #730). When the window holds ZERO owner messages, the owner is almost
+  // certainly talking on a surface that never persists `sender_type='user'`
+  // rows — a bare orchestrator session with no `[CHAT:…]` wrapper. There, no
+  // phrasing can ever satisfy the gate, and the generic "no such message
+  // found" text sends both orc and owner into a pointless retry loop hunting
+  // for the magic word.
+  //
+  // The lookup deliberately stays chat-only: the guard's whole value is that
+  // the orchestrator cannot forge the evidence, and a session transcript is
+  // something the orchestrator writes. Widening the search would hand it the
+  // forgery it was built to prevent (2026-06-02 incident) — so we fix the
+  // diagnosis, not the trust boundary.
+  if (recentOwnerMessages.length === 0) {
+    return {
+      allowed: false,
+      reason:
+        'Cold-launching a dormant team requires an explicit owner approval, and ' +
+        'NO owner chat messages at all were recorded in the lookback window. This ' +
+        'is a channel problem, not a wording problem: approval must be given on a ' +
+        'surface that records owner messages (Slack, or the Chat UI). Approving ' +
+        'from a raw orchestrator session cannot satisfy this gate no matter how ' +
+        'it is phrased — the guard reads the owner\'s real chat history precisely ' +
+        'so the orchestrator cannot fabricate it. Ask the owner to send the ' +
+        'approval (启动/批准/go ahead/do it/proceed/approved) in Slack or the Chat UI.',
+    };
+  }
+
   return {
     allowed: false,
     reason:

--- a/backend/src/services/orchestrator/onboarding/materialize-team.integration.test.ts
+++ b/backend/src/services/orchestrator/onboarding/materialize-team.integration.test.ts
@@ -84,6 +84,33 @@ describe('materializeTeam — REAL provisioning (integration)', () => {
     expect(workers.some((w) => Array.isArray(w.skillOverrides) && w.skillOverrides.length > 0)).toBe(true);
   });
 
+  /**
+   * Issue #729 — three stub teams leaked into the developer's REAL
+   * `~/.crewly/teams` during a verification run. The live path called
+   * `StorageService.getInstance()` with no argument, so it resolved the ambient
+   * CREWLY_HOME and ignored the injected `teamsDir` completely: injection was a
+   * half-truth that only governed the fallback stub write.
+   */
+  it('persists the live team under the INJECTED root, not the ambient home', async () => {
+    const scratchHome = path.join(TMP_HOME, 'injected-root');
+
+    const result = await materializeTeam(softwareRec, {
+      teamsDir: path.join(scratchHome, 'teams'),
+      projectFlagPath: path.join(scratchHome, 'onboarding-complete.json'),
+    });
+    expect(result.provisioned).toBe(true);
+
+    // The team directory landed under the injected root.
+    const entries = await fs.readdir(path.join(scratchHome, 'teams'));
+    expect(entries).toContain(result.teamId);
+
+    // …and NOT under the ambient CREWLY_HOME the singleton would have picked.
+    const ambientTeams = await fs
+      .readdir(path.join(TMP_HOME, 'teams'))
+      .catch(() => [] as string[]);
+    expect(ambientTeams).not.toContain(result.teamId);
+  });
+
   it('flips the onboarding flag with the live team id', async () => {
     const flagPath = path.join(TMP_HOME, 'flag-2.json');
     const result = await materializeTeam(softwareRec, {

--- a/backend/src/services/orchestrator/onboarding/materialize-team.ts
+++ b/backend/src/services/orchestrator/onboarding/materialize-team.ts
@@ -152,7 +152,19 @@ export async function materializeTeam(
 ): Promise<MaterializeResult> {
   const now = opts.now ?? defaultNow;
   const log = opts.log ?? noopLog;
-  const provisionTeam = opts.provisionTeam ?? defaultProvisionTeam;
+  // Bind the live provisioner to the SAME root the caller injected (issue
+  // #729). `teamsDir` is `<crewlyHome>/teams`, so its parent is the home the
+  // storage layer must use. Without this the live path went through
+  // `StorageService.getInstance()` with no argument — resolving the ambient
+  // CREWLY_HOME and ignoring the injected root entirely. A verification run
+  // that carefully pointed `teamsDir` at a scratch dir still persisted live
+  // teams into the developer's real `~/.crewly/teams`, which is how three stub
+  // teams leaked there. In production `dirname(teamsDir)` IS the real home, so
+  // the cached singleton is returned unchanged.
+  const provisionTeam =
+    opts.provisionTeam
+    ?? ((rec, name, owner, parent) =>
+      defaultProvisionTeam(rec, name, owner, parent, path.dirname(opts.teamsDir)));
   const createdAt = now().toISOString();
   const teamName = humanizeTemplateName(recommendation.templateId);
 
@@ -234,6 +246,10 @@ export async function materializeTeam(
  * @param recommendation - The confirmed recommendation (carries `templateId`).
  * @param teamName - Human-readable team name to assign.
  * @param ownerUserId - Owner principal, or undefined for OSS single-user mode.
+ * @param parentTeamId - Parent team id for a nested child team, else undefined.
+ * @param storageHome - Crewly home the team must be persisted under. Passed
+ *   explicitly (never re-resolved from the environment) so an injected root is
+ *   honoured by the live path too — see issue #729.
  * @returns The persisted team id + member count, or `null` when the template
  *          is not registered (caller falls back to a minimal stub).
  * @throws Propagates a tier-gating error from `createTeamFromTemplate` (the
@@ -244,6 +260,7 @@ async function defaultProvisionTeam(
   teamName: string,
   ownerUserId: string | undefined,
   parentTeamId: string | undefined,
+  storageHome: string,
 ): Promise<ProvisionedTeam | null> {
   const { TemplateService } = await import('../../template/template.service.js');
   const { StorageService } = await import('../../core/storage.service.js');
@@ -265,7 +282,9 @@ async function defaultProvisionTeam(
     result.team.parentTeamId = parentTeamId;
   }
 
-  await StorageService.getInstance().saveTeam(result.team);
+  // Explicit home — see the binding comment in materializeTeam. A bare
+  // getInstance() here would silently re-resolve the ambient CREWLY_HOME.
+  await StorageService.getInstance(storageHome).saveTeam(result.team);
 
   return { teamId: result.team.id, memberCount: result.memberCount };
 }

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -11,6 +11,7 @@ import {
   reconcileRequestStatus,
   detectOrphanWorkItems,
   detectTTLExpiredWorkItems,
+  pickTTLExpiryTarget,
   detectUnverifiedWorkItems,
   DEFAULT_VERIFY_ESCALATE_MS,
   VERIFY_ESCALATED_AT_KEY,
@@ -27,7 +28,11 @@ import {
 import type { AgentHealth } from './reconcile-rules.js';
 import { createWorkItem, createRequest, createTaskClaim } from '../../types/v2/index.js';
 import type { WorkItem, WorkItemStatus, Request, TaskClaim } from '../../types/v2/index.js';
-import { WORK_ITEM_TRANSITIONS } from '../../types/v2/work-item.types.js';
+import {
+  WORK_ITEM_TRANSITIONS,
+  WORK_ITEM_STATUSES,
+  TERMINAL_WORK_ITEM_STATUSES,
+} from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -501,6 +506,111 @@ describe('detectTTLExpiredWorkItems', () => {
     for (const c of corrections) {
       expect(c.newState).toBe('cancelled');
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Request 13548bd5 (2026-08-20 Orca audit) — the `done_by_worker` fix above
+  // was never applied to its siblings. `rejected` and `failed` are equally
+  // non-terminal, equally absent from TERMINAL_WORK_ITEM_STATUSES, and equally
+  // lack a `→ cancelled` edge — so the TTL rule emitted an illegal correction
+  // for them on EVERY pass, forever, exactly as it had for `done_by_worker`.
+  // -------------------------------------------------------------------------
+  describe('legal-target invariant (Request 13548bd5)', () => {
+    const staleAt = () => new Date(Date.now() - 25 * 3600 * 1000).toISOString();
+
+    /**
+     * THE regression guard. Rather than enumerating the statuses that were
+     * broken when this was written, assert the INVARIANT over every status
+     * the type system knows about. A newly-added WorkItemStatus that has no
+     * legal terminal edge now fails this test at author time instead of
+     * throwing on every reconciler pass in production.
+     */
+    it('never emits an illegal transition for ANY non-terminal status', () => {
+      const nonTerminal = WORK_ITEM_STATUSES.filter(
+        (s) => !TERMINAL_WORK_ITEM_STATUSES.has(s),
+      );
+      // Guard the guard: if this ever hits zero the loop below is vacuous.
+      expect(nonTerminal.length).toBeGreaterThan(0);
+
+      for (const status of nonTerminal) {
+        const stale = makeWorkItem({ status, createdAt: staleAt() });
+        const { corrections } = detectTTLExpiredWorkItems([stale]);
+
+        // Either we skip the item entirely, or the correction we emit is a
+        // legal edge per the state machine. Never anything else.
+        for (const c of corrections) {
+          expect(WORK_ITEM_TRANSITIONS[status].has(c.newState as WorkItemStatus))
+            .toBe(true);
+          expect(TERMINAL_WORK_ITEM_STATUSES.has(c.newState as WorkItemStatus))
+            .toBe(true);
+        }
+      }
+    });
+
+    it('skips TTL-expired `rejected` items instead of emitting `rejected → cancelled`', () => {
+      const stale = makeWorkItem({ status: 'rejected', createdAt: staleAt() });
+
+      const { corrections, expiredIds } = detectTTLExpiredWorkItems([stale]);
+
+      expect(corrections).toHaveLength(0);
+      expect(expiredIds).toHaveLength(0);
+    });
+
+    it('skips TTL-expired `failed` items instead of emitting `failed → cancelled`', () => {
+      const stale = makeWorkItem({ status: 'failed', createdAt: staleAt() });
+
+      const { corrections, expiredIds } = detectTTLExpiredWorkItems([stale]);
+
+      expect(corrections).toHaveLength(0);
+      expect(expiredIds).toHaveLength(0);
+    });
+
+    it('still sweeps healthy statuses when a skipped status is in the same batch', () => {
+      // Regression on the `continue` placement: a skipped item must not
+      // short-circuit the rest of the batch.
+      const items = [
+        makeWorkItem({ status: 'rejected', createdAt: staleAt() }),
+        makeWorkItem({ status: 'queued', createdAt: staleAt() }),
+        makeWorkItem({ status: 'failed', createdAt: staleAt() }),
+        makeWorkItem({ status: 'running', createdAt: staleAt() }),
+      ];
+
+      const { corrections, expiredIds } = detectTTLExpiredWorkItems(items);
+
+      expect(corrections).toHaveLength(2);
+      expect(expiredIds).toHaveLength(2);
+      expect(corrections.map((c) => c.previousState).sort())
+        .toEqual(['queued', 'running']);
+      for (const c of corrections) {
+        expect(c.newState).toBe('cancelled');
+      }
+    });
+  });
+
+  describe('pickTTLExpiryTarget', () => {
+    it('returns a legal, strictly-terminal target or null for every status', () => {
+      for (const status of WORK_ITEM_STATUSES) {
+        const target = pickTTLExpiryTarget(status);
+        if (target === null) continue;
+        expect(WORK_ITEM_TRANSITIONS[status].has(target)).toBe(true);
+        expect(TERMINAL_WORK_ITEM_STATUSES.has(target)).toBe(true);
+      }
+    });
+
+    it('preserves the 2026-05-12 done_by_worker → verified behaviour', () => {
+      expect(pickTTLExpiryTarget('done_by_worker')).toBe('verified');
+    });
+
+    it('prefers `cancelled` over `done` for `running` (timeout is not completion)', () => {
+      // `running` permits both. A TTL sweep must never mark work as `done`.
+      expect(pickTTLExpiryTarget('running')).toBe('cancelled');
+    });
+
+    it('returns null for statuses whose only outbound edge is non-terminal', () => {
+      // `failed → queued` is the retry edge and is genuinely live; there is
+      // no terminal edge, so TTL must decline rather than invent one.
+      expect(pickTTLExpiryTarget('failed')).toBeNull();
+    });
   });
 });
 

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -1138,7 +1138,9 @@ describe('runPruningPass', () => {
     ];
 
     const result = runPruningPass(workItems, 24 * 3600000, 60 * 60 * 1000);
-    expect(result.ttlExpiredCount).toBe(1);
+    // ttl-1 is `queued`, so its TTL target is `cancelled` — real cleanup.
+    expect(result.ttlCancelledCount).toBe(1);
+    expect(result.ttlAutoVerifiedCount).toBe(0);
     expect(result.orphanCancelledCount).toBe(1);
     // stale-1 is stale (2h old), ttl-1 is also queued and old (25h) so it's also stale
     expect(result.staleQueuedCount).toBe(2);
@@ -1152,7 +1154,8 @@ describe('runPruningPass', () => {
     ];
 
     const result = runPruningPass(workItems);
-    expect(result.ttlExpiredCount).toBe(0);
+    expect(result.ttlCancelledCount).toBe(0);
+    expect(result.ttlAutoVerifiedCount).toBe(0);
     expect(result.orphanCancelledCount).toBe(0);
     expect(result.cascadeCancelledCount).toBe(0);
     expect(result.staleQueuedCount).toBe(0);
@@ -1218,7 +1221,8 @@ describe('runPruningPass', () => {
     const result = runPruningPass(items);
     // Fresh items, so nothing is TTL-expired — every correction here comes
     // from orphan/cascade, and none of them may be an accomplishment.
-    expect(result.ttlExpiredCount).toBe(0);
+    expect(result.ttlCancelledCount).toBe(0);
+    expect(result.ttlAutoVerifiedCount).toBe(0);
     expect(result.totalCorrections.length).toBeGreaterThan(0);
     for (const c of result.totalCorrections) {
       expect(c.newState).toBe('cancelled');
@@ -1240,8 +1244,10 @@ describe('runPruningPass', () => {
 
     const result = runPruningPass([parent, child]);
 
-    // Liveness: the TTL rule still acted on the parent.
-    expect(result.ttlExpiredCount).toBe(1);
+    // Liveness: the TTL rule still acted on the parent — as an ACCEPTANCE,
+    // which must never be reported under a cancellation counter.
+    expect(result.ttlAutoVerifiedCount).toBe(1);
+    expect(result.ttlCancelledCount).toBe(0);
     const parentCorrection = result.totalCorrections.find((c) => c.entityId === 'accepted-parent');
     expect(parentCorrection?.newState).toBe('verified');
     // Soundness: the child was NOT cascaded off it.
@@ -1262,9 +1268,49 @@ describe('runPruningPass', () => {
 
     const result = runPruningPass([parent, child]);
 
-    expect(result.ttlExpiredCount).toBe(1);
+    expect(result.ttlCancelledCount).toBe(1);
+    expect(result.ttlAutoVerifiedCount).toBe(0);
     expect(result.cascadeCancelledCount).toBe(1);
     expect(result.totalCorrections.find((c) => c.entityId === 'doomed-child')?.newState)
+      .toBe('cancelled');
+  });
+
+  it('partitions TTL outcomes: a `done_by_worker → verified` item is NOT counted as a cancellation', () => {
+    // The two TTL outcomes are opposites: `running → cancelled` DISCARDS the
+    // work, `done_by_worker → verified` ACCEPTS it. The old single
+    // `ttlExpiredCount` (= expiredIds.length) reported both as one number,
+    // and the reconciler folded that into `ReconcileResult.staleItemsCleaned`
+    // — so accepted work was reported to operators as thrown away.
+    const now = Date.now();
+    const accepted = makeWorkItem({
+      id: 'ttl-accepted',
+      status: 'done_by_worker',
+      createdAt: new Date(now - 25 * 3600000).toISOString(),
+    });
+    const discarded = makeWorkItem({
+      id: 'ttl-discarded',
+      status: 'running',
+      createdAt: new Date(now - 25 * 3600000).toISOString(),
+    });
+
+    const result = runPruningPass([accepted, discarded]);
+
+    // Exactly one of each, in the counter that matches its semantics.
+    expect(result.ttlCancelledCount).toBe(1);
+    expect(result.ttlAutoVerifiedCount).toBe(1);
+    // Unrelated items, so no cascade noise inflating the cleanup total.
+    expect(result.orphanCancelledCount).toBe(0);
+    expect(result.cascadeCancelledCount).toBe(0);
+
+    // The counters must partition the TTL corrections exactly — nothing
+    // double-counted, nothing silently dropped.
+    const ttlCorrections = result.totalCorrections.filter(
+      (c) => c.entityId === 'ttl-accepted' || c.entityId === 'ttl-discarded',
+    );
+    expect(result.ttlCancelledCount + result.ttlAutoVerifiedCount).toBe(ttlCorrections.length);
+    expect(result.totalCorrections.find((c) => c.entityId === 'ttl-accepted')?.newState)
+      .toBe('verified');
+    expect(result.totalCorrections.find((c) => c.entityId === 'ttl-discarded')?.newState)
       .toBe('cancelled');
   });
 });

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -12,6 +12,7 @@ import {
   detectOrphanWorkItems,
   detectTTLExpiredWorkItems,
   pickTTLExpiryTarget,
+  pickCascadeTarget,
   detectUnverifiedWorkItems,
   DEFAULT_VERIFY_ESCALATE_MS,
   VERIFY_ESCALATED_AT_KEY,
@@ -525,26 +526,58 @@ describe('detectTTLExpiredWorkItems', () => {
      * legal terminal edge now fails this test at author time instead of
      * throwing on every reconciler pass in production.
      */
-    it('never emits an illegal transition for ANY non-terminal status', () => {
+    /**
+     * THE regression guard, in BOTH directions.
+     *
+     * An earlier version of this test only asserted that emitted corrections
+     * were legal. That is soundness alone — it passes just as happily if the
+     * picker returns null for everything, or if detectTTLExpiredWorkItems is
+     * gutted to return no corrections at all. A rule that does nothing is
+     * trivially never illegal.
+     *
+     * So the expectation is DERIVED from the transition table rather than
+     * hand-listed, and both halves are asserted: every status that HAS a
+     * legal terminal edge must emit exactly one correction (liveness), and
+     * every correction must be a legal terminal edge (soundness).
+     */
+    it('emits exactly the statuses with a legal terminal edge, and only legal edges', () => {
+      const emitted = new Map<WorkItemStatus, WorkItemStatus>();
       const nonTerminal = WORK_ITEM_STATUSES.filter(
-        (s) => !TERMINAL_WORK_ITEM_STATUSES.has(s),
+        (st) => !TERMINAL_WORK_ITEM_STATUSES.has(st),
       );
-      // Guard the guard: if this ever hits zero the loop below is vacuous.
       expect(nonTerminal.length).toBeGreaterThan(0);
 
       for (const status of nonTerminal) {
-        const stale = makeWorkItem({ status, createdAt: staleAt() });
-        const { corrections } = detectTTLExpiredWorkItems([stale]);
+        const { corrections } = detectTTLExpiredWorkItems([
+          makeWorkItem({ status, createdAt: staleAt() }),
+        ]);
+        const hasTerminalEdge = [...WORK_ITEM_TRANSITIONS[status]]
+          .some((t) => TERMINAL_WORK_ITEM_STATUSES.has(t));
 
-        // Either we skip the item entirely, or the correction we emit is a
-        // legal edge per the state machine. Never anything else.
-        for (const c of corrections) {
-          expect(WORK_ITEM_TRANSITIONS[status].has(c.newState as WorkItemStatus))
-            .toBe(true);
-          expect(TERMINAL_WORK_ITEM_STATUSES.has(c.newState as WorkItemStatus))
-            .toBe(true);
-        }
+        // Liveness — the rule must still DO something where it legally can.
+        expect(corrections).toHaveLength(hasTerminalEdge ? 1 : 0);
+        if (!hasTerminalEdge) continue;
+
+        // Soundness — what it does must be legal AND terminal.
+        const to = corrections[0].newState as WorkItemStatus;
+        expect(WORK_ITEM_TRANSITIONS[status].has(to)).toBe(true);
+        expect(TERMINAL_WORK_ITEM_STATUSES.has(to)).toBe(true);
+        emitted.set(status, to);
       }
+
+      // Pin the exact shape so a silent widening or narrowing shows in the diff.
+      expect(Object.fromEntries(emitted)).toEqual({
+        queued: 'cancelled',
+        scheduled: 'cancelled',
+        proposed: 'cancelled',
+        accepted: 'cancelled',
+        running: 'cancelled',
+        blocked: 'cancelled',
+        escalated: 'cancelled',
+        done_by_worker: 'verified',
+      });
+      expect(emitted.has('rejected')).toBe(false);
+      expect(emitted.has('failed')).toBe(false);
     });
 
     it('skips TTL-expired `rejected` items instead of emitting `rejected → cancelled`', () => {
@@ -583,6 +616,304 @@ describe('detectTTLExpiredWorkItems', () => {
         .toEqual(['queued', 'running']);
       for (const c of corrections) {
         expect(c.newState).toBe('cancelled');
+      }
+    });
+  });
+
+  // Request 13548bd5 follow-through: the TTL rule was not the only site
+  // hardcoding `→ cancelled`. detectOrphanWorkItems and cascadeCancelChildren
+  // did too, reproducing the identical forever-throwing loop for orphaned
+  // children in `rejected` / `failed` / `done_by_worker`.
+  //
+  // The FIRST fix (469a3a21) routed both rules through `pickTTLExpiryTarget`.
+  // That stopped the throw but imported the TTL rule's time semantics, so a
+  // `done_by_worker` child was stamped `verified` the moment an unrelated
+  // ancestor died. These tests pin BOTH halves: the rule still fires where a
+  // cancel is legal (liveness), and it never emits a non-cancel outcome
+  // (soundness). A test that only checks "every emitted correction is legal"
+  // passes when the rule emits nothing at all — do not weaken these back to
+  // that shape.
+  describe('illegal-cancel guard in orphan + cascade rules', () => {
+    /** Non-terminal statuses that legally permit `→ cancelled`. */
+    const CANCELLABLE = WORK_ITEM_STATUSES.filter(
+      (st) => !TERMINAL_WORK_ITEM_STATUSES.has(st) && WORK_ITEM_TRANSITIONS[st].has('cancelled'),
+    );
+    /** Non-terminal statuses with NO `→ cancelled` edge — must be skipped. */
+    const NOT_CANCELLABLE = WORK_ITEM_STATUSES.filter(
+      (st) => !TERMINAL_WORK_ITEM_STATUSES.has(st) && !WORK_ITEM_TRANSITIONS[st].has('cancelled'),
+    );
+
+    /** Guards the table itself, so an empty sweep can never pass silently. */
+    it('the status table actually contains both cancellable and skippable statuses', () => {
+      expect(CANCELLABLE.length).toBeGreaterThan(0);
+      expect(NOT_CANCELLABLE.length).toBeGreaterThan(0);
+      // Pin today's shape so a transition-table edit surfaces here.
+      expect([...NOT_CANCELLABLE].sort()).toEqual(['done_by_worker', 'failed', 'rejected']);
+    });
+
+    const deadParent = () => makeWorkItem({
+      id: 'parent-dead', status: 'failed', retryCount: 3, maxRetries: 3,
+    });
+
+    it('detectOrphanWorkItems cancels every child whose status permits it (liveness)', () => {
+      const parent = deadParent();
+
+      for (const status of CANCELLABLE) {
+        const child = makeWorkItem({ status, parentWorkItemId: parent.id });
+        const map = new Map([[parent.id, parent], [child.id, child]]);
+        const { corrections, orphanIds } = detectOrphanWorkItems([child], map);
+
+        expect(corrections).toHaveLength(1);
+        expect(corrections[0].previousState).toBe(status);
+        expect(corrections[0].newState).toBe('cancelled');
+        expect(orphanIds).toEqual([child.id]);
+      }
+    });
+
+    it('detectOrphanWorkItems emits nothing for a child with no legal cancel edge (soundness)', () => {
+      const parent = deadParent();
+
+      for (const status of NOT_CANCELLABLE) {
+        const child = makeWorkItem({ status, parentWorkItemId: parent.id });
+        const map = new Map([[parent.id, parent], [child.id, child]]);
+        const { corrections, orphanIds } = detectOrphanWorkItems([child], map);
+
+        expect(corrections).toEqual([]);
+        expect(orphanIds).toEqual([]);
+      }
+    });
+
+    it('detectOrphanWorkItems never emits an illegal transition for any non-terminal child', () => {
+      const nonTerminal = WORK_ITEM_STATUSES.filter(
+        (st) => !TERMINAL_WORK_ITEM_STATUSES.has(st),
+      );
+      const parent = deadParent();
+      let emitted = 0;
+
+      for (const status of nonTerminal) {
+        const child = makeWorkItem({ status, parentWorkItemId: parent.id });
+        const map = new Map([[parent.id, parent], [child.id, child]]);
+        const { corrections } = detectOrphanWorkItems([child], map);
+
+        for (const c of corrections) {
+          expect(WORK_ITEM_TRANSITIONS[status].has(c.newState as WorkItemStatus)).toBe(true);
+          emitted++;
+        }
+      }
+      // Liveness floor: without this the loop above is vacuously true.
+      expect(emitted).toBe(CANCELLABLE.length);
+    });
+
+    it('skips a rejected orphan rather than emitting rejected → cancelled', () => {
+      const parent = deadParent();
+      const child = makeWorkItem({ status: 'rejected', parentWorkItemId: parent.id });
+      const map = new Map([[parent.id, parent], [child.id, child]]);
+
+      const { corrections } = detectOrphanWorkItems([child], map);
+      expect(corrections).toHaveLength(0);
+    });
+
+    it('cascadeCancelChildren cancels every child whose status permits it (liveness)', () => {
+      for (const status of CANCELLABLE) {
+        const child = makeWorkItem({ status, parentWorkItemId: 'ancestor-1' });
+        const { corrections, cascadedIds } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+        expect(corrections).toHaveLength(1);
+        expect(corrections[0].previousState).toBe(status);
+        expect(corrections[0].newState).toBe('cancelled');
+        expect(cascadedIds).toEqual([child.id]);
+      }
+    });
+
+    it('cascadeCancelChildren emits nothing for a child with no legal cancel edge (soundness)', () => {
+      for (const status of NOT_CANCELLABLE) {
+        const child = makeWorkItem({ status, parentWorkItemId: 'ancestor-1' });
+        const { corrections, cascadedIds } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+        expect(corrections).toEqual([]);
+        expect(cascadedIds).toEqual([]);
+      }
+    });
+
+    it('cascadeCancelChildren never emits an illegal transition for any non-terminal child', () => {
+      const nonTerminal = WORK_ITEM_STATUSES.filter(
+        (st) => !TERMINAL_WORK_ITEM_STATUSES.has(st),
+      );
+      let emitted = 0;
+
+      for (const status of nonTerminal) {
+        const child = makeWorkItem({ status, parentWorkItemId: 'ancestor-1' });
+        const { corrections } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+        for (const c of corrections) {
+          expect(WORK_ITEM_TRANSITIONS[status].has(c.newState as WorkItemStatus)).toBe(true);
+          emitted++;
+        }
+      }
+      expect(emitted).toBe(CANCELLABLE.length);
+    });
+
+    it('still cascades a queued child (guard must not disable the rule)', () => {
+      const child = makeWorkItem({ status: 'queued', parentWorkItemId: 'ancestor-1' });
+      const { corrections } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+      expect(corrections).toHaveLength(1);
+      expect(corrections[0].newState).toBe('cancelled');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // The defect this branch's second round exists to remove.
+  // -------------------------------------------------------------------------
+  describe('TTL time-semantics must not leak into orphan/cascade', () => {
+    /**
+     * `pickTTLExpiryTarget('done_by_worker') → 'verified'` is a deliberate
+     * TIME judgement: 24h with nobody objecting counts as implicit acceptance.
+     * Orphan and cascade have no time dimension — they fire the instant a dead
+     * ancestor is reconciled. Sharing the picker meant seconds-old, entirely
+     * unreviewed work was auto-accepted because something unrelated upstream
+     * failed.
+     */
+    it('a ~1s-old done_by_worker child under a permanently-failed parent produces NO correction', () => {
+      const parent = makeWorkItem({
+        id: 'parent-dead', status: 'failed', retryCount: 3, maxRetries: 3,
+      });
+      const child = makeWorkItem({
+        id: 'child-fresh',
+        status: 'done_by_worker',
+        parentWorkItemId: parent.id,
+        createdAt: new Date(Date.now() - 1000).toISOString(),
+      });
+      const map = new Map([[parent.id, parent], [child.id, child]]);
+
+      const { corrections, orphanIds } = detectOrphanWorkItems([child], map);
+
+      expect(corrections).toEqual([]);
+      expect(orphanIds).toEqual([]);
+      // The point of the regression: it must not be auto-accepted.
+      expect(corrections.map((c) => c.newState)).not.toContain('verified');
+    });
+
+    it('cascadeCancelChildren never auto-verifies a fresh done_by_worker descendant', () => {
+      const child = makeWorkItem({
+        id: 'child-fresh',
+        status: 'done_by_worker',
+        parentWorkItemId: 'ancestor-1',
+        createdAt: new Date(Date.now() - 1000).toISOString(),
+      });
+
+      const { corrections, cascadedIds } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+      expect(corrections).toEqual([]);
+      expect(cascadedIds).toEqual([]);
+    });
+
+    it('a skipped done_by_worker child does not stop its cancellable sibling being cancelled', () => {
+      // Liveness guard on the `continue`: skipping one child must not abort
+      // the sweep for the rest of the generation.
+      const parent = makeWorkItem({
+        id: 'parent-dead', status: 'failed', retryCount: 3, maxRetries: 3,
+      });
+      const unreviewed = makeWorkItem({
+        id: 'child-dbw', status: 'done_by_worker', parentWorkItemId: parent.id,
+      });
+      const live = makeWorkItem({ id: 'child-running', status: 'running', parentWorkItemId: parent.id });
+      const map = new Map<string, WorkItem>([
+        [parent.id, parent], [unreviewed.id, unreviewed], [live.id, live],
+      ]);
+
+      const { corrections, orphanIds } = detectOrphanWorkItems([unreviewed, live], map);
+
+      expect(orphanIds).toEqual(['child-running']);
+      expect(corrections).toHaveLength(1);
+      expect(corrections[0].newState).toBe('cancelled');
+    });
+
+    it('a skipped done_by_worker child keeps its own descendants alive (no phantom ancestor)', () => {
+      // `cascadedIds` doubles as the next generation of dead ancestors. If a
+      // skipped child were pushed anyway, its grandchildren would be cancelled
+      // off a parent that was never cancelled.
+      const unreviewed = makeWorkItem({
+        id: 'child-dbw', status: 'done_by_worker', parentWorkItemId: 'ancestor-1',
+      });
+      const grandchild = makeWorkItem({
+        id: 'grandchild', status: 'running', parentWorkItemId: 'child-dbw',
+      });
+
+      const { corrections, cascadedIds } = cascadeCancelChildren(
+        new Set(['ancestor-1']),
+        [unreviewed, grandchild],
+      );
+
+      expect(cascadedIds).toEqual([]);
+      expect(corrections).toEqual([]);
+    });
+
+    it('cascade reason/evidence are DERIVED from the actual newState', () => {
+      // A `toContain(newState)` check is too weak to catch this: the old
+      // hardcoded "Cascade cancel: ancestor WorkItem was cancelled/failed"
+      // contains the substring "cancelled" by accident. Pin the derivation.
+      const child = makeWorkItem({ id: 'c1', status: 'running', parentWorkItemId: 'ancestor-1' });
+      const { corrections } = cascadeCancelChildren(new Set(['ancestor-1']), [child]);
+
+      const c = corrections[0];
+      expect(c.reason.startsWith(`Cascade ${c.newState}`)).toBe(true);
+      // Evidence must record the transition that was actually chosen.
+      expect(c.evidence).toContain(`${c.previousState} → ${c.newState}`);
+    });
+
+    it('orphan reason/evidence are DERIVED from the actual newState', () => {
+      const parent = makeWorkItem({
+        id: 'parent-dead', status: 'failed', retryCount: 3, maxRetries: 3,
+      });
+      const child = makeWorkItem({ id: 'c1', status: 'running', parentWorkItemId: parent.id });
+      const map = new Map([[parent.id, parent], [child.id, child]]);
+      const { corrections } = detectOrphanWorkItems([child], map);
+
+      const c = corrections[0];
+      expect(c.evidence.startsWith(`Orphan ${c.newState}`)).toBe(true);
+      expect(c.evidence).not.toContain('Cascade cancel');
+      // The reason still names the parent that caused it.
+      expect(c.reason).toContain(parent.id);
+    });
+  });
+
+  describe('pickCascadeTarget', () => {
+    it('returns `cancelled` or null for every status — never an accomplishment', () => {
+      for (const status of WORK_ITEM_STATUSES) {
+        const target = pickCascadeTarget(status);
+        expect(target === null || target === 'cancelled').toBe(true);
+        if (target === null) continue;
+        expect(WORK_ITEM_TRANSITIONS[status].has(target)).toBe(true);
+        expect(TERMINAL_WORK_ITEM_STATUSES.has(target)).toBe(true);
+      }
+    });
+
+    it('cancels the statuses a cascade legitimately owns (liveness)', () => {
+      expect(pickCascadeTarget('running')).toBe('cancelled');
+      expect(pickCascadeTarget('queued')).toBe('cancelled');
+      expect(pickCascadeTarget('blocked')).toBe('cancelled');
+      expect(pickCascadeTarget('escalated')).toBe('cancelled');
+    });
+
+    it('declines done_by_worker instead of auto-accepting it', () => {
+      expect(pickCascadeTarget('done_by_worker')).toBeNull();
+    });
+
+    it('declines rejected and failed, consistent with the TTL rule', () => {
+      expect(pickCascadeTarget('rejected')).toBeNull();
+      expect(pickCascadeTarget('failed')).toBeNull();
+    });
+
+    it('diverges from pickTTLExpiryTarget exactly where time semantics apply', () => {
+      // The whole reason the two pickers exist separately.
+      expect(pickTTLExpiryTarget('done_by_worker')).toBe('verified');
+      expect(pickCascadeTarget('done_by_worker')).toBeNull();
+      // Everywhere a cancel is legal they agree.
+      for (const status of WORK_ITEM_STATUSES) {
+        if (pickCascadeTarget(status) === 'cancelled') {
+          expect(pickTTLExpiryTarget(status)).toBe('cancelled');
+        }
       }
     });
   });
@@ -869,6 +1200,72 @@ describe('runPruningPass', () => {
 
     const result = runPruningPass([parent, child]);
     expect(result.orphanCancelledCount).toBe(1);
+  });
+
+  it('never emits a `verified` correction from the orphan or cascade rules', () => {
+    // `verified` may only ever originate from the TTL rule's 24h
+    // implicit-acceptance fallback. Anything else is unreviewed work being
+    // rubber-stamped. Pin it at the aggregate level so a future rule wired
+    // into the pruning pass cannot reintroduce it unnoticed.
+    const deadParent = makeWorkItem({
+      id: 'dead', status: 'failed', retryCount: 3, maxRetries: 3,
+    });
+    const items: WorkItem[] = [deadParent];
+    for (const status of WORK_ITEM_STATUSES) {
+      items.push(makeWorkItem({ id: `child-${status}`, status, parentWorkItemId: 'dead' }));
+    }
+
+    const result = runPruningPass(items);
+    // Fresh items, so nothing is TTL-expired — every correction here comes
+    // from orphan/cascade, and none of them may be an accomplishment.
+    expect(result.ttlExpiredCount).toBe(0);
+    expect(result.totalCorrections.length).toBeGreaterThan(0);
+    for (const c of result.totalCorrections) {
+      expect(c.newState).toBe('cancelled');
+    }
+  });
+
+  it('a TTL auto-verified parent does not cascade-cancel its children', () => {
+    // `detectTTLExpiredWorkItems` emits `done_by_worker → verified` after 24h.
+    // Seeding the cascade set from the raw expired-id list treated that
+    // ACCEPTED parent as a dead ancestor and killed its live children —
+    // the same "cancelled off a parent that was never cancelled" defect.
+    const now = Date.now();
+    const parent = makeWorkItem({
+      id: 'accepted-parent',
+      status: 'done_by_worker',
+      createdAt: new Date(now - 25 * 3600000).toISOString(),
+    });
+    const child = makeWorkItem({ id: 'live-child', status: 'running', parentWorkItemId: 'accepted-parent' });
+
+    const result = runPruningPass([parent, child]);
+
+    // Liveness: the TTL rule still acted on the parent.
+    expect(result.ttlExpiredCount).toBe(1);
+    const parentCorrection = result.totalCorrections.find((c) => c.entityId === 'accepted-parent');
+    expect(parentCorrection?.newState).toBe('verified');
+    // Soundness: the child was NOT cascaded off it.
+    expect(result.cascadeCancelledCount).toBe(0);
+    expect(result.totalCorrections.find((c) => c.entityId === 'live-child')).toBeUndefined();
+  });
+
+  it('a TTL-cancelled parent still cascade-cancels its children', () => {
+    // Companion to the test above: filtering the seed set must not disable
+    // the genuine TTL → cascade chain.
+    const now = Date.now();
+    const parent = makeWorkItem({
+      id: 'ttl-dead-parent',
+      status: 'running',
+      createdAt: new Date(now - 25 * 3600000).toISOString(),
+    });
+    const child = makeWorkItem({ id: 'doomed-child', status: 'running', parentWorkItemId: 'ttl-dead-parent' });
+
+    const result = runPruningPass([parent, child]);
+
+    expect(result.ttlExpiredCount).toBe(1);
+    expect(result.cascadeCancelledCount).toBe(1);
+    expect(result.totalCorrections.find((c) => c.entityId === 'doomed-child')?.newState)
+      .toBe('cancelled');
   });
 });
 

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -290,6 +290,74 @@ export function reconcileRequestStatus(
 }
 
 // ---------------------------------------------------------------------------
+// Cascade Target Picker (shared by the orphan + deep-cascade rules)
+// ---------------------------------------------------------------------------
+
+/**
+ * Preference order used when choosing a CASCADE target.
+ *
+ * Deliberately cancel-only. See {@link pickCascadeTarget} for why this list
+ * must never grow an "accomplishment" outcome such as `verified` or `done`.
+ */
+const CASCADE_TARGET_PREFERENCE: readonly WorkItemStatus[] = ['cancelled'] as const;
+
+/**
+ * Pick a state-machine-legal target for a WorkItem being cascade-cancelled
+ * because an ancestor died, or `null` when no legal target exists.
+ *
+ * Table-driven off {@link WORK_ITEM_TRANSITIONS} for the same reason the TTL
+ * picker is ({@link pickTTLExpiryTarget}): hardcoding `→ cancelled` per rule
+ * has already caused the same forever-throwing production loop twice, because
+ * a fix applied at one call site was never applied to its siblings. Adding a
+ * new {@link WorkItemStatus} can therefore only ever make cascade *skip* an
+ * item — inert — never emit an edge the state machine rejects on every pass.
+ *
+ * **Why this is NOT `pickTTLExpiryTarget`.** Commit 469a3a21 routed both
+ * cascade rules through the TTL picker to close the illegal-edge bug. That
+ * fixed the crash but imported a semantic that does not belong here. The TTL
+ * picker falls back to `verified` for `done_by_worker` on purpose: a TTL
+ * expiry means "24h elapsed with nobody objecting", and treating silence as
+ * implicit acceptance is a defensible reading of a 24h-old review request.
+ *
+ * Cascade has no time dimension whatsoever. It fires the instant a dead
+ * ancestor is reconciled. Borrowing the TTL fallback meant a child that
+ * entered `done_by_worker` one second ago was stamped `verified` — TL-
+ * unreviewed work auto-accepted with no age gate, no verdict, and no TL —
+ * precisely the invariant `ReconcilerService.runFull` orders
+ * {@link detectUnverifiedWorkItems} ahead of the pruning pass to protect.
+ * An unrelated ancestor failing is not evidence that a child's output is good.
+ *
+ * So cascade declines instead. `done_by_worker`, `rejected` and `failed` all
+ * return `null` and are left untouched, which is consistent with what the TTL
+ * rule already does for `rejected` / `failed`: no legal *cancel* edge means no
+ * correction, not a different correction. Those statuses own their own
+ * lifecycles (TL verdict, retry, escalation); a cascade sweep is not entitled
+ * to resolve them.
+ *
+ * @param current - Current WorkItem status
+ * @returns `'cancelled'` when that edge is legal from `current`, else `null`
+ *   (the caller must skip the item and emit no correction)
+ *
+ * @example
+ * ```typescript
+ * pickCascadeTarget('running');        // 'cancelled'
+ * pickCascadeTarget('done_by_worker'); // null → skip; never auto-accept
+ * pickCascadeTarget('rejected');       // null → skip
+ * ```
+ */
+export function pickCascadeTarget(current: WorkItemStatus): WorkItemStatus | null {
+  const legalTargets = WORK_ITEM_TRANSITIONS[current];
+  if (!legalTargets) return null;
+
+  for (const candidate of CASCADE_TARGET_PREFERENCE) {
+    if (TERMINAL_WORK_ITEM_STATUSES.has(candidate) && legalTargets.has(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Rule: Detect Orphan WorkItems
 // ---------------------------------------------------------------------------
 
@@ -343,14 +411,27 @@ export function detectOrphanWorkItems(
     if (!parent) continue;
 
     if (isParentPermanentlyTerminal(parent)) {
+      // `→ cancelled` is NOT legal from every non-terminal status
+      // (`rejected` / `failed` only permit `→ queued`; `done_by_worker`
+      // only `→ verified` / `→ rejected`). Hardcoding `cancelled` here
+      // reproduced Request 13548bd5's forever-throwing loop for orphaned
+      // children. Route through the CANCEL-ONLY picker — NOT the TTL one,
+      // which would auto-`verified` a `done_by_worker` child on the strength
+      // of an unrelated ancestor dying. See {@link pickCascadeTarget}.
+      const orphanTarget = pickCascadeTarget(wi.status);
+      if (orphanTarget === null) continue;
       corrections.push(createCorrection({
         entityType: 'work_item',
         entityId: wi.id,
         previousState: wi.status,
-        newState: 'cancelled',
+        newState: orphanTarget,
         reason: `Parent WorkItem ${parent.id} is ${parent.status} (permanent: retries ${parent.retryCount}/${parent.maxRetries})`,
-        evidence: `Cascade cancel: parent.status=${parent.status}, parent.retryCount=${parent.retryCount}/${parent.maxRetries}, child.status=${wi.status}`,
+        evidence: `Orphan ${orphanTarget}: parent.status=${parent.status}, parent.retryCount=${parent.retryCount}/${parent.maxRetries}, child.status=${wi.status}`,
       }));
+      // Only genuinely cancelled ids may enter `orphanIds`. The list seeds
+      // the deep-cascade set in `runPruningPass`, so pushing a
+      // non-`cancelled` outcome here would cascade-cancel the descendants of
+      // a parent that was never cancelled.
       orphanIds.push(wi.id);
     }
   }
@@ -388,6 +469,15 @@ const TTL_EXPIRY_TARGET_PREFERENCE: readonly WorkItemStatus[] = [
  * Pick a state-machine-legal terminal status for a TTL-expired WorkItem,
  * or `null` when no legal terminal target exists.
  *
+ * **Scope: the TTL rule only.** The `verified` fallback below encodes a TIME
+ * semantic — "24h elapsed with nobody objecting, treat silence as implicit
+ * acceptance" — which is only defensible because a TTL expiry *is* the passage
+ * of time. Rules with no time dimension must NOT borrow this picker; commit
+ * 469a3a21 briefly shared it with the orphan + deep-cascade rules and that
+ * silently auto-`verified` seconds-old `done_by_worker` children whenever an
+ * unrelated ancestor failed. Those rules use {@link pickCascadeTarget}, which
+ * is cancel-only. Read that JSDoc before wiring a third caller into this one.
+ *
  * This picker is TABLE-DRIVEN off {@link WORK_ITEM_TRANSITIONS} rather
  * than hardcoded per-status branches. That is deliberate: the hardcoded
  * form has now caused the same production incident twice, because a fix
@@ -411,24 +501,34 @@ const TTL_EXPIRY_TARGET_PREFERENCE: readonly WorkItemStatus[] = [
  *    same forever-throwing loop recurred for them (Request 13548bd5,
  *    surfaced by the 2026-08-20 Orca audit).
  *
- * The table-driven form closes the whole bug class: a status can only
- * receive a target the transition matrix actually permits, and a status
- * with no legal terminal target is skipped rather than corrected into an
- * exception. Adding a new {@link WorkItemStatus} can no longer silently
+ * The table-driven form closes this bug class **for the TTL rule**: a status
+ * can only receive a target the transition matrix actually permits, and a
+ * status with no legal terminal target is skipped rather than corrected into
+ * an exception. Adding a new {@link WorkItemStatus} can no longer silently
  * reintroduce this — worst case the new status is skipped by TTL, which
  * is inert, instead of throwing on every reconciler pass forever.
  *
- * `null` results (currently `rejected` and `failed`) are intentional and
- * safe, NOT a leak:
- * - `failed` has its own lifecycle — {@link detectRetryableFailedWorkItems}
- *   re-queues it while retries remain, and `V3DataService.onTaskFailed`
- *   escalates it to the orchestrator once the retry budget is spent.
- * - `rejected` has its own lifecycle — `EventToWorkItemBridge`'s
- *   `task:rejected` handler spawns either a retry WorkItem or a TL
- *   escalation WorkItem; the source WI is meant to stay `rejected` as an
- *   audit record.
- * Neither needs the TTL sweeper, and forcing a target on either produces
- * an illegal edge, not a cleanup.
+ * `null` results (currently `rejected` and `failed`) are intentional — the
+ * alternative is an illegal edge, not a cleanup. Both statuses have their own
+ * lifecycle, though NEITHER is fully covered today; see the caveats, which are
+ * tracked as follow-ups rather than silently assumed away:
+ *
+ * - `failed`: {@link detectRetryableFailedWorkItems} re-queues it while
+ *   retries remain, and `V3DataService.onTaskFailed` escalates it to the
+ *   orchestrator once the budget is spent. CAVEAT: that escalation only fires
+ *   for failures arriving via the `v3:task_failed` event. A WI that reaches
+ *   `failed` another way (direct `failItem`, the SLA `pickFailTarget`
+ *   `running → failed` path, reconciler-driven failures) with
+ *   `retryCount >= maxRetries` currently has no lifecycle at all.
+ * - `rejected`: `EventToWorkItemBridge`'s `task:rejected` handler spawns a
+ *   retry or TL-escalation WorkItem, and the source stays `rejected` as an
+ *   audit record. CAVEAT: `verifyItem` is the only publisher of
+ *   `task:rejected`, so rejections arriving via
+ *   `RequestSlaSubscriber.failOrphanRespondWi` produce no successor and
+ *   currently strand.
+ *
+ * Skipping them here is still correct: the TTL sweeper cannot legally act on
+ * either, so these gaps belong to the owning lifecycles, not to this rule.
  *
  * @param current - Current (non-terminal) WorkItem status
  * @returns A legal terminal status for TTL expiry, or `null` when the
@@ -662,14 +762,25 @@ export function cascadeCancelChildren(
       if (!wi.parentWorkItemId) continue;
 
       if (cancelledIds.has(wi.parentWorkItemId) || cascadedIds.includes(wi.parentWorkItemId)) {
+        // See the orphan rule above — `→ cancelled` is not legal from
+        // every non-terminal status. Skip children the state machine
+        // gives no legal cancel edge for instead of emitting a correction
+        // that throws on every pass. Cancel-only by construction: a dead
+        // ancestor is not a verdict on a `done_by_worker` child's output.
+        const cascadeTarget = pickCascadeTarget(wi.status);
+        if (cascadeTarget === null) continue;
         corrections.push(createCorrection({
           entityType: 'work_item',
           entityId: wi.id,
           previousState: wi.status,
-          newState: 'cancelled',
-          reason: `Cascade cancel: ancestor WorkItem was cancelled/failed`,
-          evidence: `parentWorkItemId=${wi.parentWorkItemId} is in cancelled set`,
+          newState: cascadeTarget,
+          reason: `Cascade ${cascadeTarget}: ancestor WorkItem was cancelled/failed`,
+          evidence: `parentWorkItemId=${wi.parentWorkItemId} is in cancelled set, child.status=${wi.status} → ${cascadeTarget}`,
         }));
+        // Only genuinely cancelled ids may enter `cascadedIds` — the loop
+        // below treats this list as the next generation of dead ancestors,
+        // so a non-`cancelled` entry would cancel grandchildren off a parent
+        // that is still very much alive.
         cascadedIds.push(wi.id);
         changed = true;
       }
@@ -805,9 +916,22 @@ export function runPruningPass(
       cancelledIds.add(wi.id);
     }
   }
-  // Include newly detected TTL + orphan IDs
-  for (const id of ttl.expiredIds) cancelledIds.add(id);
-  for (const id of orphans.orphanIds) cancelledIds.add(id);
+  // Include newly detected TTL + orphan IDs — but ONLY those whose correction
+  // is actually `→ cancelled`. `detectTTLExpiredWorkItems` also emits
+  // `done_by_worker → verified` (the 24h implicit-acceptance fallback), and a
+  // `verified` parent is NOT a dead ancestor: `isParentPermanentlyTerminal`
+  // above deliberately counts only `cancelled` / permanently-`failed`. Seeding
+  // the cascade set from the raw id list contradicted that definition and
+  // cancelled the descendants of a parent that had just been ACCEPTED.
+  // `orphans.orphanIds` is cancel-only by construction (see
+  // {@link pickCascadeTarget}) but is filtered the same way so the invariant
+  // is enforced here rather than assumed from a callee.
+  for (const c of ttl.corrections) {
+    if (c.newState === 'cancelled') cancelledIds.add(c.entityId);
+  }
+  for (const c of orphans.corrections) {
+    if (c.newState === 'cancelled') cancelledIds.add(c.entityId);
+  }
 
   // 4. Deep cascade cancel
   const cascade = cascadeCancelChildren(cancelledIds, allWorkItems);

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -863,8 +863,33 @@ export function detectStaleQueuedWorkItems(
  * Result of a pruning pass, aggregating all pruning-related corrections.
  */
 export interface PruningResult {
-  /** WorkItems cancelled due to TTL expiry */
-  ttlExpiredCount: number;
+  /**
+   * WorkItems the TTL rule **cancelled** (`… → cancelled`) — genuine cleanup,
+   * the work is discarded.
+   *
+   * Replaces the former `ttlExpiredCount`, which was `expiredIds.length` and
+   * therefore lumped these together with the auto-ACCEPTED items below. The
+   * reconciler folded that combined number into
+   * `ReconcileResult.staleItemsCleaned`, so an operator reading
+   * `staleItemsCleaned = 10` concluded 10 items were thrown away when some of
+   * them had in fact been accepted. Two opposite outcomes must never share a
+   * counter; see {@link ttlAutoVerifiedCount}.
+   */
+  ttlCancelledCount: number;
+  /**
+   * WorkItems the TTL rule **auto-accepted** rather than discarded — today
+   * exclusively the `done_by_worker → verified` 24h implicit-acceptance
+   * fallback (see {@link pickTTLExpiryTarget}). Counted separately and
+   * deliberately EXCLUDED from `ReconcileResult.staleItemsCleaned`: this is
+   * work that passed, not work that was cleaned up.
+   *
+   * Defined as "TTL acted, but the target was not `cancelled`", so if the
+   * target-preference list ever yields a third acceptance-shaped terminal
+   * (`done` is listed but unreachable today — every status that permits
+   * `done` also permits the higher-priority `cancelled`) it lands here rather
+   * than being silently dropped from both counters.
+   */
+  ttlAutoVerifiedCount: number;
   /** WorkItems cancelled due to orphan cascade */
   orphanCancelledCount: number;
   /** WorkItems cancelled due to deep cascade */
@@ -892,7 +917,11 @@ export interface PruningResult {
  * @param allWorkItems - All WorkItems in the system
  * @param ttlMs - TTL threshold (default: 24h)
  * @param staleThresholdMs - Stale queue threshold (default: 1h)
- * @returns Aggregated pruning result
+ * @returns Aggregated pruning result. The TTL outcome is reported as two
+ *   separate counters — {@link PruningResult.ttlCancelledCount} (discarded)
+ *   and {@link PruningResult.ttlAutoVerifiedCount} (accepted) — because only
+ *   the former is "cleanup". Callers aggregating a cleaned-up total must sum
+ *   the cancel-shaped counters ONLY.
  */
 export function runPruningPass(
   allWorkItems: WorkItem[],
@@ -926,8 +955,17 @@ export function runPruningPass(
   // `orphans.orphanIds` is cancel-only by construction (see
   // {@link pickCascadeTarget}) but is filtered the same way so the invariant
   // is enforced here rather than assumed from a callee.
+  //
+  // The same split drives the two TTL counters: a `→ cancelled` correction is
+  // cleanup, anything else is an acceptance the caller must NOT report as
+  // "cleaned". `ttl.corrections` and `ttl.expiredIds` are pushed in lockstep,
+  // so these two counts partition the whole TTL outcome with nothing lost.
+  let ttlCancelledCount = 0;
   for (const c of ttl.corrections) {
-    if (c.newState === 'cancelled') cancelledIds.add(c.entityId);
+    if (c.newState === 'cancelled') {
+      cancelledIds.add(c.entityId);
+      ttlCancelledCount++;
+    }
   }
   for (const c of orphans.corrections) {
     if (c.newState === 'cancelled') cancelledIds.add(c.entityId);
@@ -940,7 +978,8 @@ export function runPruningPass(
   const stale = detectStaleQueuedWorkItems(allWorkItems, staleThresholdMs);
 
   return {
-    ttlExpiredCount: ttl.expiredIds.length,
+    ttlCancelledCount,
+    ttlAutoVerifiedCount: ttl.corrections.length - ttlCancelledCount,
     orphanCancelledCount: orphans.orphanIds.length,
     cascadeCancelledCount: cascade.cascadedIds.length,
     staleQueuedCount: stale.staleIds.length,

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -25,6 +25,7 @@ import {
   isGracePeriodExceeded,
   TERMINAL_WORK_ITEM_STATUSES,
   TERMINAL_REQUEST_STATUSES,
+  WORK_ITEM_TRANSITIONS,
   createCorrection,
   DEFAULT_GRACE_PERIOD_MS,
 } from '../../types/v2/index.js';
@@ -362,38 +363,94 @@ export function detectOrphanWorkItems(
 // ---------------------------------------------------------------------------
 
 /**
- * Pick the legal terminal status for a TTL-expired WorkItem.
+ * Preference order used when choosing a TTL-expiry target.
  *
- * The reconciler's TTL rule used to unconditionally issue
- * `→ cancelled` corrections. That works for `queued` / `running` /
- * `blocked` / etc. — they all permit `→ cancelled` per
- * `WORK_ITEM_TRANSITIONS`. But `done_by_worker` only permits
- * `→ verified` and `→ rejected` (the work IS done from the worker's
- * point of view; auto-cancelling would lose audit trail). Same for
- * `proposed` (auto-acceptance after timeout is the right semantic).
+ * The picker walks this list and returns the first entry that is BOTH
+ * strictly terminal (per {@link TERMINAL_WORK_ITEM_STATUSES}) and a legal
+ * outbound edge from the WorkItem's current status (per
+ * {@link WORK_ITEM_TRANSITIONS}).
  *
- * Mirrors the `pickResolveTarget` helper in `request-sla.subscriber.ts`,
- * which makes the identical choice for SLA-timeout-resolved WIs.
- *
- * Dogfood symptom 2026-05-12: 10 stale `done_by_worker` WIs sat in
- * pool for 86+ hours. The TTL rule fired every minute, every attempt
- * failed with `Invalid status transition for WorkItem ...:
- * done_by_worker → cancelled`, the log filled with ERROR noise and
- * the WIs never cleaned up. Fix routes through this picker so the
- * correction target matches what the state machine accepts.
- *
- * @param current - Current non-terminal WI status
- * @returns Legal terminal status for TTL expiry
+ * `cancelled` is first because a TTL expiry is an abandonment, not an
+ * accomplishment. `verified` follows so `done_by_worker` — which has no
+ * `→ cancelled` edge — auto-approves rather than stranding: 24h of
+ * nobody objecting is treated as implicit acceptance. `done` is last and
+ * in practice unreachable (every status that permits `→ done` also
+ * permits `→ cancelled`), but is listed so the table stays total if a
+ * future status permits `→ done` alone.
  */
-function pickTTLExpiryTarget(current: WorkItemStatus): WorkItemStatus {
-  // done_by_worker has no `→ cancelled` edge — auto-approve via
-  // `verified` instead. Treat 24h-of-no-objection as implicit
-  // acceptance. The worker reported done; nobody pushed back.
-  if (current === 'done_by_worker') return 'verified';
-  // running has both `→ done` and `→ cancelled` — prefer `cancelled`
-  // for TTL since `done` should only come from an explicit completion
-  // event, not a timeout.
-  return 'cancelled';
+const TTL_EXPIRY_TARGET_PREFERENCE: readonly WorkItemStatus[] = [
+  'cancelled',
+  'verified',
+  'done',
+] as const;
+
+/**
+ * Pick a state-machine-legal terminal status for a TTL-expired WorkItem,
+ * or `null` when no legal terminal target exists.
+ *
+ * This picker is TABLE-DRIVEN off {@link WORK_ITEM_TRANSITIONS} rather
+ * than hardcoded per-status branches. That is deliberate: the hardcoded
+ * form has now caused the same production incident twice, because a fix
+ * applied to one status was never applied to its siblings.
+ *
+ * History — read this before "simplifying" it back:
+ *
+ * 1. Original form issued an unconditional `→ cancelled` correction.
+ *    That is legal from `queued` / `scheduled` / `accepted` / `running` /
+ *    `blocked` / `escalated`, but NOT from `done_by_worker`, which only
+ *    permits `→ verified` / `→ rejected`.
+ * 2. Dogfood symptom 2026-05-12: 10 stale `done_by_worker` WIs sat in the
+ *    pool for 86+ hours. The TTL rule fired every minute, every attempt
+ *    threw `Invalid status transition for WorkItem ...: done_by_worker →
+ *    cancelled`, the log filled with ERROR noise, and the WIs were never
+ *    cleaned up. Fixed by special-casing `done_by_worker → verified`.
+ * 3. That fix was NOT applied to the siblings. `rejected` and `failed`
+ *    are also non-terminal, are also absent from
+ *    {@link TERMINAL_WORK_ITEM_STATUSES}, and also have no `→ cancelled`
+ *    edge — `failed → queued` is their only outbound edge. So the exact
+ *    same forever-throwing loop recurred for them (Request 13548bd5,
+ *    surfaced by the 2026-08-20 Orca audit).
+ *
+ * The table-driven form closes the whole bug class: a status can only
+ * receive a target the transition matrix actually permits, and a status
+ * with no legal terminal target is skipped rather than corrected into an
+ * exception. Adding a new {@link WorkItemStatus} can no longer silently
+ * reintroduce this — worst case the new status is skipped by TTL, which
+ * is inert, instead of throwing on every reconciler pass forever.
+ *
+ * `null` results (currently `rejected` and `failed`) are intentional and
+ * safe, NOT a leak:
+ * - `failed` has its own lifecycle — {@link detectRetryableFailedWorkItems}
+ *   re-queues it while retries remain, and `V3DataService.onTaskFailed`
+ *   escalates it to the orchestrator once the retry budget is spent.
+ * - `rejected` has its own lifecycle — `EventToWorkItemBridge`'s
+ *   `task:rejected` handler spawns either a retry WorkItem or a TL
+ *   escalation WorkItem; the source WI is meant to stay `rejected` as an
+ *   audit record.
+ * Neither needs the TTL sweeper, and forcing a target on either produces
+ * an illegal edge, not a cleanup.
+ *
+ * @param current - Current (non-terminal) WorkItem status
+ * @returns A legal terminal status for TTL expiry, or `null` when the
+ *   status has no legal terminal target and must be skipped
+ *
+ * @example
+ * ```typescript
+ * pickTTLExpiryTarget('running');        // 'cancelled'
+ * pickTTLExpiryTarget('done_by_worker'); // 'verified'
+ * pickTTLExpiryTarget('rejected');       // null  → skip, do not correct
+ * ```
+ */
+export function pickTTLExpiryTarget(current: WorkItemStatus): WorkItemStatus | null {
+  const legalTargets = WORK_ITEM_TRANSITIONS[current];
+  if (!legalTargets) return null;
+
+  for (const candidate of TTL_EXPIRY_TARGET_PREFERENCE) {
+    if (TERMINAL_WORK_ITEM_STATUSES.has(candidate) && legalTargets.has(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
 }
 
 /**
@@ -403,6 +460,15 @@ function pickTTLExpiryTarget(current: WorkItemStatus): WorkItemStatus {
  * Picks a state-machine-legal terminal target for each expired WI via
  * {@link pickTTLExpiryTarget}, so the correction never fails with
  * `Invalid status transition`.
+ *
+ * Two categories are skipped without a correction:
+ * 1. Strictly terminal WIs ({@link TERMINAL_WORK_ITEM_STATUSES}) — already done.
+ * 2. WIs whose status has NO legal terminal target (picker returns `null`).
+ *    Emitting a correction for these is what produced the forever-throwing
+ *    reconciler loop in Request 13548bd5 — the correction was illegal, the
+ *    transition threw on every pass, and the item was never cleaned up.
+ *    Skipping is inert and correct: those statuses (`rejected`, `failed`)
+ *    own their own retry/escalation lifecycles. See {@link pickTTLExpiryTarget}.
  *
  * @param workItems - All non-terminal WorkItems to check
  * @param ttlMs - Maximum age before auto-cancel (default: 24h)
@@ -424,6 +490,9 @@ export function detectTTLExpiredWorkItems(
 
     if (age > ttlMs) {
       const target = pickTTLExpiryTarget(wi.status);
+      // No legal terminal edge from this status — skip rather than emit a
+      // correction the state machine will reject on every single pass.
+      if (target === null) continue;
       corrections.push(createCorrection({
         entityType: 'work_item',
         entityId: wi.id,

--- a/backend/src/services/reconciler/reconciler.service.test.ts
+++ b/backend/src/services/reconciler/reconciler.service.test.ts
@@ -7,7 +7,7 @@
 import { ReconcilerService } from './reconciler.service.js';
 import type { ReconcilerDataProvider } from './reconciler.service.js';
 import { createWorkItem, createRequest, createTaskClaim, isValidWorkItemTransition } from '../../types/v2/index.js';
-import type { WorkItem, Request, TaskClaim, ReconcileCorrection, WakeAction } from '../../types/v2/index.js';
+import type { WorkItem, WorkItemStatus, Request, TaskClaim, ReconcileCorrection, WakeAction } from '../../types/v2/index.js';
 import type { AgentHealth } from './reconcile-rules.js';
 
 // ---------------------------------------------------------------------------
@@ -22,6 +22,24 @@ jest.mock('../settings/index.js', () => ({
   getSettingsService: () => ({
     getSettings: mockGetSettings,
   }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock escalation router
+//
+// `enforceVerification` dynamically imports EscalationRouterService to escalate
+// overdue `done_by_worker` items. Stub it so the verification-enforcement
+// invariant is observable (and so the real singleton is never constructed).
+// ---------------------------------------------------------------------------
+
+const mockEscalateUnverified = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../v3/escalation-router.service.js', () => ({
+  EscalationRouterService: {
+    getInstance: () => ({
+      escalateUnverifiedWorkItem: mockEscalateUnverified,
+    }),
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -80,6 +98,7 @@ describe('ReconcilerService', () => {
     mockGetSettings.mockResolvedValue({
       general: { maxConcurrentAgents: 10 },
     });
+    mockEscalateUnverified.mockClear();
   });
 
   afterEach(() => {
@@ -546,17 +565,22 @@ describe('ReconcilerService', () => {
       provider = createMockProvider({
         getActiveWorkItems: jest.fn().mockResolvedValue(pool),
         // Enforce the real state machine, exactly as TaskPoolService does.
-        applyCorrection: jest.fn(async (correction: any) => {
+        applyCorrection: jest.fn(async (correction: ReconcileCorrection) => {
           if (correction.entityType !== 'work_item') return;
           const item = byId.get(correction.entityId);
           if (!item) return;
-          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+          // `ReconcileCorrection.newState` is typed `string`, not
+          // `WorkItemStatus` — a weak spot that lets an illegal status reach
+          // the pool untyped. Narrow explicitly here so this fake enforces
+          // the same contract TaskPoolService.transitionStatus does.
+          const next = correction.newState as WorkItemStatus;
+          if (!isValidWorkItemTransition(item.status, next)) {
             throw new Error(
               `Invalid status transition for WorkItem ${correction.entityId}: ` +
-              `${item.status} → ${correction.newState}`,
+              `${item.status} → ${next}`,
             );
           }
-          item.status = correction.newState;
+          item.status = next;
         }),
       });
       service = new ReconcilerService(provider);
@@ -576,6 +600,136 @@ describe('ReconcilerService', () => {
       expect(byId.get('wi-dbw')!.status).toBe('verified');
     });
 
+    // ---------------------------------------------------------------------
+    // The `runFull` step-3d invariant, asserted rather than commented.
+    //
+    // reconciler.service.ts orders `enforceVerification` BEFORE the pruning
+    // pass so unverified work gets a real verdict opportunity and is never
+    // silently auto-accepted. That ordering was load-bearing but untested:
+    // commit 469a3a21 let the pruning pass auto-`verified` a `done_by_worker`
+    // item via the shared TTL picker, which bypassed the guard entirely and
+    // no test noticed.
+    // ---------------------------------------------------------------------
+    describe('unverified work is never silently auto-accepted (runFull step 3d)', () => {
+      /** Reads a WorkItem's current status without a non-null assertion. */
+      function statusOf(byId: Map<string, WorkItem>, id: string): WorkItemStatus | undefined {
+        return byId.get(id)?.status;
+      }
+
+      /** Builds a provider that enforces the real WORK_ITEM_TRANSITIONS matrix. */
+      function strictProvider(pool: WorkItem[], byId: Map<string, WorkItem>): ReconcilerDataProvider {
+        return createMockProvider({
+          getActiveWorkItems: jest.fn().mockResolvedValue(pool),
+          applyCorrection: jest.fn(async (correction: ReconcileCorrection) => {
+            if (correction.entityType !== 'work_item') return;
+            const item = byId.get(correction.entityId);
+            if (!item) return;
+            const next = correction.newState as WorkItemStatus;
+            if (!isValidWorkItemTransition(item.status, next)) {
+              throw new Error(
+                `Invalid status transition for WorkItem ${correction.entityId}: ` +
+                `${item.status} → ${next}`,
+              );
+            }
+            item.status = next;
+          }),
+        });
+      }
+
+      it('REGRESSION: a ~1s-old done_by_worker child under a permanently-failed parent is not verified', async () => {
+        const parent = makeWorkItem({
+          id: 'parent-dead', status: 'failed', retryCount: 3, maxRetries: 3,
+        });
+        const child = makeWorkItem({
+          id: 'child-unreviewed',
+          status: 'done_by_worker',
+          parentWorkItemId: 'parent-dead',
+          createdAt: new Date(Date.now() - 1000).toISOString(),
+        });
+        const pool = [parent, child];
+        const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+        provider = strictProvider(pool, byId);
+        service = new ReconcilerService(provider);
+
+        const result = await service.runFull();
+
+        expect(result.errors).toEqual([]);
+        // The whole point: TL-unreviewed output must survive the pass intact.
+        expect(statusOf(byId, 'child-unreviewed')).toBe('done_by_worker');
+        expect(result.corrections.filter((c) => c.entityId === 'child-unreviewed'))
+          .toEqual([]);
+        expect(result.corrections.map((c) => c.newState)).not.toContain('verified');
+      });
+
+      it('escalates for a verdict BEFORE the pruning pass can touch the item', async () => {
+        // 3h old: past DEFAULT_VERIFY_ESCALATE_MS (2h) so the guard fires,
+        // but nowhere near the 24h TTL, so nothing may legitimately expire it.
+        const child = makeWorkItem({
+          id: 'wi-awaiting',
+          status: 'done_by_worker',
+          createdAt: new Date(Date.now() - 3 * 3600 * 1000).toISOString(),
+        });
+        const pool = [child];
+        const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+        provider = strictProvider(pool, byId);
+        service = new ReconcilerService(provider);
+
+        const result = await service.runFull();
+
+        expect(result.errors).toEqual([]);
+        // Guard ran and asked for a real verdict...
+        expect(mockEscalateUnverified).toHaveBeenCalledTimes(1);
+        expect(mockEscalateUnverified.mock.calls[0][0]).toMatchObject({ id: 'wi-awaiting' });
+        // ...and the item is still awaiting one, not auto-accepted.
+        expect(statusOf(byId, 'wi-awaiting')).toBe('done_by_worker');
+        expect(provider.applyCorrection).not.toHaveBeenCalled();
+      });
+
+      it('the escalation guard runs before any correction is applied', async () => {
+        // Ordering is the invariant. Assert it on the call graph, not by
+        // reading the source.
+        const stale = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
+        const pool = [
+          makeWorkItem({ id: 'wi-dbw', status: 'done_by_worker', createdAt: stale }),
+          makeWorkItem({ id: 'wi-running', status: 'running', createdAt: stale }),
+        ];
+        const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+        provider = strictProvider(pool, byId);
+        service = new ReconcilerService(provider);
+
+        await service.runFull();
+
+        expect(mockEscalateUnverified).toHaveBeenCalled();
+        const applyMock = provider.applyCorrection as jest.Mock;
+        expect(applyMock).toHaveBeenCalled();
+        expect(mockEscalateUnverified.mock.invocationCallOrder[0])
+          .toBeLessThan(applyMock.mock.invocationCallOrder[0]);
+      });
+
+      it('only the 24h TTL rule may produce a `verified` correction', async () => {
+        // Liveness half: TTL's implicit-acceptance fallback is intentional and
+        // must still work. Soundness half is the test above — a fresh item
+        // under a dead ancestor gets nothing.
+        const stale = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
+        const pool = [makeWorkItem({ id: 'wi-ancient', status: 'done_by_worker', createdAt: stale })];
+        const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+        provider = strictProvider(pool, byId);
+        service = new ReconcilerService(provider);
+
+        const result = await service.runFull();
+
+        const verified = result.corrections.filter((c) => c.newState === 'verified');
+        expect(verified).toHaveLength(1);
+        expect(verified[0].entityId).toBe('wi-ancient');
+        expect(verified[0].reason).toContain('TTL');
+        expect(statusOf(byId, 'wi-ancient')).toBe('verified');
+      });
+    });
+
     it('stays error-free across repeated passes (the bug recurred every pass)', async () => {
       const staleAt = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
       const pool = [
@@ -589,16 +743,21 @@ describe('ReconcilerService', () => {
 
       provider = createMockProvider({
         getActiveWorkItems: jest.fn().mockResolvedValue(pool),
-        applyCorrection: jest.fn(async (correction: any) => {
+        applyCorrection: jest.fn(async (correction: ReconcileCorrection) => {
           const item = byId.get(correction.entityId);
           if (!item) return;
-          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+          // `ReconcileCorrection.newState` is typed `string`, not
+          // `WorkItemStatus` — a weak spot that lets an illegal status reach
+          // the pool untyped. Narrow explicitly here so this fake enforces
+          // the same contract TaskPoolService.transitionStatus does.
+          const next = correction.newState as WorkItemStatus;
+          if (!isValidWorkItemTransition(item.status, next)) {
             throw new Error(
               `Invalid status transition for WorkItem ${correction.entityId}: ` +
-              `${item.status} → ${correction.newState}`,
+              `${item.status} → ${next}`,
             );
           }
-          item.status = correction.newState;
+          item.status = next;
         }),
       });
       service = new ReconcilerService(provider);
@@ -625,16 +784,21 @@ describe('ReconcilerService', () => {
 
       provider = createMockProvider({
         getActiveWorkItems: jest.fn().mockResolvedValue([wi]),
-        applyCorrection: jest.fn(async (correction: any) => {
+        applyCorrection: jest.fn(async (correction: ReconcileCorrection) => {
           const item = byId.get(correction.entityId);
           if (!item) return;
-          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+          // `ReconcileCorrection.newState` is typed `string`, not
+          // `WorkItemStatus` — a weak spot that lets an illegal status reach
+          // the pool untyped. Narrow explicitly here so this fake enforces
+          // the same contract TaskPoolService.transitionStatus does.
+          const next = correction.newState as WorkItemStatus;
+          if (!isValidWorkItemTransition(item.status, next)) {
             throw new Error(
               `Invalid status transition for WorkItem ${correction.entityId}: ` +
-              `${item.status} → ${correction.newState}`,
+              `${item.status} → ${next}`,
             );
           }
-          item.status = correction.newState;
+          item.status = next;
         }),
       });
       service = new ReconcilerService(provider);

--- a/backend/src/services/reconciler/reconciler.service.test.ts
+++ b/backend/src/services/reconciler/reconciler.service.test.ts
@@ -6,7 +6,7 @@
 
 import { ReconcilerService } from './reconciler.service.js';
 import type { ReconcilerDataProvider } from './reconciler.service.js';
-import { createWorkItem, createRequest, createTaskClaim } from '../../types/v2/index.js';
+import { createWorkItem, createRequest, createTaskClaim, isValidWorkItemTransition } from '../../types/v2/index.js';
 import type { WorkItem, Request, TaskClaim, ReconcileCorrection, WakeAction } from '../../types/v2/index.js';
 import type { AgentHealth } from './reconcile-rules.js';
 
@@ -506,6 +506,149 @@ describe('ReconcilerService', () => {
       const result = await service.runFull();
       expect(result.errors.length).toBeGreaterThan(0);
       expect(result.errors[0]).toContain('Write failed');
+    });
+
+    // ---------------------------------------------------------------------
+    // Request 13548bd5 (2026-08-20) — full-loop-cycle guard.
+    //
+    // The unit tests in reconcile-rules.test.ts prove the TTL picker never
+    // NAMES an illegal target. This proves the assembled loop never ATTEMPTS
+    // one: the provider below enforces the real WORK_ITEM_TRANSITIONS matrix
+    // and throws the exact error string TaskPoolService.transitionStatus
+    // throws, so any illegal correction surfaces in `result.errors`.
+    //
+    // Before the fix, the `rejected` and `failed` items in this pool each
+    // produced `Invalid status transition ... → cancelled` on EVERY pass,
+    // forever.
+    // ---------------------------------------------------------------------
+    it('applies a full reconcile cycle with zero Invalid status transition errors', async () => {
+      const staleAt = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
+      const pool = [
+        makeWorkItem({ id: 'wi-rejected', status: 'rejected', createdAt: staleAt }),
+        // Retry-EXHAUSTED: detectRetryableFailedWorkItems deliberately
+        // ignores it, so this item reaches the TTL rule — the exact case that
+        // used to throw on every pass and strand the item forever.
+        makeWorkItem({
+          id: 'wi-failed', status: 'failed', createdAt: staleAt,
+          retryCount: 3, maxRetries: 3,
+        }),
+        makeWorkItem({ id: 'wi-dbw', status: 'done_by_worker', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-queued', status: 'queued', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-running', status: 'running', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-blocked', status: 'blocked', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-escalated', status: 'escalated', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-proposed', status: 'proposed', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-accepted', status: 'accepted', createdAt: staleAt }),
+        makeWorkItem({ id: 'wi-scheduled', status: 'scheduled', createdAt: staleAt }),
+      ];
+      const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue(pool),
+        // Enforce the real state machine, exactly as TaskPoolService does.
+        applyCorrection: jest.fn(async (correction: any) => {
+          if (correction.entityType !== 'work_item') return;
+          const item = byId.get(correction.entityId);
+          if (!item) return;
+          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+            throw new Error(
+              `Invalid status transition for WorkItem ${correction.entityId}: ` +
+              `${item.status} → ${correction.newState}`,
+            );
+          }
+          item.status = correction.newState;
+        }),
+      });
+      service = new ReconcilerService(provider);
+
+      const result = await service.runFull();
+
+      expect(result.errors.filter((e) => e.includes('Invalid status transition')))
+        .toEqual([]);
+      expect(result.errors).toEqual([]);
+
+      // The two audit-record statuses are left untouched by the sweeper...
+      expect(byId.get('wi-rejected')!.status).toBe('rejected');
+      expect(byId.get('wi-failed')!.status).toBe('failed');
+      // (a retry-ELIGIBLE failed item is a different path — the retry rule
+      // legally requeues it; see the dedicated case below.)
+      // ...while the genuinely stale in-flight work is still cleaned up.
+      expect(byId.get('wi-dbw')!.status).toBe('verified');
+    });
+
+    it('stays error-free across repeated passes (the bug recurred every pass)', async () => {
+      const staleAt = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
+      const pool = [
+        makeWorkItem({ id: 'wi-rejected', status: 'rejected', createdAt: staleAt }),
+        makeWorkItem({
+          id: 'wi-failed', status: 'failed', createdAt: staleAt,
+          retryCount: 3, maxRetries: 3,
+        }),
+      ];
+      const byId = new Map(pool.map((wi) => [wi.id, wi]));
+
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue(pool),
+        applyCorrection: jest.fn(async (correction: any) => {
+          const item = byId.get(correction.entityId);
+          if (!item) return;
+          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+            throw new Error(
+              `Invalid status transition for WorkItem ${correction.entityId}: ` +
+              `${item.status} → ${correction.newState}`,
+            );
+          }
+          item.status = correction.newState;
+        }),
+      });
+      service = new ReconcilerService(provider);
+
+      for (let pass = 0; pass < 3; pass++) {
+        const result = await service.runFull();
+        expect(result.errors).toEqual([]);
+      }
+      // Nothing to correct: both are terminal-for-practical-purposes audit
+      // records with no legal terminal edge. Previously each pass produced
+      // one doomed correction per item — 6 thrown errors across 3 passes.
+      expect(provider.applyCorrection).not.toHaveBeenCalled();
+    });
+
+    it('still auto-retries a retry-ELIGIBLE failed item (legal failed → queued)', async () => {
+      // Guard against over-correcting the fix: skipping `failed` in the TTL
+      // rule must not disable the genuine retry path.
+      const staleAt = new Date(Date.now() - 96 * 3600 * 1000).toISOString();
+      const wi = makeWorkItem({
+        id: 'wi-retryable', status: 'failed', createdAt: staleAt,
+        retryCount: 0, maxRetries: 3,
+      });
+      const byId = new Map([[wi.id, wi]]);
+
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue([wi]),
+        applyCorrection: jest.fn(async (correction: any) => {
+          const item = byId.get(correction.entityId);
+          if (!item) return;
+          if (!isValidWorkItemTransition(item.status, correction.newState)) {
+            throw new Error(
+              `Invalid status transition for WorkItem ${correction.entityId}: ` +
+              `${item.status} → ${correction.newState}`,
+            );
+          }
+          item.status = correction.newState;
+        }),
+      });
+      service = new ReconcilerService(provider);
+
+      const result = await service.runFull();
+
+      expect(result.errors).toEqual([]);
+      expect(provider.applyCorrection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityId: 'wi-retryable',
+          previousState: 'failed',
+          newState: 'queued',
+        }),
+      );
     });
   });
 

--- a/backend/src/services/reconciler/reconciler.service.test.ts
+++ b/backend/src/services/reconciler/reconciler.service.test.ts
@@ -181,6 +181,46 @@ describe('ReconcilerService', () => {
       expect(result.staleItemsCleaned).toBeGreaterThan(0);
     });
 
+    it('counts a TTL-cancelled item in staleItemsCleaned but NOT a TTL auto-verified one', async () => {
+      // `staleItemsCleaned` must mean exactly one thing: work that was
+      // DISCARDED. The TTL rule produces two opposite outcomes —
+      // `running → cancelled` (discarded) and `done_by_worker → verified`
+      // (the 24h implicit-acceptance fallback, i.e. ACCEPTED). Summing the
+      // old combined `ttlExpiredCount` reported the accepted item to
+      // operators as thrown away.
+      const now = Date.now();
+      const accepted = makeWorkItem({
+        id: 'ttl-accepted',
+        status: 'done_by_worker',
+        createdAt: new Date(now - 25 * 3600000).toISOString(),
+      });
+      const discarded = makeWorkItem({
+        id: 'ttl-discarded',
+        status: 'running',
+        createdAt: new Date(now - 25 * 3600000).toISOString(),
+      });
+
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue([accepted, discarded]),
+      });
+      service = new ReconcilerService(provider);
+
+      const result = await service.runFull();
+
+      // Exactly one cleaned item: the cancelled one. The auto-verified one
+      // is outside this metric.
+      expect(result.staleItemsCleaned).toBe(1);
+
+      // ...but it is NOT silently dropped — the acceptance is still in the
+      // audit trail with its true semantics.
+      const acceptedCorrection = result.corrections.find(
+        (c) => c.entityId === 'ttl-accepted' && c.newState === 'verified',
+      );
+      expect(acceptedCorrection).toBeDefined();
+      expect(result.corrections.find((c) => c.entityId === 'ttl-discarded' && c.newState === 'cancelled'))
+        .toBeDefined();
+    });
+
     it('should detect recoverable blocked WorkItems', async () => {
       const wi = makeWorkItem({
         status: 'blocked',

--- a/backend/src/services/reconciler/reconciler.service.ts
+++ b/backend/src/services/reconciler/reconciler.service.ts
@@ -229,7 +229,26 @@ export class ReconcilerService {
       // 4. Pruning pass (F4): TTL expiry + orphan cascade + deep cascade + stale queue detection
       const pruning = runPruningPass(workItems);
       result.corrections.push(...pruning.totalCorrections);
-      result.staleItemsCleaned += pruning.ttlExpiredCount + pruning.orphanCancelledCount + pruning.cascadeCancelledCount;
+      // `staleItemsCleaned` means "work that was DISCARDED", so only the
+      // cancel-shaped counters may be summed here. The TTL rule also emits
+      // `done_by_worker → verified` (24h implicit acceptance); that item was
+      // ACCEPTED, not cleaned up, and folding it in made the metric report
+      // two opposite outcomes as one number. See `PruningResult`.
+      result.staleItemsCleaned +=
+        pruning.ttlCancelledCount + pruning.orphanCancelledCount + pruning.cascadeCancelledCount;
+
+      // 4-bis. Auto-acceptance visibility: excluded from `staleItemsCleaned`
+      // above, so surface it explicitly rather than letting it vanish — a
+      // silent metric is worse than a wrong one. The per-item audit trail is
+      // already in `result.corrections` (newState `verified`); this log makes
+      // the aggregate visible to an operator watching the reconciler.
+      if (pruning.ttlAutoVerifiedCount > 0) {
+        LoggerService.getInstance()
+          .createComponentLogger('ReconcilerService')
+          .warn('WorkItems auto-accepted by the 24h TTL fallback (NOT counted as staleItemsCleaned)', {
+            ttlAutoVerifiedCount: pruning.ttlAutoVerifiedCount,
+          });
+      }
 
       // 4a. Stale-queued visibility (2026-05-16): the pruning rule no
       // longer auto-cancels these WIs (was destroying user work — Atlas

--- a/backend/src/services/wiki/wiki-migrate.service.test.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.test.ts
@@ -209,6 +209,96 @@ describe('WikiMigrateService.scan', () => {
     ).toBe(true);
   });
 
+  /**
+   * Issue #732 — memory-entry pages were proposed by scan but could never be
+   * APPLIED: `sourceFile` was built with the platform `path.join` (backslashes
+   * on Windows) and then re-parsed with a forward-slash-only regex, so every
+   * entry threw `memory_source_unparseable`. Scan-only coverage is what let
+   * this ship — these tests exercise the write path.
+   */
+  it('applies memory-entry pages instead of skipping them as unparseable', async () => {
+    await write(
+      '.crewly/agents/crewly-product-leo-xxx/memory.json',
+      JSON.stringify({
+        agentId: 'crewly-product-leo-xxx',
+        roleKnowledge: [
+          {
+            id: 'mem-1',
+            category: 'best-practice',
+            content: 'Atomic writes guard against state-corruption collapse.',
+            createdAt: '2026-05-04T00:00:00Z',
+          },
+        ],
+      }),
+      homeDir,
+    );
+
+    const out = await svc.apply({ projectRoot, homeDir });
+    expect(out.ok).toBe(true);
+    if (!out.ok || !('applied' in out)) return;
+
+    const memoryPages = out.proposedPages.filter((p) => p.sourceType === 'memory-entry');
+    expect(memoryPages).toHaveLength(1);
+    expect(memoryPages[0].skipReason).toBeUndefined();
+    expect(out.applied).toBeGreaterThan(0);
+  });
+
+  it('re-reads memory sources from the injected homeDir, not the process home', async () => {
+    // Before the fix the re-read was hardcoded to os.homedir(), so an
+    // overridden `~` (tests, CREWLY_HOME installs) silently read the wrong
+    // tree — or nothing at all.
+    await write(
+      '.crewly/agents/agent-a/memory.json',
+      JSON.stringify({
+        roleKnowledge: [{ id: 'm-home', category: 'pattern', content: 'Scoped to injected home.' }],
+      }),
+      homeDir,
+    );
+
+    const out = await svc.apply({ projectRoot, homeDir });
+    expect(out.ok).toBe(true);
+    if (!out.ok || !('applied' in out)) return;
+
+    const page = out.proposedPages.find((p) => p.sourceId === 'm-home');
+    expect(page).toBeDefined();
+    const written = await fs.readFile(
+      path.join(page!.targetVaultPath, page!.targetRelativePath),
+      'utf8',
+    );
+    expect(written).toContain('Scoped to injected home.');
+  });
+
+  it('parses a Windows-style sourceFile recorded before the fix', async () => {
+    // Windows installs already persisted backslash paths; the parse must heal
+    // that existing backlog, not just avoid creating new ones.
+    await write(
+      '.crewly/agents/win-agent/memory.json',
+      JSON.stringify({
+        roleKnowledge: [{ id: 'm-win', category: 'pattern', content: 'Recorded on Windows.' }],
+      }),
+      homeDir,
+    );
+
+    const render = (
+      svc as unknown as {
+        renderForPage: (page: unknown, homeDir: string) => Promise<string>;
+      }
+    ).renderForPage.bind(svc);
+
+    const body = await render(
+      {
+        sourceType: 'memory-entry',
+        sourceFile: '~\\.crewly\\agents\\win-agent\\memory.json',
+        sourceId: 'm-win',
+        targetVaultPath: path.join(projectRoot, '.crewly', 'wiki'),
+        targetRelativePath: 'llm-curated/patterns/x.md',
+      },
+      homeDir,
+    );
+
+    expect(body).toContain('Recorded on Windows.');
+  });
+
   it('respects includeAgentMemory=false', async () => {
     await write(
       `.crewly/agents/x/memory.json`,

--- a/backend/src/services/wiki/wiki-migrate.service.ts
+++ b/backend/src/services/wiki/wiki-migrate.service.ts
@@ -694,7 +694,7 @@ export class WikiMigrateService {
         continue;
       }
       try {
-        const finalRel = await this.writePage(page);
+        const finalRel = await this.writePage(page, homeDir);
         manifest.entries.push({
           sourceId: page.sourceId,
           contentHash: page.contentHash,
@@ -1310,7 +1310,11 @@ export class WikiMigrateService {
           migratedIds.has(id) || migratedHashes.has(hash) ? 'already migrated' : undefined;
         out.push({
           sourceType: 'memory-entry',
-          sourceFile: path.join('~/.crewly/agents', agentEntry.name, 'memory.json'),
+          // `path.posix` deliberately, NOT `path.join`: this is a synthetic
+          // display/identity string (it is re-parsed below, never handed to
+          // fs.*). Platform `join` rewrites the separators to `\` on Windows,
+          // which the re-parse then fails to read back — see issue #732.
+          sourceFile: path.posix.join('~/.crewly/agents', agentEntry.name, 'memory.json'),
           sourceId: id,
           contentHash: hash,
           targetVaultPath: vaultPath,
@@ -1332,9 +1336,12 @@ export class WikiMigrateService {
    * Write the proposed page's body to disk under the target vault.
    * Returns the FINAL relativePath written (with a suffix if a collision
    * forced one).
+   *
+   * @param page - The proposed page to write
+   * @param homeDir - Resolved `~` for re-reading home-scoped sources
    */
-  private async writePage(page: WikiMigrateProposedPage): Promise<string> {
-    const body = await this.renderForPage(page);
+  private async writePage(page: WikiMigrateProposedPage, homeDir: string): Promise<string> {
+    const body = await this.renderForPage(page, homeDir);
 
     // Special case: log.md — APPEND rather than overwrite/collide. The
     // log is shared across all imports and the page emitter writes a
@@ -1382,7 +1389,7 @@ export class WikiMigrateService {
    * — re-derive from the source on apply. This avoids duplicating large
    * blobs in API responses.
    */
-  private async renderForPage(page: WikiMigrateProposedPage): Promise<string> {
+  private async renderForPage(page: WikiMigrateProposedPage, homeDir: string): Promise<string> {
     // For simplicity we re-read the source and re-render. The hash will
     // re-match because the rendering is deterministic.
     // TODO(perf): cache the rendered bodies on the page object if scans
@@ -1453,11 +1460,15 @@ export class WikiMigrateService {
       }
       case 'memory-entry': {
         // sourceId is the entry id; re-find by scanning agent dirs.
-        const homeAgentsRoot = page.sourceFile.replace(/~\/\.crewly\/agents\/.*$/, '');
-        const home = homeAgentsRoot.startsWith('~/')
-          ? path.join(os.homedir(), '.crewly', 'agents')
-          : path.join(os.homedir(), '.crewly', 'agents');
-        const m = page.sourceFile.match(/agents\/([^/]+)\//);
+        // Honors the caller's homeDir — the scan side reads agents from
+        // `<homeDir>/.crewly/agents`, so re-reading from the process homedir
+        // would look in a different tree whenever `~` is overridden.
+        const home = path.join(homeDir, '.crewly', 'agents');
+        // Separator-agnostic on purpose: new rows are written posix-style, but
+        // Windows installs already persisted `~\.crewly\agents\<name>\…` rows
+        // before #732 was fixed. Accepting both heals that existing backlog
+        // instead of leaving it permanently unmigratable.
+        const m = page.sourceFile.match(/agents[/\\]([^/\\]+)[/\\]/);
         if (!m) throw new Error('memory_source_unparseable');
         const agentName = m[1];
         const raw = await fs.readFile(

--- a/backend/src/websocket/chat.gateway.test.ts
+++ b/backend/src/websocket/chat.gateway.test.ts
@@ -381,6 +381,32 @@ describe('ChatGateway', () => {
       // Should succeed (ChatService doesn't throw for unknown convIds)
       expect(message).not.toBeNull();
     });
+
+    /**
+     * `source` is a closed enum (RECORD_TURN_SOURCES) and the audit
+     * discriminator for the turn. A caller once spread `source:'crewly-agent'`
+     * over it; the write then failed enum validation and the agent's reply was
+     * dropped AFTER the model had already produced it — the user just saw
+     * silence. Callers may add metadata; they may not redefine provenance.
+     */
+    it('keeps the canonical source even when a caller tries to override it', async () => {
+      const gateway = new ChatGateway(io as unknown as SocketIOServer);
+      await gateway.initialize();
+
+      const conv = await chatService.createNewConversation();
+
+      const message = await gateway.processNotifyMessage(
+        'session-override',
+        'Reply that must not be dropped',
+        conv.id,
+        { source: 'crewly-agent', extra: 'kept' }
+      );
+
+      expect(message).not.toBeNull();
+      expect(message?.metadata?.source).toBe('in-process-runtime');
+      // Non-reserved caller metadata still flows through.
+      expect(message?.metadata?.extra).toBe('kept');
+    });
   });
 
   // ===========================================================================

--- a/backend/src/websocket/chat.gateway.ts
+++ b/backend/src/websocket/chat.gateway.ts
@@ -256,9 +256,15 @@ export class ChatGateway {
         senderId: sessionId,
         content,
         metadata: {
-          source: 'in-process-runtime',
           sessionId,
           ...(metadata ?? {}),
+          // `source` is set LAST so a caller cannot clobber the audit
+          // discriminator. It is a closed enum (RECORD_TURN_SOURCES) owned by
+          // this path; when a caller spread an out-of-enum value over it, the
+          // write failed validation and the agent's reply was dropped after the
+          // work was already done. Callers may add metadata, not redefine
+          // where the turn came from.
+          source: 'in-process-runtime',
         },
       });
       const legacyMessage = v2MessageToLegacy(message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crewly",
-  "version": "1.11.6",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crewly",
-      "version": "1.11.6",
+      "version": "1.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crewly",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "type": "module",
   "description": "Multi-agent orchestration platform for AI coding teams — coordinates Claude Code, Gemini CLI, and Codex agents with a real-time web dashboard",
   "workspaces": [

--- a/packages/crewly-agent/src/cli.ts
+++ b/packages/crewly-agent/src/cli.ts
@@ -10,15 +10,19 @@ import type {
 
 type ParentMessage =
   | { type: 'init'; config: CrewlyAgentConfig }
-  | { type: 'run'; message: string; conversationId?: string; metadata?: Record<string, string> }
+  | { type: 'run'; runId?: string; message: string; conversationId?: string; metadata?: Record<string, string> }
   | { type: 'abort' }
   | { type: 'get-state' }
   | { type: 'shutdown' };
 
 type WorkerMessage =
   | { type: 'ready' }
-  | { type: 'result'; data: AgentRunResult }
-  | { type: 'error'; error: string; code?: string }
+  // `runId` is echoed straight back from the `run` that produced it so the
+  // parent can match a reply to its request. Without it the parent has to
+  // guess, and guessing wrong books one conversation's answer against
+  // another. Optional so an older parent that sends no id still works.
+  | { type: 'result'; runId?: string; data: AgentRunResult }
+  | { type: 'error'; runId?: string; error: string; code?: string }
   | { type: 'log'; level: 'debug' | 'info' | 'warn' | 'error'; message: string }
   | { type: 'stream'; event: 'text'; data: { chunk: string } }
   | { type: 'stream'; event: 'toolStart'; data: { toolName: string; args: Record<string, unknown> } }
@@ -71,9 +75,10 @@ async function handleMessage(message: ParentMessage): Promise<void> {
         runner = null;
       }
       break;
-    case 'run':
+    case 'run': {
+      const { runId } = message;
       if (!runner || !runner.isInitialized()) {
-        send({ type: 'error', error: 'Worker not initialized', code: 'NOT_INITIALIZED' });
+        send({ type: 'error', runId, error: 'Worker not initialized', code: 'NOT_INITIALIZED' });
         return;
       }
       currentAbort = new AbortController();
@@ -88,16 +93,18 @@ async function handleMessage(message: ParentMessage): Promise<void> {
           },
         );
         currentAbort = null;
-        send({ type: 'result', data: result });
+        send({ type: 'result', runId, data: result });
       } catch (error) {
         currentAbort = null;
         send({
           type: 'error',
+          runId,
           error: error instanceof Error ? error.message : String(error),
           code: 'RUN_FAILED',
         });
       }
       break;
+    }
     case 'abort':
       if (currentAbort) {
         currentAbort.abort();
@@ -145,6 +152,9 @@ rl.on('line', (line) => {
   handleMessage(message).catch((error) => {
     send({
       type: 'error',
+      // Carry the correlation id here too — an unhandled failure must settle
+      // the run it belongs to, not whichever run happens to be oldest.
+      runId: message.type === 'run' ? message.runId : undefined,
       error: error instanceof Error ? error.message : String(error),
       code: 'UNHANDLED',
     });

--- a/packages/crewly-agent/src/runtime/agent-runner.service.test.ts
+++ b/packages/crewly-agent/src/runtime/agent-runner.service.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, vi, type Mocked, type MockInstance } from 'vitest';
-import { AgentRunnerService, ToolCallLoopDetector } from './agent-runner.service.js';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mocked, type MockInstance } from 'vitest';
+import { AgentRunnerService, AgentRunTimeoutError, ToolCallLoopDetector } from './agent-runner.service.js';
 import { ModelManager } from './model-manager.js';
 import { CrewlyApiClient } from './api-client.js';
-import type { CrewlyAgentConfig, SecurityPolicy, AuditEntry } from './types.js';
+import { CREWLY_AGENT_DEFAULTS, type CrewlyAgentConfig, type SecurityPolicy, type AuditEntry } from './types.js';
 
 describe('AgentRunnerService', () => {
   let runner: AgentRunnerService;
@@ -2352,4 +2352,138 @@ describe('B4 — DeepSeek tool_choice passthrough regression', () => {
       expect(runner.getConversationCount()).toBe(1);
     });
   });
+
+});
+
+/**
+ * Wall-clock run budget — the 假死 (silent-catatonia) guard.
+ *
+ * Regression cover for the production incident where a stalled model
+ * connection hung `await streamResult` forever. `MESSAGE_TIMEOUT_MS` and
+ * `MODEL_TIMEOUT_MS` existed as documented constants but nothing ever read
+ * them, so the orchestrator went silent for 12 days without a single log
+ * line. These tests assert the budget is actually ENFORCED, not merely
+ * declared.
+ */
+describe('AgentRunnerService run wall-clock budget', () => {
+  let runner: AgentRunnerService;
+  let mockGenerateText: vi.Mock<any>;
+  let mockModelManager: any;
+  let mockApiClient: any;
+
+  const baseConfig: CrewlyAgentConfig = {
+    model: { provider: 'anthropic', modelId: 'claude-sonnet-4-20250514', temperature: 0.3, maxTokens: 8192 },
+    maxSteps: 10,
+    sessionName: 'budget-session',
+    apiBaseUrl: 'http://localhost:8787',
+    systemPrompt: 'You are a test agent.',
+    maxHistoryMessages: 20,
+    compactionThreshold: 0.8,
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    mockGenerateText = vi.fn<any>();
+    mockModelManager = {
+      getModel: vi.fn<any>().mockResolvedValue({ provider: 'mock', modelId: 'test-model' }),
+      getAvailableProviders: vi.fn<any>(),
+      clearCache: vi.fn<any>(),
+      consumeDeepseekReasoning: vi.fn<any>().mockResolvedValue(null),
+    };
+    mockApiClient = { get: vi.fn<any>(), post: vi.fn<any>(), delete: vi.fn<any>() };
+
+    runner = new AgentRunnerService(baseConfig, mockModelManager, mockApiClient);
+    runner._generateTextFn = mockGenerateText;
+    await runner.initialize();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+    it('rejects with AgentRunTimeoutError when the model never responds', async () => {
+      // A model call that never settles — exactly the stalled-socket shape.
+      mockGenerateText.mockImplementation(() => new Promise(() => {}));
+
+      const runPromise = runner.run('will stall');
+      const assertion = expect(runPromise).rejects.toBeInstanceOf(AgentRunTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS + 1);
+
+      await assertion;
+    });
+
+    it('does not wedge the queue — later messages still process after a timeout', async () => {
+      // THE regression: a hung run left `processing` true forever, so every
+      // subsequent message queued behind it and the agent went catatonic.
+      mockGenerateText.mockImplementationOnce(() => new Promise(() => {}));
+
+      const stalled = runner.run('will stall');
+      const stalledAssertion = expect(stalled).rejects.toBeInstanceOf(AgentRunTimeoutError);
+      await vi.advanceTimersByTimeAsync(CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS + 1);
+      await stalledAssertion;
+
+      expect(runner.isProcessing()).toBe(false);
+
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'recovered',
+        toolCalls: [],
+        steps: [],
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finishReason: 'stop',
+      });
+
+      await expect(runner.run('after the stall')).resolves.toMatchObject({ text: 'recovered' });
+    });
+
+    it('does not retry a budget expiry (it spans the retries already)', async () => {
+      mockGenerateText.mockImplementation(() => new Promise(() => {}));
+
+      const runPromise = runner.run('will stall');
+      const assertion = expect(runPromise).rejects.toBeInstanceOf(AgentRunTimeoutError);
+      await vi.advanceTimersByTimeAsync(CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS + 1);
+      await assertion;
+
+      // One attempt only — a retried timeout would multiply the stall.
+      expect(mockGenerateText).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors the per-model budget override for reasoning models', async () => {
+      const reasoningRunner = new AgentRunnerService(
+        { ...baseConfig, model: { ...baseConfig.model, modelId: 'deepseek-reasoner' } },
+        mockModelManager,
+        mockApiClient,
+      );
+      reasoningRunner._generateTextFn = mockGenerateText;
+      await reasoningRunner.initialize();
+      mockGenerateText.mockImplementation(() => new Promise(() => {}));
+
+      const runPromise = reasoningRunner.run('slow chain-of-thought');
+      const settled = vi.fn();
+      runPromise.then(settled, settled);
+
+      // Still alive at the default budget — the override must win.
+      await vi.advanceTimersByTimeAsync(CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS + 1);
+      expect(settled).not.toHaveBeenCalled();
+
+      const assertion = expect(runPromise).rejects.toBeInstanceOf(AgentRunTimeoutError);
+      await vi.advanceTimersByTimeAsync(
+        CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS['deepseek-reasoner'],
+      );
+      await assertion;
+    });
+
+    it('leaves a run that completes in time untouched', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: 'fast enough',
+        toolCalls: [],
+        steps: [],
+        usage: { inputTokens: 1, outputTokens: 1 },
+        finishReason: 'stop',
+      });
+
+      await expect(runner.run('quick')).resolves.toMatchObject({ text: 'fast enough' });
+    });
 });

--- a/packages/crewly-agent/src/runtime/agent-runner.service.ts
+++ b/packages/crewly-agent/src/runtime/agent-runner.service.ts
@@ -158,7 +158,10 @@ export class ToolCallLoopDetector {
       }
       if (this.consecutiveErrors >= this.errorThreshold) {
         this.loopDetected = true;
-        this.loopReason = `Tool "${toolName}" returned errors ${this.consecutiveErrors} consecutive times. Last result: ${String(result).slice(0, 200)}`;
+        // Serialize objects properly — `String(obj)` yields "[object Object]"
+        // and loses the actual error. Mirror isErrorResult()'s serialization.
+        const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+        this.loopReason = `Tool "${toolName}" returned errors ${this.consecutiveErrors} consecutive times. Last result: ${resultStr.slice(0, 200)}`;
         return true;
       }
     } else {
@@ -198,6 +201,40 @@ export class ToolCallLoopDetector {
  * const result = await runner.run('Check all team statuses');
  * ```
  */
+/**
+ * Thrown when a single agent run exceeds its wall-clock budget.
+ *
+ * Distinct class (rather than a message-sniffed "timeout" string) because
+ * {@link AgentRunnerService.isRecoverableError} treats anything mentioning
+ * "timeout" as retryable. A hard-budget expiry is deliberately NOT retryable:
+ * the budget covers the whole run including retries, so re-entering the retry
+ * loop would multiply the very stall the budget exists to bound.
+ *
+ * @example
+ * ```typescript
+ * try { await runner.run(msg); }
+ * catch (e) { if (e instanceof AgentRunTimeoutError) recycleAgent(); }
+ * ```
+ */
+export class AgentRunTimeoutError extends Error {
+  /** Wall-clock budget that was exceeded, in milliseconds. */
+  readonly timeoutMs: number;
+
+  /**
+   * @param timeoutMs - The budget that was exceeded, in milliseconds
+   * @param modelId - Model the run was using, for operator diagnosis
+   */
+  constructor(timeoutMs: number, modelId: string) {
+    super(
+      `Agent run exceeded its ${timeoutMs}ms wall-clock budget (model: ${modelId}) `
+      + `and was hard-aborted. The model connection stalled without delivering a `
+      + `response — see CREWLY_AGENT_MESSAGE_TIMEOUT_MS to tune the budget.`,
+    );
+    this.name = 'AgentRunTimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 /** Function type for generateText — used for dependency injection in tests */
 type GenerateTextFn = (opts: Record<string, unknown>) => Promise<Record<string, unknown>>;
 
@@ -824,17 +861,71 @@ export class AgentRunnerService {
       externalAbortSignal.addEventListener('abort', () => runAbort.abort(), { once: true });
     }
 
+    // Wall-clock budget for the ENTIRE run (all retries included).
+    //
+    // Without this, a model connection that opens but then goes silent — no
+    // bytes, no FIN, no error — hangs `await streamResult` forever: undici
+    // applies no idle deadline to a streaming body. That stalled promise wedges
+    // processQueue permanently (`this.processing` stays true), so every later
+    // message queues behind it and the agent goes silently catatonic: the
+    // process is alive and heartbeating, but no run ever completes and no error
+    // is ever raised. Bounding the run converts that invisible hang into a
+    // normal rejection the caller can log, surface, and recover from.
+    const timeoutMs = this.resolveRunTimeoutMs();
+    let hardTimer: ReturnType<typeof setTimeout> | undefined;
+    let softTimer: ReturnType<typeof setTimeout> | undefined;
+
     try {
       // If a test override is set, use generateText path (backward compatible)
-      if (this._generateTextFn) {
-        return await this.executeRunWithGenerateText(tools, runAbort.signal);
-      }
+      const runPromise = this._generateTextFn
+        ? this.executeRunWithGenerateText(tools, runAbort.signal)
+        // Production path: streamText for real-time feedback
+        : this.executeRunWithStreamText(tools, runAbort.signal);
 
-      // Production path: streamText for real-time feedback
-      return await this.executeRunWithStreamText(tools, runAbort.signal);
+      // The loser of the race stays pending. Attach a no-op catch so its
+      // eventual abort-rejection is never an unhandled rejection (which
+      // crashes the agent process under Node's default policy).
+      runPromise.catch(() => { /* settled by the race below */ });
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        softTimer = setTimeout(() => {
+          console.warn(
+            `[AgentRunner] Run exceeded soft warning threshold `
+            + `(${CREWLY_AGENT_DEFAULTS.MESSAGE_SOFT_WARNING_MS}ms) — still waiting on the model.`,
+          );
+        }, CREWLY_AGENT_DEFAULTS.MESSAGE_SOFT_WARNING_MS);
+
+        hardTimer = setTimeout(() => {
+          // Abort first so the in-flight HTTP request and any tool work are
+          // torn down, then reject — a well-behaved provider unwinds on the
+          // signal, and a wedged one no longer holds the queue hostage.
+          runAbort.abort();
+          reject(new AgentRunTimeoutError(timeoutMs, this.config.model.modelId));
+        }, timeoutMs);
+      });
+
+      return await Promise.race([runPromise, timeoutPromise]);
     } finally {
+      if (hardTimer) clearTimeout(hardTimer);
+      if (softTimer) clearTimeout(softTimer);
       this.currentRunAbort = null;
     }
+  }
+
+  /**
+   * Resolve the wall-clock budget for one run.
+   *
+   * Per-model overrides win over the global default: reasoning models emit
+   * chain-of-thought tokens far slower than plain content, so a budget tuned
+   * for a chat model would kill them mid-thought.
+   *
+   * @returns Budget in milliseconds for the currently configured model
+   */
+  private resolveRunTimeoutMs(): number {
+    return (
+      CREWLY_AGENT_DEFAULTS.MODEL_TIMEOUT_MS[this.config.model.modelId]
+      ?? CREWLY_AGENT_DEFAULTS.MESSAGE_TIMEOUT_MS
+    );
   }
 
   /**
@@ -850,6 +941,9 @@ export class AgentRunnerService {
    */
   private isRecoverableError(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
+    // Hard-budget expiry is terminal by construction: the budget spans the
+    // whole run, so retrying would just re-enter the stall it bounded.
+    if (error instanceof AgentRunTimeoutError) return false;
     const msg = error.message.toLowerCase();
     const statusMatch = msg.match(/\b(429|5\d{2})\b/);
     if (statusMatch) return true;

--- a/packages/crewly-agent/src/runtime/tool-registry.test.ts
+++ b/packages/crewly-agent/src/runtime/tool-registry.test.ts
@@ -2186,6 +2186,25 @@ describe('Tool Registry', () => {
       expect(validateFn('rm -rf ./dist')).toBeNull();
       expect(validateFn('rm -rf node_modules')).toBeNull();
     });
+
+    it('should signal the block is permanent so the model stops retrying', () => {
+      // A blocked command is a policy decision, not a transient failure. When
+      // the message read like a retryable error the model retried variations
+      // until the loop detector aborted the whole run, so the wording carries
+      // real behavioural weight and is worth pinning.
+      const reason = validateFn('kill -9 $$');
+
+      expect(reason).not.toBeNull();
+      expect(reason).toMatch(/permanently blocked/i);
+      expect(reason).toMatch(/NOT a transient error/i);
+      expect(reason).toMatch(/do NOT retry/i);
+    });
+
+    it('should still identify which pattern caused the block', () => {
+      // The matched pattern stays in the message: without it the model cannot
+      // tell which part of a compound command was rejected.
+      expect(validateFn('shutdown -h now')).toMatch(/shutdown/);
+    });
   });
 
   describe('bash_exec tool', () => {

--- a/packages/crewly-agent/src/runtime/tool-registry.ts
+++ b/packages/crewly-agent/src/runtime/tool-registry.ts
@@ -79,7 +79,10 @@ export const APPROVAL_REQUIRED_BASH_PATTERNS: Array<{ pattern: RegExp; label: st
 export function validateBashCommand(command: string): string | null {
   for (const pattern of BLOCKED_COMMAND_PATTERNS) {
     if (pattern.test(command)) {
-      return `Command blocked by security policy: matches forbidden pattern ${pattern}`;
+      // Phrased to signal the model this is a PERMANENT policy block, not a
+      // transient failure — otherwise it retries variations until the loop
+      // detector aborts the whole run.
+      return `Command permanently blocked by security policy (matched ${pattern}). This is NOT a transient error — do NOT retry this or a variation. Achieve the goal a different way (use a Crewly API/tool, or skip this step).`;
     }
   }
   return null;

--- a/packages/crewly-agent/src/runtime/types.ts
+++ b/packages/crewly-agent/src/runtime/types.ts
@@ -540,6 +540,15 @@ export const CREWLY_AGENT_DEFAULTS = {
   /** Soft warning threshold in milliseconds — logs a warning but does not kill the request.
    *  Override via CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS env var. */
   MESSAGE_SOFT_WARNING_MS: Number(process.env.CREWLY_AGENT_MESSAGE_SOFT_WARNING_MS) || 240_000,
+  /** Grace period added on top of the agent's own run budget before the PARENT
+   *  gives up waiting on the child's IPC reply.
+   *
+   *  The child enforces the run budget itself and reports a clean error, so in
+   *  normal operation the parent timer never fires. It exists for the case the
+   *  child can no longer report at all — blocked event loop, broken stdout pipe,
+   *  SIGSTOP. The grace keeps the parent from racing the child and mislabelling
+   *  a normal in-budget timeout as a wedged runtime. */
+  IPC_RUN_TIMEOUT_GRACE_MS: 30_000,
   /** Cooldown period in milliseconds after rate limit retries are exhausted */
   RATE_LIMIT_COOLDOWN_MS: 300_000,
   /** Maximum number of automatic retries for recoverable errors (429, 5xx, network) */


### PR DESCRIPTION
Three commits, one bug class: reconciler rules emitting status corrections the state machine rejects, or that the rule was never entitled to make.

## What was broken

**1. Forever-throwing TTL corrections (`b8c74b89`).** The TTL rule issued an unconditional `→ cancelled`. That is illegal from `rejected` and `failed` — their only outbound edge is `→ queued`. Every 60s pass retried, threw `Invalid status transition`, and left the items uncleaned. Same shape as the 2026-05-12 `done_by_worker` incident, which was fixed by special-casing one status without applying it to its siblings. Now table-driven off `WORK_ITEM_TRANSITIONS`: a status can only receive a target the matrix permits, and a status with no legal terminal target is skipped rather than corrected into an exception.

**2. Unearned auto-acceptance (`8b6bd039`).** Fixing (1) routed `detectOrphanWorkItems` and `cascadeCancelChildren` through the TTL picker — which imported a semantic that does not belong to them. The TTL picker falls back to `verified` for `done_by_worker` on purpose: 24h with nobody objecting is a defensible reading of implicit acceptance. Cascade has no time dimension; it fires the instant a dead ancestor is reconciled. So a child that entered `done_by_worker` **one second earlier** was stamped `verified` because an unrelated ancestor failed — TL-unreviewed work auto-accepted with no age gate and no verdict, defeating the invariant `runFull` orders `detectUnverifiedWorkItems` ahead of the pruning pass to protect.

Fixed with a separate cancel-only `pickCascadeTarget`, not a `done_by_worker` guard: a single-status guard would leave `rejected`/`failed` still emitting the illegal edge from (1). Both pickers stay table-driven, so a future `WorkItemStatus` can only ever be *skipped* by these rules — inert — never throw forever.

Same commit found a second instance: `runPruningPass` seeded the cascade set from raw `ttl.expiredIds`. TTL legitimately emits `done_by_worker → verified`, so a parent that had just been **accepted** was treated as a dead ancestor and its live children cascade-cancelled. Now filtered to `newState === 'cancelled'`.

**3. A metric that conflated opposites (`19ee63b2`).** `staleItemsCleaned` summed `ttlExpiredCount`, which included the auto-*verified* items. An operator reading `staleItemsCleaned = 10` concluded 10 items were discarded when some had been accepted. `ttlExpiredCount` is retired for two single-meaning counters; auto-acceptance stays observable via its own counter, a warn log, and the per-item corrections.

## Also in here

`detectStrandedRejectedWorkItems` / `requeueAfterRejection` were added and then reverted within this branch. Independent review found the successor predicate wrong in both directions — `getActiveWorkItems()` filters out `done`/`cancelled`, so a successor in either state was invisible and the source was re-dispatched (duplicate execution of completed work); and `buildAutoWorkItem` sets `parentWorkItemId` on the VERIFY WI too, so the rule skipped the very SLA case it was written for. Doing it correctly needs a real successor model, not a bolt-on.

That follow-up is now **deliberately not scheduled**. A survey of every path into `rejected`/`failed` established that `rejected` is unreachable in production: `verifyItem` has one production call site hardcoded to `verified`, there is no verify or reject route, and the TL's own `verify-output` skill only issues GETs and never writes a verdict back. Designing a successor for a status nothing can produce would repeat the mistake that killed the reverted rule — reasoning about a path no traffic can exercise. The verdict-loop gap is being raised separately as a product issue.

## Verification

- Reconciler suites **260/260** (baseline 235 at branch start; +25).
- The headline invariant test originally asserted soundness only — it passed if the rule did nothing. Rewritten to derive expectations from the transition table and assert **liveness and soundness**.
- Mutation-verified throughout: reintroducing the original bug fails 9 tests; nulling the picker fails 14; routing cascade back through the TTL picker fails 6; folding auto-verified back into `staleItemsCleaned` fails its named test.
- No new type errors: the reconciler files are clean, and the project-level count matches `main` exactly — the pre-existing errors are in controller `ApiContext` and self-improvement test files, untouched by this diff.
- Reviewed independently by Victor on a separate worktree with his own probes, including a liveness check confirming the rules were not simply made inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)