### PR TITLE
fix(task-pool): let in-process crewly-agent runtimes pass the claim liveness gate

### DIFF
--- a/backend/src/services/orchestrator/orchestrator-status.service.test.ts
+++ b/backend/src/services/orchestrator/orchestrator-status.service.test.ts
@@ -17,6 +17,10 @@ const mockSessionState: { exists: boolean; backendAvailable: boolean; childProce
 // Track calls to updateAgentStatus for assertions
 const mockUpdateAgentStatus = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
+// Team members keyed by session name, used by findMemberBySessionName.
+// Drives the runtime-type half of the isAgentActive in-process fallback gate.
+const mockMembersBySession: Map<string, { runtimeType: string }> = new Map();
+
 // Mock storage service (using path without .js since moduleNameMapper strips it)
 jest.mock('../core/storage.service', () => ({
   StorageService: {
@@ -27,6 +31,10 @@ jest.mock('../core/storage.service', () => ({
           throw data;
         }
         return data;
+      },
+      findMemberBySessionName: async (sessionName: string) => {
+        const member = mockMembersBySession.get(sessionName);
+        return member ? { team: { id: 'team-1' }, member } : null;
       },
       updateAgentStatus: (...args: unknown[]) => mockUpdateAgentStatus(...(args as [])),
     }),
@@ -131,6 +139,7 @@ describe('OrchestratorStatusService', () => {
     mockSessionState.backendAvailable = true;
     mockSessionState.childProcessAlive = false;
     mockInProcessRegistryState.active = false;
+    mockMembersBySession.clear();
     mockUpdateAgentStatus.mockClear();
   });
 
@@ -140,6 +149,7 @@ describe('OrchestratorStatusService', () => {
     mockSessionState.backendAvailable = true;
     mockSessionState.childProcessAlive = false;
     mockInProcessRegistryState.active = false;
+    mockMembersBySession.clear();
     mockUpdateAgentStatus.mockClear();
   });
 
@@ -519,6 +529,80 @@ describe('OrchestratorStatusService', () => {
 
       const result = await isAgentActive('crewly-auditor');
       expect(result).toBe(false);
+    });
+
+    describe('in-process crewly-agent fallback', () => {
+      it('returns true for the orchestrator when it has no PTY session but a ready in-process runtime', async () => {
+        // crewly-orc lives in orchestrator.json, not in any team's members array
+        mockOrchestratorData.value = {
+          sessionName: 'crewly-orc',
+          agentStatus: 'active',
+          workingStatus: 'idle',
+          runtimeType: 'crewly-agent',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        mockSessionState.exists = false; // no PTY session — in-process runtime
+        mockInProcessRegistryState.active = true;
+
+        const result = await isAgentActive('crewly-orc');
+        expect(result).toBe(true);
+      });
+
+      it('returns true for a team member configured as crewly-agent with a ready in-process runtime', async () => {
+        mockMembersBySession.set('crewly-product-quinn', { runtimeType: 'crewly-agent' });
+        mockSessionState.exists = false;
+        mockInProcessRegistryState.active = true;
+
+        const result = await isAgentActive('crewly-product-quinn');
+        expect(result).toBe(true);
+      });
+
+      it('does NOT widen the gate: a PTY-less claude-code agent stays inactive even if the registry reports active', async () => {
+        mockMembersBySession.set('crewly-product-leo', { runtimeType: 'claude-code' });
+        mockSessionState.exists = false;
+        mockInProcessRegistryState.active = true; // would pass if runtime type were ignored
+
+        const result = await isAgentActive('crewly-product-leo');
+        expect(result).toBe(false);
+      });
+
+      it('returns false for a crewly-agent member when the in-process registry has no ready runtime', async () => {
+        mockMembersBySession.set('crewly-product-quinn', { runtimeType: 'crewly-agent' });
+        mockSessionState.exists = false;
+        mockInProcessRegistryState.active = false;
+
+        const result = await isAgentActive('crewly-product-quinn');
+        expect(result).toBe(false);
+      });
+
+      it('returns false for an unknown session even when the registry reports active', async () => {
+        mockSessionState.exists = false;
+        mockInProcessRegistryState.active = true;
+        mockOrchestratorData.value = null;
+
+        const result = await isAgentActive('session-that-does-not-exist');
+        expect(result).toBe(false);
+      });
+
+      it('returns true for a crewly-agent runtime when the session backend is entirely unavailable', async () => {
+        mockMembersBySession.set('crewly-product-quinn', { runtimeType: 'crewly-agent' });
+        mockSessionState.backendAvailable = false;
+        mockInProcessRegistryState.active = true;
+
+        const result = await isAgentActive('crewly-product-quinn');
+        expect(result).toBe(true);
+      });
+
+      it('keeps the PTY path authoritative: a live PTY claude-code agent is active without any registry entry', async () => {
+        mockMembersBySession.set('crewly-product-leo', { runtimeType: 'claude-code' });
+        mockSessionState.exists = true;
+        mockSessionState.childProcessAlive = true;
+        mockInProcessRegistryState.active = false;
+
+        const result = await isAgentActive('crewly-product-leo');
+        expect(result).toBe(true);
+      });
     });
   });
 

--- a/backend/src/services/orchestrator/orchestrator-status.service.ts
+++ b/backend/src/services/orchestrator/orchestrator-status.service.ts
@@ -12,7 +12,7 @@ import { StorageService } from '../core/storage.service.js';
 import { CREWLY_CONSTANTS, WEB_CONSTANTS } from '../../../../config/index.js';
 import { getSessionBackendSync } from '../session/index.js';
 import { isInProcessRuntimeActive } from '../agent/crewly-agent/in-process-runtime-registry.js';
-import { RUNTIME_TYPES } from '../../constants.js';
+import { RUNTIME_TYPES, type RuntimeType } from '../../constants.js';
 
 /** Dashboard URL for user-facing messages */
 const DASHBOARD_URL = `http://localhost:${WEB_CONSTANTS.PORTS.FRONTEND}`;
@@ -216,23 +216,88 @@ export async function getOrchestratorStatus(): Promise<OrchestratorStatusResult>
 }
 
 /**
- * Check if a specific agent is currently active by verifying its PTY session exists
- * and has a running child process.
+ * Resolve the configured runtime type for a session name.
+ *
+ * Looks the session up as a team member first, then falls back to the
+ * orchestrator record (the orchestrator lives in its own `orchestrator.json`
+ * and is not part of any team's `members` array).
+ *
+ * Only called on the in-process fallback path in {@link isAgentActive}, so
+ * the extra storage reads never touch the hot PTY path.
+ *
+ * @param sessionName - The session name to resolve a runtime type for
+ * @returns The configured runtime type, or `undefined` when the session is unknown
+ */
+async function resolveRuntimeTypeForSession(
+  sessionName: string,
+): Promise<RuntimeType | undefined> {
+  const storageService = StorageService.getInstance();
+
+  const found = await storageService.findMemberBySessionName(sessionName);
+  if (found?.member?.runtimeType) {
+    return found.member.runtimeType;
+  }
+
+  const orchestrator = await storageService.getOrchestratorStatus();
+  const orchestratorSession =
+    orchestrator?.sessionName || CREWLY_CONSTANTS.SESSIONS.ORCHESTRATOR_NAME;
+  if (orchestrator && orchestratorSession === sessionName) {
+    return orchestrator.runtimeType;
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if a specific agent is currently active.
+ *
+ * Two liveness paths, checked in order:
+ * 1. **PTY path (unchanged)** — the agent's PTY session exists AND its child
+ *    process (the AI runtime) is alive. This is the ground truth for
+ *    `claude-code`, `gemini-cli` and `codex-cli` runtimes.
+ * 2. **In-process fallback** — in-process Crewly Agent runtimes have no PTY
+ *    session at all, so `sessionExists()` always returns `false` for them.
+ *    When the in-process registry reports a ready runtime for this session
+ *    AND the session's configured runtime type is `crewly-agent`, the agent
+ *    is alive. This mirrors the B0 hot-fix fallback in
+ *    {@link getOrchestratorStatus}.
+ *
+ * The fallback is deliberately narrow: it requires BOTH a ready registry
+ * entry and a `crewly-agent` runtime type. A PTY-less `claude-code` agent
+ * still reports inactive — widening the gate would let dead agents claim
+ * work from the task pool, which is worse than the bug this fixes.
+ *
+ * The registry probe runs before the storage lookup because it is a
+ * synchronous map hit; when it misses (the common case for a genuinely dead
+ * PTY agent) no storage I/O happens at all.
  *
  * @param sessionName - The agent's session name to check
- * @returns Promise resolving to true if the agent's session is alive
+ * @returns Promise resolving to true if the agent's runtime is alive
+ *
+ * @example
+ * ```typescript
+ * // crewly-orc runs in-process with no PTY session
+ * await isAgentActive('crewly-orc'); // true when its runtime is registered and ready
+ * ```
  */
 export async function isAgentActive(sessionName: string): Promise<boolean> {
   try {
     const sessionBackend = getSessionBackendSync();
-    if (!sessionBackend) {
+    if (sessionBackend && sessionBackend.sessionExists(sessionName)) {
+      // Session exists — check if child process (the AI runtime) is alive
+      if (sessionBackend.isChildProcessAlive?.(sessionName)) {
+        return true;
+      }
+    }
+
+    // Runtime-aware fallback: in-process Crewly Agent runtimes have no PTY
+    // session. Cheap synchronous registry probe first, storage lookup only
+    // if it hits.
+    if (!isInProcessRuntimeActive(sessionName)) {
       return false;
     }
-    if (!sessionBackend.sessionExists(sessionName)) {
-      return false;
-    }
-    // Session exists — check if child process (the AI runtime) is alive
-    return !!sessionBackend.isChildProcessAlive?.(sessionName);
+    const runtimeType = await resolveRuntimeTypeForSession(sessionName);
+    return runtimeType === RUNTIME_TYPES.CREWLY_AGENT;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Problem

`isAgentActive()` (`backend/src/services/orchestrator/orchestrator-status.service.ts`) consulted only the PTY session backend. In-process Crewly Agent runtimes have **no PTY session at all**, so `sessionExists()` always returned `false` for them.

That function is the task-pool claim gate — `claimFromPool` / `claimSpecificItem` return `null` (→ 404) when it's false. Net effect: `crewly-orc` could never claim any verify/review WorkItem dispatched to it, so verification work across the project could not formally close. Blocked verify WI `1a53033c`.

## Fix

Mirror the B0 hot-fix fallback already present in `getOrchestratorStatus()` in the same file: when the PTY path does not confirm liveness, fall back to the in-process runtime registry — **but only when the session's configured `runtimeType` is `crewly-agent`.**

```
PTY path (unchanged, authoritative)
  └─ session exists AND child process alive → active

in-process fallback (new, narrow)
  └─ isInProcessRuntimeActive(session)  [sync map hit]
       AND runtimeType === 'crewly-agent'  [storage lookup]
     → active
```

### The gate is deliberately NOT widened

The fallback requires **both** a ready registry entry and a `crewly-agent` runtime type. A PTY-less `claude-code` agent still returns `false`. Letting dead PTY agents claim work would strand it silently — strictly worse than the bug being fixed. There is an explicit negative test for this.

### Notes on two things that are easy to get wrong

- **`crewly-orc`'s runtime type is not in any team's `members` array** — it lives in `orchestrator.json`. A `findMemberBySessionName`-only lookup would have missed the exact case being fixed, so `resolveRuntimeTypeForSession()` checks member first, then the orchestrator record.
- **Probe ordering is load-bearing for cost**, not just style: the synchronous registry probe runs *before* the async storage lookup, so a genuinely dead PTY agent triggers zero extra I/O on the hot claim path.

## Tests

7 new cases in `orchestrator-status.service.test.ts` (next to source, per repo standard):

| Case | Expect |
|---|---|
| Orchestrator, no PTY, ready in-process runtime | `true` |
| Team member `crewly-agent`, no PTY, ready runtime | `true` |
| **PTY-less `claude-code`, registry reports active** | **`false`** — do not widen |
| `crewly-agent` member, registry not ready | `false` |
| Unknown session, registry active | `false` |
| `crewly-agent`, session backend entirely unavailable | `true` |
| Live PTY `claude-code`, no registry entry | `true` — PTY stays authoritative |

**47/47 green** in that suite. `task-pool` suites (`claim.service`, `pool-storage`, `task-pool.service`) all pass — no gate regressions.

**Mutation-checked:** reverting the source change fails 3 of the new tests. The negative test correctly stays green under revert, which is the point of it.

`npm run build`, `tsc --noEmit`, and `eslint` all clean.

## Out of scope

3 `chat-v2` suites (4 tests) fail on a `huddle` channel-type drift. Verified failing identically on clean `main` — pre-existing and unrelated; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)