### PR TITLE
fix(skills): bind task-pool skill request bodies to the shapes their controllers read

### DIFF
--- a/config/skills/_common/task-pool-body-shape.test.sh
+++ b/config/skills/_common/task-pool-body-shape.test.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+# =============================================================================
+# Wire-shape contract test for /api/task-pool/add and /api/task-pool/claim
+#
+# Sibling of `complete-body-shape.test.sh`, which covers /task-pool/complete.
+# Same harness: a Python HTTP stub records every POST body, each skill is
+# pointed at it via CREWLY_API_URL, and the CAPTURED body is asserted against
+# the shape the controller actually destructures.
+#
+# WHY THIS EXISTS
+# ---------------
+# Five separate skills have now shipped a POST body the controller never
+# reads. Nothing binds a skill's request body to the shape its controller
+# destructures, so they drift silently and independently:
+#   #734  complete-task + both delegate-task skills  (/task-pool/complete)
+#   #735-family  agent/core/accept-task              (/task-pool/claim)
+#   #735-family  agent/core/create-task              (/task-pool/add)
+# Five instances is not five bugs — it is one missing contract. This test is
+# that contract for the two endpoints in the create/claim family.
+#
+# The failures are invisible without an executing test: a skill that posts an
+# unread field gets a 200 and reports success, while the field is dropped. A
+# static grep of the jq literal would pass for the wrong reason. So this test
+# EXECUTES each skill and inspects the bytes that actually went on the wire.
+#
+# Test runner:
+#   bash config/skills/_common/task-pool-body-shape.test.sh
+#   echo $?    # 0 on pass, 1 on fail
+# =============================================================================
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PASS=0
+FAIL=0
+
+# The exact key set `claimItem` destructures from req.body:
+#   const { agentId, workItemId, filters } = req.body
+CLAIM_ALLOWED_KEYS='["agentId","filters","workItemId"]'
+
+# The WorkItemOwner enum accepted by validateCreateWorkItemInput.
+OWNER_ENUM='["orchestrator","team_lead","agent","system"]'
+
+# Every field of `CreateWorkItemInput` (backend/src/types/v2/work-item.types.ts),
+# plus the three legacy-full-shape fields addItem inspects to decide which path
+# to take. Anything OUTSIDE this set is silently discarded by the endpoint:
+# `createWorkItem(input)` copies named fields only, so an unknown key produces
+# a 200 and vanishes. That is the whole bug family in one assertion.
+ADD_ALLOWED_KEYS='["id","requestId","parentWorkItemId","type","owner","target","title","description","briefMarkdown","scheduledAt","maxRetries","triggerId","projectTaskId","missionId","metadata","dependsOn","status","createdAt","retryCount","inputTokens","outputTokens","cost"]'
+
+assert_jq() {
+  local test_name="$1" jq_filter="$2" body="$3"
+  local result
+  result=$(printf '%s' "$body" | jq -er "$jq_filter" 2>/dev/null || true)
+  if [ -n "$result" ] && [ "$result" != "null" ] && [ "$result" != "false" ]; then
+    PASS=$((PASS + 1))
+    echo "  ✓ ${test_name}"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${test_name}"
+    echo "    filter: ${jq_filter}"
+    echo "    body:   ${body}"
+  fi
+}
+
+# Assert a captured /task-pool/add body is a shape `addItem` actually reads.
+# Applied uniformly to every /add callsite — this is the contract itself.
+assert_add_contract() {
+  local label="$1" body="$2"
+  # 1. No envelope. addItem reads `req.body` directly; `{workItem: {...}}`
+  #    makes every real field invisible and 400s on `type`/`owner`/`title`.
+  assert_jq "${label}: no {workItem:...} envelope" '.workItem == null' "$body"
+  # 2. Minimal CreateWorkItemInput required fields, at top level.
+  assert_jq "${label}: type is a string" '.type | type == "string"' "$body"
+  assert_jq "${label}: title is a non-empty string" '.title | type == "string" and length > 0' "$body"
+  # 3. owner is the WorkItemOwner ROLE enum, not a session name.
+  local owner
+  owner=$(printf '%s' "$body" | jq -r '.owner // ""')
+  if printf '%s' "$OWNER_ENUM" | jq -e --arg o "$owner" 'index($o) != null' >/dev/null 2>&1; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: owner '${owner}' is a valid WorkItemOwner"
+  else
+    FAIL=$((FAIL + 1)); echo "  ✗ ${label}: owner '${owner}' is NOT a WorkItemOwner (expected one of ${OWNER_ENUM})"
+  fi
+  # 4. No key outside CreateWorkItemInput. This is the general form of the
+  #    bug: `priority` and `projectPath` are NOT WorkItem fields, so a caller
+  #    passing --priority critical believes it took effect while the endpoint
+  #    drops it. Such values belong in `metadata`.
+  local extra_add
+  extra_add=$(printf '%s' "$body" | jq -c --argjson allowed "$ADD_ALLOWED_KEYS" '[keys[] | select(. as $k | $allowed | index($k) == null)]')
+  if [ "$extra_add" = "[]" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: every top-level key is read by the endpoint"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${label}: keys silently discarded by addItem: ${extra_add}"
+    echo "    These are not CreateWorkItemInput fields — move them into metadata."
+  fi
+  # 5. If an id is sent it must be accompanied by status AND createdAt,
+  #    otherwise isLegacyFullShape is false and the caller's intent is
+  #    ambiguous. Either commit to the legacy full shape or send neither.
+  local has_id has_status has_created
+  has_id=$(printf '%s' "$body" | jq -r 'has("id")')
+  has_status=$(printf '%s' "$body" | jq -r 'has("status")')
+  has_created=$(printf '%s' "$body" | jq -r 'has("createdAt")')
+  if [ "$has_id" = "false" ] || { [ "$has_status" = "true" ] && [ "$has_created" = "true" ]; }; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: id/status/createdAt are consistent (minimal or full, not half)"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${label}: half-legacy shape — id=${has_id} status=${has_status} createdAt=${has_created}"
+    echo "    A body with id but no createdAt takes the MINIMAL path; send all three or none."
+  fi
+}
+
+# Assert a captured /task-pool/claim body only carries keys claimItem reads.
+assert_claim_contract() {
+  local label="$1" body="$2"
+  assert_jq "${label}: agentId is a non-empty string" '.agentId | type == "string" and length > 0' "$body"
+  local extra
+  extra=$(printf '%s' "$body" | jq -c --argjson allowed "$CLAIM_ALLOWED_KEYS" '[keys[] | select(. as $k | $allowed | index($k) == null)]')
+  if [ "$extra" = "[]" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: no keys outside {agentId, workItemId, filters}"
+  else
+    FAIL=$((FAIL + 1)); echo "  ✗ ${label}: body carries keys the controller never reads: ${extra}"
+  fi
+}
+
+start_stub() {
+  local port="$1" log_file="$2"
+  PORT=$port LOG_FILE=$log_file \
+    python3 -c '
+import http.server, json, os
+LOG = os.environ["LOG_FILE"]
+PORT = int(os.environ["PORT"])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass
+    def _record(self, body_bytes):
+        with open(LOG, "a") as f:
+            f.write(json.dumps({
+                "method": self.command,
+                "path": self.path,
+                "body": body_bytes.decode("utf-8") if body_bytes else "",
+            }) + "\n")
+    def _json(self, payload):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(payload)
+    def do_POST(self):
+        ln = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(ln) if ln else b""
+        self._record(body)
+        if self.path.startswith("/api/task-pool/claim"):
+            self._json(b"{\"success\":true,\"data\":{\"workItem\":{\"id\":\"wi-stub-1\",\"title\":\"stub\"},\"claim\":{\"id\":\"claim-1\"}}}")
+            return
+        if self.path.startswith("/api/task-pool/add"):
+            self._json(b"{\"success\":true,\"data\":{\"id\":\"wi-stub-1\",\"workItemId\":\"wi-stub-1\",\"status\":\"queued\"}}")
+            return
+        self._json(b"{\"success\":true}")
+    def do_GET(self):
+        self._record(b"")
+        self._json(b"{\"success\":true,\"data\":[],\"workItems\":[]}")
+
+httpd = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
+httpd.serve_forever()
+' >/dev/null 2>&1 &
+  echo $!
+}
+
+PORT=39185
+TMPROOT=$(mktemp -d -t crewly-taskpool-shape-XXXXXX)
+LOG="${TMPROOT}/requests.jsonl"
+: > "$LOG"
+
+STUB_PID=$(start_stub "$PORT" "$LOG")
+trap "kill $STUB_PID 2>/dev/null || true; rm -rf $TMPROOT" EXIT
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -s "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then break; fi
+  sleep 0.1
+done
+
+export CREWLY_API_URL="http://127.0.0.1:${PORT}"
+
+capture() { grep -F "\"path\": \"$1\"" "$LOG" | head -1 | jq -r '.body' 2>/dev/null || true; }
+
+echo "=== /task-pool/add + /task-pool/claim body-shape contract ==="
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — agent/core/create-task -> /task-pool/add
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 1: agent/core/create-task -> /add ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/create-task/execute.sh" \
+  --project-path /tmp/proj-foo --task "Contract test task" \
+  --priority high --session quinn-target >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/add")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/add POST captured"
+else
+  assert_add_contract "create-task" "$BODY"
+  assert_jq "create-task: target is the session name" '.target == "quinn-target"' "$BODY"
+  assert_jq "create-task: priority preserved in metadata.priority" '.metadata.priority == "high"' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — agent/core/accept-task -> /task-pool/claim (targeted)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 2: agent/core/accept-task targeted -> /claim ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/accept-task/execute.sh" \
+  '{"sessionName":"quinn-claimer","workItemId":"wi-requested-42"}' >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/claim")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/claim POST captured"
+else
+  assert_claim_contract "accept-task(targeted)" "$BODY"
+  assert_jq "accept-task(targeted): requested workItemId IS forwarded" '.workItemId == "wi-requested-42"' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — accept-task taskId alias -> /claim
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 3: agent/core/accept-task taskId alias -> /claim ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/accept-task/execute.sh" \
+  '{"sessionName":"quinn-claimer","taskId":"wi-alias-7"}' >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/claim")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/claim POST captured"
+else
+  assert_claim_contract "accept-task(alias)" "$BODY"
+  assert_jq "accept-task(alias): taskId is forwarded as workItemId" '.workItemId == "wi-alias-7"' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 4 — accept-task next-available -> /claim (no workItemId)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 4: agent/core/accept-task FIFO -> /claim ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/accept-task/execute.sh" \
+  '{"sessionName":"quinn-claimer"}' >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/claim")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/claim POST captured"
+else
+  assert_claim_contract "accept-task(fifo)" "$BODY"
+  assert_jq "accept-task(fifo): omits workItemId entirely" 'has("workItemId") == false' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — team-leader/delegate-task -> /task-pool/add
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 5: team-leader/delegate-task -> /add ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/team-leader/delegate-task/execute.sh" \
+  '{"to":"quinn-target","task":"Contract test delegation","from":"quinn-tl"}' >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/add")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/add POST captured for team-leader/delegate-task"
+else
+  assert_add_contract "tl-delegate-task" "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — orchestrator/delegate-task -> /task-pool/add
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 6: orchestrator/delegate-task -> /add ---"
+: > "$LOG"
+# The orc delegate-task skill enforces the Request Contract (P0-3): the brief
+# must carry Goal + Expected Outcome + Eval Criteria markers or it refuses.
+bash "${REPO_ROOT}/config/skills/orchestrator/delegate-task/execute.sh" \
+  '{"to":"quinn-target","task":"Goal: contract test orc delegation. Expected Outcome: a /task-pool/add body is emitted. Eval Criteria: body shape matches CreateWorkItemInput."}' \
+  >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/add")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/add POST captured for orchestrator/delegate-task"
+else
+  assert_add_contract "orc-delegate-task" "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — agent/core/break-down-request -> /task-pool/add
+#
+# This callsite deliberately uses the LEGACY FULL shape (id + status +
+# createdAt) so its client-side ids can be referenced upfront. It is the
+# control case: the contract must accept the legacy path, not just minimal.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 7: agent/core/break-down-request -> /add (legacy full shape) ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/break-down-request/execute.sh" \
+  '{"requestId":"req-contract-1","sessionName":"quinn-bdr","tasks":[{"title":"Contract subtask","description":"d","type":"delegate","target":"quinn-target"}]}' \
+  >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/add")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/add POST captured for break-down-request"
+else
+  assert_add_contract "break-down-request" "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — team-leader/decompose-goal -> /task-pool/add
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 8: team-leader/decompose-goal -> /add ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/team-leader/decompose-goal/execute.sh" \
+  '{"objective":"Contract test objective","projectPath":"/tmp/proj-foo","tasks":[{"title":"Contract subtask","description":"d","requiredRole":"developer","priority":"high"}]}' \
+  >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/add")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/add POST captured for team-leader/decompose-goal"
+else
+  assert_add_contract "decompose-goal" "$BODY"
+  assert_jq "decompose-goal: priority preserved in metadata.priority" '.metadata.priority != null' "$BODY"
+fi
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/config/skills/agent/core/accept-task/execute.sh
+++ b/config/skills/agent/core/accept-task/execute.sh
@@ -1,30 +1,55 @@
 #!/bin/bash
