### PR TITLE
fix(skills): reject the dead skipGates field, unbreak block-task, stop capping delegation TTL

### DIFF
--- a/config/skills/_common/complete-body-shape.test.sh
+++ b/config/skills/_common/complete-body-shape.test.sh
@@ -47,6 +47,34 @@ assert_eq_json() {
   fi
 }
 
+# The exact key set `completeItem` destructures from req.body:
+#   const { agentId, tokenUsage, result } = req.body
+# (`workItemId` arrives as a PATH param, not in the body.)
+#
+# Added 2026-08-21 after `skipGates` shipped as a dead field: the skill parsed
+# it, put it on the wire, and nothing read it — POST /task-pool/complete runs no
+# quality gates at all. The per-field assertions below could not catch that,
+# because you cannot write an assertion for a field you do not know exists.
+# A key-SUBSET assertion catches the whole class instead of one field at a time.
+# Ported from the sibling task-pool-body-shape.test.sh, where the same shape
+# found three unknown instances on its first run.
+COMPLETE_ALLOWED_KEYS='["agentId","tokenUsage","result"]'
+
+# Assert a captured /task-pool/complete body carries only keys the endpoint reads.
+assert_complete_contract() {
+  local label="$1" body="$2"
+  local extra
+  extra=$(printf '%s' "$body" | jq -c --argjson allowed "$COMPLETE_ALLOWED_KEYS" '[keys[] | select(. as $k | $allowed | index($k) == null)]')
+  if [ "$extra" = "[]" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: every top-level key is read by completeItem"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  ✗ ${label}: keys silently discarded by completeItem: ${extra}"
+    echo "    completeItem destructures only {agentId, tokenUsage, result}."
+    echo "    A key outside that set is accepted, dropped, and believed to have worked."
+  fi
+}
+
 assert_jq() {
   local test_name="$1" jq_filter="$2" body="$3"
   local result
@@ -155,6 +183,7 @@ if [ -z "$COMPLETE_LINE" ]; then
   echo "  ✗ no /task-pool/complete POST captured"
 else
   COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_complete_contract "report-status" "$COMPLETE_BODY"
   assert_jq "agentId is the session name" '.agentId == "quinn-test"' "$COMPLETE_BODY"
   assert_jq "result.summary is non-empty" '.result.summary | length > 0' "$COMPLETE_BODY"
   assert_jq "result.summary matches input" '.result.summary == "Report-status smoke summary"' "$COMPLETE_BODY"
@@ -181,6 +210,7 @@ if [ -z "$COMPLETE_LINE" ]; then
   echo "  ✗ no /task-pool/complete POST captured"
 else
   COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_complete_contract "complete-task" "$COMPLETE_BODY"
   assert_jq "agentId is the session name" '.agentId == "quinn-ct"' "$COMPLETE_BODY"
   assert_jq "result.summary matches" '.result.summary == "Complete-task smoke summary"' "$COMPLETE_BODY"
   assert_jq "result.prNumber merged into result (was top-level result before)" '.result.prNumber == 42' "$COMPLETE_BODY"
@@ -205,6 +235,7 @@ if [ -z "$COMPLETE_LINE" ]; then
   echo "  ✗ no /task-pool/complete POST captured"
 else
   COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_complete_contract "orc-complete-task" "$COMPLETE_BODY"
   assert_jq "agentId defaults to crewly-orc" '.agentId == "crewly-orc"' "$COMPLETE_BODY"
   assert_jq "result.summary matches" '.result.summary == "Orc complete-task smoke summary"' "$COMPLETE_BODY"
   assert_jq "no top-level summary leak" '.summary == null' "$COMPLETE_BODY"
@@ -223,6 +254,7 @@ if [ -z "$COMPLETE_LINE" ]; then
   echo "  ✗ no /task-pool/complete POST captured"
 else
   COMPLETE_BODY=$(printf '%s' "$COMPLETE_LINE" | jq -r '.body')
+  assert_complete_contract "scenario-4" "$COMPLETE_BODY"
   assert_jq "agentId overridden to caller value" '.agentId == "crewly-product-leo-21a5477e"' "$COMPLETE_BODY"
 fi
 
@@ -242,6 +274,40 @@ if [ "$EXIT" -ne 0 ] && printf '%s' "$OUTPUT" | grep -q "summary is required"; t
 else
   FAIL=$((FAIL + 1))
   echo "  ✗ should reject empty summary; exit=$EXIT, output=$OUTPUT"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 5 — complete-task REJECTS skipGates loudly
+#
+# skipGates was accepted and silently discarded: the skill put it on the wire
+# and completeItem never read it, so a caller believed gates were skipped when
+# POST /task-pool/complete runs no gates at all. The disposition chosen was
+# reject-loudly rather than honour (incoherent — nothing to skip) or drop
+# silently (leaves the false belief intact). This locks that in.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 5: complete-task rejects skipGates ---"
+: > "$LOG"
+SKIPGATES_OUT=$(bash "${REPO_ROOT}/config/skills/agent/core/complete-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","sessionName":"quinn-sg","summary":"s","skipGates":true}' 2>&1 || true)
+SKIPGATES_RC=$?
+
+if printf '%s' "$SKIPGATES_OUT" | grep -q "skipGates is not supported"; then
+  PASS=$((PASS + 1)); echo "  ✓ errors with an explanation naming the field"
+else
+  FAIL=$((FAIL + 1)); echo "  ✗ expected a skipGates rejection, got: ${SKIPGATES_OUT}"
+fi
+
+if printf '%s' "$SKIPGATES_OUT" | grep -q "check-quality-gates"; then
+  PASS=$((PASS + 1)); echo "  ✓ points the caller at where gates actually live"
+else
+  FAIL=$((FAIL + 1)); echo "  ✗ rejection does not say where to run gates instead"
+fi
+
+if grep -qF '"path": "/api/task-pool/complete/' "$LOG"; then
+  FAIL=$((FAIL + 1)); echo "  ✗ completed the WorkItem anyway — rejection must happen BEFORE the POST"
+else
+  PASS=$((PASS + 1)); echo "  ✓ no complete POST emitted — fails before mutating state"
 fi
 
 echo ""

--- a/config/skills/_common/task-pool-body-shape.test.sh
+++ b/config/skills/_common/task-pool-body-shape.test.sh
@@ -34,6 +34,10 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 PASS=0
 FAIL=0
 
+# The exact key set `blockItem` destructures from req.body:
+#   const { agentId, reason } = req.body   — and agentId is HARD-REQUIRED (400)
+BLOCK_ALLOWED_KEYS='["agentId","reason"]'
+
 # The exact key set `claimItem` destructures from req.body:
 #   const { agentId, workItemId, filters } = req.body
 CLAIM_ALLOWED_KEYS='["agentId","filters","workItemId"]'
@@ -120,6 +124,20 @@ assert_claim_contract() {
     PASS=$((PASS + 1)); echo "  ✓ ${label}: no keys outside {agentId, workItemId, filters}"
   else
     FAIL=$((FAIL + 1)); echo "  ✗ ${label}: body carries keys the controller never reads: ${extra}"
+  fi
+}
+
+# Assert a captured /task-pool/block body matches what blockItem reads.
+assert_block_contract() {
+  local label="$1" body="$2"
+  assert_jq "${label}: agentId present (endpoint 400s without it)" '.agentId | type == "string" and length > 0' "$body"
+  assert_jq "${label}: reason is a non-empty string" '.reason | type == "string" and length > 0' "$body"
+  local extra
+  extra=$(printf '%s' "$body" | jq -c --argjson allowed "$BLOCK_ALLOWED_KEYS" '[keys[] | select(. as $k | $allowed | index($k) == null)]')
+  if [ "$extra" = "[]" ]; then
+    PASS=$((PASS + 1)); echo "  ✓ ${label}: no keys outside {agentId, reason}"
+  else
+    FAIL=$((FAIL + 1)); echo "  ✗ ${label}: keys silently discarded by blockItem: ${extra}"
   fi
 }
 
@@ -319,6 +337,29 @@ if [ -z "$BODY" ]; then
 else
   assert_add_contract "decompose-goal" "$BODY"
   assert_jq "decompose-goal: priority preserved in metadata.priority" '.metadata.priority != null' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — agent/core/block-task -> /task-pool/block/:id
+#
+# This callsite sent {reason, questions?, urgency?} and NO agentId, so every
+# call 400'd with "agentId is required" — the skill agents use to report being
+# blocked could not report anything. `questions`/`urgency` had no field on the
+# endpoint and were discarded; they are now folded into `reason`, which is read.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 9: agent/core/block-task -> /block ---"
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/block-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","sessionName":"quinn-blocker","reason":"missing creds","urgency":"high","questions":"who owns X?"}' \
+  >/dev/null 2>&1 || true
+BODY=$(capture "/api/task-pool/block/wi-stub-1")
+if [ -z "$BODY" ]; then
+  FAIL=$((FAIL + 1)); echo "  ✗ no /task-pool/block POST captured for block-task"
+else
+  assert_block_contract "block-task" "$BODY"
+  assert_jq "block-task: urgency folded into reason, not dropped" '.reason | test("urgency")' "$BODY"
+  assert_jq "block-task: questions folded into reason, not dropped" '.reason | test("who owns X")' "$BODY"
 fi
 
 echo ""

--- a/config/skills/agent/core/block-task/execute.sh
+++ b/config/skills/agent/core/block-task/execute.sh
@@ -7,7 +7,12 @@
 # `/task-pool/block/:workItemId` is.
 #
 # Input shape:
-#   { "workItemId": "abc-123", "reason": "missing creds", "questions"?: "...", "urgency"?: "..." }
+#   { "workItemId": "abc-123", "sessionName": "dev-1", "reason": "missing creds",
+#     "questions"?: "...", "urgency"?: "..." }
+#
+# `sessionName` is REQUIRED (sent as `agentId`) — the endpoint 400s without it.
+# `questions`/`urgency` are folded into `reason`; the endpoint has no field for
+# them.
 #
 # Backwards-compat: if `absoluteTaskPath` is provided instead of
 # `workItemId`, we emit a warning and skip the call rather than fall back
@@ -35,12 +40,32 @@ fi
 require_param "workItemId" "$WORK_ITEM_ID"
 require_param "reason" "$REASON"
 
+SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // .agentId // empty')
+[ -z "$SESSION_NAME" ] && SESSION_NAME="${CREWLY_SESSION_NAME:-}"
+require_param "sessionName (or agentId, or CREWLY_SESSION_NAME)" "$SESSION_NAME"
+
+# `blockItem` destructures ONLY `{agentId, reason}` and hard-requires agentId
+# (400 "agentId is required"). This skill previously sent neither agentId nor a
+# readable home for `questions`/`urgency`, so EVERY call 400'd — the skill
+# agents use to report being blocked could not report anything.
+#
+# `questions` and `urgency` have no field on this endpoint. Rather than drop
+# caller-supplied content on the floor (the same silent-discard bug in a new
+# shape), they are folded into `reason`, which IS read and is forwarded to
+# TaskProjection.markBlocked. The information survives; only the structure is
+# lost, and the endpoint has nowhere to put the structure.
+if [ -n "$URGENCY" ]; then
+  REASON="[urgency: ${URGENCY}] ${REASON}"
+fi
+if [ -n "$QUESTIONS" ]; then
+  REASON="${REASON}
+
+Open questions: ${QUESTIONS}"
+fi
+
 BODY=$(jq -n \
+  --arg agentId "$SESSION_NAME" \
   --arg reason "$REASON" \
-  --arg questions "$QUESTIONS" \
-  --arg urgency "$URGENCY" \
-  '{reason: $reason} +
-   (if $questions != "" then {questions: $questions} else {} end) +
-   (if $urgency != "" then {urgency: $urgency} else {} end)')
+  '{agentId: $agentId, reason: $reason}')
 
 api_call POST "/task-pool/block/${WORK_ITEM_ID}" "$BODY"

--- a/config/skills/agent/core/complete-task/SKILL.md
+++ b/config/skills/agent/core/complete-task/SKILL.md
@@ -48,7 +48,7 @@ Mark a task as complete with a summary of the work done. If the task has an outp
 | `summary` | Yes | Summary of the work completed |
 | `absoluteTaskPath` | No | **Legacy (V1).** Still accepted so older callers keep working, but it does NOT identify a WorkItem |
 | `output` | No | Structured output object (required if task has an output schema) |
-| `skipGates` | No | Set to `true` to skip quality gate checks |
+| ~~`skipGates`~~ | **Rejected** | **Not supported.** This endpoint runs no quality gates, so there is nothing to skip. Passing it is a hard error. Use the `check-quality-gates` skill for gates. |
 
 ### Which WorkItem gets completed
 

--- a/config/skills/agent/core/complete-task/execute.sh
+++ b/config/skills/agent/core/complete-task/execute.sh
@@ -23,7 +23,23 @@ WORK_ITEM_ID=$(printf '%s' "$INPUT" | jq -r '.workItemId // empty')
 ABSOLUTE_TASK_PATH=$(printf '%s' "$INPUT" | jq -r '.absoluteTaskPath // empty')
 SESSION_NAME=$(printf '%s' "$INPUT" | jq -r '.sessionName // empty')
 SUMMARY=$(printf '%s' "$INPUT" | jq -r '.summary // empty')
+# `skipGates` is REJECTED, not ignored.
+#
+# It was previously parsed here and forwarded in the request body. Nothing ever
+# read it: `completeItem` destructures only `{agentId, tokenUsage, result}`
+# (task-pool.controller.ts), and `POST /task-pool/complete/:id` runs no quality
+# gates at all — gates live behind `POST /quality-gates/check`, reached via the
+# `check-quality-gates` skill. So the field promised to skip something this
+# endpoint never runs.
+#
+# Accepting-and-ignoring is the worst of the three dispositions: the caller
+# believes gates were skipped, the belief is unfalsifiable, and nothing ever
+# fails. Honouring it is incoherent (there is nothing here to skip). So it
+# fails loudly instead. Safe to hard-error: no caller in the repo passes it.
 SKIP_GATES=$(printf '%s' "$INPUT" | jq -r '.skipGates // empty')
+if [ -n "$SKIP_GATES" ]; then
+  error_exit "skipGates is not supported by complete-task and never was — it was accepted and silently discarded. POST /task-pool/complete runs no quality gates, so there is nothing here to skip. Quality gates live behind the 'check-quality-gates' skill (POST /quality-gates/check); run or skip them there. Remove skipGates from this call."
+fi
 OUTPUT_JSON=$(printf '%s' "$INPUT" | jq -c '.output // empty')
 require_param "sessionName" "$SESSION_NAME"
 require_param "summary" "$SUMMARY"
@@ -116,7 +132,6 @@ fi
 BODY=$(jq -n \
   --arg agentId "$SESSION_NAME" \
   --arg summary "$SUMMARY" \
-  --arg skipGates "$SKIP_GATES" \
   --argjson output "${OUTPUT_JSON:-null}" \
   '{
     agentId: $agentId,
@@ -124,8 +139,7 @@ BODY=$(jq -n \
               + (if $output != null and ($output | type) == "object"
                  then $output
                  else {} end))
-  }
-   + (if $skipGates == "true" then {skipGates: true} else {} end)')
+  }')
 
 api_call POST "/task-pool/complete/${WORK_ITEM_ID}" "$BODY"
 

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -270,11 +270,23 @@ if [ -z "$RESOLVED_SESSION" ]; then
 fi
 
 if [ "$MONITOR_IDLE" = "true" ] && [ -n "$RESOLVED_SESSION" ]; then
+  # ttlMinutes is deliberately OMITTED so the server default applies.
+  #
+  # This used to hardcode `ttlMinutes: 120`, silently capping every delegation
+  # subscription at 2h against a system default of 8h
+  # (EVENT_BUS_CONSTANTS.DEFAULT_SUBSCRIPTION_TTL_MINUTES = 480, applied by
+  # event-bus.service.ts via `input.ttlMinutes ?? DEFAULT`). A subscription
+  # that expires 6h early stops the TL ever being woken for a long-running
+  # delegation — the same failure shape as a lease lapsing under an agent that
+  # is simply heads-down.
+  #
+  # Omitting beats re-hardcoding 480: the constant stays the single source of
+  # truth and the skill cannot drift from it again.
   SUB_BODY=$(jq -n \
     --arg eventType "agent:idle" \
     --arg sessionName "$TO" \
     --arg subscriber "$RESOLVED_SESSION" \
-    '{eventType: $eventType, filter: {sessionName: $sessionName}, subscriberSession: $subscriber, oneShot: true, ttlMinutes: 120}')
+    '{eventType: $eventType, filter: {sessionName: $sessionName}, subscriberSession: $subscriber, oneShot: true}')
   SUB_RESULT=$(api_call POST "/events/subscribe" "$SUB_BODY" 2>/dev/null || true)
   SUB_ID=$(echo "$SUB_RESULT" | jq -r '.data.id // empty' 2>/dev/null || true)
   if [ -n "$SUB_ID" ]; then

