### PR TITLE
fix(skills): stop complete-task and both delegate-task skills rejecting valid input

### DIFF
--- a/config/skills/agent/core/complete-task/SKILL.md
+++ b/config/skills/agent/core/complete-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: Complete Task
 description: Mark a task as complete with a summary of the work done.
-version: 1.1.0
+version: 1.2.0
 category: task-management
 skillType: claude-skill
 assignableRoles:
@@ -43,23 +43,55 @@ Mark a task as complete with a summary of the work done. If the task has an outp
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `absoluteTaskPath` | Yes | Absolute filesystem path to the task file |
+| `workItemId` | Preferred | ID of the V3 WorkItem to complete. This is the only input that selects the WorkItem |
 | `sessionName` | Yes | Your agent session name |
 | `summary` | Yes | Summary of the work completed |
+| `absoluteTaskPath` | No | **Legacy (V1).** Still accepted so older callers keep working, but it does NOT identify a WorkItem |
 | `output` | No | Structured output object (required if task has an output schema) |
 | `skipGates` | No | Set to `true` to skip quality gate checks |
+
+### Which WorkItem gets completed
+
+Resolution order:
+
+1. `workItemId`, if you pass it — always wins.
+2. Otherwise, a lookup of the WorkItem currently `running` against your
+   `sessionName` (`GET /api/task-pool/items?status=running&target=<session>`).
+3. If neither resolves, the skill exits non-zero with an error naming the
+   session it searched. It never reports success without completing something.
+
+Pass `workItemId` whenever you know it — the lookup in step 2 depends on the
+pool state at that instant and cannot disambiguate two concurrently running
+items for one session.
 
 ## Example
 
 ```bash
-bash config/skills/agent/complete-task/execute.sh '{"absoluteTaskPath":"/projects/app/tasks/implement-login.md","sessionName":"dev-1","summary":"Implemented login form with validation and tests"}'
+bash config/skills/agent/core/complete-task/execute.sh '{"workItemId":"wi-abc123","sessionName":"dev-1","summary":"Implemented login form with validation and tests"}'
+```
+
+### Letting the skill resolve your running WorkItem
+
+```bash
+bash config/skills/agent/core/complete-task/execute.sh '{"sessionName":"dev-1","summary":"Implemented login form with validation and tests"}'
 ```
 
 ### With structured output
 
 ```bash
-bash config/skills/agent/complete-task/execute.sh '{"absoluteTaskPath":"/projects/app/tasks/implement-login.md","sessionName":"dev-1","summary":"Implemented login","output":{"summary":"Login form with validation","filesChanged":["src/login.tsx","src/login.test.tsx"],"testsAdded":2}}'
+bash config/skills/agent/core/complete-task/execute.sh '{"workItemId":"wi-abc123","sessionName":"dev-1","summary":"Implemented login","output":{"summary":"Login form with validation","filesChanged":["src/login.tsx","src/login.test.tsx"],"testsAdded":2}}'
 ```
+
+Note: a `summary` key inside `output` overrides the top-level `summary`.
+
+### Legacy V1 caller (still supported)
+
+```bash
+bash config/skills/agent/core/complete-task/execute.sh '{"absoluteTaskPath":"/projects/app/.crewly/tasks/in_progress/implement-login.md","sessionName":"dev-1","summary":"Implemented login"}'
+```
+
+`absoluteTaskPath` is carried for logging context only; the WorkItem is still
+resolved by step 2 above.
 
 ## Output Schema
 

--- a/config/skills/agent/core/complete-task/execute.sh
+++ b/config/skills/agent/core/complete-task/execute.sh
@@ -5,14 +5,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../../_common/lib.sh"
 
 INPUT=$(read_json_input "${1:-}")