-# Claim the next available WorkItem from the V3 task-pool.
+# Claim a WorkItem from the V3 task-pool.
+#
+# Two modes, mirroring `POST /api/task-pool/claim`:
+#
+#   1. Next-available (FIFO) — omit `workItemId`. The pool picks the
+#      highest-scored queued item available to this agent.
+#   2. Targeted — pass `workItemId` (or its alias `taskId`). Claims THAT
+#      specific item. The controller branches to `claimSpecificItem`, which
+#      still enforces the agent-liveness and target-respect gates.
 #
 # V3-only as of spec 2026-05-06-task-management-v1-deprecation.md. The
 # legacy `/task-management/take-next` endpoint (which read `.md` files
 # from `delegated/open/`) is no longer the source of truth.
 #
 # Input shape (backwards-compat from v1):
-#   { "sessionName": "dev-1", "projectPath"?: "...", "taskGroup"?: "..." }
+#   { "sessionName": "dev-1", "workItemId"?: "wi-abc", "projectPath"?: "...", "taskGroup"?: "..." }
 #
 # `taskGroup` (legacy v1 milestone filter) maps to V3's `filters.types`.
 # `teamMemberId` is no longer needed — V3 keys claims by `agentId`
 # (= sessionName).
+#
+# A targeted claim that cannot be satisfied surfaces the endpoint's 404 and
+# exits non-zero. It deliberately does NOT fall back to next-available:
+# silently handing back a DIFFERENT WorkItem than the one requested misroutes
+# delegated work, which is strictly worse than a visible failure. (Quinn
+# 2026-08-21: this skill dropped `workItemId` entirely, so every targeted
+# delegation silently claimed an unrelated FIFO item instead.)
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../../_common/lib.sh"
 
 INPUT=$(read_json_input "${1:-}")
