### PR TITLE
feat(reconciler): a real successor model for rejected/failed WorkItems

### DIFF
--- a/backend/src/services/event-bus/event-to-workitem-bridge.service.ts
+++ b/backend/src/services/event-bus/event-to-workitem-bridge.service.ts
@@ -478,6 +478,12 @@ export class EventToWorkItemBridge {
         retryCount: sourceWI.retryCount,
         cap,
       });
+      // The review WI is a real successor: a TL picks the work up from there.
+      await this.recordSuccessor(
+        sourceWI.id,
+        escalationId,
+        `retry cap ${cap} reached — escalated for review`,
+      );
       return;
     }
 
@@ -509,6 +515,48 @@ export class EventToWorkItemBridge {
       retryAttempt,
       cap,
     });
+    // Record on the SOURCE that this retry is its successor. The source stays
+    // in `rejected` — whose only outbound edge is `→ queued`, so it can never
+    // reach a terminal state — and without this stamp the only way to know it
+    // was dealt with is to scan for a child, which is exactly the inference
+    // that made the 469a3a21 rule wrong in both directions. It also converts
+    // every silent failure above (source lookup empty, addToPool no-op on an
+    // id collision) into a visibly UNDISPOSED source that the reconciler's
+    // safety net will pick up, instead of a strand nobody can see.
+    await this.recordSuccessor(sourceWI.id, retryId, `retry ${retryAttempt}/${cap}`);
+  };
+
+  /**
+   * Stamp a source WorkItem with the successor that now carries its work.
+   *
+   * The bridge never mutates status (see the class doc comment) and this keeps
+   * that invariant: `disposeFailedWorkItem` with a `successorWorkItemId`
+   * writes metadata only, no transition. Best-effort — the successor WI is
+   * already in the pool by this point, so failing to stamp must not undo real
+   * work. An unstamped source simply looks undisposed, and the reconciler's
+   * safety net will reconcile it.
+   *
+   * @param sourceWorkItemId - The `rejected` item being succeeded.
+   * @param successorId      - The WorkItem now carrying the work.
+   * @param reason           - Audit-trail justification.
+   */
+  private recordSuccessor = async (
+    sourceWorkItemId: string,
+    successorId: string,
+    reason: string,
+  ): Promise<void> => {
+    try {
+      await this.taskPool.disposeFailedWorkItem(sourceWorkItemId, {
+        reason,
+        successorWorkItemId: successorId,
+      });
+    } catch (err) {
+      this.logger.warn('Failed to stamp successor on source WorkItem (non-fatal)', {
+        sourceWorkItemId,
+        successorId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   };
 
   /**

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -33,6 +33,7 @@ import {
   WORK_ITEM_TRANSITIONS,
   WORK_ITEM_STATUSES,
   TERMINAL_WORK_ITEM_STATUSES,
+  LAST_REQUEUED_AT_METADATA_KEY,
 } from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
@@ -617,6 +618,82 @@ describe('detectTTLExpiredWorkItems', () => {
       for (const c of corrections) {
         expect(c.newState).toBe('cancelled');
       }
+    });
+
+    /**
+     * Data-loss regression: a granted retry must not be TTL-cancelled a
+     * minute after it is granted.
+     *
+     * Before the TTL anchor, age was measured from `createdAt`, which is
+     * never mutated — not by `requeueAfterFailure`, not by anything in the
+     * repo. So a WorkItem that ran for more than the 24h TTL, failed, and was
+     * legitimately auto-retried by `detectRetryableFailedWorkItems` landed
+     * back in `queued` still carrying its original `createdAt`. The very next
+     * reconciler pass (60s later) then saw a >24h-old `queued` item and
+     * cancelled it. The retry was destroyed before the agent could pick it up,
+     * and — because `→ cancelled` from `queued` is perfectly legal — it did so
+     * without a single error log.
+     *
+     * `maxRetries` was therefore unreachable for any WorkItem whose work
+     * outlived the TTL: every retry died on arrival.
+     */
+    describe('TTL anchor — a requeued item gets a fresh window (data-loss regression)', () => {
+      it('does NOT cancel a just-requeued item whose original createdAt is stale', () => {
+        const justRequeued = makeWorkItem({
+          status: 'queued',
+          createdAt: staleAt(), // first asked for 25h ago
+          metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: new Date().toISOString() },
+        });
+
+        const { corrections, expiredIds } = detectTTLExpiredWorkItems([justRequeued]);
+
+        expect(corrections).toHaveLength(0);
+        expect(expiredIds).toHaveLength(0);
+      });
+
+      it('still cancels a requeued item once the NEW window itself expires', () => {
+        // Liveness: the anchor must postpone the TTL, never disable it.
+        // Without this half, "never cancel anything requeued" would pass.
+        const staleSinceRequeue = makeWorkItem({
+          status: 'queued',
+          createdAt: staleAt(),
+          metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: staleAt() },
+        });
+
+        const { corrections, expiredIds } = detectTTLExpiredWorkItems([staleSinceRequeue]);
+
+        expect(expiredIds).toEqual([staleSinceRequeue.id]);
+        expect(corrections).toHaveLength(1);
+        expect(corrections[0].newState).toBe('cancelled');
+      });
+
+      it('is inert for an item that has never been requeued', () => {
+        // The anchor must change nothing for the overwhelmingly common case.
+        const neverRequeued = makeWorkItem({ status: 'queued', createdAt: staleAt() });
+
+        const { corrections } = detectTTLExpiredWorkItems([neverRequeued]);
+
+        expect(corrections).toHaveLength(1);
+        expect(corrections[0].previousState).toBe('queued');
+        expect(corrections[0].newState).toBe('cancelled');
+      });
+
+      it('reports which clock it actually measured, so the audit trail is not misleading', () => {
+        // The evidence string previously said only "Created at <createdAt>",
+        // which would now describe a different timestamp than the one the
+        // decision was made on.
+        const requeuedAt = staleAt();
+        const wi = makeWorkItem({
+          status: 'queued',
+          createdAt: new Date(Date.now() - 100 * 3600 * 1000).toISOString(),
+          metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: requeuedAt },
+        });
+
+        const { corrections } = detectTTLExpiredWorkItems([wi]);
+
+        expect(corrections[0].evidence).toContain(requeuedAt);
+        expect(corrections[0].evidence).toContain('TTL measured from');
+      });
     });
   });
 

--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -23,6 +23,7 @@ import {
   selectBestAgent,
   computeAgentScore,
   runPruningPass,
+  detectUndisposedStrandedWorkItems,
   UNCLAIMED_THRESHOLD_MS,
   MAX_WAKE_ACTIONS_PER_PASS,
 } from './reconcile-rules.js';
@@ -34,6 +35,7 @@ import {
   WORK_ITEM_STATUSES,
   TERMINAL_WORK_ITEM_STATUSES,
   LAST_REQUEUED_AT_METADATA_KEY,
+  DISPOSITION_METADATA_KEY,
 } from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