-[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"absoluteTaskPath\":\"/path/to/task\",\"sessionName\":\"dev-1\",\"summary\":\"Implemented feature X\",\"output\":{\"key\":\"value\"}}'"
+[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"workItemId\":\"wi-abc123\",\"sessionName\":\"dev-1\",\"summary\":\"Implemented feature X\",\"output\":{\"key\":\"value\"}}'"
 
+# `workItemId` is the V3 identifier and the ONLY input that drives the API
+# call (see the resolution block further down). `absoluteTaskPath` is the
+# legacy V1 input: still ACCEPTED so pre-existing callers keep working, but
+# it neither selects the WorkItem nor is required.
+#
+# It used to be `require_param`'d here, contradicting this skill's own
+# resolution logic: passing `workItemId` alone — the documented V3 flow —
+# returned `{"error":"Missing required parameter: absoluteTaskPath"}`, so
+# every agent completing a V3 WorkItem had to bypass the skill and curl
+# /api/task-pool/complete by hand. Same silent-friction class as the
+# create-task `{workItem: ...}` wrapper: the skill rejected a request that
+# was, by its own contract, correct.
+WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
 ABSOLUTE_TASK_PATH=$(printf '%s' "$INPUT" | jq -r '.absoluteTaskPath // empty')
 SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
 SUMMARY=$(printf '%s' "$INPUT" | jq -r '.summary // empty')
 SKIP_GATES=$(printf '%s' "$INPUT" | jq -r '.skipGates // empty')
 OUTPUT_JSON=$(printf '%s' "$INPUT" | jq -c '.output // empty')
-require_param "absoluteTaskPath" "$ABSOLUTE_TASK_PATH"
 require_param "sessionName" "$SESSION_NAME"
 require_param "summary" "$SUMMARY"
 
@@ -48,7 +60,7 @@ fi
 
 # #186: If the task file was already moved from in_progress/ to done/ by
 # report-status (via complete-by-session), succeed silently instead of failing.
-if echo "$ABSOLUTE_TASK_PATH" | grep -q '/in_progress/'; then
+if [ -n "$ABSOLUTE_TASK_PATH" ] && echo "$ABSOLUTE_TASK_PATH" | grep -q '/in_progress/'; then
   DONE_PATH="${ABSOLUTE_TASK_PATH/\/in_progress\///done/}"
   if [ -f "$DONE_PATH" ] && [ ! -f "$ABSOLUTE_TASK_PATH" ]; then
     echo '{"success":true,"message":"Task already completed (moved to done by report-status)"}'
@@ -69,15 +81,20 @@ fi
 # The legacy `absoluteTaskPath` input is still accepted but no longer
 # drives the API call — it's only used for logging context. Callers
 # should switch to passing `workItemId`.
-WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
+#
+# WORK_ITEM_ID was read from the input up top alongside the other params,
+# so the identifier is known before any of the legacy path handling runs.
 if [ -z "$WORK_ITEM_ID" ]; then
   POOL_RESP=$(api_call GET "/task-pool/items?status=running&target=${SESSION_NAME}" 2>/dev/null || echo '{}')
   WORK_ITEM_ID=$(echo "$POOL_RESP" | jq -r '.workItems[0].id // .data[0].id // empty' 2>/dev/null || true)
 fi
 
+# Neither an explicit `workItemId` nor the pool lookup produced a target.
+# Fail loudly and name both accepted identifiers — exiting 0 here would let
+# a worker believe its task was closed while the pool still shows it
+# running, which is the silent no-op this skill must never perform.
 if [ -z "$WORK_ITEM_ID" ]; then
-  echo '{"error":"Could not resolve a running WorkItem for this session — pass `workItemId` explicitly."}' >&2
-  exit 1
+  error_exit "Could not resolve a WorkItem to complete: no 'workItemId' was passed and no running WorkItem is assigned to session '${SESSION_NAME}'. Pass 'workItemId' explicitly — find it with GET /api/task-pool/items?status=running&target=${SESSION_NAME}. Note: 'absoluteTaskPath' is a legacy input and does NOT identify a WorkItem."
 fi
 
 # Hygiene #4: emit canonical body shape `{agentId, result:{summary, ...output}}`

--- a/config/skills/agent/core/complete-task/execute.test.sh
+++ b/config/skills/agent/core/complete-task/execute.test.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# =============================================================================
+# Tests for complete-task skill
+#
+# Guards how this skill resolves WHICH WorkItem to complete.
+#
+# `absoluteTaskPath` used to be `require_param`'d, which contradicted the
+# skill's own resolution logic: the V3 path selects the WorkItem from
+# `workItemId` (or a pool lookup) and treats `absoluteTaskPath` as legacy
+# logging context only. Passing `workItemId` alone therefore returned
+# `{"error":"Missing required parameter: absoluteTaskPath"}` and agents had
+# to bypass the skill and curl /api/task-pool/complete by hand.
+#
+# These tests fail if that requirement is reintroduced, if the legacy
+# `absoluteTaskPath` path stops working, or if resolving nothing degrades
+# into a silent no-op instead of a clear error.
+#
+# `curl` is stubbed on PATH, so every case runs offline and deterministically
+# while still proving the real HTTP request the skill would have issued.
+# =============================================================================
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+ERRORS=""
+
+assert_contains() {
+  local test_name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  ✓ ${test_name}"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  ✗ ${test_name}\n    expected to contain: ${needle}\n    actual: ${haystack}"
+    echo "  ✗ ${test_name}"
+    echo "    expected to contain: ${needle}"
+  fi
+}
+
+assert_not_contains() {
+  local test_name="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  ✗ ${test_name}\n    expected NOT to contain: ${needle}\n    actual: ${haystack}"
+    echo "  ✗ ${test_name}"
+    echo "    expected NOT to contain: ${needle}"
+  else
+    PASS=$((PASS + 1))
+    echo "  ✓ ${test_name}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# curl stub
+#
+# api_call() shells out to bare `curl`, so shadowing it on PATH intercepts
+# every request without touching the skill. The stub records `METHOD URL` and
+# the request body, then emits `<body>\n<http_code>` — the exact shape
+# api_call parses because of its `-w '\n%{http_code}'`.
+#
+# GET /task-pool/items returns one WorkItem so the legacy pool-lookup path
+# resolves, or an empty list when STUB_POOL_EMPTY=1, which is how the
+# "resolves nothing" case is exercised.
+# ---------------------------------------------------------------------------
+STUB_DIR="$(mktemp -d)"
+cat > "$STUB_DIR/curl" << 'STUB_EOF'
+#!/bin/bash
+METHOD="GET"; BODY=""; URL=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -X) METHOD="$2"; shift 2 ;;
+    -d) BODY="$2";   shift 2 ;;
+    -H) shift 2 ;;
+    -w) shift 2 ;;
+    -s) shift ;;
+    *)  URL="$1";    shift ;;
+  esac
+done
+echo "${METHOD} ${URL}" >> "$CURL_LOG"
+# Flatten to one line per request: jq -n pretty-prints, and the assertions
+# below need one parseable JSON document per log line.
+printf '%s\n' "$(printf '%s' "$BODY" | tr '\n' ' ')" >> "$CURL_BODY_LOG"
+
+if [ "$METHOD" = "GET" ] && printf '%s' "$URL" | grep -q '/task-pool/items'; then
+  if [ "${STUB_POOL_EMPTY:-0}" = "1" ]; then
+    echo '{"success":true,"data":[],"count":0}'
+  else
+    echo '{"success":true,"data":[{"id":"wi-from-pool"}],"count":1}'
+  fi
+  echo "200"
+  exit 0
+fi
+
+echo '{"success":true,"stub":true}'
+echo "200"
+STUB_EOF
+chmod +x "$STUB_DIR/curl"
+
+export CREWLY_API_URL="http://stub.invalid"
+export PATH="$STUB_DIR:$PATH"
+
+# Runs execute.sh with a fresh request log. Sets OUT (stdout+stderr),
+# REQUESTS (one "METHOD URL" per line) and BODIES (request bodies).
+run_skill() {
+  CURL_LOG="$(mktemp)"; export CURL_LOG
+  CURL_BODY_LOG="$(mktemp)"; export CURL_BODY_LOG
+  OUT="$(bash "$SCRIPT_DIR/execute.sh" "$1" 2>&1)" || true
+  REQUESTS="$(cat "$CURL_LOG")"
+  BODIES="$(cat "$CURL_BODY_LOG")"
+  rm -f "$CURL_LOG" "$CURL_BODY_LOG"
+}
+
+echo "=== complete-task tests ==="
+
+echo ""
+echo "--- workItemId alone is sufficient (the reported bug) ---"
+
+run_skill '{"workItemId":"wi-explicit","sessionName":"dev-1","summary":"Implemented feature X"}'
+assert_not_contains "workItemId alone does NOT demand absoluteTaskPath" \
+  "Missing required parameter: absoluteTaskPath" "$OUT"
+assert_contains "workItemId alone reaches POST /task-pool/complete/<id>" \
+  "POST http://stub.invalid/api/task-pool/complete/wi-explicit" "$REQUESTS"
+assert_not_contains "workItemId alone skips the pool lookup entirely" \
+  "/task-pool/items" "$REQUESTS"
+
+echo ""
+echo "--- Canonical completion body ---"
+
+# The endpoint reads `result.summary`; a top-level `summary` is ignored and
+# 400s (task-pool.controller.ts `completeItem`).
+# Tolerate no-match so a regression elsewhere reports as a failed assertion
+# rather than killing the run under `set -e` / `pipefail`.
+COMPLETE_BODY="$(printf '%s' "$BODIES" | grep 'agentId' | head -1 || true)"
+assert_contains "body carries agentId" '"agentId": "dev-1"' "$COMPLETE_BODY"
+assert_contains "body nests summary under result" '"summary": "Implemented feature X"' "$COMPLETE_BODY"
+RESULT_SUMMARY="$(printf '%s' "$COMPLETE_BODY" | jq -r '.result.summary // "MISSING"' 2>/dev/null || echo "MISSING")"
+assert_contains "result.summary is populated" "Implemented feature X" "$RESULT_SUMMARY"
+
+echo ""
+echo "--- Legacy absoluteTaskPath callers keep working (no regression) ---"
+
+run_skill '{"absoluteTaskPath":"/proj/.crewly/tasks/in_progress/t.md","sessionName":"dev-2","summary":"Legacy caller"}'
+assert_contains "legacy-only call falls back to the pool lookup" \
+  "GET http://stub.invalid/api/task-pool/items" "$REQUESTS"
+assert_contains "legacy-only call completes the resolved WorkItem" \
+  "POST http://stub.invalid/api/task-pool/complete/wi-from-pool" "$REQUESTS"
+
+run_skill '{"absoluteTaskPath":"/proj/.crewly/tasks/in_progress/t.md","workItemId":"wi-both","sessionName":"dev-2","summary":"Both identifiers"}'
+assert_contains "explicit workItemId wins when both are supplied" \
+  "POST http://stub.invalid/api/task-pool/complete/wi-both" "$REQUESTS"
+
+echo ""
+echo "--- Neither identifier resolves: clear error, not a silent no-op ---"
+
+STUB_POOL_EMPTY=1 run_skill '{"sessionName":"dev-3","summary":"Nothing to complete"}'
+assert_contains "unresolvable completion reports an error" '"error"' "$OUT"
+assert_contains "error names the workItemId parameter to pass" "workItemId" "$OUT"
+assert_contains "error names the session it searched" "dev-3" "$OUT"
+assert_not_contains "unresolvable completion does NOT POST a completion" \
+  "/task-pool/complete/" "$REQUESTS"
+
+CURL_LOG="$(mktemp)"; export CURL_LOG
+CURL_BODY_LOG="$(mktemp)"; export CURL_BODY_LOG
+if STUB_POOL_EMPTY=1 bash "$SCRIPT_DIR/execute.sh" \
+     '{"sessionName":"dev-3","summary":"Nothing to complete"}' > /dev/null 2>&1; then
+  FAIL=$((FAIL + 1))
+  echo "  ✗ unresolvable completion exits non-zero"
+  ERRORS="${ERRORS}\n  ✗ unresolvable completion exits non-zero (exited 0)"
+else
+  PASS=$((PASS + 1))
+  echo "  ✓ unresolvable completion exits non-zero"
+fi
+rm -f "$CURL_LOG" "$CURL_BODY_LOG"
+
+echo ""
+echo "--- Remaining required parameters still enforced ---"
+
+run_skill '{"workItemId":"wi-1","summary":"no session"}'
+assert_contains "Missing sessionName returns error" "sessionName" "$OUT"
+
+run_skill '{"workItemId":"wi-1","sessionName":"dev-1"}'
+assert_contains "Missing summary returns error" "summary" "$OUT"
+
+OUT="$(bash "$SCRIPT_DIR/execute.sh" '' 2>&1)" || true
+assert_contains "Empty input returns usage error" "Usage" "$OUT"
+assert_contains "Usage example leads with workItemId" "workItemId" "$OUT"
+
+echo ""
+echo "--- Source-level guards ---"
+
+SRC="$(cat "$SCRIPT_DIR/execute.sh")"
+
+assert_not_contains "absoluteTaskPath is NOT a required parameter" \
+  'require_param "absoluteTaskPath"' "$SRC"
+assert_contains "absoluteTaskPath is still parsed (legacy callers accepted)" \
+  "jq -r '.absoluteTaskPath // empty'" "$SRC"
+assert_contains "sessionName is still required" 'require_param "sessionName"' "$SRC"
+assert_contains "summary is still required" 'require_param "summary"' "$SRC"
+assert_contains "unresolved WorkItem exits via error_exit" \
+  'error_exit "Could not resolve a WorkItem to complete' "$SRC"
+assert_contains "legacy in_progress shortcut only runs on the legacy path" \
+  'if [ -n "$ABSOLUTE_TASK_PATH" ] && echo "$ABSOLUTE_TASK_PATH" | grep -q' "$SRC"
+
+# Cleanup
+rm -rf "$STUB_DIR"
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+if [ $FAIL -gt 0 ]; then
+  echo -e "\nFailures:${ERRORS}"
+  exit 1
+fi