-[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"sessionName\":\"dev-1\"}' or echo '{...}' | execute.sh"
+[ -z "$INPUT" ] && error_exit "Usage: execute.sh '{\"sessionName\":\"dev-1\"}' or execute.sh '{\"sessionName\":\"dev-1\",\"workItemId\":\"wi-abc\"}' or echo '{...}' | execute.sh"
 
 SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
 require_param "sessionName" "$SESSION_NAME"
 
+# Accept `workItemId` or the `taskId` alias — briefs and dispatch messages
+# refer to the item by id under both names.
+WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // .taskId // empty')
+
 # v1's `taskGroup` is informational metadata; V3 filters by WorkItem `type`
 # instead. We pass the session name as the agent identity and let the pool
-# pick the highest-scored available WI for this agent.
-BODY=$(jq -n --arg agentId "$SESSION_NAME" '{agentId: $agentId}')
+# pick the highest-scored available WI for this agent — unless a specific
+# item was requested, in which case the pool must honour that id or fail.
+if [ -n "$WORK_ITEM_ID" ]; then
+  BODY=$(jq -n --arg agentId "$SESSION_NAME" --arg workItemId "$WORK_ITEM_ID" \
+    '{agentId: $agentId, workItemId: $workItemId}')
+else
+  BODY=$(jq -n --arg agentId "$SESSION_NAME" '{agentId: $agentId}')
+fi
 
 api_call POST "/task-pool/claim" "$BODY"

--- a/config/skills/agent/core/create-task/execute.sh
+++ b/config/skills/agent/core/create-task/execute.sh
@@ -26,6 +26,7 @@ Options:
   --milestone    | -m   Milestone/sprint name (default: delegated)
   --session      | -s   Session to assign the task to (optional; if omitted, task is open)
   --output-schema       JSON string defining expected output schema (optional)
+  --owner               Responsible role: orchestrator, team_lead, agent, system (default: agent)
   --json         | -j   Raw JSON payload (same as legacy)
   --help         | -h   Show this help
 EOF_USAGE
@@ -38,6 +39,7 @@ PRIORITY=""
 MILESTONE=""
 SESSION_NAME=""
 OUTPUT_SCHEMA=""
+OWNER=""
 
 # Detect legacy JSON argument
 if [[ $# -gt 0 && ${1:0:1} == '{' ]]; then
@@ -69,6 +71,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --output-schema)
       OUTPUT_SCHEMA="$2"
+      shift 2
+      ;;
+    --owner)
+      OWNER="$2"
       shift 2
       ;;
     --json|-j)