@@ -2001,5 +2003,151 @@ describe('detectUnverifiedWorkItems', () => {
     });
     const { unverifiedIds } = detectUnverifiedWorkItems([wi], NOW);
     expect(unverifiedIds).toContain(wi.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectUndisposedStrandedWorkItems — successor model safety net
+// ---------------------------------------------------------------------------
+describe('detectUndisposedStrandedWorkItems', () => {
+  const HOUR = 3600 * 1000;
+
+  /** A WI that entered a stranding status `hoursAgo` ago. */
+  function stranded(
+    status: 'rejected' | 'failed',
+    hoursAgo = 1,
+    overrides: Partial<WorkItem> = {},
+  ): WorkItem {
+    return makeWorkItem({
+      status,
+      completedAt: new Date(Date.now() - hoursAgo * HOUR).toISOString(),
+      ...overrides,
+    });
+  }
+
+  /** Build a well-formed disposition stamp. */
+  function stamp(
+    kind: 'succeeded_by' | 'terminal',
+    extra: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      [DISPOSITION_METADATA_KEY]: {
+        kind,
+        at: new Date().toISOString(),
+        by: 'system',
+        reason: 'already handled',
+        ...extra,
+      },
+    };
+  }
+
+  it('flags an undisposed stranded item once the grace window has passed', () => {
+    const { items } = detectUndisposedStrandedWorkItems([stranded('rejected')]);
+    expect(items).toHaveLength(1);
+  });
+
+  it('covers both stranding statuses, and only those', () => {
+    // Derived from the transition table, so this really asserts that the set of
+    // "neither terminal nor able to reach terminal" statuses is exactly
+    // {rejected, failed} — a future status of that shape is covered for free
+    // instead of silently stranding.
+    const all = WORK_ITEM_STATUSES.map((status) =>
+      makeWorkItem({
+        status,
+        completedAt: new Date(Date.now() - HOUR).toISOString(),
+      }),
+    );
+    const { items } = detectUndisposedStrandedWorkItems(all);
+    expect(items.map((i) => i.status).sort()).toEqual(['failed', 'rejected']);
+  });
+
+  it('leaves an item alone inside the grace window so the eager writer wins', () => {
+    const fresh = makeWorkItem({
+      status: 'failed',
+      completedAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(detectUndisposedStrandedWorkItems([fresh]).items).toHaveLength(0);
+  });
+
+  it('returns the oldest strand first', () => {
+    const young = stranded('failed', 1);
+    const old = stranded('rejected', 10);
+    const { items } = detectUndisposedStrandedWorkItems([young, old]);
+    expect(items.map((i) => i.id)).toEqual([old.id, young.id]);
+  });
+
+  /**
+   * The two directions the reverted 469a3a21 rule got wrong.
+   *
+   * It answered "does a successor exist?" by scanning `getActiveWorkItems()`
+   * for a child. Both failures follow from the QUESTION, not the code, and no
+   * refinement of the query fixes either — which is why the predicate is now a
+   * local field read instead of a scan.
+   */
+  describe('successor predicate — correct in BOTH directions', () => {
+    it('direction 1: does NOT re-dispatch an item whose successor already finished', () => {
+      // The reverted rule looked for successors in getActiveWorkItems(), which
+      // drops `done`/`cancelled`. A successor that had already completed was
+      // invisible, so the rule concluded "no successor" and re-dispatched the
+      // source — executing completed work a second time.
+      const completedSuccessor = makeWorkItem({ status: 'done' });
+      const source = stranded(
+        'rejected',
+        10,
+        { metadata: stamp('succeeded_by', { successorWorkItemId: completedSuccessor.id }) },
+      );
+
+      const { items } = detectUndisposedStrandedWorkItems([source, completedSuccessor]);
+
+      // Read off the source itself, so the successor's status is irrelevant —
+      // there is no collection for a filter to hide it from.
+      expect(items).toHaveLength(0);
+    });
+
+    it('direction 2: DOES flag an item whose only child is an unrelated VERIFY WI', () => {
+      // `buildAutoWorkItem` sets `parentWorkItemId` on VERIFY WorkItems too, so
+      // the reverted rule read a verification child as a successor and skipped
+      // the exact SLA case it existed to rescue.
+      const source = stranded('rejected', 10);
+      const verifyChild = makeWorkItem({
+        id: `${source.id}:verify:${source.id}`,
+        status: 'queued',
+        parentWorkItemId: source.id,
+      });
+
+      const { items } = detectUndisposedStrandedWorkItems([source, verifyChild]);
+
+      // No stamp on the source → still stranded, regardless of who claims it as
+      // a parent. `parentWorkItemId` is never consulted.
+      expect(items.map((i) => i.id)).toEqual([source.id]);
+    });
+  });
+
+  it('skips an item already disposed, whatever the disposition was', () => {
+    for (const kind of ['succeeded_by', 'terminal'] as const) {
+      const disposed = stranded('failed', 10, { metadata: stamp(kind) });
+      expect(detectUndisposedStrandedWorkItems([disposed]).items).toHaveLength(0);
+    }
+  });
+
+  it('treats a malformed stamp as absent rather than trusting it', () => {
+    // `metadata` is Record<string, unknown> and round-trips through storage.
+    // Re-disposing is idempotent and safe; trusting a broken record is not.
+    const malformed: unknown[] = [{ kind: 'nonsense' }, { at: 'x' }, 'string', 42, null];
+    for (const bad of malformed) {
+      const wi = stranded('failed', 10, {
+        metadata: { [DISPOSITION_METADATA_KEY]: bad },
+      });
+      expect(detectUndisposedStrandedWorkItems([wi]).items).toHaveLength(1);
+    }
+  });
+
+  it('emits no status corrections at all — a disposition is not a transition', () => {
+    // The `terminal` outcome leaves the item exactly where it is. Returning a
+    // correction here would put an illegal edge back into the pipeline that
+    // #733 just cleaned of them, since neither stranding status has a legal
+    // terminal target.
+    const result = detectUndisposedStrandedWorkItems([stranded('rejected', 10)]);
+    expect(Object.keys(result)).toEqual(['items']);
   });
 });

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -28,6 +28,7 @@ import {
   WORK_ITEM_TRANSITIONS,
   createCorrection,
   DEFAULT_GRACE_PERIOD_MS,
+  getTtlAnchorAt,
 } from '../../types/v2/index.js';
 
 // ---------------------------------------------------------------------------
@@ -585,8 +586,12 @@ export function detectTTLExpiredWorkItems(
   for (const wi of workItems) {
     if (TERMINAL_WORK_ITEM_STATUSES.has(wi.status)) continue;
 
-    const createdAt = new Date(wi.createdAt).getTime();
-    const age = now - createdAt;
+    // Age is measured from the TTL anchor, not `createdAt`. For an item that
+    // has never been requeued these are the same value; for one that HAS been
+    // requeued after a failure, the retry gets a fresh TTL window instead of
+    // inheriting the original request's age. See {@link getTtlAnchorAt}.
+    const anchorAt = new Date(getTtlAnchorAt(wi)).getTime();
+    const age = now - anchorAt;
 
     if (age > ttlMs) {
       const target = pickTTLExpiryTarget(wi.status);
@@ -599,7 +604,9 @@ export function detectTTLExpiredWorkItems(
         previousState: wi.status,
         newState: target,
         reason: `WorkItem exceeded TTL of ${Math.round(ttlMs / 3600000)}h`,
-        evidence: `Created at ${wi.createdAt}, age=${Math.round(age / 3600000)}h`,
+        evidence:
+          `Created at ${wi.createdAt}, TTL measured from ${getTtlAnchorAt(wi)}, ` +
+          `age=${Math.round(age / 3600000)}h`,
       }));
       expiredIds.push(wi.id);
     }

--- a/backend/src/services/reconciler/reconcile-rules.ts
+++ b/backend/src/services/reconciler/reconcile-rules.ts
@@ -30,6 +30,10 @@ import {
   DEFAULT_GRACE_PERIOD_MS,
   getTtlAnchorAt,
 } from '../../types/v2/index.js';
+import {
+  DISPOSITION_REQUIRED_STATUSES,
+  isWorkItemDisposed,
+} from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
 // Agent Health Types (abstraction over existing services)
@@ -1352,6 +1356,89 @@ function countByStatus(statuses: string[]): Record<string, number> {
 // ---------------------------------------------------------------------------
 // Rule: Auto-Retry Failed WorkItems
 // ---------------------------------------------------------------------------
+
+/**
+ * Grace period before the safety net acts on an undisposed stranded item.
+ *
+ * The eager writers (the SLA subscriber, the bridge) dispose their own items
+ * within the same tick. This window lets them win the common case, so the
+ * reconciler only picks up the genuinely dropped ones — a writer that threw,
+ * a bridge whose source lookup came back empty, a retry id that collided with
+ * an already-terminal retry. Short enough that a real strand is caught within
+ * a couple of passes; long enough that the safety net is not racing the
+ * writers it exists to back up.
+ */
+export const DISPOSITION_GRACE_MS = 5 * 60 * 1000;
+
+/**
+ * Safety net: find `rejected`/`failed` WorkItems that nobody dealt with.
+ *
+ * This rule is the backstop, NOT the primary mechanism. The paths that park an
+ * item in a stranding status are each responsible for disposing of it eagerly
+ * (see `TaskPoolService.disposeFailedWorkItem`). This exists because some of
+ * them fail silently — the bridge creates no successor if its source lookup
+ * returns empty or its retry id collides with an already-terminal retry, and
+ * before this rule the resulting strand had no symptom at all: PR #733 correctly
+ * stopped the pruning rules from emitting illegal corrections for these
+ * statuses, which also removed the recurring error log that used to be the only
+ * way to notice.
+ *
+ * Deliberately returns items rather than corrections. A disposition is not a
+ * status change — the `terminal` outcome leaves the item exactly where it is
+ * and writes an audit record instead — so there is nothing for the correction
+ * pipeline to apply, and inventing a correction here would put an illegal edge
+ * back into a pipeline that was just cleaned of them. The caller performs the
+ * disposition through the funnel.
+ *
+ * Termination: every disposition either stamps the item (skipped forever after)
+ * or requeues it with `retryCount` bumped (bounded by `maxRetries`). The rule
+ * cannot re-fire indefinitely on the same item.
+ *
+ * @param workItems - The reconciler's WorkItem snapshot.
+ * @param graceMs   - Override for {@link DISPOSITION_GRACE_MS} (tests).
+ * @param now       - Injectable clock for deterministic tests.
+ * @returns The items needing disposition, oldest strand first.
+ *
+ * @example
+ * ```typescript
+ * const { items } = detectUndisposedStrandedWorkItems(workItems);
+ * for (const wi of items) await pool.disposeFailedWorkItem(wi.id, {...});
+ * ```
+ */
+export function detectUndisposedStrandedWorkItems(
+  workItems: WorkItem[],
+  graceMs: number = DISPOSITION_GRACE_MS,
+  now: number = Date.now(),
+): { items: WorkItem[] } {
+  const items: WorkItem[] = [];
+
+  for (const wi of workItems) {
+    if (!DISPOSITION_REQUIRED_STATUSES.has(wi.status)) continue;
+    // THE successor predicate: a local field read. The reverted 469a3a21 rule
+    // asked the same question by scanning other WorkItems and was wrong in
+    // both directions — see WorkItemDisposition's doc comment.
+    if (isWorkItemDisposed(wi)) continue;
+
+    // `completedAt` is set by transitionStatus for every stranding status, so
+    // it is when the item ENTERED the strand. Fall back to createdAt only if
+    // it is somehow absent.
+    const strandedSince = new Date(wi.completedAt ?? wi.createdAt).getTime();
+    if (Number.isNaN(strandedSince)) continue;
+    if (now - strandedSince < graceMs) continue;
+
+    items.push(wi);
+  }
+
+  // Oldest strand first: if a pass is interrupted, the longest-suffering items
+  // are the ones already dealt with.
+  items.sort(
+    (a, b) =>
+      new Date(a.completedAt ?? a.createdAt).getTime() -
+      new Date(b.completedAt ?? b.createdAt).getTime(),
+  );
+
+  return { items };
+}
 
 /**
  * Detects WorkItems in 'failed' status that still have remaining retries

--- a/backend/src/services/reconciler/reconciler.service.test.ts
+++ b/backend/src/services/reconciler/reconciler.service.test.ts
@@ -9,6 +9,11 @@ import type { ReconcilerDataProvider } from './reconciler.service.js';
 import { createWorkItem, createRequest, createTaskClaim, isValidWorkItemTransition } from '../../types/v2/index.js';
 import type { WorkItem, WorkItemStatus, Request, TaskClaim, ReconcileCorrection, WakeAction } from '../../types/v2/index.js';
 import type { AgentHealth } from './reconcile-rules.js';
+import {
+  WORK_ITEM_STATUSES,
+  WORK_ITEM_TRANSITIONS,
+  DISPOSITION_METADATA_KEY,
+} from '../../types/v2/work-item.types.js';
 
 // ---------------------------------------------------------------------------
 // Mock settings service for maxConcurrentAgents tests
@@ -38,6 +43,19 @@ jest.mock('../v3/escalation-router.service.js', () => ({
   EscalationRouterService: {
     getInstance: () => ({
       escalateUnverifiedWorkItem: mockEscalateUnverified,
+    }),
+  },
+}));
+
+// `disposeStrandedWorkItems` dynamically imports TaskPoolService to run the
+// disposition funnel. Stub it so the safety net is observable without standing
+// up the real pool singleton.
+const mockDisposeFailedWorkItem = jest.fn().mockResolvedValue({ kind: 'terminal' });
+
+jest.mock('../task-pool/task-pool.service.js', () => ({
+  TaskPoolService: {
+    getInstance: () => ({
+      disposeFailedWorkItem: mockDisposeFailedWorkItem,
     }),
   },
 }));
@@ -99,6 +117,7 @@ describe('ReconcilerService', () => {
       general: { maxConcurrentAgents: 10 },
     });
     mockEscalateUnverified.mockClear();
+    mockDisposeFailedWorkItem.mockClear();
   });
 
   afterEach(() => {
@@ -1230,6 +1249,138 @@ describe('ReconcilerService', () => {
 
       // Must not throw.
       await expect(service.runFull()).resolves.toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // EVAL 5 — full-cycle invariant
+  // -----------------------------------------------------------------------
+  /**
+   * One complete `runFull` over a pool holding every `WorkItemStatus` must
+   * produce zero illegal transitions AND must not leave a strand behind.
+   *
+   * The per-rule invariant tests in `reconcile-rules.test.ts` already derive
+   * their expectations from `WORK_ITEM_TRANSITIONS` and assert liveness plus
+   * soundness. This is the cycle-level counterpart: rules that are individually
+   * sound can still combine badly — #733 found exactly that, where the TTL rule
+   * legitimately emitted `done_by_worker → verified` and the pruning pass then
+   * treated the just-ACCEPTED parent as a dead ancestor.
+   *
+   * Both halves are asserted deliberately. Soundness alone passes just as
+   * happily if every rule is gutted to do nothing, and "do nothing" is exactly
+   * the state the reverted 469a3a21 rule left the codebase in.
+   */
+  describe('EVAL 5 — one full cycle produces no illegal transition and no surviving strand', () => {
+    const HOUR = 3600 * 1000;
+
+    /** One WorkItem in each status, all old enough to be actionable. */
+    function seedEveryStatus(): WorkItem[] {
+      const old = new Date(Date.now() - 48 * HOUR).toISOString();
+      return WORK_ITEM_STATUSES.map((status) =>
+        makeWorkItem({
+          status,
+          target: undefined, // no agent → no stuck-rule corrections to reason about
+          createdAt: old,
+          completedAt: old,
+        }),
+      );
+    }
+
+    it('soundness: every applied correction is a legal edge for the status it came from', async () => {
+      const workItems = seedEveryStatus();
+      const byId = new Map(workItems.map((wi) => [wi.id, wi]));
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue(workItems),
+      });
+      service = new ReconcilerService(provider, {
+        fastLoopIntervalMs: 10_000,
+        fullLoopIntervalMs: 60_000,
+      });
+
+      const result = await service.runFull();
+
+      const workItemCorrections = result.corrections.filter(
+        (c) => c.entityType === 'work_item',
+      );
+      for (const c of workItemCorrections) {
+        const source = byId.get(c.entityId);
+        if (!source) continue;
+        expect(
+          WORK_ITEM_TRANSITIONS[source.status].has(c.newState as WorkItemStatus),
+        ).toBe(true);
+      }
+    });
+
+    it('liveness: the stranding statuses are handed to the funnel, and only those', async () => {
+      const workItems = seedEveryStatus();
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue(workItems),
+      });
+      service = new ReconcilerService(provider, {
+        fastLoopIntervalMs: 10_000,
+        fullLoopIntervalMs: 60_000,
+      });
+
+      await service.runFull();
+
+      const disposedIds = mockDisposeFailedWorkItem.mock.calls.map(
+        (call) => call[0] as string,
+      );
+      const expected = workItems
+        .filter((wi) => wi.status === 'rejected' || wi.status === 'failed')
+        .map((wi) => wi.id);
+
+      expect(disposedIds.sort()).toEqual(expected.sort());
+      // Non-empty, so "the rule did nothing" cannot pass this.
+      expect(disposedIds).toHaveLength(2);
+    });
+
+    it('a strand that is already disposed is left alone on subsequent cycles', async () => {
+      // Re-entrancy at cycle level: the funnel is idempotent, but the rule must
+      // not keep handing the same item back to it every 60s either.
+      const disposed = makeWorkItem({
+        status: 'rejected',
+        target: undefined,
+        completedAt: new Date(Date.now() - 48 * HOUR).toISOString(),
+        metadata: {
+          [DISPOSITION_METADATA_KEY]: {
+            kind: 'terminal',
+            at: new Date().toISOString(),
+            by: 'system',
+            reason: 'already handled',
+          },
+        },
+      });
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue([disposed]),
+      });
+      service = new ReconcilerService(provider, {
+        fastLoopIntervalMs: 10_000,
+        fullLoopIntervalMs: 60_000,
+      });
+
+      await service.runFull();
+      await service.runFull();
+
+      expect(mockDisposeFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('a disposition failure does not abort the rest of the cycle', async () => {
+      mockDisposeFailedWorkItem.mockRejectedValueOnce(new Error('pool down'));
+      const workItems = seedEveryStatus();
+      provider = createMockProvider({
+        getActiveWorkItems: jest.fn().mockResolvedValue(workItems),
+      });
+      service = new ReconcilerService(provider, {
+        fastLoopIntervalMs: 10_000,
+        fullLoopIntervalMs: 60_000,
+      });
+
+      const result = await service.runFull();
+
+      // Both strands still attempted; the throw is contained.
+      expect(mockDisposeFailedWorkItem).toHaveBeenCalledTimes(2);
+      expect(result).toBeDefined();
     });
   });
 });