--- a/config/skills/orchestrator/delegate-task/SKILL.md
+++ b/config/skills/orchestrator/delegate-task/SKILL.md
@@ -41,7 +41,7 @@ The script auto-resolves `config/skills/...` references to absolute paths so del
 | `--task` / `-T` | `task` | Yes | Task description (or pipe via stdin) |
 | `--task-file` | — | No | Read task description from a file path |
 | `--priority` / `-P` | `priority` | No | Priority: `low`, `normal`, `high` (default: `normal`) |
-| `--context` / `-c` | `context` | No | Additional context for the task |
+| `--context` / `-c` | `context` | No | Additional context for the task. Scanned for the Request Contract alongside `--task` |
 | `--project` / `-p` | `projectPath` | No | Project path; creates task file in `.crewly/tasks/` |
 | `--team` / `-g` | `teamId` | No | Team ID for cross-team validation |
 | `--task-type` | `taskType` | No | Task type: `general`, `technical` (default: `general`) |

--- a/config/skills/orchestrator/delegate-task/execute.sh
+++ b/config/skills/orchestrator/delegate-task/execute.sh
@@ -95,26 +95,51 @@ require_param "task (--task)" "$TASK"
 # downstream are entitled to push back per the Brief Reception Protocol when
 # these are absent. Spec:
 # .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §"Fix P0-3".