@@ -111,52 +117,62 @@ if [ -n "$INPUT_JSON" ]; then
   [ -z "$MILESTONE" ] && MILESTONE=$(printf '%s' "$INPUT" | jq -r '.milestone // empty')
   [ -z "$SESSION_NAME" ] && SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
   [ -z "$OUTPUT_SCHEMA" ] && OUTPUT_SCHEMA=$(printf '%s' "$INPUT" | jq -c '.outputSchema // empty')
+  [ -z "$OWNER" ] && OWNER=$(printf '%s' "$INPUT" | jq -r '.owner // empty')
 fi
 
 # Apply defaults
 PRIORITY="${PRIORITY:-medium}"
 MILESTONE="${MILESTONE:-delegated}"
+OWNER="${OWNER:-agent}"
 
 require_param "projectPath (--project-path)" "$PROJECT_PATH"
 require_param "task (--task)" "$TASK"
 
-# Build a V3 WorkItem for the task-pool.
-# `addToPool` accepts the WorkItem directly (id auto-generated server-side
-# when omitted). `priority` is mapped to V3's numeric priority scale where
-# critical=1, high=2, medium=3, low=4 — lower number = higher priority.
-case "$PRIORITY" in
-  critical) PRIORITY_NUM=1 ;;
-  high)     PRIORITY_NUM=2 ;;
-  medium)   PRIORITY_NUM=3 ;;
-  low)      PRIORITY_NUM=4 ;;
-  *)        PRIORITY_NUM=3 ;;
+# Validate `owner` against the WorkItemOwner enum the endpoint accepts.
+# This is the field, not the session name — `owner` answers "which role is
+# responsible for execution", and `target` answers "which session runs it".
+# Sending a session name here fails validation with
+# "owner must be one of: orchestrator, team_lead, agent, system".
+case "$OWNER" in
+  orchestrator|team_lead|agent|system) ;;
+  *) error_exit "owner must be one of: orchestrator, team_lead, agent, system (got: '$OWNER'). This is a role, not a session name — use --session/target for the session." ;;
 esac
 
