### PR TITLE
fix(test-infra): stop root vitest collecting .claude agent scratch space

### DIFF
--- a/config/vitest-exclude.constants.test.ts
+++ b/config/vitest-exclude.constants.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import {
+  AGENT_SCRATCH_EXCLUDE_PATTERN,
+  ROOT_VITEST_EXCLUDE_PATTERNS,
+} from './vitest-exclude.constants.js';
+
+/**
+ * Regression guard for the root-level vitest exclusion contract.
+ *
+ * Background: `.claude/` is agent scratch space holding full git worktree
+ * copies of this repository. Vitest's built-in `defaultExclude` does not
+ * cover it, so a root-level run without this exclusion collects thousands of
+ * stale duplicate test files from other agents' branches.
+ *
+ * These tests fail if the pattern is changed, or if `vitest.config.ts` stops
+ * applying it — which is the failure mode that actually matters, since a
+ * correct constant that nothing consumes fixes nothing.
+ */
+describe('root vitest exclusion contract', () => {
+  /** Source text of the root vitest config, read once for the wiring assertions. */
+  const configPath = resolve(__dirname, '..', 'vitest.config.ts');
+  const configSource = readFileSync(configPath, 'utf8');
+
+  describe('exclusion patterns', () => {
+    it('excludes the .claude agent scratch directory at any depth', () => {
+      expect(AGENT_SCRATCH_EXCLUDE_PATTERN).toBe('**/.claude/**');
+    });
+
+    it('includes the agent-scratch pattern in the root exclude list', () => {
+      expect(ROOT_VITEST_EXCLUDE_PATTERNS).toContain(
+        AGENT_SCRATCH_EXCLUDE_PATTERN
+      );
+    });
+
+    it('leads each pattern with a globstar so nested checkouts cannot re-enter collection', () => {
+      for (const pattern of ROOT_VITEST_EXCLUDE_PATTERNS) {
+        expect(pattern.startsWith('**/')).toBe(true);
+      }
+    });
+  });
+
+  describe('vitest.config.ts wiring', () => {
+    it('imports the shared exclusion constants rather than inlining the glob', () => {
+      expect(configSource).toContain('ROOT_VITEST_EXCLUDE_PATTERNS');
+      expect(configSource).toMatch(
+        /from\s+['"]\.\/config\/vitest-exclude\.constants\.js['"]/
+      );
+    });
+
+    it('spreads the exclusion patterns into test.exclude', () => {
+      expect(configSource).toMatch(/exclude:\s*\[[^\]]*\.\.\.ROOT_VITEST_EXCLUDE_PATTERNS/s);
+    });
+
+    it("spreads vitest's defaultExclude so node_modules and dist stay excluded", () => {
+      // Assigning test.exclude REPLACES vitest's built-in list. Dropping this
+      // spread would silently re-enable collection of node_modules and dist —
+      // a far worse regression than the one this config exists to fix.
+      expect(configSource).toMatch(/exclude:\s*\[\s*\.\.\.defaultExclude/s);
+      expect(configSource).toMatch(
+        /import\s*\{[^}]*\bdefaultExclude\b[^}]*\}\s*from\s+['"]vitest\/config['"]/s
+      );
+    });
+  });
+});

--- a/config/vitest-exclude.constants.ts
+++ b/config/vitest-exclude.constants.ts
@@ -1,0 +1,56 @@
+/**
+ * Test-collection exclusion patterns for root-level vitest runs.
+ *
+ * The repository root has no vitest project of its own — the real vitest
+ * suites live in `frontend/` and `packages/chat-ui/`, each with their own
+ * config. A bare `npx vitest` at the root therefore falls back to vitest's
+ * built-in defaults, whose exclude list covers only `node_modules`, `dist`,
+ * `cypress` and a handful of dotfolders (`.idea`, `.git`, `.cache`,
+ * `.output`, `.temp`).
+ *
+ * `.claude/` is NOT in that list. It is agent scratch space and holds full
+ * git worktree copies of this repository, so a root-level run collects
+ * thousands of stale duplicate test files — files that belong to other
+ * agents' in-flight branches and are frequently written in jest syntax.
+ * Collecting them produces a wall of import errors that has nothing to do
+ * with the working tree under review.
+ *
+ * These patterns are kept here, rather than inline in `vitest.config.ts`,
+ * so the exclusion is a named, testable contract: `vitest-exclude.constants.test.ts`
+ * fails if the pattern is changed or the config stops applying it.
+ *
+ * @see vitest.config.ts — the sole consumer, which spreads these on top of
+ *      vitest's `defaultExclude` (never replacing it).
+ */
+
+/**
+ * Glob matching everything inside the `.claude/` agent scratch directory, at
+ * any depth. Covers `.claude/worktrees/<branch>/**` (full repo copies) and
+ * `.claude/agents/**`.
+ *
+ * Deliberately matches `**\/.claude/**` rather than `.claude/**` so that a
+ * nested checkout cannot smuggle the directory back into collection.
+ */
+export const AGENT_SCRATCH_EXCLUDE_PATTERN = '**/.claude/**';
+
+/**
+ * Exclusion globs applied to root-level vitest runs, on top of vitest's own
+ * `defaultExclude`.
+ *
+ * IMPORTANT: consumers must SPREAD vitest's `defaultExclude` alongside these.
+ * Assigning `test.exclude` replaces the built-in list outright, which would
+ * silently re-enable collection of `node_modules` and `dist`.
+ *
+ * @example
+ * ```typescript
+ * import { defineConfig, defaultExclude } from 'vitest/config';
+ * import { ROOT_VITEST_EXCLUDE_PATTERNS } from './config/vitest-exclude.constants.js';
+ *
+ * export default defineConfig({
+ *   test: { exclude: [...defaultExclude, ...ROOT_VITEST_EXCLUDE_PATTERNS] },
+ * });
+ * ```
+ */
+export const ROOT_VITEST_EXCLUDE_PATTERNS: readonly string[] = [
+  AGENT_SCRATCH_EXCLUDE_PATTERN,
+];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,34 @@
+/// <reference types="vitest" />
+import { defineConfig, defaultExclude } from 'vitest/config';
+
+import { ROOT_VITEST_EXCLUDE_PATTERNS } from './config/vitest-exclude.constants.js';
+
+/**
+ * Root-level vitest configuration.
+ *
+ * The repository root is not itself a vitest project — the real vitest suites
+ * live in `frontend/` and `packages/chat-ui/`, each with its own config, and
+ * the root test runner is jest (see `jest.config.js`). This file exists for a
+ * narrower reason: without it, a bare `npx vitest` at the root falls back to
+ * vitest's built-in defaults, which do not exclude `.claude/`. That directory
+ * is agent scratch space containing full git worktree copies of this repo, so
+ * the fallback collects thousands of stale duplicate test files from other
+ * agents' in-flight branches.
+ *
+ * Scope is deliberately minimal: exclusions only. Nothing here changes which
+ * real source roots are collected, and nothing here affects jest or the two
+ * package-level vitest configs (vite resolves config from its own root, so a
+ * run started inside `frontend/` never sees this file).
+ *
+ * @see config/vitest-exclude.constants.ts — the exclusion contract and its test.
+ */
+export default defineConfig({
+  test: {
+    /**
+     * Vitest's `defaultExclude` is spread FIRST and must never be dropped:
+     * assigning `test.exclude` replaces the built-in list outright, which
+     * would silently re-enable collection of `node_modules` and `dist`.
+     */
+    exclude: [...defaultExclude, ...ROOT_VITEST_EXCLUDE_PATTERNS],
+  },
+});


### PR DESCRIPTION
Closes the CI-hygiene half of the reconciler follow-ups (WorkItem `c7204fc2`).

## Verdict on the exit-code-masking claim: REFUTED

The original review note said "collection fails but still exits 0". I could not reproduce that in any invocation shape. Vitest 3.2.4 exits non-zero on collection errors everywhere I probed. **Every exit code below was read via `$?` directly, never through a pipe.**

| # | Invocation | Expected | `$?` |
|---|---|---|---|
| A | `vitest list --dir <broken>` | fail | **1** |
| B | `vitest run --dir <broken>` | fail | **1** |
| C | `vitest run --dir <good>` | pass | **0** |
| D | `vitest run` (no test files matched) | fail | **1** |
| H | `cd frontend && vitest run --dir <broken>` — the in-package shape, with that package's own config, jsdom and setupFiles active | fail | **1** |

Case H is the one the brief singled out as "most likely what Victor ran". It exits 1.

### Where the "exits 0" came from

The same command, measured two ways:

```
vitest list --dir <broken> | tail -5 ; echo $?   ->  0    # tail's status
vitest list --dir <broken>          ; echo $?    ->  1    # vitest's status
```

A pipeline's `$?` is the exit status of its *last* command. The claim was a measurement artifact, not masking. There is no exit-code bug to fix, so this PR fixes only the confirmed half — the collection scope.

## The confirmed half: `.claude` was being collected

The repo root has no vitest config, so `npx vitest` fell back to vitest's defaults. Vitest prints its own exclude list on the no-files path, which is how I confirmed the gap:

```
exclude: **/node_modules/**, **/dist/**, **/cypress/**,
         **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,...}.config.*
```

`.claude` is not in it — and `.claude/` holds full worktree copies of this repo.

### Before / after, root-level `vitest list`

| | files collected under `.claude/` | `Error:` lines | `$?` |
|---|---|---|---|
| before | **2109** | 3364 | 1 |
| after | **0** | 705 | 1 |

Before, per worktree copy: `agent-aa4942eddbf4fc500` 533, `quinn-claim-liveness` 531, `agent-a3798bf8e24603dc4` 531, `fix-remember-silent-success` 512, plus 2 from a *nested* `.claude/worktrees/stale-repro` inside one of them.

The residual 705 errors are pre-existing and come from real source roots (4 files under `frontend/src`, collected from the root without frontend's alias config). They are outside this PR's scope — flagged below, not silently absorbed. The run still exits 1, which is correct: it is now failing for real reasons rather than drowning in scratch-space noise.

### Why the pattern leads with a globstar

`**/.claude/**`, not `.claude/**`. One worktree copy contains its own nested `.claude/worktrees/`, so an anchored pattern would miss it. That nesting is real in the current tree, not hypothetical, and the constants test pins the globstar prefix.

## Behavioural proof

A purpose-built two-file fixture — a deliberately broken jest-syntax file inside `.claude/worktrees/stale/`, and a healthy one in a real source root:

- **with the fix:** exit **0**, collects only `src/ok.test.ts`. The broken scratch file is never imported.
- **without the fix:** exit **1**, `Do not import @jest/globals outside of the Jest test environment` — the exact error class from the original report.

That is eval criterion 2 in both directions: broken file under `.claude` not collected; a real source root still fails loudly.

## Regression guard, mutation-tested

`config/vitest-exclude.constants.test.ts` (6 tests) sits in jest's `config/` root, so it runs in the normal root suite. A guard nobody has tried to break is not a guard, so I broke it twice:

| mutation | result |
|---|---|
| drop `...ROOT_VITEST_EXCLUDE_PATTERNS` from the config | **1 failed** |
| drop `...defaultExclude` from the config | **1 failed** |
| restored | **6 passed** |

The second mutation matters as much as the first: assigning `test.exclude` *replaces* vitest's built-in list, so a well-meaning cleanup that drops the spread would silently re-enable `node_modules` collection — a worse regression than the one this PR fixes.

## Blast radius

- **jest untouched.** Its `roots` are already correctly scoped. `config/` root: 6 suites pass, including the new one.
- **`packages/chat-ui` unaffected** — 23 files / 228 tests pass, exit 0. Vite resolves config from its own root, so a run started inside a package never sees the root config.
- **`.claude/worktrees` not deleted or moved.** It is live scratch space owned by other agents; this changes the collection config, not the filesystem.
- **typecheck:** 25 pre-existing errors, none in the added files. **eslint:** clean on all three files.
- **Test-beside-source** honoured; JSDoc on both exported constants.

## Pre-existing issues found, deliberately not fixed here

1. `config/skills/agent/computer-use/tests/computer-use.test.ts` — 35 failures. Identical count with my files removed from the tree, so it is pre-existing on `origin/main`, not a regression from this PR.
2. `frontend/src/components/Auth/` has orphan tests: `CloudAuthModal.test.tsx` and `LoginForm.test.tsx` are tracked at `origin/main` with no corresponding component file, so they cannot resolve their imports. Same CI-hygiene family, worth its own item.
3. Root-level `vitest` still collects `frontend/` without frontend's alias config. Making the root config delegate to the real vitest projects would clean that up, but that is a scope change rather than an exclusion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)