### PR TITLE
fix(task-pool): stop releaseBack destroying assignments and charging false retries

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -267,10 +267,30 @@ describe('TaskPoolController', () => {
       const res = mockRes();
       await releaseItem(req, res);
 
-      expect(mockService.releaseBack).toHaveBeenCalledWith('wi-1', 'agent busy');
+      expect(mockService.releaseBack).toHaveBeenCalledWith('wi-1', 'agent busy', {
+        unassign: false,
+      });
       expect(res.json).toHaveBeenCalledWith({
         success: true,
         message: 'WorkItem wi-1 released back to pool',
+      });
+    });
+
+    it('forwards an explicit unassign request', async () => {
+      // Un-assignment must be opt-in and explicit — never a silent side
+      // effect of releasing. See WI 25aadd30.
+      mockService.releaseBack.mockResolvedValue(undefined);
+
+      const req = mockReq({
+        params: { workItemId: 'wi-1' } as Record<string, string>,
+        body: { reason: 'agent declined', unassign: true },
+      });
+      const res = mockRes();
+
+      await releaseItem(req, res);
+
+      expect(mockService.releaseBack).toHaveBeenCalledWith('wi-1', 'agent declined', {
+        unassign: true,
       });
     });
 
@@ -284,7 +304,9 @@ describe('TaskPoolController', () => {
       const res = mockRes();
       await releaseItem(req, res);
 
-      expect(mockService.releaseBack).toHaveBeenCalledWith('wi-1', 'released via API');
+      expect(mockService.releaseBack).toHaveBeenCalledWith('wi-1', 'released via API', {
+        unassign: false,
+      });
     });
 
     it('returns 404 when item not found', async () => {

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -460,9 +460,14 @@ export async function claimItem(req: Request, res: Response): Promise<void> {
 /**
  * Releases a claimed WorkItem back to the pool.
  *
+ * The item keeps its `target` by default — a release ends an attempt, it
+ * does not revoke an assignment. Pass `unassign: true` to also return the
+ * item to the unassigned pool, for the case where the caller genuinely
+ * means "someone else should take this".
+ *
  * Request body:
  * ```json
- * { "reason": "agent busy" }
+ * { "reason": "agent busy", "unassign": false }
  * ```
  *
  * @param req - Express request with workItemId param
@@ -471,7 +476,7 @@ export async function claimItem(req: Request, res: Response): Promise<void> {
 export async function releaseItem(req: Request, res: Response): Promise<void> {
   try {
     const { workItemId } = req.params;
-    const { reason } = req.body as { reason?: string };
+    const { reason, unassign } = req.body as { reason?: string; unassign?: boolean };
 
     if (!workItemId) {
       res.status(400).json({ success: false, error: 'workItemId param is required' });
@@ -479,7 +484,9 @@ export async function releaseItem(req: Request, res: Response): Promise<void> {
     }
 
     const releaseReason = reason || 'released via API';
-    await getService().releaseBack(workItemId, releaseReason);
+    await getService().releaseBack(workItemId, releaseReason, {
+      unassign: unassign === true,
+    });
 
     res.json({ success: true, message: `WorkItem ${workItemId} released back to pool` });
   } catch (error) {

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -551,7 +551,11 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
   }
 
   /**
-   * Re-queues a WorkItem (increments retryCount, sets status to 'queued').
+   * Re-queues a WorkItem (sets status to 'queued', keeps its `target`).
+   *
+   * Does NOT increment `retryCount`: a reconciler requeue is an
+   * administrative recovery, not a failure, and that counter means
+   * failures only. The release is recorded in `releaseCount` instead.
    *
    * @param workItemId - The WorkItem ID to re-queue
    */

--- a/backend/src/services/reconciler/reconciler.service.ts
+++ b/backend/src/services/reconciler/reconciler.service.ts
@@ -552,7 +552,10 @@ export class ReconcilerService {
 
         // blocked → queued (agent-back-online recovery) is special: it
         // needs the full lifecycle — release the dangling claim, clear
-        // startedAt, increment retryCount — which `releaseBack` owns.
+        // startedAt, record the release — which `releaseBack` owns.
+        // NOTE: this path deliberately does NOT charge a retry. An agent
+        // coming back online is a recovery, not a failure; `retryCount`
+        // means failures only. `releaseBack` records it in `releaseCount`.
         // The earlier code called `applyCorrection` (which flips status
         // to queued via updateItemStatus) AND `requeueWorkItem` (which
         // calls `releaseBack`, which expects status running|blocked).

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -893,7 +893,159 @@ describe('TaskPoolService', () => {
       const items = await service.getAvailableItems();
       expect(items).toHaveLength(1);
       expect(items[0].status).toBe('queued');
-      expect(items[0].retryCount).toBe(1);
+      // A release is not a failure: retryCount stays put, and the churn is
+      // recorded separately. (This assertion previously expected 1 — it
+      // encoded the bug fixed in WI 25aadd30.)
+      expect(items[0].retryCount).toBe(0);
+      expect(items[0].releaseCount).toBe(1);
+    });
+
+    // -----------------------------------------------------------------
+    // WI 25aadd30 — a release is an administrative event, not a failure.
+    //
+    // Before this fix `releaseBack` cleared `target` and incremented
+    // `retryCount` on every release of a running item. A lease timeout —
+    // an agent heads-down for longer than the lease — was therefore
+    // treated as both "this work no longer belongs to you" and "you
+    // failed once". Four live WorkItems reached retryCount 3/3 with zero
+    // actual failures, and their assigned workers could no longer be
+    // woken for their own work.
+    // -----------------------------------------------------------------
+    describe('release is not a failure (WI 25aadd30)', () => {
+      it('preserves target when a lease lapses and the claim is revoked', async () => {
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        const claimed = await service.claimFromPool('agent-leo');
+        expect(claimed).not.toBeNull();
+
+        // Lease lapses -> reconciler revokes the claim. This is the exact
+        // production path that orphaned the four WorkItems.
+        await service.revokeAndRelease(claimed!.claim.id, 'grace period exceeded');
+
+        const released = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(released.status).toBe('queued');
+        expect(released.target).toBe('agent-leo');
+        expect(released.retryCount).toBe(0);
+      });
+
+      it('does not charge a retry for repeated lease churn', async () => {
+        const wi = makeWorkItem({ target: 'agent-leo', maxRetries: 3 });
+        await service.addToPool(wi);
+
+        // Three consecutive claim/lapse cycles — the shape that drove live
+        // items to 3/3. retryCount must not move; releaseCount must.
+        for (let i = 0; i < 3; i++) {
+          const claimed = await service.claimFromPool('agent-leo');
+          expect(claimed).not.toBeNull();
+          await service.releaseBack(wi.id, `lease expired (cycle ${i})`);
+        }
+
+        const churned = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(churned.retryCount).toBe(0);
+        expect(churned.retryCount).toBeLessThan(churned.maxRetries);
+        expect(churned.releaseCount).toBe(3);
+        expect(churned.target).toBe('agent-leo');
+      });
+
+      it('keeps the assigned worker wakeable after a release (wake-gate predicate)', async () => {
+        // The wake gate (team.controller checkWakeGate, rule 2) admits a
+        // worker only when the pool holds a queued/blocked WI whose
+        // `target` equals their session. Clearing target on release made
+        // the assigned worker unwakeable for their own work, surfacing as
+        // `wake_gate_no_pool_work`. This asserts the exact predicate the
+        // gate evaluates.
+        const sessionName = 'crewly-product-leo-21a5477e';
+        const wi = makeWorkItem({ target: sessionName });
+        await service.addToPool(wi);
+        const claimed = await service.claimFromPool(sessionName);
+        await service.revokeAndRelease(claimed!.claim.id, 'lease expired');
+
+        const items = await service.getAllItems();
+        const wakeable = items.filter(
+          (w) =>
+            (w.status === 'queued' || w.status === 'blocked') &&
+            w.target === sessionName,
+        );
+        expect(wakeable).toHaveLength(1);
+        expect(wakeable[0].id).toBe(wi.id);
+      });
+
+      it('clears target ONLY when un-assignment is explicitly requested', async () => {
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+
+        await service.releaseBack(wi.id, 'agent declined', { unassign: true });
+
+        const released = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(released.target).toBeUndefined();
+        // Still not a failure, even when deliberately handed back.
+        expect(released.retryCount).toBe(0);
+        expect(released.releaseCount).toBe(1);
+      });
+
+      it('leaves the blocked -> queued unblock path intact', async () => {
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+        await service.updateItemStatus(wi.id, 'blocked');
+
+        await service.releaseBack(wi.id, 'agent back online');
+
+        const unblocked = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(unblocked.status).toBe('queued');
+        expect(unblocked.target).toBe('agent-leo');
+        expect(unblocked.startedAt).toBeUndefined();
+        expect(unblocked.retryCount).toBe(0);
+      });
+
+      it('drops an incidental claim stamp so broadcast work returns to the pool', async () => {
+        // A broadcast item (no target) gets `target` stamped by whoever
+        // claims it. That stamp is bookkeeping, not an assignment, so a
+        // release must return the item to the broadcast pool — otherwise
+        // one claim would bind unassigned work to a single agent forever,
+        // and a dead agent's stamp would make the item unclaimable.
+        const wi = makeWorkItem();
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+
+        const stamped = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(stamped.target).toBe('agent-leo');
+        expect(stamped.targetSource).toBe('claim');
+
+        await service.releaseBack(wi.id, 'lease expired');
+
+        const released = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(released.target).toBeUndefined();
+        expect(released.targetSource).toBeUndefined();
+        expect(released.retryCount).toBe(0);
+      });
+
+      it('keeps a deliberate assignment across a release, unlike a claim stamp', async () => {
+        // The contrast that the whole fix turns on: same release, two
+        // different provenances, two different outcomes.
+        const assigned = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(assigned);
+        await service.claimFromPool('agent-leo');
+        await service.releaseBack(assigned.id, 'lease expired');
+
+        const kept = (await service.getAllItems()).find((i) => i.id === assigned.id)!;
+        expect(kept.target).toBe('agent-leo');
+      });
+
+      it('still charges a retry on the genuine failure path', async () => {
+        // The counter must keep working where it MEANS something —
+        // otherwise this fix would just disable retry accounting.
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        await service.claimFromPool('agent-leo');
+        await service.failItem(wi.id, 'boom');
+        await service.requeueAfterFailure(wi.id, 'transient error');
+
+        const requeued = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(requeued.retryCount).toBe(1);
+        expect(requeued.target).toBe('agent-leo');
+      });
     });
 
     it('throws when item not found', async () => {
@@ -2239,7 +2391,7 @@ describe('TaskPoolService', () => {
       }
     });
 
-    it('releaseBack from running calls transitionStatus(running→queued, system) with retryCount bump', async () => {
+    it('releaseBack from running calls transitionStatus(running→queued, system) without a retryCount bump', async () => {
       const wi = makeWorkItem();
       await service.addToPool(wi);
       await service.claimFromPool('agent-leo');
@@ -2252,7 +2404,9 @@ describe('TaskPoolService', () => {
         const items = await service.getAllItems();
         const released = items.find((i) => i.id === wi.id)!;
         expect(released.status).toBe('queued');
-        expect(released.retryCount).toBe(1);
+        // retryCount means failures only; a release bumps releaseCount.
+        expect(released.retryCount).toBe(0);
+        expect(released.releaseCount).toBe(1);
         expect(released.startedAt).toBeUndefined();
       } finally {
         restore();

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -174,6 +174,23 @@ export interface ClaimResult {
  * }
  * ```
  */
+
+/**
+ * Options for {@link TaskPoolService.releaseBack}.
+ */
+export interface ReleaseBackOptions {
+  /**
+   * When true, clear the item's `target` as well, returning it to the
+   * unassigned pool.
+   *
+   * Defaults to false: a release ends an attempt, it does not revoke an
+   * assignment. This must be requested BY NAME so that un-assignment is
+   * always a deliberate act by a caller who means it, never a silent
+   * side effect of a lease expiring.
+   */
+  unassign?: boolean;
+}
+
 export class TaskPoolService {
   private static instance: TaskPoolService | null = null;
 
@@ -778,7 +795,12 @@ export class TaskPoolService {
         'system',
         (wi) => {
           if (!wi.target) {
+            // Broadcast claim: record that this target is an incidental
+            // claim stamp, not a deliberate assignment, so releaseBack
+            // returns the item to the broadcast pool instead of binding
+            // it to this agent forever.
             wi.target = agentId;
+            wi.targetSource = 'claim';
           }
           // else: target already === agentId per the filter; leave as-is.
         },
@@ -874,7 +896,10 @@ export class TaskPoolService {
         'system',
         (wi) => {
           if (!wi.target) {
+            // Broadcast claim — see claimFromPool: this is a claim stamp,
+            // not an assignment.
             wi.target = agentId;
+            wi.targetSource = 'claim';
           }
         },
       );
@@ -896,11 +921,59 @@ export class TaskPoolService {
    *
    * The item's status reverts to 'queued' and the claim is marked 'released'.
    *
+   * A release is an ADMINISTRATIVE event, not a failure. Two invariants
+   * follow, and both were violated before 2026-08-21:
+   *
+   * 1. **`target` is preserved.** A release says "this attempt ended", not
+   *    "this work no longer belongs to that agent". Clearing it silently
+   *    destroyed a deliberate assignment — and because the wake gate admits
+   *    a worker only when a queued/blocked WI carries `target === their
+   *    session`, it also made the assigned worker unwakeable for their own
+   *    work (`wake_gate_no_pool_work`). The sibling failure path,
+   *    {@link requeueAfterFailure}, already keeps `target` on the far
+   *    stronger grounds of an actual failure; there is no coherent reading
+   *    in which a lease lapse un-assigns work that a failure would not.
+   *    Genuine un-assignment is still possible, but it must be asked for by
+   *    name via `options.unassign` — never inferred from a lease expiring.
+   *
+   *    One carve-out, and it is not an exception to the rule so much as a
+   *    sharpening of it: `claimFromPool` stamps `target` on a *broadcast*
+   *    item to record who picked it up. That stamp is not an assignment,
+   *    and it is dropped on release (`targetSource === 'claim'`) so the
+   *    item returns to the broadcast pool. Preserving it would let one
+   *    claim permanently bind unassigned work to a single agent — and if
+   *    that agent died, only a dead session could ever re-claim it.
+   *
+   * 2. **`retryCount` is untouched.** That counter means failures only (see
+   *    {@link WorkItem.retryCount}); consumers branch on
+   *    `retryCount < maxRetries` to decide retry-in-place vs terminal-and-
+   *    escalate. Charging a retry for lease churn drove live work to 3/3
+   *    with zero failures. Release churn is counted separately in
+   *    {@link WorkItem.releaseCount}, which nothing branches on.
+   *
    * @param workItemId - ID of the work item to release
    * @param reason - Why the item is being released
-   * @throws Error if work item not found or not currently claimed
+   * @param options - Release options
+   * @param options.unassign - When true, ALSO clear `target`, returning the
+   *   item to the unassigned pool. Opt-in only, for the case where a caller
+   *   genuinely means "someone else should take this". Defaults to false.
+   * @throws Error if work item not found, or its status is not
+   *   'running' or 'blocked'
+   *
+   * @example
+   * ```typescript
+   * // Lease lapsed / claim revoked — the owner keeps the work.
+   * await pool.releaseBack(id, 'claim revoked: grace exceeded');
+   *
+   * // Deliberate hand-back — anyone may pick this up.
+   * await pool.releaseBack(id, 'agent declined', { unassign: true });
+   * ```
    */
-  async releaseBack(workItemId: string, reason: string): Promise<void> {
+  async releaseBack(
+    workItemId: string,
+    reason: string,
+    options: ReleaseBackOptions = {},
+  ): Promise<void> {
     const workItem = await this.storage.findWorkItem(workItemId);
     if (!workItem) {
       throw new Error(`WorkItem not found: ${workItemId}`);
@@ -925,15 +998,24 @@ export class TaskPoolService {
     // guarded transitionStatus helper. The state-machine entry for
     // `running → queued` is a TRANS-2 addition, gated to system/TL/orc;
     // `blocked → queued` was already TL/orc/system-gated by TRANS-1.
-    // Side-effect mutations (startedAt clear, target preservation when
-    // unblocking, retryCount bump) move into the atomic mutator.
-    const wasBlocked = workItem.status === 'blocked';
+    // Side-effect mutations (startedAt clear, opt-in target clear,
+    // releaseCount bump) move into the atomic mutator.
+    //
+    // `target` survives every release; only an explicit `unassign` clears
+    // it. `retryCount` is NOT touched here — a release is not a failure —
+    // and release churn is recorded in `releaseCount` instead.
+    const unassign = options.unassign === true;
     await this.transitionStatus(workItemId, 'queued', 'system', (wi) => {
       wi.startedAt = undefined;
-      if (!wasBlocked) {
+      // Drop the target only when the caller explicitly asked, or when the
+      // target was never an assignment in the first place — a broadcast
+      // item stamped by whoever happened to claim it belongs back in the
+      // broadcast pool, not bound to that agent.
+      if (unassign || wi.targetSource === 'claim') {
         wi.target = undefined;
+        wi.targetSource = undefined;
       }
-      wi.retryCount += 1;
+      wi.releaseCount = (wi.releaseCount ?? 0) + 1;
     });
 
     await this.storage.flush();
@@ -941,6 +1023,7 @@ export class TaskPoolService {
       workItemId,
       reason,
       claimId: claim?.id,
+      unassigned: unassign,
     });
   }
 
@@ -1679,6 +1762,9 @@ export class TaskPoolService {
     const handoffNote = `[HANDOFF] ${fromAgent} → ${newTarget}: ${reason || '(no reason)'}`;
     await this.storage.updateWorkItem(workItemId, (item) => {
       item.target = newTarget;
+      // An explicit handoff is a deliberate assignment: it must survive a
+      // later release.
+      item.targetSource = 'assigned';
       const existing = (item.metadata && typeof item.metadata === 'object' ? item.metadata : {}) as Record<
         string,
         unknown

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -251,10 +251,55 @@ export interface WorkItem {
    * TaskPoolService.blockItem (explicit worker block).
    */
   blockedReason?: string;
-  /** Number of retry attempts so far */
+  /**
+   * Number of FAILED attempts so far.
+   *
+   * SEMANTICS (deliberate, load-bearing): this counter means *failures
+   * only*. It is incremented by `requeueAfterFailure` — the path taken
+   * when work genuinely failed — and by nothing else. Consumers branch on
+   * `retryCount < maxRetries` to choose retry-in-place vs terminal-and-
+   * escalate, so anything that inflates it without a real failure takes
+   * live work terminal.
+   *
+   * In particular, an administrative release (lease expiry, claim revoke,
+   * reconciler requeue, an agent handing work back) is NOT a failure and
+   * MUST NOT touch this field — see {@link releaseCount}. Before
+   * 2026-08-21 `releaseBack` incremented it on every release, so an agent
+   * who simply went heads-down for longer than the lease accumulated
+   * retries it never earned and was driven to 3/3 with zero failures.
+   */
   retryCount: number;
   /** Maximum retries before permanent failure */
   maxRetries: number;
+  /**
+   * Number of administrative releases back to the pool (lease expiry,
+   * claim revoke, reconciler requeue, explicit hand-back).
+   *
+   * Purely diagnostic — deliberately kept SEPARATE from {@link retryCount}
+   * so release churn stays observable without being mistaken for failure.
+   * Nothing branches on this field; it exists so a release loop can be
+   * spotted without corrupting retry semantics.
+   *
+   * Optional for back-compat: items persisted before this field existed
+   * read as `undefined`, which callers treat as 0.
+   */
+  releaseCount?: number;
+  /**
+   * Provenance of {@link target} — how this item came to point at an agent.
+   *
+   * - `'assigned'` (or absent): a DELIBERATE assignment. A TL delegated the
+   *   work, or it was handed off explicitly. This survives a release: the
+   *   work still belongs to that agent.
+   * - `'claim'`: an incidental stamp. The item was a broadcast item with no
+   *   target, and `claimFromPool` / `claimSpecificItem` recorded whoever
+   *   picked it up. This must NOT survive a release — otherwise a single
+   *   claim would permanently bind broadcast work to one agent, and if that
+   *   agent died the item could only ever be re-claimed by a dead session.
+   *
+   * The distinction exists because "preserve the target on release" is
+   * correct for an assignment and actively harmful for a claim stamp.
+   */
+  targetSource?: 'assigned' | 'claim';
   /** Trigger ID that created or will wake this WorkItem */
   triggerId?: string;
   /** Link to ProjectTask (for durable project work) */


### PR DESCRIPTION
WorkItem 25aadd30. **Base SHA: `09a97caa`** (origin/main at branch time).

## What was wrong

`releaseBack` treated every release of a `running` item as two claims at once: *this work no longer belongs to this worker*, and *this worker failed once*.

```js
if (!wasBlocked) { wi.target = undefined; }   // destroys the assignment
wi.retryCount += 1;                           // charges a failure for lease churn
```

A lease timeout — an agent heads-down longer than the lease — hit both. Hence four live WorkItems at `retryCount` 3/3 with zero failures, and their workers locked out of their own work: the wake gate (`checkWakeGate` rule 2) admits a worker only when a queued/blocked WI carries `target === their session`, so clearing `target` produces `wake_gate_no_pool_work` for the very agent the work was assigned to.

The argument that settles it is already in the codebase. `requeueAfterFailure` — the *real* failure path — does:

```js
wi.retryCount += 1;
// Keep `target` — the original agent should get the retry.
```

A genuine failure keeps the assignment. There is no coherent reading in which a lease lapse un-assigns work that a failure would not. Inconsistency, not tradeoff.

## What changed

**1. `retryCount` is failures only.** `releaseBack` no longer touches it, and the meaning is now written into the type rather than left as folklore. Release churn goes to a new `releaseCount` that nothing branches on — the separate counter you pre-approved, not an overload of the existing one.

**2. `target` survives a release.** Un-assignment is opt-in via `options.unassign`, plumbed through `POST /task-pool/release/:workItemId`. Un-assignment is now always something a caller asks for by name.

**3. Target provenance — the one thing I added beyond the brief, flagged for your review.**

`claimFromPool` *stamps* `target = agentId` on broadcast items with no target, to record who picked them up. Preserving that stamp blindly would permanently bind unassigned work to whoever grabbed it first — and if that agent died, the item could only ever be re-claimed by a dead session. That is a worse availability bug than the one being fixed, and it broke a real existing test (`allows another agent to claim after release`) when I first implemented plain preservation.

So `targetSource` distinguishes the two cases:

| provenance | meaning | on release |
|---|---|---|
| `'assigned'` / absent | TL delegated it, or explicit handoff | **kept** |
| `'claim'` | broadcast item, stamped by whoever claimed it | **dropped** |

This is the target half only — I did not touch `retryCount` semantics, per your binding decision.

## Caller audit (eval 2)

Every `releaseBack` call site, and whether it wanted un-assignment:

| caller | context | wanted un-assignment? |
|---|---|---|
| `task-pool.controller.releaseItem` | `POST /release/:workItemId` | Only if asked — now opt-in via `unassign` |
| `TaskPoolService.revokeAndRelease` | claim revoked, grace exceeded | **No** — this is the bug path |
| `reconciler-data-provider.releaseToPool` | `revoked` correction | **No** |
| `reconciler-data-provider.requeueWorkItem` | blocked → queued recovery | **No** — already preserved |

**Not one caller wanted it.** The silent default served nobody; it only destroyed assignments.

## Tests

New `release is not a failure (WI 25aadd30)` suite, mapped to your criteria:

- target preserved when a lease lapses and the claim is revoked *(1)*
- three consecutive claim/lapse cycles leave `retryCount` at 0 and below `maxRetries`, `releaseCount` at 3 *(3, 4)*
- the assigned worker still satisfies the wake-gate predicate after a release *(5)*
- `unassign: true` clears target — and only then *(2)*
- blocked → queued unblock path intact: status, target, `startedAt` all unchanged *(6)*
- **`requeueAfterFailure` still increments** — so this fix cannot quietly become "retries are never counted"
- claim stamp dropped / assignment kept, the contrast the fix turns on

Results: task-pool service **162/162**, controller + reconciler ×2 + types **290/290**. Typecheck **25 errors, byte-identical to the `origin/main` baseline**, none in touched files. Lint clean on every file I touched (`reconciler-data-provider.ts` has 3 unused-import errors — verified identical on pristine `origin/main`; my diff there is a JSDoc comment).

## Two things I changed that reviewers should look at deliberately

**Two existing tests asserted the bug** and had to be updated:
- `releases a claimed item back to queued` expected `retryCount).toBe(1)`
- `releaseBack from running ... with retryCount bump` (renamed to `without a retryCount bump`)

Both now assert `retryCount` 0 / `releaseCount` 1, with a comment recording that the old expectation encoded the defect. Calling this out because "I edited a passing test" deserves scrutiny, not a silent diff.

**A tension between eval 3 and eval 6.** Eval 3 says no retryCount increment for administrative releases; eval 6 says the blocked → queued unblock path is unchanged — and that path *did* increment. I resolved it toward your binding decision ("releaseBack must NOT increment retryCount"): an agent coming back online is a recovery, not a failure. Nothing in the blocked path's test coverage asserted the increment, so nothing regressed, and the stale comment in `reconciler.service.ts` that advertised it is corrected. Say the word if you wanted the other reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)