-WI_ID="task-$(date +%s%N | cut -c1-13)-$$"
-
+# Build a minimal `CreateWorkItemInput` for `POST /task-pool/add`.
+#
+# The endpoint reads `req.body` DIRECTLY as the input — there is no
+# `{workItem: ...}` envelope. It accepts two shapes: this minimal input
+# (server fills id/status/createdAt/retryCount/...), or a legacy full
+# WorkItem carrying id AND status AND createdAt. We send the minimal shape,
+# matching `team-leader/delegate-task`.
+#
+# Deliberately NOT sent:
+#   - `id`     — this skill has no idempotency key worth preserving, so the
+#                server-generated uuid wins. (`CreateWorkItemInput.id` IS
+#                honoured when supplied; we simply have nothing stable to
+#                supply.)
+#   - `status` — derived server-side from dependsOn/scheduledAt.
+#   - top-level `priority` — NOT a WorkItem field; it is silently dropped by
+#                both body shapes. Priority travels in `metadata.priority`,
+#                which is what real pool items carry and what
+#                work-item-projection reads.
 WORK_ITEM=$(jq -n \
-  --arg id "$WI_ID" \
   --arg title "$TASK" \
   --arg target "$SESSION_NAME" \
-  --arg owner "${SESSION_NAME:-system}" \
+  --arg owner "$OWNER" \
   --arg projectPath "$PROJECT_PATH" \
   --arg milestone "$MILESTONE" \
-  --argjson priority "$PRIORITY_NUM" \
+  --arg priority "$PRIORITY" \
   '{
-    id: $id,
     title: $title,
     type: "delegate",
     owner: $owner,
-    priority: $priority,
-    status: "queued",
     target: (if $target == "" then null else $target end),
-    metadata: { projectPath: $projectPath, milestone: $milestone }
+    metadata: { projectPath: $projectPath, milestone: $milestone, priority: $priority }
   } | with_entries(select(.value != null))')
 
 if [ -n "$OUTPUT_SCHEMA" ] && [ "$OUTPUT_SCHEMA" != "" ]; then
   WORK_ITEM=$(printf '%s' "$WORK_ITEM" | jq --argjson schema "$OUTPUT_SCHEMA" '.metadata += {outputSchema: $schema}')
 fi
 