+#
+# Scans the WHOLE delegated brief, not just `--task`. The Request Contract can
+# legitimately live in `--task`, in `--context`, or be split across the two,
+# and delegators routinely put the long-form G/O/E in `--context` while
+# `--task` carries the one-line ask. `--context` is delivered to the target
+# (see the TASK_MESSAGE assembly below), so a contract written there does
+# reach the recipient — it was simply not being looked at here. Scanning only
+# `--task` therefore warned "Request Contract incomplete" at briefs whose
+# contract was fully present, just in the other field.
+#
+# That false positive is corrosive rather than cosmetic: this warning is the
+# signal TLs and workers use to decide whether to push back under the Brief
+# Reception Protocol, so crying wolf trains them to ignore a real one.
+#
+# The check is NOT weakened — a marker genuinely absent from BOTH fields
+# still warns, and the missing-field list is still per-marker.
+#
+# Mirrors the same fix in config/skills/team-leader/delegate-task/execute.sh.
+#
+# $1 = task, $2 = context (either may be empty).
 warn_missing_request_contract() {
-  local task="$1"
+  # Join with a newline rather than concatenating: the patterns below anchor
+  # on `^`, which grep evaluates per line, and a seam newline also prevents a
+  # task ending in "go" plus a context starting "al:" from fabricating a
+  # spurious "goal:" match across the boundary.
+  local brief
+  brief="$(printf '%s\n%s' "${1:-}" "${2:-}")"
   local missing=()
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
     missing+=("Goal")
   fi
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
     missing+=("Outcome")
   fi
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
     missing+=("Eval")
   fi
   if [ ${#missing[@]} -gt 0 ]; then
     local list
     list=$(IFS=, ; echo "${missing[*]}")
-    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. TLs and workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
+    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Neither the task nor the context field carries them. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. TLs and workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
   fi
 }
 
-warn_missing_request_contract "$TASK"
+warn_missing_request_contract "$TASK" "$CONTEXT"
 
 # #180: Validate target agent belongs to the specified team
 if [ -n "$TEAM_ID" ] && [ "$FORCE_CROSS_TEAM" != "true" ]; then

--- a/config/skills/orchestrator/delegate-task/execute.test.sh
+++ b/config/skills/orchestrator/delegate-task/execute.test.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Tests for ORC delegate-task execute.sh
 #
-# Focused on the auto-claim transition added 2026-05-20 — the skill must
+# Covers two things:
+#   1. the auto-claim transition (Tests 1-6), and
+#   2. the Request Contract checker (Test 7), which scans BOTH `--task` and
+#      `--context` — see the note above Test 7.
+#
+# Note the harness runs a COPY of the real execute.sh under a stubbed
+# api_call, so production logic is exercised verbatim; no part of the skill
+# is reimplemented here. Keep it that way — a hand-copied mirror of skill
+# logic silently stops tracking the skill.
+#
+# Tests 1-6 are focused on the auto-claim transition added 2026-05-20 — the skill must
 # call POST /task-pool/claim immediately after POST /task-pool/add succeeds,
 # so the WI transitions queued → running at dispatch time and doesn't rot
 # in queued waiting for a pull that may never come (the 2026-05-20
@@ -195,6 +205,148 @@ OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
   2>/dev/null || true)
 
 assert_output_contains "result reports custom fallbackMinutes=120" '"fallbackMinutes": 120' "$OUT"
+
+# ---------------------------------------------------------------------------
+# Test 7: Request Contract checker scans --task AND --context
+#
+# The checker used to read only `--task`. This skill has its own `--context`
+# flag and delivers it to the target, so an orchestrator that put the
+# long-form Goal / Expected Outcome / Eval Criteria in `--context` was told
+# the contract was "incomplete" while every marker was in fact present. That
+# false positive is what the Brief Reception Protocol keys off, so it has to
+# be right in both directions: silent when the contract is present anywhere,
+# and still loud when a marker is in neither field.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== ORC delegate-task — Request Contract checker ==="
+
+CTX_FULL="**Goal:** Ship the importer. **Expected Outcome:** CSVs land in prod. **Eval Criteria:** all tests green."
+
+# 7a: contract entirely in --context — must NOT warn
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "build the importer" \
+  --context "$CTX_FULL" \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: contract present in --context was still reported incomplete: $OUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: contract in --context suppresses the warning"
+  PASS=$((PASS + 1))
+fi
+
+# 7b: contract split across --task and --context — must NOT warn
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "**Goal:** ship the importer" \
+  --context "**Expected Outcome:** CSVs land in prod. **Eval Criteria:** all tests green." \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: split contract was reported incomplete: $OUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: contract split across --task and --context suppresses the warning"
+  PASS=$((PASS + 1))
+fi
+
+# 7c: contract entirely in --task, no --context — must NOT warn (no regression)
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "$CTX_FULL" \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: contract in --task alone was reported incomplete: $OUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: contract in --task alone still suppresses the warning"
+  PASS=$((PASS + 1))
+fi
+
+# 7d: one marker absent from BOTH — check is not weakened
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "**Goal:** ship it" \
+  --context "**Expected Outcome:** it ships." \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete" && echo "$OUT" | grep -q "Eval"; then
+  echo "  PASS: still warns for the one marker absent from both fields"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected an Eval-missing warning, got: $OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# 7e: nothing anywhere — all three still named
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "just do the thing" \
+  --context "here is some background prose" \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete" && \
+   echo "$OUT" | grep -q "Goal" && \
+   echo "$OUT" | grep -q "Outcome" && \
+   echo "$OUT" | grep -q "Eval"; then
+  echo "  PASS: all three markers reported missing"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected all three named, got: $OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# 7f: warning stays non-fatal — dispatch still happens
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "unstructured task" \
+  2>&1 || true)
+assert_log_contains "dispatch proceeds despite an incomplete contract" "POST /task-pool/add"
+
+# 7g: markers are not fabricated across the task/context seam
+> "$CALL_LOG"
+OUT=$(CALL_LOG="$CALL_LOG" CREWLY_ROOT=/tmp/crewly-test \
+  bash "${SKILL_PARENT}/delegate-task/execute.sh" \
+  --to crewly-test-bob \
+  --task "please go" \
+  --context "al: nothing here. Expected Outcome: y. Eval Criteria: z." \
+  2>&1 || true)
+if echo "$OUT" | grep -q "Request Contract incomplete" && echo "$OUT" | grep -q "Goal"; then
+  echo "  PASS: seam does not fabricate a Goal marker"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: 'go'+'al:' across the seam was accepted as a Goal marker: $OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# 7h: source-level guard on the production call site. The scenarios above run
+# a copy of execute.sh, but pin the call line explicitly so reverting it to
+# the task-only form fails loudly even if a future refactor moves the checker.
+SRC=$(cat "$SCRIPT_DIR/execute.sh")
+if printf '%s' "$SRC" | grep -q -- 'warn_missing_request_contract "$TASK" "$CONTEXT"'; then
+  echo "  PASS: call site passes \$TASK and \$CONTEXT"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: execute.sh does not call warn_missing_request_contract with both fields"
+  FAIL=$((FAIL + 1))
+fi
+if printf '%s' "$SRC" | grep -qE '^warn_missing_request_contract "\$TASK"$'; then
+  echo "  FAIL: execute.sh still has a task-only call to the contract checker"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no task-only call to the contract checker remains"
+  PASS=$((PASS + 1))
+fi
 
 # --- Summary ---
 echo ""