--- a/backend/src/services/reconciler/reconciler.service.ts
+++ b/backend/src/services/reconciler/reconciler.service.ts
@@ -35,6 +35,7 @@ import {
   reconcileRequestStatus,
   detectRecoverableWorkItems,
   detectRetryableFailedWorkItems,
+  detectUndisposedStrandedWorkItems,
   detectDependencyResolvedWorkItems,
   detectUnclaimedTasks,
   detectUnverifiedWorkItems,
@@ -225,6 +226,13 @@ export class ReconcilerService {
       // explicit verdict so unverified work is never silently auto-accepted by
       // the 24h TTL fallback (pickTTLExpiryTarget('done_by_worker') → verified).
       await this.enforceVerification(workItems);
+
+      // 3e. Successor model safety net: `rejected`/`failed` items that nobody
+      // disposed of. Runs BEFORE the pruning pass for the same reason
+      // enforceVerification does — the pruning rules deliberately skip these
+      // statuses (no legal terminal edge), so if this pass does not deal with
+      // them nothing downstream will, and the strand is silent.
+      await this.disposeStrandedWorkItems(workItems);
 
       // 4. Pruning pass (F4): TTL expiry + orphan cascade + deep cascade + stale queue detection
       const pruning = runPruningPass(workItems);
@@ -599,6 +607,54 @@ export class ReconcilerService {
    *
    * @param workItems - All active WorkItems for this pass.
    */
+  /**
+   * Dispose of `rejected`/`failed` WorkItems that no writer dealt with.
+   *
+   * The writers dispose their own items eagerly; this catches the ones that
+   * fell through — a writer that threw, a bridge successor that never
+   * materialised. Runs the same funnel the writers use, so the outcome and the
+   * audit record are identical regardless of who noticed.
+   *
+   * Non-fatal throughout: a stranded item is already the failure case, and
+   * throwing here would take down the rest of the reconcile pass with it.
+   *
+   * @param workItems - The pass's WorkItem snapshot.
+   */
+  private async disposeStrandedWorkItems(workItems: WorkItem[]): Promise<void> {
+    const log = LoggerService.getInstance().createComponentLogger('ReconcilerService');
+    try {
+      const { items } = detectUndisposedStrandedWorkItems(workItems);
+      if (items.length === 0) return;
+
+      const { TaskPoolService } = await import('../task-pool/task-pool.service.js');
+      const pool = TaskPoolService.getInstance();
+
+      for (const wi of items) {
+        try {
+          const disposition = await pool.disposeFailedWorkItem(wi.id, {
+            reason:
+              `Stranded in '${wi.status}' with no successor ` +
+              `(retryCount=${wi.retryCount}/${wi.maxRetries})`,
+          });
+          log.warn('Disposed a stranded WorkItem the writers missed', {
+            workItemId: wi.id,
+            status: wi.status,
+            kind: disposition?.kind ?? 'none',
+          });
+        } catch (err) {
+          log.warn('Disposition of a stranded WorkItem failed (non-fatal)', {
+            workItemId: wi.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    } catch (err) {
+      log.warn('disposeStrandedWorkItems pass failed (non-fatal)', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   private async enforceVerification(workItems: WorkItem[]): Promise<void> {
     const log = LoggerService.getInstance().createComponentLogger('ReconcilerService');
     try {

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -9,12 +9,20 @@ import { PoolStorage } from './pool-storage.js';
 import {
   createWorkItem,
   LAST_REQUEUED_AT_METADATA_KEY,
+  getWorkItemDisposition,
 } from '../../types/v2/work-item.types.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 
 // Mock LoggerService
+const mockEscalateFailedWorkItem = jest.fn<Promise<string | null>, [unknown, string]>();
+jest.mock('../v3/escalation-router.service.js', () => ({
+  EscalationRouterService: {
+    getInstance: () => ({ escalateFailedWorkItem: mockEscalateFailedWorkItem }),
+  },
+}));
+
 jest.mock('../core/logger.service.js', () => ({
   LoggerService: {
     getInstance: () => ({
@@ -1855,6 +1863,198 @@ describe('TaskPoolService', () => {
       expect(wi.status).toBe('queued');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // disposeFailedWorkItem — the successor model funnel
+  // ---------------------------------------------------------------------------
+  describe('disposeFailedWorkItem', () => {
+    beforeEach(() => {
+      mockEscalateFailedWorkItem.mockClear();
+      mockEscalateFailedWorkItem.mockResolvedValue('esc-1');
+    });
+
+    /** Drive a WI to `failed` with a chosen amount of retry budget consumed. */
+    async function strandFailed(retriesUsed: number, maxRetries = 3): Promise<string> {
+      const wi = makeWorkItem({ target: 'agent-leo' });
+      wi.maxRetries = maxRetries;
+      await service.addToPool(wi);
+      await service.claimFromPool('agent-leo');
+      await service.failItem(wi.id, 'boom');
+      if (retriesUsed > 0) {
+        const found = (await service.getAllItems()).find((x) => x.id === wi.id)!;
+        found.retryCount = retriesUsed;
+      }
+      return wi.id;
+    }
+
+    it('retries in place while the budget lasts, and does NOT stamp', async () => {
+      const id = await strandFailed(0);
+
+      const disposition = await service.disposeFailedWorkItem(id, { reason: 'stranded' });
+
+      expect(disposition?.kind).toBe('retried_in_place');
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      expect(wi.status).toBe('queued');
+      expect(wi.retryCount).toBe(1);
+      // Not stamped on purpose: the item left the stranding statuses under its
+      // own power, and a stamp would describe a failure that is no longer the
+      // current one — which would make the safety net skip the NEXT strand.
+      expect(getWorkItemDisposition(wi)).toBeNull();
+      expect(mockEscalateFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('goes terminal once the budget is spent, escalating and stamping', async () => {
+      const id = await strandFailed(3, 3);
+
+      const disposition = await service.disposeFailedWorkItem(id, { reason: 'stranded' });
+
+      expect(disposition?.kind).toBe('terminal');
+      expect(disposition?.escalationId).toBe('esc-1');
+      expect(mockEscalateFailedWorkItem).toHaveBeenCalledTimes(1);
+
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      // Deliberately still `failed`. Adding a `→ cancelled` edge so it could
+      // reach a strictly terminal status would re-open the illegal-correction
+      // surface PR #733 closed, and would turn a deliberate decision into a
+      // 24h auto-acceptance default. `failed` + an audit record IS the
+      // deliberate terminal state.
+      expect(wi.status).toBe('failed');
+      expect(getWorkItemDisposition(wi)?.kind).toBe('terminal');
+    });
+
+    it('records a real successor when the caller owns one', async () => {
+      const id = await strandFailed(0);
+
+      const disposition = await service.disposeFailedWorkItem(id, {
+        reason: 'bridge retry',
+        successorWorkItemId: `${id}:retry:1`,
+      });
+
+      expect(disposition?.kind).toBe('succeeded_by');
+      expect(disposition?.successorWorkItemId).toBe(`${id}:retry:1`);
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      // Source untouched — the successor carries the work now.
+      expect(wi.status).toBe('failed');
+      expect(wi.retryCount).toBe(0);
+      expect(mockEscalateFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — a second call returns the first disposition, no re-escalation', async () => {
+      const id = await strandFailed(3, 3);
+
+      const first = await service.disposeFailedWorkItem(id, { reason: 'stranded' });
+      const second = await service.disposeFailedWorkItem(id, { reason: 'stranded again' });
+
+      expect(second).toEqual(first);
+      // Re-entrancy is the termination argument: concurrent reconciler passes
+      // must converge rather than escalate twice.
+      expect(mockEscalateFailedWorkItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('terminates: repeated disposal walks the budget down, then stops retrying', async () => {
+      const id = await strandFailed(0, 2);
+
+      for (let i = 0; i < 2; i++) {
+        const d = await service.disposeFailedWorkItem(id, { reason: `pass ${i}` });
+        expect(d?.kind).toBe('retried_in_place');
+        await service.claimFromPool('agent-leo');
+        await service.failItem(id, 'boom again');
+      }
+
+      const final = await service.disposeFailedWorkItem(id, { reason: 'final' });
+      expect(final?.kind).toBe('terminal');
+
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      expect(wi.retryCount).toBe(2);
+      expect(wi.maxRetries).toBe(2);
+    });
+
+    it('no-ops for a status that is not stranded', async () => {
+      const wi = makeWorkItem();
+      await service.addToPool(wi); // queued
+
+      expect(await service.disposeFailedWorkItem(wi.id, { reason: 'n/a' })).toBeNull();
+      expect(mockEscalateFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Composition guard for #739 + the successor model.
+     *
+     * Neither PR proves this on its own: #739 proves a release moves
+     * `releaseCount`, and the funnel proves it branches on `retryCount`. What
+     * matters in production is the two together, because the funnel's
+     * `terminal` branch is destructive — it stops the work and escalates.
+     *
+     * Before #739 this was a live bug with a real incident behind it: four WIs
+     * were found at retryCount 3/3 having failed zero times, purely from lease
+     * lapses while their agents were heads-down. Run through this funnel, every
+     * one of them would have been read as "out of retries" and taken straight
+     * to terminal — live, healthy work stopped on the strength of churn.
+     */
+    it('churn does NOT consume the failure budget — a released-but-never-failed WI still retries', async () => {
+      const wi = makeWorkItem({ target: 'agent-leo' });
+      wi.maxRetries = 3;
+      await service.addToPool(wi);
+
+      // Three lease lapses, zero failures — the exact shape of the incident.
+      for (let i = 0; i < 3; i++) {
+        await service.claimFromPool('agent-leo');
+        await service.releaseBack(wi.id, 'lease lapsed');
+      }
+
+      const churned = (await service.getAllItems()).find((x) => x.id === wi.id)!;
+      expect(churned.retryCount).toBe(0);
+      expect(churned.releaseCount).toBe(3);
+
+      // Now it genuinely fails, once.
+      await service.claimFromPool('agent-leo');
+      await service.failItem(wi.id, 'first real failure');
+
+      const disposition = await service.disposeFailedWorkItem(wi.id, { reason: 'stranded' });
+
+      // Must retry. If churn were still charged to retryCount this would read
+      // 3/3 and come back `terminal`, stopping work that never failed.
+      expect(disposition?.kind).toBe('retried_in_place');
+      const after = (await service.getAllItems()).find((x) => x.id === wi.id)!;
+      expect(after.status).toBe('queued');
+      expect(after.retryCount).toBe(1);
+      expect(mockEscalateFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('no-ops for a missing WorkItem rather than throwing', async () => {
+      expect(await service.disposeFailedWorkItem('ghost', { reason: 'n/a' })).toBeNull();
+    });
+
+    it('still stamps when the escalation throws, recording the gap instead of hiding it', async () => {
+      mockEscalateFailedWorkItem.mockRejectedValueOnce(new Error('messaging down'));
+      const id = await strandFailed(3, 3);
+
+      const disposition = await service.disposeFailedWorkItem(id, { reason: 'stranded' });
+
+      // A messaging blip must not leave the item stranded a SECOND time.
+      expect(disposition?.kind).toBe('terminal');
+      expect(disposition?.escalationId).toBeUndefined();
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      expect(getWorkItemDisposition(wi)?.escalationId).toBeUndefined();
+    });
+
+    it('clears a stale disposition when the item goes back on the queue', async () => {
+      // A stamp describes how a PAST failure was dealt with. If it outlived the
+      // failure, the safety net would read it on the item's NEXT strand and skip
+      // an item that genuinely needs disposing.
+      const id = await strandFailed(3, 3);
+      await service.disposeFailedWorkItem(id, { reason: 'stranded' });
+      expect(
+        getWorkItemDisposition((await service.getAllItems()).find((x) => x.id === id)!),
+      ).not.toBeNull();
+
+      await service.requeueAfterFailure(id, 'operator retry');
+
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      expect(getWorkItemDisposition(wi)).toBeNull();
+    });
+  });
+
 
   // -----------------------------------------------------------------------
   // getPoolStatus

--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -6,7 +6,10 @@
 
 import { TaskPoolService, WorkItemClaimedError } from './task-pool.service.js';
 import { PoolStorage } from './pool-storage.js';
-import { createWorkItem } from '../../types/v2/work-item.types.js';
+import {
+  createWorkItem,
+  LAST_REQUEUED_AT_METADATA_KEY,
+} from '../../types/v2/work-item.types.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -1757,6 +1760,55 @@ describe('TaskPoolService', () => {
       // Oldest entries dropped — first kept is attempt 3.
       expect(history[0].reason).toBe('attempt 3');
       expect(history[9].reason).toBe('attempt 12');
+    });
+
+    it('stamps a TTL anchor so the granted retry gets a fresh expiry window', async () => {
+      // Without this, the reconciler's TTL rule keeps measuring from the
+      // original `createdAt` — so a WI whose work outlived the 24h TTL is
+      // cancelled on the next pass and the retry is destroyed on arrival.
+      // See getTtlAnchorAt in work-item.types.ts.
+      const before = Date.now();
+      const id = await failOne('agent-leo');
+      await service.requeueAfterFailure(id, 'agent crashed mid-task');
+
+      const wi = (await service.getAllItems()).find((x) => x.id === id)!;
+      const anchor = wi.metadata?.[LAST_REQUEUED_AT_METADATA_KEY];
+      expect(typeof anchor).toBe('string');
+      const anchorMs = new Date(anchor as string).getTime();
+      expect(Number.isNaN(anchorMs)).toBe(false);
+      expect(anchorMs).toBeGreaterThanOrEqual(before);
+      expect(anchorMs).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('leaves createdAt untouched — the anchor postpones TTL without rewriting history', async () => {
+      // `createdAt` feeds age metrics, ordering and postmortems. Overloading
+      // it to mean "time in current attempt" is how it silently breaks
+      // something nobody is looking at.
+      const wi = makeWorkItem({ target: 'agent-leo' });
+      await service.addToPool(wi);
+      const createdAtBefore = (await service.getAllItems()).find((x) => x.id === wi.id)!.createdAt;
+
+      await service.claimFromPool('agent-leo');
+      await service.failItem(wi.id, 'boom');
+      await service.requeueAfterFailure(wi.id, 'boom');
+
+      const after = (await service.getAllItems()).find((x) => x.id === wi.id)!;
+      expect(after.createdAt).toBe(createdAtBefore);
+    });
+
+    it('moves the anchor forward on each successive retry', async () => {
+      const id = await failOne('agent-leo');
+      await service.requeueAfterFailure(id, 'attempt 1');
+      const first = (await service.getAllItems()).find((x) => x.id === id)!
+        .metadata?.[LAST_REQUEUED_AT_METADATA_KEY] as string;
+
+      await service.claimFromPool('agent-leo');
+      await service.failItem(id, 'again');
+      await service.requeueAfterFailure(id, 'attempt 2');
+      const second = (await service.getAllItems()).find((x) => x.id === id)!
+        .metadata?.[LAST_REQUEUED_AT_METADATA_KEY] as string;
+
+      expect(new Date(second).getTime()).toBeGreaterThanOrEqual(new Date(first).getTime());
     });
 
     it('clears `error` field so a successful retry does not surface stale text', async () => {

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -19,7 +19,12 @@ import type {
   WorkItemType,
   WorkItemOwner,
 } from '../../types/v2/work-item.types.js';
-import { isWorkItem, isValidWorkItemTransition, isTransitionPermitted } from '../../types/v2/work-item.types.js';
+import {
+  isWorkItem,
+  isValidWorkItemTransition,
+  isTransitionPermitted,
+  LAST_REQUEUED_AT_METADATA_KEY,
+} from '../../types/v2/work-item.types.js';
 import {
   createTaskClaim,
   type TaskClaim,
@@ -1485,6 +1490,13 @@ export class TaskPoolService {
         lastFailureReason: reason,
         lastFailureAt: now,
         retryAttempt: wi.retryCount,
+        // TTL anchor (see getTtlAnchorAt). The age-based expiry rules must
+        // measure this retry's window from HERE, not from the original
+        // `createdAt` — otherwise a WorkItem that failed after the 24h TTL is
+        // TTL-cancelled on the next reconciler pass, silently destroying the
+        // retry we just granted. `createdAt` is deliberately left untouched so
+        // it keeps meaning "when this work was first asked for".
+        [LAST_REQUEUED_AT_METADATA_KEY]: now,
       };
       // Clear the error field so a successful retry doesn't surface a
       // stale error message; the metadata above keeps the history.

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -24,7 +24,11 @@ import {
   isValidWorkItemTransition,
   isTransitionPermitted,
   LAST_REQUEUED_AT_METADATA_KEY,
+  DISPOSITION_METADATA_KEY,
+  DISPOSITION_REQUIRED_STATUSES,
+  getWorkItemDisposition,
 } from '../../types/v2/work-item.types.js';
+import type { WorkItemDisposition } from '../../types/v2/work-item.types.js';
 import {
   createTaskClaim,
   type TaskClaim,
@@ -1498,6 +1502,12 @@ export class TaskPoolService {
         // it keeps meaning "when this work was first asked for".
         [LAST_REQUEUED_AT_METADATA_KEY]: now,
       };
+      // A disposition describes how a PAST failure was dealt with. This item
+      // is back in play, so any existing stamp is history and must not be
+      // allowed to outlive the failure it described — otherwise the
+      // safety-net rule would read a stale stamp and skip the item the next
+      // time it strands. See DISPOSITION_METADATA_KEY.
+      delete wi.metadata[DISPOSITION_METADATA_KEY];
       // Clear the error field so a successful retry doesn't surface a
       // stale error message; the metadata above keeps the history.
       wi.error = undefined;
@@ -1510,6 +1520,187 @@ export class TaskPoolService {
       maxRetries: workItem.maxRetries,
       reason,
     });
+  }
+
+  /**
+   * Decide and record how a stranded WorkItem is dealt with — the single
+   * funnel every `rejected`/`failed` writer must route through.
+   *
+   * `rejected` and `failed` are the only two statuses that are neither
+   * terminal nor able to reach a terminal state: their sole outbound edge is
+   * `→ queued`. An item parked in either is finished as far as every consumer
+   * is concerned (see `SLA_TERMINAL_WORK_ITEM_STATUSES`) and unfinished as far
+   * as the state machine is concerned, and until this funnel existed nothing
+   * owned closing that gap. Items written there by a path that did not itself
+   * arrange a successor simply stopped, permanently and — since PR #733
+   * correctly stopped the pruning rules emitting illegal corrections for them
+   * — silently.
+   *
+   * Exactly one of three things happens, and the choice is recorded rather
+   * than left to be re-derived later by scanning other WorkItems:
+   *
+   * 1. **retried in place** — `failed` with retry budget left. The item goes
+   *    back on the queue via {@link requeueAfterFailure}, which bumps
+   *    `retryCount`. Deliberately NOT stamped: the item has left the stranding
+   *    statuses under its own power, and a stamp would be a claim about a
+   *    failure that is no longer the current one.
+   * 2. **succeeded by another item** — the caller already created a successor
+   *    (the `EventToWorkItemBridge` retry/escalation WorkItem). Stamped with
+   *    its id.
+   * 3. **terminal** — budget spent, or a status with no retry path. Stamped,
+   *    and escalated so a human or the orchestrator renders the verdict. This
+   *    is the "deliberate terminal state with an audit record" case: the item
+   *    stays in `rejected`/`failed` by design, because the alternative —
+   *    adding `→ cancelled` edges — would re-open the illegal-correction
+   *    surface #733 closed and turn a deliberate decision into a 24h default.
+   *
+   * Idempotent and re-entrant: an already-disposed item is returned unchanged,
+   * so concurrent reconciler passes converge and the safety-net rule cannot
+   * fire twice on the same strand. Terminating: the only branch that repeats
+   * is (1), and it bumps `retryCount`, so it can run at most `maxRetries`
+   * times before (3) becomes the only reachable outcome.
+   *
+   * @param workItemId - The stranded WorkItem.
+   * @param options    - `reason` is carried into the audit record and the
+   *                     escalation. `actor` defaults to `'system'`.
+   *                     `successorWorkItemId` selects outcome (2) when the
+   *                     caller owns a real successor.
+   * @returns The recorded disposition, or `null` when there was nothing to do
+   *          (item missing, or not in a stranding status).
+   *
+   * @example
+   * ```typescript
+   * await pool.disposeFailedWorkItem(wi.id, { reason: 'SLA escalation timeout' });
+   * ```
+   */
+  async disposeFailedWorkItem(
+    workItemId: string,
+    options: {
+      reason: string;
+      actor?: WorkItemOwner;
+      successorWorkItemId?: string;
+    },
+  ): Promise<WorkItemDisposition | null> {
+    const { reason, actor = 'system', successorWorkItemId } = options;
+    const workItem = await this.storage.findWorkItem(workItemId);
+    if (!workItem) return null;
+
+    // Only the stranding statuses need a disposition. Anything else is either
+    // still in play or already strictly terminal.
+    if (!DISPOSITION_REQUIRED_STATUSES.has(workItem.status)) return null;
+
+    // Idempotency: the stamp IS the key. Two passes converge here.
+    const existing = getWorkItemDisposition(workItem);
+    if (existing) return existing;
+
+    const now = new Date().toISOString();
+
+    // (2) The caller owns a real successor — record it and stop.
+    if (successorWorkItemId) {
+      return this.stampDisposition(workItemId, {
+        kind: 'succeeded_by',
+        at: now,
+        by: actor,
+        reason,
+        successorWorkItemId,
+      });
+    }
+
+    // (1) Retry in place. Only `failed` has a retry path — `rejected` reaches
+    // `queued` too, but re-running work a reviewer rejected without a fresh
+    // verdict would re-execute exactly what was turned down.
+    // `retryCount` is FAILURES ONLY — this branch is load-bearing on that
+    // semantic, not incidentally coupled to it. Reading a churn-inflated count
+    // here would send work that never failed straight to `terminal`.
+    //
+    // That is an invariant rather than an assumption as of #739: `releaseBack`
+    // used to bump `retryCount` on every lease lapse, so a worker who simply
+    // stopped heartbeating was charged a failure. Release churn now goes to
+    // {@link WorkItem.releaseCount}, which nothing branches on. Keep it that
+    // way — if a future change makes anything other than a failure move
+    // `retryCount`, this branch silently starts terminating live work, and a
+    // second counter here would hide that rather than surface it.
+    if (workItem.status === 'failed' && workItem.retryCount < workItem.maxRetries) {
+      await this.requeueAfterFailure(workItemId, reason);
+      this.logger.info('Stranded WorkItem retried in place', {
+        workItemId,
+        retryCount: workItem.retryCount + 1,
+        maxRetries: workItem.maxRetries,
+        reason,
+      });
+      // Not stamped — see the doc comment. The item is queued again, and the
+      // requeue itself is the audit record (metadata.failureHistory).
+      return {
+        kind: 'retried_in_place',
+        at: now,
+        by: actor,
+        reason,
+      };
+    }
+
+    // (3) Terminal. Escalate for the verdict, then stamp — in that order, so a
+    // failed escalation cannot leave a stamp claiming an escalation happened.
+    let escalationId: string | undefined;
+    try {
+      const { EscalationRouterService } = await import(
+        '../v3/escalation-router.service.js'
+      );
+      escalationId =
+        (await EscalationRouterService.getInstance().escalateFailedWorkItem(
+          workItem,
+          reason,
+        )) ?? undefined;
+    } catch (err) {
+      // Best-effort, matching every other escalation call site: a messaging
+      // blip must not leave the item stranded a second time. The stamp is
+      // still written, without an escalationId, so the gap is visible in the
+      // audit record rather than hidden by a retry loop.
+      this.logger.warn('escalateFailedWorkItem threw during disposition (non-fatal)', {
+        workItemId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    return this.stampDisposition(workItemId, {
+      kind: 'terminal',
+      at: now,
+      by: actor,
+      reason,
+      escalationId,
+    });
+  }
+
+  /**
+   * Persist a disposition record onto a WorkItem's metadata.
+   *
+   * Writes metadata only — no status transition — so it is safe to call on an
+   * item whose status has no legal outbound edge, which is precisely the
+   * situation a `terminal` disposition describes.
+   *
+   * @param workItemId  - WorkItem to stamp.
+   * @param disposition - The record to write.
+   * @returns The disposition as written.
+   */
+  private async stampDisposition(
+    workItemId: string,
+    disposition: WorkItemDisposition,
+  ): Promise<WorkItemDisposition> {
+    const workItem = await this.storage.findWorkItem(workItemId);
+    if (workItem) {
+      workItem.metadata = {
+        ...(workItem.metadata ?? {}),
+        [DISPOSITION_METADATA_KEY]: disposition,
+      };
+      await this.storage.flush();
+    }
+    this.logger.info('WorkItem disposition recorded', {
+      workItemId,
+      kind: disposition.kind,
+      successorWorkItemId: disposition.successorWorkItemId,
+      escalationId: disposition.escalationId,
+      reason: disposition.reason,
+    });
+    return disposition;
   }
 
   // -----------------------------------------------------------------------

--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -40,7 +40,13 @@ import {
   type WorkItem,
   type WorkItemStatus,
   WORK_ITEM_TRANSITIONS,
+  TERMINAL_WORK_ITEM_STATUSES,
+  SLA_TERMINAL_WORK_ITEM_STATUSES,
 } from '../../types/v2/work-item.types.js';
+import {
+  pickTTLExpiryTarget,
+  pickCascadeTarget,
+} from '../reconciler/reconcile-rules.js';
 import type { TaskPoolService } from '../task-pool/task-pool.service.js';
 import type { RequestService } from './request.service.js';
 
@@ -340,6 +346,67 @@ describe('pickFailTarget', () => {
       expect(allowed.has(to)).toBe(true);
     }
   });
+});
+
+/**
+ * Executable refutation of a claim that was load-bearing and untested.
+ *
+ * PR #733's description argued that `rejected` is "unreachable in production" —
+ * `verifyItem` has one production call site hardcoded to `'verified'`, there is
+ * no verify/reject route, and the TL `verify-output` skill never writes a
+ * verdict. All of that is true, and all of it is about `verifyItem`.
+ *
+ * `verifyItem` is not the only writer. {@link pickFailTarget} is the other one,
+ * and `RequestSlaSubscriber.failOrphanRespondWi` drives it via
+ * `taskPool.transitionStatus` directly — so `task:rejected` is never published
+ * and `EventToWorkItemBridge` never creates the successor WorkItem that the
+ * `verifyItem` route would have produced.
+ *
+ * A successor model built on "rejected cannot happen" would therefore be wrong
+ * in production and right in every test. These assertions exist so that stops
+ * being a prose argument in a merged PR body and becomes something CI can fail.
+ *
+ * Each `it` below is one link in the chain. They are deliberately *not* merged
+ * into a single test: when this breaks, the failing test name should say which
+ * link moved.
+ */
+describe('`rejected` reachability — the SLA escalation path (regression guard for PR #733)', () => {
+  it('link 1: the failOrphanRespondWi terminal guard does not stop a done_by_worker WI', () => {
+    // request-sla.subscriber.ts:~1508 short-circuits on SLA_TERMINAL_WORK_ITEM_STATUSES.
+    // done_by_worker is absent from that set, so the guard lets it through.
+    expect(SLA_TERMINAL_WORK_ITEM_STATUSES.has('done_by_worker')).toBe(false);
+  });
+
+  it('link 2: pickFailTarget turns that WI into `rejected`', () => {
+    expect(pickFailTarget('done_by_worker')).toBe('rejected');
+  });
+
+  it('link 3: done_by_worker → rejected is legal, so transitionStatus accepts the write', () => {
+    expect(WORK_ITEM_TRANSITIONS.done_by_worker.has('rejected')).toBe(true);
+  });
+
+  it('link 4: once `rejected`, the only outbound edge is `queued` — no terminal escape', () => {
+    // This is what makes it STRANDING rather than merely an unusual status:
+    // neither `rejected` nor `failed` can reach done/verified/cancelled, so
+    // nothing can close them out without first putting the work back in play.
+    expect([...WORK_ITEM_TRANSITIONS.rejected]).toEqual(['queued']);
+    expect([...WORK_ITEM_TRANSITIONS.failed]).toEqual(['queued']);
+    expect(TERMINAL_WORK_ITEM_STATUSES.has('rejected')).toBe(false);
+    expect(TERMINAL_WORK_ITEM_STATUSES.has('failed')).toBe(false);
+  });
+
+  it('link 5: and the reconciler correctly refuses to touch them, so nothing cleans up', () => {
+    // Post-#733 this is the CORRECT behaviour — emitting a correction here
+    // would be an illegal transition. It is asserted because it removes the
+    // only symptom this bug used to have: before #733 a >24h `rejected` WI
+    // threw `Invalid status transition` every 60s. The disease outlived the
+    // symptom, and the successor model is what actually treats it.
+    expect(pickTTLExpiryTarget('rejected')).toBeNull();
+    expect(pickTTLExpiryTarget('failed')).toBeNull();
+    expect(pickCascadeTarget('rejected')).toBeNull();
+    expect(pickCascadeTarget('failed')).toBeNull();
+  });
+
 });
 
 describe('closeRequestPath', () => {

--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -112,11 +112,19 @@ function buildFakeTaskPool(): {
   addCalls: WorkItem[];
   setStatus: (id: string, status: WorkItemStatus) => void;
   transitionCalls: Array<{ id: string; status: WorkItemStatus; actor: string }>;
+  disposeCalls: Array<{ id: string; reason: string }>;
 } {
   const stored = new Map<string, WorkItem>();
   const addCalls: WorkItem[] = [];
   const transitionCalls: Array<{ id: string; status: WorkItemStatus; actor: string }> = [];
+  const disposeCalls: Array<{ id: string; reason: string }> = [];
   const taskPool = {
+    disposeFailedWorkItem: jest.fn(
+      async (id: string, options: { reason: string }) => {
+        disposeCalls.push({ id, reason: options.reason });
+        return null;
+      },
+    ),
     addToPool: jest.fn(async (wi: WorkItem) => {
       // Real addToPool is idempotent; mimic by short-circuiting on duplicate id.
       if (stored.has(wi.id)) return;
@@ -153,6 +161,7 @@ function buildFakeTaskPool(): {
     taskPool,
     addCalls,
     transitionCalls,
+    disposeCalls,
     setStatus: (id, status) => {
       const wi = stored.get(id);
       if (wi) wi.status = status;
@@ -860,6 +869,93 @@ describe('RequestSlaSubscriber', () => {
       expect(closeTransitions).toHaveLength(1);
       // queued WI → cancelled (legal); only running WIs go to failed.
       expect(closeTransitions[0].status).toBe('cancelled');
+    });
+
+    /**
+     * EVAL 6 — reproduce the STRANDING CONDITION itself.
+     *
+     * Not a reproduction of the 469a3a21 revert: that rule is gone and there is
+     * no live regression to re-run. What reproduces reliably is the underlying
+     * gap, and this is the path Victor named for it.
+     *
+     * Deterministic, no mocked internals: the subscriber's real 10-minute timer
+     * fires, `pickFailTarget` runs for real, and the fake pool enforces the
+     * canonical `WORK_ITEM_TRANSITIONS` matrix — so if the transition were
+     * illegal, this test would throw rather than pass.
+     */
+    describe('EVAL 6 — the stranding condition, reproduced', () => {
+      /** Arm a tracked Request whose WI has reached the given status. */
+      async function escalateWith(status: WorkItemStatus): Promise<string> {
+        const r = buildRequest();
+        svc.registry.set(r.id, r);
+        bus.publish(buildEvent(r.id));
+        await sub.flushPending();
+
+        const wiId = respondToUserWorkItemId(r.id);
+        // The tracker only clears on a VERIFIED_REPLY_REASON. An orc that
+        // reported done without one leaves the WI here when the timer fires.
+        pool.setStatus(wiId, status);
+
+        jest.advanceTimersByTime(10_000);
+        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        return wiId;
+      }
+
+      it('a done_by_worker WI is driven to `rejected` — the status #733 called unreachable', async () => {
+        const wiId = await escalateWith('done_by_worker');
+
+        const wi = await pool.taskPool.findWorkItem(wiId);
+        expect(wi?.status).toBe('rejected');
+      });
+
+      it('and no successor WorkItem is created, because the bridge never hears about it', async () => {
+        const before = pool.addCalls.length;
+        const wiId = await escalateWith('done_by_worker');
+
+        // This path writes via `transitionStatus` directly rather than
+        // `verifyItem`, so `task:rejected` is never published and
+        // `EventToWorkItemBridge` never builds the `${id}:retry:1` successor
+        // that the verifyItem route would have produced.
+        const newItems = pool.addCalls.slice(before);
+        expect(newItems.some((wi) => wi.id.startsWith(`${wiId}:retry:`))).toBe(false);
+      });
+
+      it('and the item it lands in cannot reach any terminal state — that is the strand', async () => {
+        await escalateWith('done_by_worker');
+
+        // The whole reason this is stranding rather than merely an unusual
+        // status: nothing can close it out without first putting the work back
+        // in play, and no rule does.
+        expect([...WORK_ITEM_TRANSITIONS.rejected]).toEqual(['queued']);
+        expect(TERMINAL_WORK_ITEM_STATUSES.has('rejected')).toBe(false);
+      });
+
+      it('THE FIX: the strand is handed to the disposition funnel', async () => {
+        const wiId = await escalateWith('done_by_worker');
+
+        expect(pool.disposeCalls).toHaveLength(1);
+        expect(pool.disposeCalls[0].id).toBe(wiId);
+        expect(pool.disposeCalls[0].reason).toContain('done_by_worker');
+      });
+
+      it('THE FIX: a running WI driven to `failed` is disposed too', async () => {
+        const wiId = await escalateWith('running');
+
+        const wi = await pool.taskPool.findWorkItem(wiId);
+        expect(wi?.status).toBe('failed');
+        expect(pool.disposeCalls.map((c) => c.id)).toEqual([wiId]);
+      });
+
+      it('but a `cancelled` close is NOT disposed — it is already strictly terminal', async () => {
+        // The common case: respond_to_user WIs are born `queued`, and
+        // pickFailTarget('queued') is 'cancelled'. Disposing that would be
+        // noise, and would imply a strand where there is none.
+        const wiId = await escalateWith('queued');
+
+        const wi = await pool.taskPool.findWorkItem(wiId);
+        expect(wi?.status).toBe('cancelled');
+        expect(pool.disposeCalls).toHaveLength(0);
+      });
     });
 
     it('still closes the orphan WI when the Slack DM callback throws', async () => {

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -1512,7 +1512,12 @@ export class RequestSlaSubscriber {
       // Same state-machine constraint as markResolved: `queued → failed`
       // is illegal per WORK_ITEM_TRANSITIONS. Route queued WIs to
       // `cancelled`; running WIs go to `failed` as before.
-      const target = pickFailTarget(wi.status);
+      // Capture BEFORE the transition: `transitionStatus` mutates the stored
+      // record in place, so reading `wi.status` afterwards yields the status we
+      // just wrote, not the one we came from. The audit reason and the log
+      // below both need the origin.
+      const fromStatus = wi.status;
+      const target = pickFailTarget(fromStatus);
       await this.taskPool.transitionStatus(
         workItemId,
         target,
@@ -1529,9 +1534,24 @@ export class RequestSlaSubscriber {
       this.logger.info('SLA escalation orphan WI auto-closed', {
         workItemId,
         requestId,
-        fromStatus: wi.status,
+        fromStatus,
         toStatus: target,
       });
+
+      // `cancelled` is strictly terminal and needs nothing further. `failed`
+      // and `rejected` do: their only outbound edge is `→ queued`, so without
+      // a disposition the item stops here permanently. This path writes them
+      // via `transitionStatus` directly rather than `failItem`/`verifyItem`,
+      // so neither the `task:failed` retry/escalate branch in
+      // `V3DataService.onTaskFailed` nor the `task:rejected` bridge successor
+      // ever fires for it — it was the reproducible stranding path. Route it
+      // through the funnel so the item is retried, succeeded, or deliberately
+      // closed with an audit record.
+      if (target === 'failed' || target === 'rejected') {
+        await this.taskPool.disposeFailedWorkItem(workItemId, {
+          reason: `SLA escalation timeout (from ${fromStatus})`,
+        });
+      }
     } catch (err) {
       this.logger.warn('SLA escalation orphan-fail threw', {
         workItemId,

--- a/backend/src/types/v2/index.ts
+++ b/backend/src/types/v2/index.ts
@@ -59,6 +59,8 @@ export {
   isWorkItem,
   validateCreateWorkItemInput,
   createWorkItem,
+  LAST_REQUEUED_AT_METADATA_KEY,
+  getTtlAnchorAt,
 } from './work-item.types.js';
 
 // Trigger types

--- a/backend/src/types/v2/work-item.types.test.ts
+++ b/backend/src/types/v2/work-item.types.test.ts
@@ -21,6 +21,8 @@ import {
   isWorkItem,
   validateCreateWorkItemInput,
   createWorkItem,
+  getTtlAnchorAt,
+  LAST_REQUEUED_AT_METADATA_KEY,
 } from './work-item.types.js';
 import type { CreateWorkItemInput, WorkItem } from './work-item.types.js';
 
@@ -521,6 +523,64 @@ describe('WorkItem Types', () => {
       const wi = createWorkItem({ ...input, dependsOn: [] });
       expect(wi.status).toBe('queued');
       expect(wi.dependsOn).toBeUndefined();
+    });
+  });
+
+  describe('getTtlAnchorAt', () => {
+    const base = { createdAt: '2026-01-01T00:00:00.000Z' };
+
+    it('falls back to createdAt when the item has never been requeued', () => {
+      expect(getTtlAnchorAt(base)).toBe(base.createdAt);
+      expect(getTtlAnchorAt({ ...base, metadata: {} })).toBe(base.createdAt);
+      expect(getTtlAnchorAt({ ...base, metadata: { other: 'x' } })).toBe(base.createdAt);
+    });
+
+    it('returns the requeue timestamp once one has been recorded', () => {
+      const requeuedAt = '2026-01-05T12:00:00.000Z';
+      expect(
+        getTtlAnchorAt({
+          ...base,
+          metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: requeuedAt },
+        }),
+      ).toBe(requeuedAt);
+    });
+
+    it('never mutates or reinterprets createdAt itself', () => {
+      const wi = {
+        ...base,
+        metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: '2026-01-05T12:00:00.000Z' },
+      };
+      getTtlAnchorAt(wi);
+      expect(wi.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('ignores a non-string metadata value rather than trusting it', () => {
+      // `metadata` is Record<string, unknown> and round-trips through storage,
+      // so a wrong-typed value is reachable without a type error at the writer.
+      for (const bad of [42, null, undefined, {}, ['2026-01-05T12:00:00.000Z']]) {
+        expect(
+          getTtlAnchorAt({ ...base, metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: bad } }),
+        ).toBe(base.createdAt);
+      }
+    });
+
+    it('ignores an unparseable date rather than producing a NaN age', () => {
+      // A NaN age would make `age > ttlMs` false forever, silently disabling
+      // TTL for this item — a quiet failure, which is the mode we are trying
+      // to get rid of. Fall back to a timestamp that definitely parses.
+      expect(
+        getTtlAnchorAt({ ...base, metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: 'not-a-date' } }),
+      ).toBe(base.createdAt);
+      expect(
+        Number.isNaN(
+          new Date(
+            getTtlAnchorAt({
+              ...base,
+              metadata: { [LAST_REQUEUED_AT_METADATA_KEY]: 'not-a-date' },
+            }),
+          ).getTime(),
+        ),
+      ).toBe(false);
     });
   });
 });

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -158,6 +158,55 @@ export const TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus> = new Set(
  * release based on the current WI state?", and use {@link TERMINAL_WORK_ITEM_STATUSES}
  * when answering "is the state machine done with this WI?".
  */
+/**
+ * Metadata key recording the last time a WorkItem was put back on the queue
+ * after a failure.
+ *
+ * Written by `TaskPoolService.requeueAfterFailure`. Read only through
+ * {@link getTtlAnchorAt} — call sites must not reach for it directly, so the
+ * "which timestamp does age mean?" decision stays in one place.
+ */
+export const LAST_REQUEUED_AT_METADATA_KEY = 'lastRequeuedAt';
+
+/**
+ * The timestamp that age-based expiry rules must measure from.
+ *
+ * `createdAt` answers "when was this work first asked for?" and is never
+ * mutated anywhere in the codebase — age metrics, ordering and postmortems all
+ * depend on that. It is therefore the wrong clock for a TTL, because a WorkItem
+ * that is legitimately retried is not stale merely because its *original*
+ * request is old.
+ *
+ * Using `createdAt` for TTL caused a live data-loss bug: a WorkItem that failed
+ * after the 24h TTL and was auto-retried by `detectRetryableFailedWorkItems`
+ * landed back in `queued` still carrying its original `createdAt`, so the very
+ * next reconciler pass (60s later) TTL-cancelled it. Every retry granted past
+ * the 24h mark was silently destroyed a minute after being granted.
+ *
+ * This function resolves the anchor instead: a requeued item's TTL window
+ * restarts from the requeue, while an item that has never been requeued keeps
+ * `createdAt` and behaves exactly as before.
+ *
+ * @param wi - The WorkItem whose age is being measured.
+ * @returns ISO-8601 timestamp to measure age from. Falls back to `createdAt`
+ *          when no requeue has happened, or when the stored value is not a
+ *          usable date (defensive: `metadata` is untyped and may be
+ *          round-tripped through storage by older writers).
+ *
+ * @example
+ * ```typescript
+ * const age = Date.now() - new Date(getTtlAnchorAt(wi)).getTime();
+ * ```
+ */
+export function getTtlAnchorAt(wi: Pick<WorkItem, 'createdAt' | 'metadata'>): string {
+  const raw = wi.metadata?.[LAST_REQUEUED_AT_METADATA_KEY];
+  if (typeof raw !== 'string') return wi.createdAt;
+  // Reject unparseable values rather than letting a NaN age silently disable
+  // (or instantly trip) the TTL rule for this item.
+  if (Number.isNaN(new Date(raw).getTime())) return wi.createdAt;
+  return raw;
+}
+
 export const SLA_TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus> =
   new Set<WorkItemStatus>([
     'done',

--- a/backend/src/types/v2/work-item.types.ts
+++ b/backend/src/types/v2/work-item.types.ts
@@ -166,6 +166,113 @@ export const TERMINAL_WORK_ITEM_STATUSES: ReadonlySet<WorkItemStatus> = new Set(
  * {@link getTtlAnchorAt} — call sites must not reach for it directly, so the
  * "which timestamp does age mean?" decision stays in one place.
  */
+/**
+ * How a WorkItem that landed in `rejected`/`failed` was dealt with.
+ *
+ * - `retried_in_place`  the same WorkItem went back on the queue (`→ queued`)
+ *                       with `retryCount` bumped. The successor IS the item.
+ * - `succeeded_by`      a distinct WorkItem picked the work up (the
+ *                       `EventToWorkItemBridge` retry/escalation WI). The
+ *                       source stays where it is; `successorWorkItemId` names
+ *                       the item that carries the work now.
+ * - `terminal`          no successor, deliberately. The retry budget is spent
+ *                       or the status has no retry path, so the work stops
+ *                       here and an escalation carries the decision to a human
+ *                       or the orchestrator. `escalationId` names that record.
+ */
+export type WorkItemDispositionKind =
+  | 'retried_in_place'
+  | 'succeeded_by'
+  | 'terminal';
+
+/**
+ * The audit record proving a `rejected`/`failed` WorkItem was actually dealt
+ * with, rather than merely left in a status nothing acts on.
+ *
+ * This exists because the previous attempt at a successor model (reverted in
+ * `469a3a21`) tried to INFER whether a successor existed by scanning other
+ * WorkItems, and inference over a live filtered collection is wrong in both
+ * directions by construction:
+ *
+ *  - `getActiveWorkItems()` drops `done`/`cancelled`, so a successor that had
+ *    already completed was invisible → the rule concluded "no successor" and
+ *    re-dispatched the source → completed work ran a second time.
+ *  - `buildAutoWorkItem` sets `parentWorkItemId` on VERIFY WorkItems too, so an
+ *    unrelated verification child read as a successor → the rule skipped the
+ *    exact SLA case it was written to rescue.
+ *
+ * No refinement of that query fixes it, because the query is reconstructing
+ * information the writer already had and discarded. So the writer records it
+ * instead: whoever performs the disposition stamps it, in the same operation.
+ * The predicate then becomes a local field read with no collection to filter
+ * and no `parentWorkItemId` to misread.
+ */
+export interface WorkItemDisposition {
+  /** What was done. See {@link WorkItemDispositionKind}. */
+  kind: WorkItemDispositionKind;
+  /** ISO-8601 timestamp of the disposition. */
+  at: string;
+  /** Role that performed it. `'system'` for reconciler/subscriber paths. */
+  by: WorkItemOwner;
+  /** Human-readable justification, carried into the audit trail. */
+  reason: string;
+  /** Set when `kind === 'succeeded_by'`: the WorkItem now carrying the work. */
+  successorWorkItemId?: string;
+  /** Set when `kind === 'terminal'`: the PendingEscalation raised, if any. */
+  escalationId?: string;
+}
+
+/** Metadata key under which {@link WorkItemDisposition} is stored. */
+export const DISPOSITION_METADATA_KEY = 'disposition';
+
+/**
+ * Reads a WorkItem's disposition record, validating its shape.
+ *
+ * `metadata` is `Record<string, unknown>` and round-trips through storage, so
+ * the value is validated rather than cast. An unrecognised shape is treated as
+ * absent — the safety-net rule will then re-dispose the item, which is safe
+ * (dispositions are idempotent) whereas trusting a malformed record is not.
+ *
+ * @param wi - WorkItem (or any object carrying `metadata`) to read.
+ * @returns The disposition, or `null` if the item has not been disposed.
+ *
+ * @example
+ * ```typescript
+ * if (!isWorkItemDisposed(wi)) await pool.disposeFailedWorkItem(wi.id, {...});
+ * ```
+ */
+export function getWorkItemDisposition(
+  wi: Pick<WorkItem, 'metadata'>,
+): WorkItemDisposition | null {
+  const raw = wi.metadata?.[DISPOSITION_METADATA_KEY];
+  if (typeof raw !== 'object' || raw === null) return null;
+  const candidate = raw as Partial<WorkItemDisposition>;
+  const kindOk =
+    candidate.kind === 'retried_in_place' ||
+    candidate.kind === 'succeeded_by' ||
+    candidate.kind === 'terminal';
+  if (!kindOk) return null;
+  if (typeof candidate.at !== 'string' || typeof candidate.reason !== 'string') {
+    return null;
+  }
+  return candidate as WorkItemDisposition;
+}
+
+/**
+ * Whether a WorkItem has an explicit disposition record.
+ *
+ * This is THE successor predicate. It is a local field read by design — see
+ * {@link WorkItemDisposition} for why the scan-based version it replaces could
+ * not be made correct.
+ *
+ * @param wi - WorkItem to test.
+ * @returns True if the item has been dealt with and must not be re-dispatched.
+ */
+export function isWorkItemDisposed(wi: Pick<WorkItem, 'metadata'>): boolean {
+  return getWorkItemDisposition(wi) !== null;
+}
+
+
 export const LAST_REQUEUED_AT_METADATA_KEY = 'lastRequeuedAt';
 
 /**
@@ -454,6 +561,29 @@ export const WORK_ITEM_TRANSITIONS: Record<WorkItemStatus, ReadonlySet<WorkItemS
   failed:         new Set(['queued']),
   cancelled:      new Set<WorkItemStatus>(),
 };
+
+/**
+ * Statuses that require a disposition record before a WorkItem can be
+ * considered dealt with.
+ *
+ * These are exactly the statuses that are neither terminal
+ * ({@link TERMINAL_WORK_ITEM_STATUSES}) nor able to reach a terminal state —
+ * their only outbound edge is `→ queued`. That combination is what makes them
+ * strand: every consumer treats them as finished (see
+ * {@link SLA_TERMINAL_WORK_ITEM_STATUSES}) while the state machine does not.
+ *
+ * Derived rather than hand-listed so a future `WorkItemStatus` with the same
+ * shape is covered automatically instead of silently stranding.
+ */
+export const DISPOSITION_REQUIRED_STATUSES: ReadonlySet<WorkItemStatus> = new Set(
+  (Object.keys(WORK_ITEM_TRANSITIONS) as WorkItemStatus[]).filter((status) => {
+    if (TERMINAL_WORK_ITEM_STATUSES.has(status)) return false;
+    const outbound = WORK_ITEM_TRANSITIONS[status];
+    if (outbound.size === 0) return false;
+    // No outbound edge reaches a strictly terminal status.
+    return ![...outbound].some((next) => TERMINAL_WORK_ITEM_STATUSES.has(next));
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Role-Based Transition Permissions

--- a/specs/2026-08-21-workitem-successor-model.md
+++ b/specs/2026-08-21-workitem-successor-model.md
@@ -1,0 +1,281 @@
+# Successor model for `rejected` / `failed` WorkItems
+
+Status: DESIGN — awaiting TL (Sam) + Arch (Victor) sign-off before implementation.
+Author: Leo (developer). WorkItem 702ef3d1, Deliverable A.
+Base: `origin/main` @ fc2bb6df (which already contains Deliverable B, merged as PR #733 / 13e40ac7).
+
+---
+
+## 0. Why this document exists
+
+`469a3a21` reverted `detectStrandedRejectedWorkItems` / `requeueAfterRejection` because the
+successor predicate was wrong in both directions. The revert note asked for "a real successor
+model, not a bolt-on". This is that model.
+
+The single most important finding is in §3: **the reverted rule failed because it tried to
+INFER a successor by scanning other WorkItems.** Inference over a live collection is wrong in
+both directions by construction — you cannot see successors the query filters out, and you
+cannot distinguish a successor from an unrelated child. The fix is not a better query. It is
+to stop inferring and make disposition an **explicit, recorded property of the WorkItem
+itself**.
+
+---
+
+## 1. The state-machine fact that creates the stranding
+
+`WORK_ITEM_TRANSITIONS` (`backend/src/types/v2/work-item.types.ts:343`):
+
+```ts
+rejected:       new Set(['queued']),
+failed:         new Set(['queued']),
+verified:       new Set<WorkItemStatus>(),
+done:           new Set<WorkItemStatus>(),
+cancelled:      new Set<WorkItemStatus>(),
+```
+
+`TERMINAL_WORK_ITEM_STATUSES` (`:133`) = `{done, verified, cancelled}`.
+
+So `rejected` and `failed` are the only two statuses that are **neither terminal nor able to
+reach a terminal state**. Their sole outbound edge is `→ queued`. A WI parked in either one
+is finished as far as every consumer is concerned but unfinished as far as the state machine
+is concerned, and *nothing owns closing the gap*.
+
+The codebase already knows this. `SLA_TERMINAL_WORK_ITEM_STATUSES` (`:161`) exists purely to
+paper over it, and its own JSDoc says so:
+
+> treat `failed` and `rejected` as terminal for *their* purposes — even though those statuses
+> are NOT terminal in the strict state-machine sense
+
+**The stranding is the delta between those two sets.** That is the bug, stated exactly.
+
+---
+
+## 2. Eval 1 — exhaustive enumeration of paths into `rejected` / `failed`
+
+### 2a. Into `rejected`
+
+| # | Path | Successor today | Verdict |
+|---|---|---|---|
+| R1 | `TaskPoolService.verifyItem(verdict='rejected')` — `task-pool.service.ts:1157` | Publishes `task:rejected` (`:591`) → `EventToWorkItemBridge` (`:297`) creates successor WI `${sourceWI.id}:retry:${n}` (`event-to-workitem-bridge.service.ts:488`), or an escalation WI at cap (`:454`). | **HAS successor.** Correct as-is. |
+| R2 | `RequestSlaSubscriber.failOrphanRespondWi` → `pickFailTarget('done_by_worker') === 'rejected'` — `request-sla.subscriber.ts:226`, called from **4 sites** (`:1436, :1445, :1454, :1483`) | Calls `taskPool.transitionStatus(...)` **directly** (`:1517`). Does not go through `verifyItem`, so `task:rejected` is **never published**, so the bridge never fires. | **STRANDED.** No successor, no terminal edge, no audit beyond one `logger.info`. |
+| R3 | `proposed → rejected` — legal per the table, gated to `owner='agent'` by `TRANSITION_PERMISSIONS` (`:380`) | No production writer found. Reachable via the generic `transitionStatus` guard only. | **Unwired but reachable.** Must be closed by the safety net (§4.3), not by a dedicated rule. |
+
+> **Correction to PR #733's premise — VERIFIED BY EXECUTABLE PROOF, NOT ARGUMENT.**
+>
+> #733's body states that `rejected` is *"unreachable in production"* and that a successor for
+> it was therefore deliberately not scheduled.
+>
+> The *evidence* #733 cites is correct: an independent sweep of every writer confirms
+> `verifyItem` has exactly one production call site (`task-pool.service.ts:1107`), hardcoded to
+> `'verified'`; there is no verify/reject HTTP route (`task-pool.routes.ts:36-104`); no skill
+> writes a verdict; and `proposed → rejected` (R3) has zero writers. So R1 and R3 are indeed
+> dead.
+>
+> The *conclusion drawn from it is false.* The sweep was over `verifyItem`, and `verifyItem` is
+> not the only writer. **R2 reaches `rejected` in production today** via `pickFailTarget`, from
+> a subscriber booted at `index.ts:664`, on a 10-minute `setTimeout` (`:1205`), with four live
+> call sites — one of which is a `finally` block (`:1483`) that runs on *every* escalation
+> regardless of outcome.
+>
+> Proven mechanically rather than asserted (5/5 green):
+> 1. `SLA_TERMINAL_WORK_ITEM_STATUSES.has('done_by_worker') === false` → the guard at `:1508`
+>    does not stop it;
+> 2. `pickFailTarget('done_by_worker') === 'rejected'`;
+> 3. `WORK_ITEM_TRANSITIONS['done_by_worker'].has('rejected') === true` → `transitionStatus` accepts it;
+> 4. `[...WORK_ITEM_TRANSITIONS['rejected']] === ['queued']` → no terminal escape;
+> 5. `pickTTLExpiryTarget('rejected') === null` and `pickCascadeTarget('rejected') === null`
+>    → post-#733 every pruning rule deliberately skips it, so nothing will ever clean it up.
+>
+> Together those five are the stranding, end to end, with no timing and no mocks.
+>
+> **Frequency, stated honestly:** the `respond_to_user` WI is born `queued`
+> (`request-sla.subscriber.ts:1600`), and `pickFailTarget('queued')` returns `'cancelled'`. So
+> the common case is benign. `rejected` requires the WI to have reached `done_by_worker` — i.e.
+> the orchestrator reported done but no `VERIFIED_REPLY_REASON` cleared the tracker — before
+> the 10-minute timer fires. That is a narrow window, not a rare-in-principle one: it is exactly
+> the "worker done, TL has not verified" state that `enforceVerification` exists to service and
+> that the code elsewhere expects to persist for hours.
+>
+> **This does not invalidate Deliverable B.** #733's *code* is correct and its pickers are
+> right. What is wrong is one paragraph of its rationale, and the follow-up it de-scheduled on
+> the strength of that paragraph. Escalated to Sam (who authored the claim) before any fix code
+> was written.
+
+### 2b. Into `failed`
+
+| # | Path | Successor today | Verdict |
+|---|---|---|---|
+| F1 | `V3DataService.onTaskFailed` → `failItem` — `v3-data.service.ts:461` | Re-reads the WI, then branches (`:473`): `retryCount < maxRetries` → `requeueAfterFailure`; else → `escalateFailedWorkItem`. | **HAS successor (retry) or audit (escalation).** Correct as-is. This is the reference implementation the other paths should match. |
+| F2 | Reconciler emits `newState:'failed'` → `applyCorrection` — `reconciler-data-provider.ts:490` | Explicitly escalates via `escalateFailedWorkItem` with a comment noting it bypasses the canonical event path. | **HAS audit.** Correct as-is. |
+| F3 | `failOrphanRespondWi` → `pickFailTarget('running') === 'failed'` — `request-sla.subscriber.ts:225` | Raw `transitionStatus`. No `failItem`, no event, no escalation. Falls through to the reconciler's `detectRetryableFailedWorkItems` (`reconcile-rules.ts`), which requeues **only if** `retryCount < maxRetries`. | **PARTIALLY covered.** Retries-remaining self-heals by luck. **Retries-exhausted → STRANDED**, with no escalation record. |
+| F4 | Bridge's own failure modes: `resolveSourceWorkItem` returns `null` (`:~380`, `event.workItemId ?? event.taskId` missing or WI not found); TL-parse throw; `retryId` `${id}:retry:${n}` colliding with an already-terminal retry WI so `addToPool` no-ops | Source WI stays `rejected`; the successor that was supposed to exist never does. | **STRANDED,** and invisibly so — this is the failure mode that makes *inferring* a successor unsafe. |
+
+### 2c. The stranded set, stated precisely
+
+1. **S1** — `rejected` written by any path other than R1 (today: R2, and R3 if ever wired).
+2. **S2** — `failed` with `retryCount >= maxRetries` written by any path other than F1/F2 (today: F3).
+3. **S3** — `rejected`/`failed` whose intended bridge successor silently failed to materialise (F4).
+
+Everything else already has a successor or an audit record and must **not** be touched.
+
+### 2d. One survey claim rejected
+
+An independent sweep of this area reported that the TTL rule still emits an illegal
+`rejected → cancelled` every 60s for any `rejected` WI older than 24h. **That is false on
+`main` and I am recording it here so it does not propagate.** It describes the pre-#733 world.
+`pickTTLExpiryTarget` (`reconcile-rules.ts:~590`) walks `TTL_EXPIRY_TARGET_PREFERENCE` and
+returns a candidate only if it is BOTH strictly terminal AND a legal outbound edge; for
+`rejected`/`failed` the only edge is `queued`, which is not terminal, so it returns `null` and
+`detectTTLExpiredWorkItems` skips. Verified by direct execution (§2a proof, assertion 5).
+The practical consequence matters for this design: post-#733 the stranding is **silent**. There
+is no longer a recurring error log to notice it by.
+
+---
+
+## 3. Eval 2 — why the reverted predicate was wrong, and why this one cannot be
+
+The reverted rule asked: *"does a successor WorkItem exist for this source?"* — answered by
+scanning `getActiveWorkItems()` for a child. Both failure directions follow from the question,
+not from the implementation:
+
+- **False "yes" is impossible to rule out.** `ReconcilerDataProvider.getActiveWorkItems()`
+  (`reconciler-data-provider.ts`) filters `status !== 'done' && status !== 'cancelled'`. A
+  successor that already completed is invisible → the rule concludes "no successor" → it
+  re-dispatches the source → **already-completed work runs twice.**
+- **False "no" is equally structural.** `buildAutoWorkItem` sets `parentWorkItemId` on the
+  VERIFY WI as well as on retry WIs, so an unrelated VERIFY child reads as a successor → the
+  rule skips → **the exact SLA case it was written to rescue is the case it skips.**
+
+No refinement of the query fixes this, because the query is reconstructing information the
+writer already had and threw away.
+
+**The predicate in this design is a local field read, not a scan:**
+
+```
+isDisposed(wi) := wi.metadata.disposition !== undefined
+```
+
+- It cannot suffer a visibility bug: there is no collection to filter.
+- It cannot suffer a false-parent bug: `parentWorkItemId` is not consulted.
+- It is stamped by the same operation that performs the disposition, so "recorded" and
+  "actually happened" cannot drift.
+
+---
+
+## 4. The model
+
+### 4.1 One funnel, three dispositions
+
+Every writer that parks a WI in `rejected`/`failed` must route through a single funnel on
+`TaskPoolService`:
+
+```ts
+disposeFailedWorkItem(workItemId, { reason, actor }): Promise<Disposition>
+```
+
+which resolves to exactly one of:
+
+| Disposition | When | Effect |
+|---|---|---|
+| `retried_in_place` | `retryCount < maxRetries` | `failed → queued` via the existing `requeueAfterFailure` (bumps `retryCount`). Stamp `{kind:'retried_in_place', at, by, reason}`. |
+| `succeeded_by` | The path owns a *new* successor WI (R1/bridge) | Source keeps its status; stamp `{kind:'succeeded_by', successorWorkItemId, at, by}`. |
+| `terminal` | Retries exhausted, or the status has no retry path (`rejected` outside R1) | `escalateFailedWorkItem` for the audit record + orchestrator verdict. Stamp `{kind:'terminal', escalationId, at, by, reason}`. |
+
+### 4.2 Deliberately NOT changing `WORK_ITEM_TRANSITIONS`
+
+The tempting move is to add `failed → cancelled` / `rejected → cancelled` so a disposed WI can
+reach a strictly-terminal status. **Rejected.** Victor's Expected Outcome permits *"a deliberate
+terminal state with an audit record"* — and `failed` + a `terminal` disposition stamp **is**
+exactly that. Adding the edges would:
+
+- re-open the surface PR #733 just closed (TTL/orphan/cascade would start emitting corrections
+  for these statuses again, and `pickTTLExpiryTarget`/`pickCascadeTarget` would need re-deriving);
+- convert a *deliberate* terminal decision into a *default* one after 24h, which is the very
+  auto-acceptance semantic #733 removed;
+- for zero benefit — nothing downstream requires `cancelled` specifically; every consumer
+  already reads `SLA_TERMINAL_WORK_ITEM_STATUSES`.
+
+Consequence: the reconciler's soundness property is preserved untouched. `rejected`/`failed`
+still have no legal terminal edge, so the pruning rules still legally **skip** them. The new
+rule (§4.3) does not emit a status correction at all for the terminal case — it stamps and
+escalates. **Zero new illegal-transition surface.**
+
+### 4.3 The reconciler's role: safety net only
+
+New rule `detectUndisposedFailedWorkItems`:
+
+```
+for wi in workItems:
+  if wi.status not in {rejected, failed}: continue
+  if isDisposed(wi): continue                       # idempotent — re-entrant by construction
+  if age(wi, since = lastStatusChange) < GRACE_MS: continue   # let the eager writer win
+  → run the funnel
+```
+
+- **Terminating (Eval 4):** every funnel outcome writes a stamp; a stamped WI is skipped
+  forever after. The `retried_in_place` branch additionally bumps `retryCount` through
+  `requeueAfterFailure`, so `maxRetries` stays reachable and the retry branch can fire at most
+  `maxRetries` times.
+- **Re-entrant (Eval 4):** the stamp is the idempotency key. Two concurrent passes converge.
+- The grace window exists so the eager writers (§4.4) own the common case and the reconciler
+  only catches F4-class silent failures.
+
+### 4.4 Writer changes
+
+- `RequestSlaSubscriber.failOrphanRespondWi` — after its `transitionStatus`, call the funnel.
+  This closes R2 and F3 at the source, i.e. the reproducible path.
+- `EventToWorkItemBridge` — on the success path, stamp `succeeded_by` with the retry/escalation
+  WI id. This makes R1 explicitly disposed instead of *inferably* disposed, and turns every F4
+  failure mode into a visible "undisposed" that the safety net picks up.
+
+### 4.5 Eval 3 — not reviving the 24h TTL problem
+
+`detectTTLExpiredWorkItems` measures age from `wi.createdAt` and applies to **all** non-terminal
+statuses, `queued` included. `requeueAfterFailure` does **not** reset `createdAt`.
+
+**This is a live latent defect on `main` today, independent of this design:** a WI that fails
+after 24h and is auto-retried by `detectRetryableFailedWorkItems` lands in `queued` with a
+>24h `createdAt`, and the TTL rule cancels it on the very next 60s pass — silently destroying
+the retry that was just granted.
+
+Fix, chosen to avoid mutating `createdAt` (which feeds age metrics and ordering elsewhere):
+introduce a **TTL anchor**, `ttlAnchorAt = metadata.lastRequeuedAt ?? createdAt`, written by
+`requeueAfterFailure` and read by `detectTTLExpiredWorkItems`. Each granted retry gets a fresh
+TTL window; `createdAt` keeps meaning "when this work was first asked for".
+
+---
+
+## 5. Eval 5 / 6 — verification plan
+
+- **Eval 6 (reproduce the stranding, not the revert):** drive `failOrphanRespondWi` on (a) a
+  `done_by_worker` WI → asserts it lands in `rejected` with no successor and no event; (b) a
+  `running` WI at `retryCount === maxRetries` → asserts `failed`, no escalation, and that a
+  full reconciler cycle leaves it untouched forever. Both are deterministic — no timing, no
+  reliance on the reverted rule existing.
+- **Eval 5 (invariant, extended not replaced):** the existing derived-from-`WORK_ITEM_TRANSITIONS`
+  liveness+soundness tests (`reconcile-rules.test.ts:543`, `:686`, `:738`) are extended with a
+  **full-cycle** invariant at the `ReconcilerService` level: seed one WI in every
+  `WorkItemStatus`, run a complete `runFull`, and assert every applied correction is a legal
+  edge (soundness) **and** that no WI in `rejected`/`failed` remains undisposed after the grace
+  window (liveness). Liveness is what the reverted rule lacked and what makes "do nothing"
+  fail the test.
+- Mutation checks: removing the stamp must fail the termination test; removing the TTL anchor
+  must fail the Eval-3 test; restoring the scan-based predicate must fail both Eval-2 direction
+  tests.
+
+---
+
+## 6. Scope judgement (architectural veto — NOT exercised)
+
+Victor and Sam both granted a veto if this needs Request-layer successor modelling. **I am not
+exercising it.** Everything above is contained to the WorkItem layer: one new funnel on
+`TaskPoolService`, one metadata field, one reconciler safety-net rule, two writer call sites,
+one TTL anchor. `WORK_ITEM_TRANSITIONS` is untouched (§4.2) and no Request-layer relationship
+is introduced.
+
+Two things do need explicit sign-off because they are decisions, not details:
+
+1. **§4.2** — accepting `failed`/`rejected` + disposition stamp as the deliberate terminal
+   state, rather than adding `→ cancelled` edges.
+2. **§4.5** — the TTL anchor, which changes TTL semantics for every requeued WI (and fixes a
+   defect that predates this work).


### PR DESCRIPTION
> **Rebased onto `origin/main` @ a6603c1d — sequencing gate is now open.** #739 (WI 25aadd30) landed, so `retryCount` is failures-only in `main`; this funnel's precondition is an invariant rather than an assumption. Rebase took both sides on every hunk — #739's `releaseCount`/`targetSource` work and this branch's funnel both intact and asserted. `MERGEABLE` / `CLEAN`.

Three commits, deliberately independently revertable.

## The bug, stated exactly

`rejected` and `failed` are the only two `WorkItemStatus` values that are neither terminal nor able to *reach* a terminal state — their sole outbound edge is `→ queued`. An item parked in either is finished as far as every consumer is concerned and unfinished as far as the state machine is concerned, and nothing owned closing that gap.

The codebase already knew this. `SLA_TERMINAL_WORK_ITEM_STATUSES` exists solely to paper over it, and its own JSDoc says these are *"NOT terminal in the strict state-machine sense"*. **The stranding is the delta between those two sets.**

## Correction to PR #733's premise

#733 argued `rejected` is *"unreachable in production"* and de-scheduled this follow-up on that basis. The **evidence** it cites is correct — `verifyItem` has one production call site hardcoded to `'verified'`, there is no verify/reject route, no skill writes a verdict, `proposed → rejected` has no writer.

The **conclusion** does not follow. That sweep was over `verifyItem`, and `verifyItem` is not the only writer. `pickFailTarget` (`request-sla.subscriber.ts:226`) maps `done_by_worker → rejected`, driven by `failOrphanRespondWi` through `transitionStatus` **directly** — so `task:rejected` is never published and the bridge never creates the successor the `verifyItem` route would have. It runs from a subscriber booted at `index.ts:664`, on a 10-minute timer, from four call sites, one a `finally` that fires on every escalation.

Commit 2 turns that from a prose argument into five separately-named assertions. Mutation-verified with the sharp mutation: adding `done_by_worker` to `SLA_TERMINAL_WORK_ITEM_STATUSES` fails link 1 alone — so the guard fails when the claim it guards becomes **true**, not merely when code moves.

Worth naming: #733's code is right, and it converted a **loud** bug into a **quiet** one. Before it, a >24h stranded item threw `Invalid status transition` every 60s, and that noise was the only symptom. These assertions and the safety net are the replacement.

## Why the previous attempt failed — root cause, not a bug list

`469a3a21` reverted `detectStrandedRejectedWorkItems` because its predicate was wrong in both directions. Both failures follow from the **question** it asked — *"does a successor exist?"*, answered by scanning other WorkItems — not from its implementation:

- `getActiveWorkItems()` drops `done`/`cancelled` → a completed successor was invisible → "no successor" → source re-dispatched → **completed work ran twice**.
- `buildAutoWorkItem` sets `parentWorkItemId` on VERIFY WorkItems too → an unrelated verification child read as a successor → **the rule skipped the exact SLA case it existed to rescue**.

No refinement of the query fixes either, because the query reconstructs information the writer already had and discarded. So the writer records it. The predicate is now a local field read — no collection for a filter to hide a successor from, and `parentWorkItemId` never consulted.

**Proven, not asserted:** replacing the field read with a `parentWorkItemId` scan fails *both* direction tests, reproducing the reverted rule's two bugs exactly.

## The model

`TaskPoolService.disposeFailedWorkItem` — one funnel, three outcomes:

| Outcome | When | Effect |
|---|---|---|
| `retried_in_place` | budget remains | `requeueAfterFailure` (bumps `retryCount`). **Not stamped** — the item left the stranding statuses under its own power, and a stale stamp would make the safety net skip the *next* strand. `requeueAfterFailure` also clears any prior stamp. |
| `succeeded_by` | caller owns a real successor | stamped with the successor's id (the bridge now does this) |
| `terminal` | budget spent, or no retry path | escalate for a verdict, then stamp |

`detectUndisposedStrandedWorkItems` is a **backstop**, not the primary mechanism — writers dispose eagerly, and a 5-minute grace window lets them win. It returns items rather than corrections: a disposition is not a transition, and emitting one would put an illegal edge back into the pipeline #733 just cleaned.

### Two decisions, both signed off

1. **`WORK_ITEM_TRANSITIONS` untouched.** Adding `failed → cancelled` would let a disposed item reach a strictly terminal status — and would re-open the surface #733 closed, converting a *deliberate* terminal decision into a *24h default*. `failed` + an audit record already is the deliberate terminal state. Zero new illegal-transition surface.
2. **TTL anchor rather than mutating `createdAt`** (commit 1) — `createdAt` feeds age metrics and ordering.

`DISPOSITION_REQUIRED_STATUSES` is **derived** from the transition table, not hand-listed (evaluates to exactly `{failed, rejected}`, asserted), so a future status of the same shape is covered instead of silently stranding.

## Commit 1 is a live data-loss bug on main today

Independent of the successor model. `detectTTLExpiredWorkItems` measured age from `createdAt`, which is **never mutated anywhere in the repo**. So a WorkItem whose work outlived the 24h TTL, failed, and was legitimately auto-retried landed back in `queued` still carrying its original `createdAt` — and the next pass, 60 seconds later, cancelled it. Every retry granted past the 24h mark was destroyed on arrival, silently, because `queued → cancelled` is a perfectly legal edge. `maxRetries` was unreachable for any such item.

Fixed with `getTtlAnchorAt(wi) = metadata.lastRequeuedAt ?? createdAt`. Its own commit so it can be reverted independently.

## Also fixed

`failOrphanRespondWi` read `wi.status` for its log and audit reason *after* `transitionStatus` mutated the record in place, reporting the status it had just written rather than the one it came from. Caught by the Eval-6 test.

## Verification

- **Eval 6** reproduces the **stranding condition**, not the revert: the real 10-minute timer fires, `pickFailTarget` runs for real, and the fake pool enforces the canonical matrix — an illegal edge would throw, not pass.
- **Eval 5** extends the derived liveness+soundness invariants (not replaces) with a cycle-level counterpart: one WorkItem per status through a complete `runFull`, asserting every correction is a legal edge **and** that both strands reach the funnel. Soundness alone passes a gutted rule — the state the revert left behind.
- **Composition guard for #739 + this PR**, which neither proves alone: #739 proves a release moves `releaseCount`; this PR proves the funnel branches on `retryCount`. What matters is the two together, because the `terminal` branch is destructive. The test drives three lease lapses with zero failures (the exact shape of the incident where four WIs sat at 3/3 having failed nothing), then one real failure, and asserts the funnel still returns `retried_in_place`. Mutation-verified: reintroducing #739's churn charge fails it with `Expected: 0, Received: 3`.
- Suites: **744/744** across 9 suites — reconcile-rules, reconciler.service, reconciler-data-provider, task-pool (×3), request-sla, work-item.types, bridge. `tsc` clean.
- Mutation-verified throughout: inert rule fails liveness; scan predicate fails both directions; TTL reader reverted fails the data-loss test; writer stamp removed fails the writer test.
- 5 unrelated v3 suites fail **identically on pristine `origin/main`** (same 5 suites, same 1 test) — pre-existing, not from this diff.

Design doc: `specs/2026-08-21-workitem-successor-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