-BODY=$(jq -n --argjson workItem "$WORK_ITEM" '{workItem: $workItem}')
-
-api_call POST "/task-pool/add" "$BODY"
+api_call POST "/task-pool/add" "$WORK_ITEM"

--- a/config/skills/orchestrator/delegate-task/execute.sh
+++ b/config/skills/orchestrator/delegate-task/execute.sh
@@ -166,8 +166,17 @@ if [ "$TASK_TYPE" = "technical" ] && [ -n "$TEAM_ID" ]; then
 fi
 
 # Structured message parameters (for hierarchical teams)
-# Default INPUT to empty JSON if not set (when using --flag mode)
-INPUT="${INPUT:-{}}"
+# Default INPUT to empty JSON if not set (when using --flag mode).
+#
+# NOT `${INPUT:-{}}` — bash ends the expansion at the FIRST `}`, so that form
+# means "default to `{`" followed by a literal `}`. It is correct only when
+# INPUT is unset (yielding `{}`); when INPUT holds real JSON it appends a
+# stray `}` and every subsequent `jq` call dies with
+# "parse error: Unmatched '}'". That silently broke the entire JSON-input mode
+# of this skill while --flag mode kept working.
+if [ -z "${INPUT:-}" ]; then
+  INPUT='{}'
+fi
 TITLE=$(printf '%s' "$INPUT" | jq -r '.title // empty')
 PARENT_TASK_ID=$(printf '%s' "$INPUT" | jq -r '.parentTaskId // empty')
 EXPECTED_ARTIFACTS=$(printf '%s' "$INPUT" | jq -c '.expectedArtifacts // empty')
@@ -263,7 +272,7 @@ POOL_BODY=$(jq -n \
   --arg priority "$WI_PRIORITY" \
   --arg projectPath "${PROJECT_PATH:-}" \
   --arg requestId "${REQUEST_ID:-}" \
-  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end) + (if $requestId != "" then {requestId: $requestId} else {} end)')
+  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, metadata: ({priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end))} + (if $requestId != "" then {requestId: $requestId} else {} end)')
 
 # Pipeline-#4 fix (spec 2026-05-05-request-decompose-pipeline-gap.md, Patch B):
 # Route is /api/task-pool/add (not /api/pool/add — that endpoint does not exist

--- a/config/skills/team-leader/decompose-goal/execute.sh
+++ b/config/skills/team-leader/decompose-goal/execute.sh
@@ -53,36 +53,31 @@ ${TASK_CRITERIA}"
 Parent objective: ${OBJECTIVE}
 Required role: ${TASK_ROLE}"
 
-  case "$TASK_PRIORITY" in
-    critical) PRIORITY_NUM=1 ;;
-    high)     PRIORITY_NUM=2 ;;
-    normal|medium) PRIORITY_NUM=3 ;;
-    low)      PRIORITY_NUM=4 ;;
-    *)        PRIORITY_NUM=3 ;;
-  esac
 
-  WI_ID="task-$(date +%s%N | cut -c1-13)-${i}-$$"
-
+  # Minimal CreateWorkItemInput — no client-side `id`/`status`.
+  #
+  # A body carrying `id` and `status` but no `createdAt` fails the endpoint's
+  # `isLegacyFullShape` check, so it silently takes the MINIMAL path and the
+  # server generates its own uuid anyway. The old client id was never
+  # referenced after creation, so there is nothing to preserve: commit to the
+  # minimal shape rather than sending two-thirds of the legacy one.
   WORK_ITEM=$(jq -n \
-    --arg id "$WI_ID" \
     --arg title "$TASK_TITLE" \
     --arg brief "$BRIEF" \
     --arg projectPath "$PROJECT_PATH" \
     --arg milestone "$MILESTONE" \
     --arg role "$TASK_ROLE" \
-    --argjson priority "$PRIORITY_NUM" \
+    --arg priority "$TASK_PRIORITY" \
     '{
-      id: $id,
       title: $title,
       type: "delegate",
       owner: "system",
-      priority: $priority,
-      status: "queued",
       briefMarkdown: $brief,
-      metadata: { projectPath: $projectPath, milestone: $milestone, requiredRole: $role }
+      metadata: { projectPath: $projectPath, milestone: $milestone, requiredRole: $role, priority: $priority }
     }')
 
