### PR TITLE
fix(skills): match get-team-norms triggers as whole tokens, not exact strings

### DIFF
--- a/config/skills/agent/core/get-team-norms/SKILL.md
+++ b/config/skills/agent/core/get-team-norms/SKILL.md
@@ -53,7 +53,7 @@ anything governance-related — delegating, escalating, deciding scope.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `trigger` | No | Filter to norms relevant to a moment (e.g. `"before_commit"`, `"before_delegate"`). Omit to read all. |
+| `trigger` | No | Filter to norms relevant to a moment (e.g. `"before_commit"`, `"delegation"`). Matched against the norm's `trigger:` list as whole tokens, case-insensitively — `"lead"` does NOT match a norm tagged `inbound_lead`. Pass several comma-separated to mean "any of these". Omit to read all. |
 | `teamId` | No | Team to read. Defaults to the team resolved from your `sessionName`. |
 | `sessionName` | No | Your session name, used to resolve the team when `teamId` is omitted. |
 

--- a/config/skills/agent/core/get-team-norms/execute.sh
+++ b/config/skills/agent/core/get-team-norms/execute.sh
@@ -14,6 +14,76 @@ TRIGGER=$(printf '%s' "$INPUT" | jq -r '.trigger // empty')
 TEAM_ID=$(printf '%s' "$INPUT" | jq -r '.teamId // empty')
 SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
 