--- a/config/skills/team-leader/delegate-task/execute.test.sh
+++ b/config/skills/team-leader/delegate-task/execute.test.sh
@@ -242,7 +242,7 @@ if [ "$MONITOR_IDLE" = "true" ] && [ -n "$RESOLVED_SESSION" ]; then
     --arg eventType "agent:idle" \
     --arg sessionName "$TO" \
     --arg subscriber "$RESOLVED_SESSION" \
-    '{eventType: $eventType, filter: {sessionName: $sessionName}, subscriberSession: $subscriber, oneShot: true, ttlMinutes: 120}')
+    '{eventType: $eventType, filter: {sessionName: $sessionName}, subscriberSession: $subscriber, oneShot: true}')
   SUB_RESULT=$(api_call POST "/events/subscribe" "$SUB_BODY" 2>/dev/null || true)
   SUB_ID=$(echo "$SUB_RESULT" | jq -r '.data.id // empty' 2>/dev/null || true)
   if [ -n "$SUB_ID" ]; then

--- a/sops/norms/norm-mutation-check-base-ref.md
+++ b/sops/norms/norm-mutation-check-base-ref.md
@@ -88,6 +88,39 @@ If your negative test *also* flips to red under revert, it was passing for the
 wrong reason — it depends on the fix rather than constraining it. Investigate
 before shipping.
 