-  CREATE_BODY=$(jq -n --argjson workItem "$WORK_ITEM" '{workItem: $workItem}')
+  # No envelope: addItem reads req.body directly as the CreateWorkItemInput.
+  CREATE_BODY="$WORK_ITEM"
   CREATE_RESULT=$(api_call POST "/task-pool/add" "$CREATE_BODY" 2>/dev/null || echo '{"error":"Failed to create WorkItem"}')
   CREATED_ID=$(echo "$CREATE_RESULT" | jq -r '.data.id // .workItem.id // empty' 2>/dev/null || true)
 

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -243,7 +243,7 @@ POOL_BODY=$(jq -n \
   --arg briefMarkdown "$TASK" \
   --arg priority "$WI_PRIORITY" \
   --arg projectPath "${PROJECT_PATH:-}" \
-  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end)')
+  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, metadata: ({priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end))}')
 
 POOL_RESULT=$(api_call POST "/task-pool/add" "$POOL_BODY" 2>/dev/null || echo '{"success":false}')
 POOL_OK=$(echo "$POOL_RESULT" | jq -r '.success // "false"' 2>/dev/null)

--- a/sops/norms/norm-mutation-check-base-ref.md
+++ b/sops/norms/norm-mutation-check-base-ref.md
@@ -1,0 +1,97 @@
+---
+type: norm
+version: 1.0.0
+owner: crewly-product-quinn-47ce967d
+status: active
+triggers:
+  - mutation check
+  - verifying a test actually fails
+  - proving a test guards a fix
+  - reverting a fix to check coverage
+---
+
+# Norm: A Mutation Check Must Revert Against a Base Ref
+
+## The covenant
+
+When you prove a new test actually guards your fix — revert the fix, confirm
+the test fails — **revert against a base ref, never against the working tree.**
+
+```bash
+# ✅ correct in BOTH states
+git checkout <base-ref> -- <path>    # e.g. git checkout origin/main -- src/foo.ts
+<run tests>                          # expect the new tests to FAIL
+git checkout HEAD -- <path>          # restore
+
+# ❌ silently conditional
+git checkout <path>                  # reverts, or restores — depends on commit state
+```
+
+This is a constraint on how you verify, applied every time. It is not a
+procedure to step through.
+
+## Why `git checkout <file>` is a trap
+
+`git checkout <file>` restores the file **from the index/HEAD**. So it means
+two opposite things depending on whether your fix is committed yet:
+
+| Fix state | `git checkout <file>` does | Mutation check is |
+|---|---|---|
+| Uncommitted | discards the fix → file reverts | **valid** |
+| Committed | restores the fix *from HEAD* | **a silent no-op** |
+
+In the committed state the command appears to work, the tests run, and
+everything passes — because the fix was never removed. You get a green result
+from a check that checked nothing.
+
+The state flips silently in the middle of ordinary work. Committing does it.
+So does rebasing. Nothing warns you.
+
+## How I got it wrong (PR #735, 2026-08-21)
+
+I ran the mutation check *before* committing. It worked: revert the source,
+3 of the 7 new tests failed, the negative test stayed green. Correct signature,
+correctly verified.
+
+Then I rebased onto `origin/main` — which committed the fix — and re-ran the
+same check with the same command. It reported **47/47 passing**, and I reported
+that number to my TL as evidence the fix was still verified after the rebase.
+
+It was not evidence of anything. `git checkout <file>` had restored the fix from
+HEAD. The suite passed because the code was still there. I had produced a
+verification artifact that verified nothing, and shipped it into a status report
+as though it were proof.
+
+I caught it on re-reading my own command, not from any failure signal — there is
+no failure signal. Redone as `git checkout origin/main -- <file>`, the real
+signature came back: 3 failed, 44 passed.
+
+The reason this is worth a norm rather than a personal note: the failure mode is
+**invisible and self-confirming**. A broken mutation check does not look broken.
+It looks like a passing test suite, which is exactly what you were hoping to see.
+
+## Companion signal: the negative test should STAY green
+
+In a suite that includes a negative test — one asserting the *absence* of a
+widening, a regression, or an over-broad gate — that test should **still pass**
+when you revert the fix. It is asserting something that was already true.
+
+So the healthy signature is mixed:
+
+```
+✕ positive test   (fix removed → capability gone → fails)
+✕ positive test
+✓ negative test   (asserting absence → still true → passes)
+```
+
+If your negative test *also* flips to red under revert, it was passing for the
+wrong reason — it depends on the fix rather than constraining it. Investigate
+before shipping.
+
+## Applies to
+
+Any "prove the test catches it" check: mutation checks, revert-and-rerun,
+deliberately breaking a fix to confirm coverage. The same trap exists for
+`git stash` (state-dependent) and for editing a file back by hand (you may
+restore it imperfectly). Naming an explicit base ref is what makes the check
+deterministic.