+# ---------------------------------------------------------------------------
+# Trigger matching
+# ---------------------------------------------------------------------------
+#
+# `trigger:` frontmatter is a COMMA-SEPARATED LIST, not a single value —
+# 6 of the 7 norms in the live runtime store lists such as
+# "escalation,delegation,blocker". Comparing the caller's trigger to that
+# raw string with `=` only matched when the caller happened to pass the
+# entire list verbatim, so trigger-filtered retrieval returned nothing for
+# essentially every norm and agents concluded no norms existed.
+#
+# Matching is done on whole TOKENS, deliberately not on substrings:
+# `lead` must not match `inbound_lead`, and `sale` must not match `sales`.
+# Both pairs exist in the current norms, so a substring fix would silently
+# return the wrong norms rather than none — a worse failure, because it
+# looks like it works.
+#
+# Tokens may contain internal spaces (e.g. "mutation check"), so only
+# leading/trailing whitespace is trimmed; internal spacing is preserved.
+# Comparison is case-insensitive.
+
+# Normalise a comma-separated trigger list into one trimmed, lowercase
+# token per line, dropping empties.
+#
+# $1 - Raw comma-separated trigger string (may be empty)
+normalize_trigger_tokens() {
+  printf '%s' "${1:-}" \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed '/^$/d'
+}
+
+# Decide whether a norm's stored trigger list satisfies the caller's query.
+#
+# An empty query matches everything (no filtering requested). Otherwise the
+# two token sets must intersect: a norm matches when it declares ANY of the
+# triggers the caller asked about.
+#
+# $1 - Stored `trigger:` frontmatter value
+# $2 - Caller-supplied trigger query
+# Returns 0 when the norm should be included, 1 when it should be skipped.
+trigger_matches() {
+  local stored_raw="${1:-}"
+  local query_raw="${2:-}"
+  local stored_tokens query_tokens q_token s_token
+
+  [ -z "$query_raw" ] && return 0
+
+  query_tokens=$(normalize_trigger_tokens "$query_raw")
+  [ -z "$query_tokens" ] && return 0
+
+  stored_tokens=$(normalize_trigger_tokens "$stored_raw")
+  [ -z "$stored_tokens" ] && return 1
+
+  while IFS= read -r q_token; do
+    [ -z "$q_token" ] && continue
+    while IFS= read -r s_token; do
+      [ -z "$s_token" ] && continue
+      [ "$q_token" = "$s_token" ] && return 0
+    done <<EOF
+$stored_tokens
+EOF
+  done <<EOF
+$query_tokens
+EOF
+
+  return 1
+}
+
 # Resolve teamId: explicit param > lookup by sessionName > CREWLY_SESSION_NAME env
 resolve_team_id() {
   local session="${1:-${CREWLY_SESSION_NAME:-}}"
@@ -81,8 +151,9 @@ for file in "$NORMS_DIR"/*.md; do
   FM_UPDATED_BY=$(echo "$FRONTMATTER" | sed -n 's/^updatedBy: *//p' | head -1)
   FM_UPDATED_AT=$(echo "$FRONTMATTER" | sed -n 's/^updatedAt: *//p' | head -1)
 
-  # If trigger filter is set, skip non-matching norms
-  if [ -n "$TRIGGER" ] && [ "$FM_TRIGGER" != "$TRIGGER" ]; then
+  # If a trigger filter is set, skip norms that declare none of its tokens.
+  # `trigger:` is a comma-separated list; see trigger_matches above.
+  if ! trigger_matches "$FM_TRIGGER" "$TRIGGER"; then
     continue
   fi
 

--- a/config/skills/agent/core/get-team-norms/tests/get-team-norms.test.ts
+++ b/config/skills/agent/core/get-team-norms/tests/get-team-norms.test.ts
@@ -1,0 +1,139 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Tests for the `get-team-norms` skill's trigger filtering.
+ *
+ * The skill reads `~/.crewly/teams/{teamId}/norms/*.md` and filters by the
+ * `trigger:` frontmatter field. That field is a COMMA-SEPARATED LIST, but the
+ * reader originally compared it to the caller's trigger with string equality,
+ * so a query only matched when it reproduced the entire stored list verbatim.
+ * Six of the seven norms in the live runtime store lists, making
+ * trigger-filtered retrieval non-functional for almost all of them.
+ *
+ * These tests run the real script against a throwaway CREWLY_HOME, so they
+ * assert observable behaviour rather than mirroring the implementation.
+ */
+
+const SKILL = join(__dirname, '..', 'execute.sh');
+const TEAM_ID = 'test-team-0001';
+
+let home: string;
+
+/**
+ * Writes a norm file with the given trigger list into the fixture team.
+ *
+ * @param name - Basename for the .md file
+ * @param trigger - Raw `trigger:` frontmatter value (comma-separated list)
+ */
+function writeNorm(name: string, trigger: string): void {
+  const body = `---\ntitle: ${name}\ntrigger: ${trigger}\nupdatedBy: test\nupdatedAt: 2026-08-21T00:00:00Z\n---\n\nBody of ${name}.\n`;
+  writeFileSync(join(home, '.crewly', 'teams', TEAM_ID, 'norms', `${name}.md`), body);
+}
+
+/**
+ * Runs the skill against the fixture home and returns the parsed response.
+ *
+ * @param trigger - Trigger query; omit for no filtering
+ * @returns Parsed JSON response from the skill
+ */
+function run(trigger?: string): { count: number; data: Array<{ trigger: string }> } {
+  const payload: Record<string, string> = { teamId: TEAM_ID };
+  if (trigger !== undefined) payload['trigger'] = trigger;
+  const out = execFileSync('bash', [SKILL, JSON.stringify(payload)], {
+    encoding: 'utf-8',
+    env: { ...process.env, HOME: home },
+  });
+  return JSON.parse(out);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'crewly-norms-'));
+  mkdirSync(join(home, '.crewly', 'teams', TEAM_ID, 'norms'), { recursive: true });
+  // Shapes taken from the live runtime, including the two substring traps.
+  writeNorm('escalation', 'escalation,delegation,blocker');
+  writeNorm('onboarding', 'delegation,onboarding');
+  writeNorm('sales', 'inbound_lead,sales');
+  writeNorm('intake', 'task_intake,new_request');
+  writeNorm('org', 'org_structure');
+  writeNorm('mutation', 'mutation check,verifying a test fails');
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('get-team-norms trigger filtering', () => {
+  it('returns every norm when no trigger is supplied', () => {
+    expect(run().count).toBe(6);
+  });
+
+  it('matches a token inside a comma-separated list', () => {
+    // The regression: this returned 0 because no norm's ENTIRE trigger
+    // string equals "delegation".
+    const res = run('delegation');
+    expect(res.count).toBe(2);
+    expect(res.data.map((n) => n.trigger).sort()).toEqual([
+      'delegation,onboarding',
+      'escalation,delegation,blocker',
+    ]);
+  });
+
+  it('matches a single-token norm', () => {
+    expect(run('org_structure').count).toBe(1);
+  });
+
+  it('does NOT substring-match a longer token', () => {
+    // `lead` must not match `inbound_lead`, `sale` must not match `sales`.
+    // A substring fix would return the wrong norms rather than none, which
+    // is worse than the original bug because it looks like it works.
+    expect(run('lead').count).toBe(0);
+    expect(run('sale').count).toBe(0);
+    expect(run('legation').count).toBe(0);
+  });
+
+  it('still matches the full token that those traps are substrings of', () => {
+    expect(run('inbound_lead').count).toBe(1);
+    expect(run('sales').count).toBe(1);
+  });
+
+  it('ignores surrounding whitespace and case in the query', () => {
+    expect(run('  DELEGATION  ').count).toBe(2);
+    expect(run('Org_Structure').count).toBe(1);
+  });
+
+  it('matches tokens that contain internal spaces', () => {
+    // Only leading/trailing whitespace is trimmed — internal spacing is
+    // part of the token.
+    expect(run('mutation check').count).toBe(1);
+    expect(run('verifying a test fails').count).toBe(1);
+  });
+
+  it('treats a multi-token query as "any of these"', () => {
+    // Union, not verbatim equality: the norm matches if it declares ANY of
+    // the requested triggers.
+    expect(run('escalation,onboarding').count).toBe(2);
+    expect(run('no_such_trigger,delegation').count).toBe(2);
+  });
+
+  it('remains compatible with a query that repeats a stored list verbatim', () => {
+    // This is the one shape the old exact-equality reader got right; it must
+    // keep working.
+    const res = run('escalation,delegation,blocker');
+    expect(res.count).toBeGreaterThanOrEqual(1);
+    expect(res.data.map((n) => n.trigger)).toContain('escalation,delegation,blocker');
+  });
+
+  it('returns nothing for an unknown trigger', () => {
+    expect(run('no_such_trigger').count).toBe(0);
+  });
+
+  it('returns everything for an all-whitespace or comma-only query', () => {
+    // Degenerate queries carry no tokens, so they request no filtering
+    // rather than filtering everything away.
+    expect(run('   ').count).toBe(6);
+    expect(run(',,,').count).toBe(6);
+  });
+});