--- a/config/skills/team-leader/delegate-task/SKILL.md
+++ b/config/skills/team-leader/delegate-task/SKILL.md
@@ -42,11 +42,24 @@ Assigns a task to a worker within the Team Leader's subordinate scope. Validates
 | `--task` / `-T` | `task` | Yes | Task description (or pipe via stdin) |
 | `--task-file` | — | No | Read task description from a file path |
 | `--priority` / `-P` | `priority` | No | Priority: `low`, `normal`, `high` (default: `normal`) |
-| `--context` / `-c` | `context` | No | Additional context for the worker |
+| `--context` / `-c` | `context` | No | Additional context for the worker. Scanned for the Request Contract alongside `--task` |
 | `--project` / `-p` | `projectPath` | No | Project path; creates task file in `.crewly/tasks/` |
 | `--team` / `-g` | `teamId` | No | Team ID for hierarchy validation |
 | `--tl-member` | `tlMemberId` | No | TL's member ID for hierarchy validation |
 | `--from` | `fromSession` | No | Delegating TL's session name (for monitoring) |
+
+## Request Contract check
+
+Before delegating, the skill scans the brief for Goal, Expected Outcome, and
+Eval Criteria markers, and emits a non-fatal warning on stderr naming any that
+are missing. Workers use that warning to decide whether to push back under the
+Brief Reception Protocol.
+
+`--task` and `--context` are scanned **together**, so the contract may live in
+either field or be split across both. A marker absent from both still warns.
+
+Recognised synonyms: `Objective` for Goal; `Acceptance Criteria` or
+`Evaluation Criteria` for Eval Criteria.
 
 ## Usage — CLI Flags (preferred)
 

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -82,30 +82,49 @@ require_param "task (--task)" "$TASK"
 # entitled to push back per the Brief Reception Protocol when these are
 # absent. Spec: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md
 # §"Fix P0-3".