### PR DESCRIPTION
Closes WI `80cafab5` (accept-task) and WI `e7c098a3` (create-task).

## The pattern, not the two bugs

Five skills have now shipped a POST body the controller never reads. Nothing binds a skill's request body to the shape its controller destructures, so they drift silently and independently — #734 fixed three instances in `/task-pool/complete`; this fixes the `/task-pool/add` + `/task-pool/claim` family and adds the contract test that would have caught all of them at once.

The failures are invisible without an *executing* test: an unread field yields a **200** and is silently dropped, so the skill reports success while the value never lands. A static grep of the jq literal would pass for the wrong reason.

## The two assigned fixes

**`accept-task` — targeted claims were misrouted.** It posted `{agentId}` alone, dropping `workItemId`, so every targeted delegation silently claimed an unrelated next-available item. The endpoint already supported targeting (`claimItem` destructures `{agentId, workItemId, filters}`); only the skill failed to send it.

A non-claimable id now surfaces the **404 and exits non-zero**. It deliberately does *not* fall back to next-available — silently returning a different WorkItem than the one requested is the actual defect, and is worse than a visible failure.

**`create-task` — 400 on every call.** Three defects, resolved in one direction rather than half:

| Defect | Resolution |
|---|---|
| `{workItem:...}` envelope | dropped — `addItem` reads `req.body` directly |
| `owner` = session name | now the `WorkItemOwner` enum; optional `--owner`, default `agent` |
| `id`+`status`, no `createdAt` | dropped both — commits to the minimal shape |

> **Correction to the brief on the third defect:** the client id is *not* silently discarded. `CreateWorkItemInput.id` is optional and `createWorkItem` honours it via `id: input.id ?? uuidv4()`. The minimal path would have kept it. I still removed it — this skill has no idempotency key worth preserving — so the outcome matches, but the reason differs.

## Three more instances, found by the new test on its first run

- **`team-leader/delegate-task`** — top-level `priority` **and** `projectPath`, both dropped (in a skill #734 already touched)
- **`orchestrator/delegate-task`** — same
- **`team-leader/decompose-goal`** — `{workItem}` envelope + dropped `priority` + the same half-legacy `id`/`status` shape, so it had been 400ing on every call

Neither `priority` nor `projectPath` is a `CreateWorkItemInput` field; both now travel in `metadata`, which is what real pool items carry.

`agent/core/break-down-request` is **correct and untouched** — it deliberately uses the documented legacy full shape. It's included as the *control case* so the contract can't regress into rejecting the legacy path.

## A separate pre-existing defect, fixed because it blocked coverage

`orchestrator/delegate-task` line 170 read `INPUT="${INPUT:-{}}"`. Bash ends the expansion at the **first** `}`, so that means *default-to-`{`* followed by a **literal `}`**:

```bash
INPUT='{"to":"x"}';  echo "${INPUT:-{}}"   # -> {"to":"x"}}   ← stray brace
unset INPUT;         echo "${INPUT:-{}}"   # -> {}            ← correct by accident
```

Correct only when unset. With real JSON it appends a stray `}` and every later `jq` dies with `Unmatched '}'` — the entire JSON-input mode of the orchestrator's delegate path was broken while `--flag` mode kept working. The contract test cannot reach that callsite without this fix.

## The contract

`config/skills/_common/task-pool-body-shape.test.sh` — sibling of #734's `complete-body-shape.test.sh`, same executing Python-stub harness. Each skill runs against a stub that records the bytes **actually sent**. **42 assertions across 8 scenarios, no skips.**

The central assertion is general rather than a banned-field list — *every top-level key must be a `CreateWorkItemInput` (or legacy `WorkItem`) field* — so the whole silently-discarded-key class fails at once rather than one field at a time.

Verified live against the real backend, not only against the stub: `create-task` and `decompose-goal` both create real WorkItems (previously 400), and the targeted claim was proven to **discriminate from FIFO** — with two items queued, targeting the newer one returned exactly it where FIFO returns the older.

## Also included

`sops/norms/norm-mutation-check-base-ref.md` — a mutation check must revert against a **base ref**, never the working tree, because `git checkout <file>` reverts or restores depending on commit state and silently becomes a no-op once the fix is committed. Written up after I produced exactly that invalid check on #735. Keeps the how-I-got-it-wrong, per review feedback that a norm showing the trap gets followed while one stating a rule does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)