+## The restore step has the same trap, mirrored
+
+Reverting is only half the cycle. Putting your fix *back* is where I fell in a
+second time, on 2026-08-21, hours after writing this norm:
+
+```bash
+git checkout origin/main -- <path>   # ✅ revert — correct, this is the rule above
+<run tests>                          # ✅ 3 failed, as expected
+git checkout HEAD -- <path>          # ❌ "restore" — SILENTLY DISCARDED the fix
+```
+
+`git checkout HEAD -- <path>` restores from HEAD. If your fix is **not yet
+committed**, HEAD is the pre-fix state, so that command deletes your work
+instead of restoring it. Same command, same conditional meaning, opposite
+direction — and again no error.
+
+**Back the file up before reverting, and restore from the backup:**
+
+```bash
+cp <path> /tmp/fix.bak                # ✅ survives either commit state
+git checkout <base-ref> -- <path>
+<run tests>
+cp /tmp/fix.bak <path>                # ✅ restores what you actually wrote
+```
+
+Use `git checkout HEAD -- <path>` to restore **only** when the fix is already
+committed. When in doubt, the backup works in both states, which is the whole
+point.
+
+What caught it was the test suite, not me: the run right after went from 21/21
+to 18/3. Re-running the full suite after a mutation check is what turns this
+from lost work into a five-minute detour.
+
 ## Applies to
 
 Any "prove the test catches it" check: mutation checks, revert-and-rerun,