+#
+# Scans the WHOLE delegated brief, not just `--task`. The Request Contract
+# can legitimately live in `--task`, in `--context`, or be split across the
+# two, and delegators routinely put the long-form G/O/E in `--context` while
+# `--task` carries the one-line ask. Scanning only `--task` warned
+# "Request Contract incomplete" at briefs whose contract was fully present,
+# just in the other field. That false positive is corrosive: this warning is
+# the signal workers use to decide whether to push back under the Brief
+# Reception Protocol, so crying wolf trains them to ignore a real one.
+#
+# The check is NOT weakened — a marker genuinely absent from BOTH fields
+# still warns, and the missing-field list is still per-marker.
+#
+# $1 = task, $2 = context (either may be empty).
 warn_missing_request_contract() {
-  local task="$1"
+  # Join with a newline rather than concatenating: the patterns below anchor
+  # on `^`, which grep evaluates per line, and a seam newline also prevents a
+  # task ending in "go" plus a context starting "al:" from fabricating a
+  # spurious "goal:" match across the boundary.
+  local brief
+  brief="$(printf '%s\n%s' "${1:-}" "${2:-}")"
   local missing=()
   # Goal: the standalone word "Goal" (with optional ** markdown). Also
   # accept "Objective" as a synonym some upstream callers use.
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
     missing+=("Goal")
   fi
   # Outcome: "Outcome" or "Expected Outcome".
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
     missing+=("Outcome")
   fi
   # Eval: "Eval", "Eval Criteria", "Acceptance Criteria", "Evaluation Criteria".
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
+  if ! echo "$brief" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
     missing+=("Eval")
   fi
   if [ ${#missing[@]} -gt 0 ]; then
     local list
     list=$(IFS=, ; echo "${missing[*]}")
-    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. Workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
+    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Neither the task nor the context field carries them. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. Workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
   fi
 }
 
-warn_missing_request_contract "$TASK"
+warn_missing_request_contract "$TASK" "$CONTEXT"
 
 # Resolve Crewly root from this script path:
 # config/skills/team-leader/delegate-task/execute.sh -> project root

--- a/config/skills/team-leader/delegate-task/execute.test.sh
+++ b/config/skills/team-leader/delegate-task/execute.test.sh
@@ -1,11 +1,33 @@
 #!/bin/bash
 # Tests for TL delegate-task execute.sh
 # Covers: CREWLY_SESSION_NAME resolution, fromSession fallback,
-#         graceful monitoring skip, delegation success
+#         graceful monitoring skip, delegation success, and the Request
+#         Contract checker (which scans BOTH `task` and `context`).
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PASS=0
 FAIL=0
+
+# ---------------------------------------------------------------------------
+# Extract the REAL warn_missing_request_contract out of execute.sh.
+#
+# This file used to keep a hand-copied duplicate of that function inside the
+# mock, with a comment asking future editors to keep it "byte-equivalent".
+# It did not stay byte-equivalent, and worse, nothing could detect that:
+# changing the function in execute.sh left all 16 assertions green, because
+# they were exercising the copy. Pulling the function straight out of the
+# shipped script means production edits are felt here immediately, and makes
+# the mutation test in the commit message meaningful.
+# ---------------------------------------------------------------------------
+REAL_FN_FILE="$(mktemp)"
+export REAL_FN_FILE
+sed -n '/^warn_missing_request_contract() {$/,/^}$/p' "$SCRIPT_DIR/execute.sh" > "$REAL_FN_FILE"
+if ! grep -q 'Request Contract incomplete' "$REAL_FN_FILE"; then
+  echo "FATAL: could not extract warn_missing_request_contract() from execute.sh" >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$REAL_FN_FILE"
 
 assert_succeeds() {
   local desc="$1"
@@ -74,27 +96,11 @@ shift
 # Load the real shared lib first
 source "${REAL_SKILL_DIR}/../_common/lib.sh"
 
-# Request Contract warning helper (mirror of the real script's
-# warn_missing_request_contract — must stay byte-equivalent so the test
-# exercises actual production logic, not a stub).
-warn_missing_request_contract() {
-  local task="$1"
-  local missing=()
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(goal|objective)(:|s?\b)'; then
-    missing+=("Goal")
-  fi
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(expected )?outcome(:|s?\b)'; then
-    missing+=("Outcome")
-  fi
-  if ! echo "$task" | grep -qiE '(^|[^a-zA-Z])(\*\*)?(eval|evaluation criteria|acceptance criteria)(:|s?\b)'; then
-    missing+=("Eval")
-  fi
-  if [ ${#missing[@]} -gt 0 ]; then
-    local list
-    list=$(IFS=, ; echo "${missing[*]}")
-    echo "{\"warning\":\"Request Contract incomplete: brief is missing markers for: ${list}. Per P0-3 spec, every delegated subtask MUST include Goal + Expected Outcome + Eval Criteria. Workers may push back via the Brief Reception Protocol. Source: .crewly/specs/2026-05-03-agent-improvement-p0-execution.md §Fix P0-3.\"}" >&2
-  fi
-}
+# Load the REAL warn_missing_request_contract, extracted from execute.sh by
+# the harness above. Do NOT re-declare it here — a hand-copy silently
+# decouples these scenarios from the code that actually ships.
+# shellcheck source=/dev/null
+source "$REAL_FN_FILE"
 
 # Track API calls for verification
 API_CALLS_LOG=$(mktemp)
@@ -158,9 +164,14 @@ FROM_SESSION=$(echo "$INPUT" | jq -r '.fromSession // empty')
 require_param "to" "$TO"
 require_param "task" "$TASK"
 
-# Request Contract warning (P0-3): emit non-fatal warning when brief is
-# missing Goal / Expected Outcome / Eval markers. Mirror of the real script.
-warn_missing_request_contract "$TASK"
+# Request Contract warning (P0-3): emit the non-fatal warning when the brief
+# is missing Goal / Expected Outcome / Eval markers.
+#
+# Run the PRODUCTION call line verbatim, with this mock's $TASK / $CONTEXT
+# bound. Hardcoding the arguments here would let a regression at the real
+# call site — dropping $CONTEXT, say — slip past every scenario below, which
+# is exactly how the earlier hand-copied version of this mock went blind.
+eval "$(grep -E '^warn_missing_request_contract "' "${REAL_SKILL_DIR}/execute.sh")"
 
 # Validate hierarchy
 if [ -n "$TEAM_ID" ] && [ -n "$TL_MEMBER_ID" ]; then
@@ -510,7 +521,149 @@ else
   PASS=$((PASS + 1))
 fi
 
+# -----------------------------------------------------------------------
+# Scenario 15: Contract lives ENTIRELY in `context` — must NOT warn
+#
+# This is the reported bug. A delegator whose `task` is the one-line ask and
+# whose full Goal / Expected Outcome / Eval Criteria sit in `context` was
+# told the contract was "incomplete" even though every marker was present.
+# -----------------------------------------------------------------------
+echo "Scenario 15: full contract in context field only — no warning"
+CTX_FULL="**Goal:** Ship the importer. **Expected Outcome:** CSVs land in prod. **Eval Criteria:** all tests green."
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  "{\"to\":\"crewly-product-leo-dev\",\"task\":\"build the importer\",\"context\":\"$CTX_FULL\"}" 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: contract present in context was still reported incomplete: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: contract in context suppresses the warning"
+  PASS=$((PASS + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 16: Contract SPLIT across task and context — must NOT warn
+# -----------------------------------------------------------------------
+echo "Scenario 16: contract split across task and context — no warning"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"**Goal:** ship the importer","context":"**Expected Outcome:** CSVs land in prod. **Eval Criteria:** all tests green."}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete"; then
+  echo "  FAIL: split contract was reported incomplete: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: split contract suppresses the warning"
+  PASS=$((PASS + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 17: Check is NOT weakened — a field absent from BOTH still warns
+# -----------------------------------------------------------------------
+echo "Scenario 17: field missing from both fields still warns (check not weakened)"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"**Goal:** ship it","context":"**Expected Outcome:** it ships."}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete" && \
+   echo "$RAW_OUTPUT" | grep -q "Eval"; then
+  echo "  PASS: still warns for the one marker absent from both fields"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected an Eval-missing warning, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 18: Nothing anywhere — all three still named
+# -----------------------------------------------------------------------
+echo "Scenario 18: empty contract in both fields names Goal+Outcome+Eval"
+RAW_OUTPUT=$(env CREWLY_SESSION_NAME="sam-tl" bash "$MOCK_SCRIPT" "$SKILL_DIR" \
+  '{"to":"crewly-product-leo-dev","task":"just do the thing","context":"here is some background prose"}' 2>&1)
+if echo "$RAW_OUTPUT" | grep -q "Request Contract incomplete" && \
+   echo "$RAW_OUTPUT" | grep -q "Goal" && \
+   echo "$RAW_OUTPUT" | grep -q "Outcome" && \
+   echo "$RAW_OUTPUT" | grep -q "Eval"; then
+  echo "  PASS: all three markers reported missing"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected all three named, got: $RAW_OUTPUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenarios 19-22: direct unit tests against the REAL extracted function.
+#
+# These call warn_missing_request_contract() itself (sourced from
+# execute.sh at the top of this file), so they pin the two-argument
+# signature and the scan surface with no mock in between.
+# -----------------------------------------------------------------------
+echo "Scenario 19: function scans arg 2 (context) for markers"
+FN_OUT=$(warn_missing_request_contract "bare ask" \
+  "Goal: x. Expected Outcome: y. Eval Criteria: z." 2>&1 || true)
+if [ -z "$FN_OUT" ]; then
+  echo "  PASS: no warning when all markers are in the context argument"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected silence, got: $FN_OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "Scenario 20: function still scans arg 1 (task) on its own"
+FN_OUT=$(warn_missing_request_contract \
+  "Goal: x. Expected Outcome: y. Eval Criteria: z." "" 2>&1 || true)
+if [ -z "$FN_OUT" ]; then
+  echo "  PASS: no warning when all markers are in the task argument"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected silence, got: $FN_OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "Scenario 21: function warns when a marker is in neither argument"
+FN_OUT=$(warn_missing_request_contract "Goal: x." "Expected Outcome: y." 2>&1 || true)
+if echo "$FN_OUT" | grep -q "Request Contract incomplete" && echo "$FN_OUT" | grep -q "Eval"; then
+  echo "  PASS: names Eval as missing from both arguments"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: expected Eval-missing warning, got: $FN_OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "Scenario 22: markers are not fabricated across the task/context seam"
+# "go" + "al: ..." must not join into "goal:" — the newline join prevents it.
+FN_OUT=$(warn_missing_request_contract "please go" \
+  "al: nothing here. Expected Outcome: y. Eval Criteria: z." 2>&1 || true)
+if echo "$FN_OUT" | grep -q "Goal"; then
+  echo "  PASS: seam does not fabricate a Goal marker"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: 'go'+'al:' across the seam was accepted as a Goal marker: $FN_OUT"
+  FAIL=$((FAIL + 1))
+fi
+
+# -----------------------------------------------------------------------
+# Scenario 23: source-level guard on the production call site.
+#
+# The unit tests above cannot see which arguments execute.sh actually
+# passes. This asserts the call site itself, so reverting it to the
+# task-only form fails here even though the function stays correct.
+# -----------------------------------------------------------------------
+echo "Scenario 23: execute.sh calls the checker with BOTH task and context"
+SRC=$(cat "$SKILL_DIR/execute.sh")
+if printf '%s' "$SRC" | grep -q -- 'warn_missing_request_contract "$TASK" "$CONTEXT"'; then
+  echo "  PASS: call site passes \$TASK and \$CONTEXT"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: execute.sh does not call warn_missing_request_contract with both fields"
+  FAIL=$((FAIL + 1))
+fi
+
+if printf '%s' "$SRC" | grep -qE '^warn_missing_request_contract "\$TASK"$'; then
+  echo "  FAIL: execute.sh still has a task-only call to the contract checker"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: no task-only call to the contract checker remains"
+  PASS=$((PASS + 1))
+fi
+
 # Cleanup
+rm -f "$REAL_FN_FILE"
 rm -rf "$MOCK_DIR"
 
 echo ""


### PR DESCRIPTION
Three skills refused input they should have accepted. Every agent hit at least one of them.

## complete-task demanded a parameter its own comments call obsolete

`require_param "absoluteTaskPath"` made the legacy identifier mandatory, while the resolution logic a few lines below documents that `workItemId` is preferred and `absoluteTaskPath` "no longer drives the call". Completing a V3 WorkItem with the correct argument returned `Missing required parameter: absoluteTaskPath`, so agents either invented a placeholder `v3://` path or bypassed the skill and curled the API.

Now `workItemId` alone is sufficient. `absoluteTaskPath` still resolves for existing callers — this is a relaxation, not a rewrite — and passing neither still fails loudly, naming the session it searched and the parameter to supply.

## Both delegate-task skills only scanned half the input

The Request Contract checker read the `task` field alone. A delegator who wrote a complete, correct Goal / Expected Outcome / Eval Criteria into `context` — which both skills accept, and which the orchestrator skill forwards to the worker — still got an "incomplete contract" warning. Fixed in the team-leader and orchestrator copies; `grep -rn warn_missing_request_contract config/skills/` now returns exactly two call sites, both passing `task` and `context`. The class is closed, not just the reported instance.

The two halves are joined with a newline rather than concatenated, so a `task` ending in `go` followed by a `context` starting with `al:` cannot forge a `goal:` match across the boundary. A genuinely absent field still warns; the check was not weakened to make the tests pass, and a mutation that makes it never warn fails 7 assertions.

## Tests

`complete-task` had no test file — created, 24 assertions. `delegate-task` extended 16 → 26, orchestrator 18 → 27.

All three are mutation-verified rather than merely green: restoring `require_param` fails 10; reverting either call site to `"$TASK"` fails 4; narrowing the function to its first argument fails 2–3; weakening it to never warn fails 7.

That bar mattered here. The team-leader test carried a **hand-copied duplicate** of the function under test, with a comment asking editors to keep it byte-equivalent. It had already drifted — production could be changed with all 16 assertions still passing. It now extracts the function from `execute.sh` and evaluates the real call line, so mutations are actually felt. The orchestrator test already copied the real script into a fixture directory and overrode only `api_call`; a note records that as the pattern to keep.

## Known and deliberately not touched

`complete-task` sends `skipGates` on the wire and documents it in SKILL.md, but `completeItem` destructures only `{agentId, tokenUsage, result}` and nothing in the repo reads the field. It is a silent no-op: an agent can believe it bypassed quality gates when nothing happened. Removing it is a separate change, now decided and scheduled — a field that lies is worse than a field that fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)