### PR DESCRIPTION
WI 34da728f. **Base SHA: `a6603c1d`.**

## The bug, measured

`trigger:` frontmatter is a comma-separated list, but the reader compared the caller's trigger to the raw stored string with `!=`. A query matched only when it reproduced the entire list verbatim.

Against team `03bf7d62`, before → after:

| query | before | after | |
|---|---|---|---|
| *(none)* | 5 | 5 | unchanged |
| `delegation` | **0** | **2** | 2 norms declare it |
| `sales` | **0** | **1** | |
| `onboarding` | 0 | 1 | |
| `escalation,delegation,blocker` | 1 | 2 | |
| `lead` | 0 | **0** | must not match `inbound_lead` |
| `sale` | 0 | **0** | must not match `sales` |
| `no_such_trigger` | 0 | 0 | |

Agents asked for norms relevant to what they were doing, got nothing, and concluded the team had none.

## Why not a substring match

Because `lead`/`inbound_lead` and `sale`/`sales` both exist in the current norms, a substring fix would return the **wrong** norms rather than none — worse than the original bug, because it looks like it works. Matching splits both sides on comma and compares whole tokens.

Two details the live data forced:
- **Tokens can contain spaces** (`mutation check,verifying a test fails`), so only leading/trailing whitespace is trimmed — internal spacing is part of the token.
- **Case- and whitespace-insensitive**: `"  DELEGATION  "` matches.
- A multi-token query means **"any of these"**, symmetric with how norms declare them.

## Scope

Reader only, as instructed. No frontmatter schema change, no norm files rewritten, `update-team-norm` untouched, no global norm dirs, no other teams' directories. Backward compatible with everything on disk — including the one shape the old reader got right (a query repeating a stored list verbatim), which is now pinned by a test so the fix can't regress it.

## The other norm-reading paths — reported, not touched

You asked me to report rather than fix. **None of them do trigger matching**, so none are affected by this bug:

| path | filters by | trigger-matching? |
|---|---|---|
| `prompt-builder.service.ts` (`buildTeamNormsSection`) | `roles` from `config.json` | **No** — it reads `trigger` into its type but never matches on it |
| `prompt-builder.service.ts` fallback | none — loads all `*.md` | **No** |
| `prompt-modules/team-norms.module.ts` | file list | **No** — its own comment says `trigger` is "tolerated but not acted on here" |

So injection gives an agent *all* its role's norms regardless of trigger; only on-demand retrieval was broken. `get-team-norms` is the sole trigger-matching reader in the repo — `cancel-followup`'s `TRIGGER_*` vars are scheduler triggers, unrelated.

That said, it's worth noting the two paths disagree about what `trigger` is *for*: injection ignores it, retrieval filters on it. That's a taxonomy question, not a reader bug, so it belongs with the escalated decision rather than in this PR.

## Tests

11 tests running the real `execute.sh` against a throwaway `CREWLY_HOME` — observable behaviour, not a mirror of the implementation. Fixtures copy the live shapes, including both substring traps.

Mutation-tested, because a guard nobody tried to break isn't a guard:

| mutation | result |
|---|---|
| restore the original exact-equality filter | **6 failed** |
| substring match instead of whole-token | **1 failed** — the substring-trap test specifically |
| restored | **11 passed** |

`config/` jest root: 7 suites pass including the new one. The single failing suite is `computer-use.test.ts` (35 failures) — pre-existing, and verified on a clean tree during #737, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)