### PR DESCRIPTION
Closes WI `7575e1ee` (skipGates) and WI `9c637b89` (ttlMinutes). Base: `073858c3`.

## Did the contract test already cover this? — the question worth answering

**`skipGates`: yes, it should have — and the gap was real.** The guard exists in `task-pool-body-shape.test.sh` (*every top-level key must be one the endpoint reads*), but it was only ever applied to `/task-pool/add` and `/task-pool/claim`. The sibling `complete-body-shape.test.sh` covers `/task-pool/complete` and asserted only **specific fields** — and you cannot write an assertion for a field you don't know exists.

Ported the general guard. Mutation-verified against the pre-fix skill:

```
captured body: { "agentId": "quinn-sg", "result": {...}, "skipGates": true }
guard verdict: ["skipGates"]
```

**`ttlMinutes`: no, and it couldn't have.** It's a key the receiver *does* read, carrying a wrong value. Shape contracts test **which keys**, never **what values** — by construction. I did not stretch the test to reach it. The analogous guard would be a static check flagging skill request bodies that hardcode a value duplicating a server-side default constant; that's a different tool, and I'd file it rather than bolt it on here.

## The three fixes

**`skipGates` — accepted and silently discarded.** `completeItem` destructures only `{agentId, tokenUsage, result}`. Worse, the field was incoherent on its face: `POST /task-pool/complete` runs **no quality gates at all** — gates live behind `POST /quality-gates/check`. SKILL.md documented it as working.

