### PR TITLE
fix(sla): release the active claim when the orphan-close path terminalises a WI

### DIFF
--- a/backend/src/services/task-pool/task-pool.service.test.ts
+++ b/backend/src/services/task-pool/task-pool.service.test.ts
@@ -912,6 +912,90 @@ describe('TaskPoolService', () => {
     });
 
     // -----------------------------------------------------------------
+    // WI 1bebd7ae — a terminal WorkItem must not keep an active claim.
+    //
+    // The SLA orphan-close path drives its own terminal transition because
+    // it can target cancelled/failed/rejected, which `failItem` cannot. It
+    // therefore has to release the claim itself. These tests pin the
+    // contract it depends on, against the real service.
+    // -----------------------------------------------------------------
+    describe('releaseClaim (WI 1bebd7ae)', () => {
+      it('leaves no active claim after the SLA orphan-close sequence', async () => {
+        // The exact sequence failOrphanRespondWi performs on a running WI:
+        // transition → releaseClaim → dispose.
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        const claimed = await service.claimFromPool('agent-leo');
+        expect(claimed).not.toBeNull();
+        expect(
+          await service.getClaimService().getActiveClaimByWorkItem(wi.id),
+        ).toBeDefined();
+
+        await service.transitionStatus(wi.id, 'failed', 'system');
+        await service.releaseClaim(wi.id, 'sla escalation timeout (from running)');
+
+        const after = (await service.getAllItems()).find((i) => i.id === wi.id)!;
+        expect(after.status).toBe('failed');
+        expect(
+          await service.getClaimService().getActiveClaimByWorkItem(wi.id),
+        ).toBeUndefined();
+      });
+
+      it('stamps the end reason on the released claim for auditability', async () => {
+        const wi = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(wi);
+        const claimed = await service.claimFromPool('agent-leo');
+        const claimId = claimed!.claim.id;
+
+        await service.releaseClaim(wi.id, 'sla escalation timeout (from running)');
+
+        const claim = (await service.getClaimService().getClaimById(claimId))!;
+        expect(claim.status).toBe('released');
+        expect(claim.endReason).toBe('sla escalation timeout (from running)');
+        expect(claim.endedAt).toBeDefined();
+      });
+
+      it('unwedges the agent — a leaked claim hides all further work from them', async () => {
+        // This is what the leak actually costs, and the mechanism is worth
+        // stating exactly because it is quieter than a thrown error:
+        // `claimFromPool` checks `findActiveClaimByAgent` BEFORE it scans
+        // the pool, and short-circuits by returning the held claim with
+        // `alreadyHeld: true` (issue #513). So an agent holding a leaked
+        // claim is handed back the same TERMINAL WorkItem every time they
+        // poll, and never sees the queued work waiting for them. Nothing
+        // throws; it just silently looks like there is nothing new.
+        const stranded = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(stranded);
+        await service.claimFromPool('agent-leo');
+        await service.transitionStatus(stranded.id, 'failed', 'system');
+
+        const next = makeWorkItem({ target: 'agent-leo' });
+        await service.addToPool(next);
+
+        const wedged = await service.claimFromPool('agent-leo');
+        expect(wedged).not.toBeNull();
+        expect(wedged!.alreadyHeld).toBe(true);
+        expect(wedged!.workItem.id).toBe(stranded.id);
+        expect(wedged!.workItem.status).toBe('failed');
+
+        // Releasing the terminal item's claim frees the agent to see it.
+        await service.releaseClaim(stranded.id, 'sla escalation timeout (from running)');
+        const recovered = await service.claimFromPool('agent-leo');
+        expect(recovered).not.toBeNull();
+        expect(recovered!.alreadyHeld).toBeFalsy();
+        expect(recovered!.workItem.id).toBe(next.id);
+      });
+
+      it('is a no-op when the item has no active claim', async () => {
+        const wi = makeWorkItem();
+        await service.addToPool(wi);
+        await expect(
+          service.releaseClaim(wi.id, 'nothing to release'),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    // -----------------------------------------------------------------
     // WI 25aadd30 — a release is an administrative event, not a failure.
     //
     // Before this fix `releaseBack` cleared `target` and incremented

--- a/backend/src/services/task-pool/task-pool.service.ts
+++ b/backend/src/services/task-pool/task-pool.service.ts
@@ -1064,15 +1064,32 @@ export class TaskPoolService {
   }
 
   /**
-   * Internal: release the active claim on a WorkItem (if any). Shared by
-   * `completeSimpleItem` and `submitForVerification` because both
+   * Release the active claim on a WorkItem, if it has one.
+   *
+   * Shared by `completeSimpleItem` and `submitForVerification` because both
    * represent the worker handing the item back to the system.
    *
+   * Also public for callers that must drive a terminal transition
+   * themselves rather than through {@link failItem}. The SLA orphan-close
+   * path is the live example: it targets `cancelled`, `failed` OR
+   * `rejected` depending on the origin status, so `failItem` — which always
+   * transitions to `failed` — cannot serve it. Such callers MUST call this,
+   * otherwise the claim stays `active` against a terminal WorkItem and
+   * quietly wedges the claiming agent. The mechanism is not an error, which
+   * is what makes it hard to spot: {@link claimFromPool} checks
+   * `findActiveClaimByAgent` BEFORE it scans the pool, and short-circuits by
+   * returning the held claim with `alreadyHeld: true` (issue #513). So the
+   * agent is handed the same terminal item on every poll and never sees the
+   * queued work waiting for them, until the lease/grace ladder revokes it.
+   *
+   * Idempotent: a no-op when no active claim exists.
+   *
    * @param workItemId - WorkItem whose claim should be released
-   * @param endReason - Reason recorded on the claim (`completed` /
-   *   `submitted_for_verification`) for auditability
+   * @param endReason - Reason recorded on the claim (`completed`,
+   *   `submitted_for_verification`, `sla escalation timeout ...`) for
+   *   auditability
    */
-  private async releaseClaim(workItemId: string, endReason: string): Promise<void> {
+  async releaseClaim(workItemId: string, endReason: string): Promise<void> {
     const claim = await this.storage.findActiveClaimByWorkItem(workItemId);
     if (!claim) return;
     await this.storage.updateClaim(claim.id, (c) => {

--- a/backend/src/services/v3/request-sla.subscriber.test.ts
+++ b/backend/src/services/v3/request-sla.subscriber.test.ts
@@ -113,12 +113,20 @@ function buildFakeTaskPool(): {
   setStatus: (id: string, status: WorkItemStatus) => void;
   transitionCalls: Array<{ id: string; status: WorkItemStatus; actor: string }>;
   disposeCalls: Array<{ id: string; reason: string }>;
+  releaseCalls: Array<{ id: string; endReason: string }>;
 } {
   const stored = new Map<string, WorkItem>();
   const addCalls: WorkItem[] = [];
   const transitionCalls: Array<{ id: string; status: WorkItemStatus; actor: string }> = [];
   const disposeCalls: Array<{ id: string; reason: string }> = [];
+  const releaseCalls: Array<{ id: string; endReason: string }> = [];
   const taskPool = {
+    // The orphan-close path drives the terminal transition itself (it can
+    // target cancelled/failed/rejected, which `failItem` cannot), so it must
+    // release the claim explicitly or the claim leaks against a terminal WI.
+    releaseClaim: jest.fn(async (id: string, endReason: string) => {
+      releaseCalls.push({ id, endReason });
+    }),
     disposeFailedWorkItem: jest.fn(
       async (id: string, options: { reason: string }) => {
         disposeCalls.push({ id, reason: options.reason });
@@ -162,6 +170,7 @@ function buildFakeTaskPool(): {
     addCalls,
     transitionCalls,
     disposeCalls,
+    releaseCalls,
     setStatus: (id, status) => {
       const wi = stored.get(id);
       if (wi) wi.status = status;
@@ -811,7 +820,7 @@ describe('RequestSlaSubscriber', () => {
       await sub.flushPending();
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       // No callback wired → no crash, escalateCalls empty.
       expect(escalateCalls).toHaveLength(0);
@@ -829,7 +838,7 @@ describe('RequestSlaSubscriber', () => {
       await sub.flushPending();
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       const wiId = respondToUserWorkItemId(r.id);
       const closeTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
@@ -862,7 +871,7 @@ describe('RequestSlaSubscriber', () => {
       await sub.flushPending();
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       const wiId = respondToUserWorkItemId(r.id);
       const closeTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
@@ -883,6 +892,111 @@ describe('RequestSlaSubscriber', () => {
      * canonical `WORK_ITEM_TRANSITIONS` matrix — so if the transition were
      * illegal, this test would throw rather than pass.
      */
+    // -----------------------------------------------------------------
+    // WI 1bebd7ae — the orphan-close path drives its own terminal
+    // transition, so it must release the active claim itself.
+    //
+    // It cannot delegate to `failItem`: that always transitions to
+    // `failed`, whereas this path targets `cancelled`, `failed` or
+    // `rejected` depending on the origin status. `disposeFailedWorkItem`
+    // (added by #740) does not help either — it owns disposition and
+    // touches no claims. So the claim was left `active` against a
+    // terminal WorkItem.
+    //
+    // The cost is not cosmetic: `ClaimService.createClaim` refuses a new
+    // claim while an agent holds an active one, so a leaked claim stops
+    // that agent taking ANY work until the lease/grace ladder revokes it.
+    // -----------------------------------------------------------------
+    describe('orphan close releases the active claim (WI 1bebd7ae)', () => {
+      it('releases the claim when the orphan WI is queued (→ cancelled)', async () => {
+        const r = buildRequest();
+        svc.registry.set(r.id, r);
+        bus.publish(buildEvent(r.id));
+        await sub.flushPending();
+
+        jest.advanceTimersByTime(10_000);
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
+
+        const wiId = respondToUserWorkItemId(r.id);
+        const released = pool.releaseCalls.filter((c) => c.id === wiId);
+        expect(released).toHaveLength(1);
+        expect(released[0].endReason).toContain('sla escalation timeout');
+        expect(released[0].endReason).toContain('queued');
+
+        const wi = await pool.taskPool.findWorkItem(wiId);
+        expect(wi?.status).toBe('cancelled');
+      });
+
+      it('releases the claim when the orphan WI is running (→ failed)', async () => {
+        const r = buildRequest();
+        svc.registry.set(r.id, r);
+        bus.publish(buildEvent(r.id));
+        await sub.flushPending();
+
+        const wiId = respondToUserWorkItemId(r.id);
+        pool.setStatus(wiId, 'running');
+
+        jest.advanceTimersByTime(10_000);
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
+
+        const released = pool.releaseCalls.filter((c) => c.id === wiId);
+        expect(released).toHaveLength(1);
+        expect(released[0].endReason).toContain('running');
+
+        const wi = await pool.taskPool.findWorkItem(wiId);
+        expect(wi?.status).toBe('failed');
+        // #740 disposition behaviour must be preserved, not traded away.
+        expect(pool.disposeCalls.filter((c) => c.id === wiId)).toHaveLength(1);
+      });
+
+      it('releases the claim after the transition but before disposition', async () => {
+        // Both halves of the ordering matter. Releasing only after the
+        // transition means a failed transition cannot free the claim on an
+        // item that is still running. Releasing before disposition means a
+        // requeued item never carries a stale active claim, which would make
+        // it unclaimable by anyone.
+        const r = buildRequest();
+        svc.registry.set(r.id, r);
+        bus.publish(buildEvent(r.id));
+        await sub.flushPending();
+
+        const calls: string[] = [];
+        const tp = pool.taskPool as unknown as {
+          releaseClaim: jest.Mock;
+          transitionStatus: jest.Mock;
+        };
+        tp.releaseClaim.mockImplementation(async () => {
+          calls.push('release');
+        });
+        const realTransition = tp.transitionStatus.getMockImplementation()!;
+        tp.transitionStatus.mockImplementation(async (...args: unknown[]) => {
+          calls.push('transition');
+          return realTransition(...args);
+        });
+
+        jest.advanceTimersByTime(10_000);
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
+
+        expect(calls).toEqual(['transition', 'release']);
+      });
+
+      it('does not release a claim for an already-terminal WI', async () => {
+        // The early return still applies: nothing to close, nothing to release.
+        const r = buildRequest();
+        svc.registry.set(r.id, r);
+        bus.publish(buildEvent(r.id));
+        await sub.flushPending();
+
+        const wiId = respondToUserWorkItemId(r.id);
+        pool.setStatus(wiId, 'done');
+
+        jest.advanceTimersByTime(10_000);
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
+
+        expect(pool.releaseCalls.filter((c) => c.id === wiId)).toHaveLength(0);
+      });
+    });
+
     describe('EVAL 6 — the stranding condition, reproduced', () => {
       /** Arm a tracked Request whose WI has reached the given status. */
       async function escalateWith(status: WorkItemStatus): Promise<string> {
@@ -897,7 +1011,7 @@ describe('RequestSlaSubscriber', () => {
         pool.setStatus(wiId, status);
 
         jest.advanceTimersByTime(10_000);
-        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
         return wiId;
       }
 
@@ -979,7 +1093,7 @@ describe('RequestSlaSubscriber', () => {
       await sub.flushPending();
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       const wiId = respondToUserWorkItemId(r.id);
       const closeTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
@@ -1002,7 +1116,7 @@ describe('RequestSlaSubscriber', () => {
       pool.setStatus(wiId, 'running');
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       const closeTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
       expect(closeTransitions).toHaveLength(1);
@@ -1020,7 +1134,7 @@ describe('RequestSlaSubscriber', () => {
       pool.setStatus(wiId, 'cancelled');
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       // No additional transition recorded — already terminal.
       const closeTransitions = pool.transitionCalls.filter((c) => c.id === wiId);
@@ -1291,7 +1405,7 @@ describe('RequestSlaSubscriber', () => {
         // Nothing registered for this thread — fallback is a no-op.
         await sub.markResolvedByThread('5555555555.000000');
         jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
-        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
         expect(pool.transitionCalls).toHaveLength(0);
       });
@@ -1320,7 +1434,7 @@ describe('RequestSlaSubscriber', () => {
 
         await sub.markResolvedByThread('1772899923.865659');
         jest.advanceTimersByTime(MARK_RESOLVED_RETRY_MS + 1);
-        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
         // No transitions: TERMINAL gate stops the cleanup.
         expect(pool.transitionCalls.filter((c) => c.id === 'wi-after-close')).toHaveLength(0);
@@ -1402,7 +1516,7 @@ describe('RequestSlaSubscriber', () => {
 
         // Advance past the 30s grace window — the deferred recheck fires.
         jest.advanceTimersByTime(31_000);
-        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
         // Recheck closes since no siblings linked.
         expect(svc.registry.get(r.id)?.status).toBe('done');
@@ -1444,7 +1558,7 @@ describe('RequestSlaSubscriber', () => {
         await svc.service.linkWorkItem(r.id, sibling.id);
 
         jest.advanceTimersByTime(31_000);
-        for (let i = 0; i < 5; i += 1) await Promise.resolve();
+        for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
         // sibling-count gate suppresses close on the recheck pass.
         expect(svc.registry.get(r.id)?.status).toBe('running');
@@ -1534,7 +1648,7 @@ describe('RequestSlaSubscriber', () => {
       // Yield enough microtasks for handleRequestCreated to finish its
       // sync block (timer + tracking + index sets) and be parked on the
       // addToPool await.
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       // INVARIANT: tracking + index are populated even though the WI
       // hasn't been persisted yet.
@@ -1569,7 +1683,7 @@ describe('RequestSlaSubscriber', () => {
       bus.publish(buildEvent(r.id));
 
       // Drain into the addToPool-pending state.
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
       expect(sub.trackedCount).toBe(1);
 
       // Bridge fires the close while addToPool is still in flight.
@@ -1577,7 +1691,7 @@ describe('RequestSlaSubscriber', () => {
 
       // Drain microtasks: markResolved enters findWorkItemWithRetry and
       // is now awaiting the first 50ms tick.
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
       expect(pool.transitionCalls).toHaveLength(0); // not yet — WI absent
 
       // Release addToPool BEFORE the next retry tick fires. The next
@@ -1642,7 +1756,7 @@ describe('RequestSlaSubscriber', () => {
       expect(pool.transitionCalls).toHaveLength(0);
 
       jest.advanceTimersByTime(500);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       expect(pool.transitionCalls).toHaveLength(0);
       expect(sub.trackedCount).toBe(0);
@@ -1671,7 +1785,7 @@ describe('RequestSlaSubscriber', () => {
       const breachListener = jest.fn();
       bus.onInProcess('request:sla_breached', breachListener);
       jest.advanceTimersByTime(15_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
       expect(breachListener).not.toHaveBeenCalled();
       expect(escalateCalls).toHaveLength(0);
     });
@@ -2227,7 +2341,7 @@ describe('RequestSlaSubscriber', () => {
       await sub.flushPending();
 
       jest.advanceTimersByTime(10_000);
-      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
 
       // Slack DM callback is wired in this beforeEach but must NOT be
       // invoked for a chat-v2 source — chat-v2 has no DM-back analog yet.

--- a/backend/src/services/v3/request-sla.subscriber.ts
+++ b/backend/src/services/v3/request-sla.subscriber.ts
@@ -1518,6 +1518,7 @@ export class RequestSlaSubscriber {
       // below both need the origin.
       const fromStatus = wi.status;
       const target = pickFailTarget(fromStatus);
+
       await this.taskPool.transitionStatus(
         workItemId,
         target,
@@ -1531,6 +1532,28 @@ export class RequestSlaSubscriber {
         },
         target === 'cancelled' ? 'SLA escalation timeout' : undefined,
       );
+      // The item is terminal now, so its claim must not stay active.
+      //
+      // This path cannot delegate to `failItem` — the code that normally
+      // releases the claim — because `failItem` always transitions to
+      // `failed`, whereas `pickFailTarget` yields `cancelled`, `failed` OR
+      // `rejected` depending on the origin status. `disposeFailedWorkItem`
+      // does not cover it either: that owns disposition and touches no
+      // claims. So the release is made explicitly here.
+      //
+      // Ordering is deliberate on both sides:
+      //  - AFTER the transition, so the claim is released only once the item
+      //    actually reached a terminal state. Releasing first would, on a
+      //    failed transition, free the claim on an item that is still
+      //    `running` and still being worked — a worse outcome than the leak.
+      //  - BEFORE disposition, because the funnel may requeue the item; a
+      //    requeued item carrying an active claim cannot be claimed by
+      //    anyone, which is the very stranding this fix exists to prevent.
+      await this.taskPool.releaseClaim(
+        workItemId,
+        `sla escalation timeout (from ${fromStatus})`,
+      );
+
       this.logger.info('SLA escalation orphan WI auto-closed', {
         workItemId,
         requestId,


### PR DESCRIPTION
WI 1bebd7ae. **Base SHA: `073858c3`.**

## Confirmed, by content

All three of your findings hold:

| | |
|---|---|
| `failItem` releases the claim | ✅ `findActiveClaimByWorkItem` → `updateClaim(status='released', endReason)` |
| `disposeFailedWorkItem` touches claims | ❌ **zero** claim references in it |
| the SLA path releases anything | ❌ nothing |

So #740 fixed disposition and left the leak. Disposition and claim-release are separate concerns that happened to share a line.

## What the leak actually costs — this corrects my own first answer

I initially wrote that a leaked claim blocks the agent because `createClaim` throws. **A test proved me wrong**, and the real mechanism is quieter and worse:

`claimFromPool` checks `findActiveClaimByAgent` **before** it scans the pool, and short-circuits by returning the held claim with `alreadyHeld: true` (issue #513). So an agent holding a leaked claim is handed **the same terminal WorkItem on every poll** and never sees the queued work waiting for them. Nothing throws. It looks exactly like "no new work".

It is **not permanent** — the lease/grace ladder revokes it after `600s lease + 180s grace` ≈ 13 minutes, and the reconciler's claim rule keys only off lease expiry, never on the WorkItem's status. So: a ~13-minute silent blackout per leak for that agent, plus pollution of the `claims/expired` scan during the window (`findExpiredClaims` filters on claim status only, never on the WI's).

**On priority:** real, bounded, self-healing. It wedges one agent for ~13 minutes and dirties the exact endpoint that misled you twice today — but it does not strand permanently. I'd rather give you that than the dramatic version.

## Which route I took, and why (eval 2)

**Neither** duplicating nor routing through `failItem`. `failItem` cannot serve this path — it always transitions to `failed`, while `pickFailTarget` yields `cancelled`, `failed` or `rejected`, which is precisely why the transition was hand-rolled. So I took your fallback: there is **already** a private `releaseClaim(workItemId, endReason)` helper, shared by `completeSimpleItem` and `submitForVerification`. I made it public and called it. No logic copied.

**Reported, not fixed:** `failItem` and `releaseBack` each still inline their own copy of that same claim-release body — three implementations of one operation. Consolidating them is a safe follow-up but it touches two hot paths, so I left it alone. Say the word.

## Ordering — deliberate on both sides

`transition → releaseClaim → dispose`.

- **After the transition**: my first attempt released *first* (matching `failItem`). The tests caught it, and re-examining showed release-first is wrong here — if `transitionStatus` throws, it frees the claim on an item that is still `running` and still being worked. That is worse than the leak.
- **Before disposition**: the funnel may requeue the item, and a requeued item carrying an active claim is claimable by nobody — the very stranding this prevents.

Both directions are pinned by tests.

## Eval coverage

| eval | where |
|---|---|
| 1 — releases with a meaningful `endReason` | `sla escalation timeout (from <status>)`, asserted per branch |
| 2 — route chosen + justified | above; existing helper reused, nothing duplicated |
| 3 — #740 disposition preserved | `disposeCalls` asserted alongside the release |
| 4 — running WI + active claim → no active claim, terminal status | service-level test against the **real** `TaskPoolService` |
| 5 — sibling callsites | all 4, including the `finally`, funnel through this one function; single fix covers all |

**Honest scope note on eval 4:** the subscriber harness has only a fake pool, so I covered it in two layers — the subscriber emits the call (fake, all branches), and the call genuinely clears the claim against the real service (`getActiveClaimByWorkItem` → `undefined`). I did not wire a real pool into the subscriber; I'm flagging that rather than implying end-to-end coverage I don't have.

## Mutation-tested

| mutation | result |
|---|---|
| remove the release (reintroduce the leak) | **3 failed** |
| move the release after disposition | **2 failed** |
| restored | **115 passed** |

## Results

`request-sla.subscriber` 115/115, `task-pool.service` 179/179 (294 together). Wider sweep across task-pool + v3 + reconciler + controllers: **1206/1207**, and the one failure plus 4 non-running suites are all pre-existing — 4 are vitest-syntax files being run by jest (they fail at line 1, before any of my code loads) and one is a `TS2554` in `escalation.service.test.ts`. **None of the five is a file I touched.** Typecheck 25 errors, identical to baseline, none in my files. Lint clean.

## One test-harness change worth flagging

The suite drained a fixed 5 microtasks after advancing timers; my extra `await` pushed post-transition effects past it, which is what made 3 pre-existing tests fail initially. I raised the drain to 12 uniformly (21 sites) rather than tuning individual tests — draining more microtasks is always safe, and it de-brittles the suite against any future `await` on this path. No assertion was weakened.

## Overlap with the two you have not assigned

Flagging as asked. **`8737ee7a`** (escalation resolve revives a failed WI without bumping `retryCount`) sits directly on the semantics we settled in #739: reviving a *failed* WI is a genuine retry, so that one arguably *should* increment — the opposite direction from #739, and worth deciding deliberately rather than by analogy. **`ece797e7`** (false "retries exhausted") should be re-measured after #739, since churn-inflated counters were a plausible cause of false exhaustion and may already be gone. I have not touched either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)