*Disposition: reject loudly.* Honouring is impossible (nothing to skip); dropping silently leaves the false belief intact. It now hard-errors, naming where gates actually live. Zero callers in the repo, so no breakage.

**`ttlMinutes` — capped at a quarter of the default.** Hardcoded `120` against `DEFAULT_SUBSCRIPTION_TTL_MINUTES = 480`. A subscription expiring 6h early stops the TL ever being woken for a long-running delegation — the same failure shape as a lease lapsing under an agent who is simply heads-down. Omitting beats re-hardcoding 480: `input.ttlMinutes ?? DEFAULT` means the constant stays the single source of truth.

## Instance 9, folded in per the standing rule — `block-task` 400s on every call

Found auditing the remaining `/task-pool/*` callsites. `blockItem` hard-requires `agentId`; the skill sent neither `agentId` nor a readable home for `questions`/`urgency`. Verified live:

```
{"error":true,"status":400,"details":{"error":"agentId is required"}}
```

**The skill agents use to report being blocked could not report anything.** Now sends `agentId`; `questions`/`urgency` have no field on this endpoint, so rather than discard caller content — the same bug in a new shape — they fold into `reason`, which *is* read and reaches `TaskProjection.markBlocked`. Covered by a new scenario.

## Tests

| Suite | Result |
|---|---|
| `task-pool-body-shape.test.sh` | **47 passed** (+ `/block` coverage) |
| `complete-body-shape.test.sh` | **21 passed** (+ key-subset guard, + rejection scenario) |
| `delegate-task/execute.test.sh` | **26 passed** |

## Norm updated — I fell into my own norm's blind spot

The mutation-check norm covered reverting against a base ref but not **restoring**. `git checkout HEAD -- <path>` restores from HEAD, so with an *uncommitted* fix it **discards your work** instead of restoring it — the same conditional trap, mirrored. I hit it mid-PR; the suite going 21/21 → 18/3 is what caught it. The norm now documents both directions and prescribes a backup that works in either commit state.

## One adjacent thing, not fixed

`block-task` only works on a `running` item (`queued → blocked` is an invalid transition, 500) and the skill doesn't say so. Out of scope here — flagging rather than folding in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)