### PR TITLE
fix(reconciler): stop escalating timed-out WorkItems that still have retries left

### DIFF
--- a/backend/src/services/reconciler/reconcile-rules.test.ts
+++ b/backend/src/services/reconciler/reconcile-rules.test.ts
@@ -7,6 +7,7 @@
 
 import {
   detectStuckWorkItems,
+  detectRetryableFailedWorkItems,
   detectExpiredClaims,
   reconcileRequestStatus,
   detectOrphanWorkItems,
@@ -102,6 +103,39 @@ describe('detectStuckWorkItems', () => {
 
     const { stuckIds } = detectStuckWorkItems([wi], agentMap);
     expect(stuckIds).toContain(wi.id);
+  });
+
+  // WI ece797e7 — the two branches of this rule deliberately disagree, and
+  // that asymmetry is load-bearing enough to pin. The agent-dead branch
+  // respects the retry budget; the TIMEOUT branch does not, because
+  // `detectRetryableFailedWorkItems` is what retries a timed-out item.
+  // Routing timeouts to `blocked` instead would recover them through the
+  // agent-back-online rule and report "Agent is back online" for an agent
+  // that never left. What must NOT happen is escalating off the back of
+  // this `failed` — that gate lives in applyCorrection.
+  it('sets failed (not blocked) for a first-attempt timeout, and the retry rule then re-queues it', () => {
+    const oldStart = new Date(Date.now() - 700_000).toISOString();
+    const wi = makeWorkItem({
+      status: 'running',
+      type: 'project_task',
+      target: 'agent-alive',
+      startedAt: oldStart,
+      retryCount: 0,
+      maxRetries: 3,
+    });
+    const agentMap = makeAgentMap([['agent-alive', { status: 'active' }]]);
+
+    const { corrections } = detectStuckWorkItems([wi], agentMap);
+    expect(corrections).toHaveLength(1);
+    expect(corrections[0].newState).toBe('failed');
+
+    // The retry genuinely happens — this is why `failed` is the right
+    // target state and why escalating here would be a false alarm.
+    const failed = { ...wi, status: 'failed' as const };
+    const { corrections: retries } = detectRetryableFailedWorkItems([failed]);
+    expect(retries).toHaveLength(1);
+    expect(retries[0].newState).toBe('queued');
+    expect(retries[0].reason).toContain('attempt 1/3');
   });
 
   it('should detect timed-out WorkItems even with active agents', () => {

--- a/backend/src/services/reconciler/reconciler-data-provider.test.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.test.ts
@@ -650,6 +650,68 @@ describe('LiveReconcilerDataProvider', () => {
       );
     });
 
+    // WI ece797e7 — a reconciler-driven `failed` is not automatically
+    // terminal. `detectStuckWorkItems`' TIMEOUT branch sets `failed`
+    // unconditionally (unlike its agent-dead sibling, which respects the
+    // budget), so a first-attempt timeout reached this code with
+    // retryCount=0 and escalated claiming its retries were spent — while
+    // `detectRetryableFailedWorkItems` re-queued the same item as
+    // "attempt 1/3" on the next sweep.
+    it('does NOT escalate a reconciler-driven failure while retry budget remains', async () => {
+      const retryableWi: Partial<WorkItem> = {
+        id: 'wi-timeout-1',
+        title: 'Timed out on first attempt',
+        type: 'delegate',
+        status: 'failed',
+        retryCount: 0,
+        maxRetries: 3,
+      };
+      mockEscalationRouter.escalateFailedWorkItem.mockClear();
+      (TaskPoolService as unknown as { _mockInstance: { findWorkItem: jest.Mock } })._mockInstance.findWorkItem.mockResolvedValueOnce(retryableWi);
+
+      await provider.applyCorrection({
+        entityType: 'work_item',
+        entityId: 'wi-timeout-1',
+        previousState: 'running',
+        newState: 'failed',
+        reason: 'WorkItem (type=delegate) exceeded timeout of 14400000ms',
+        evidence: 'running for 5h (limit 4h)',
+        correctedAt: new Date().toISOString(),
+      });
+
+      expect(mockEscalationRouter.escalateFailedWorkItem).not.toHaveBeenCalled();
+    });
+
+    it('DOES escalate once the retry budget is genuinely spent', async () => {
+      // The gate must not become "never escalate" — that would trade a
+      // false alarm for a silent failure, which is worse.
+      const spentWi: Partial<WorkItem> = {
+        id: 'wi-timeout-2',
+        title: 'Out of retries',
+        type: 'delegate',
+        status: 'failed',
+        retryCount: 3,
+        maxRetries: 3,
+      };
+      mockEscalationRouter.escalateFailedWorkItem.mockClear();
+      (TaskPoolService as unknown as { _mockInstance: { findWorkItem: jest.Mock } })._mockInstance.findWorkItem.mockResolvedValueOnce(spentWi);
+
+      await provider.applyCorrection({
+        entityType: 'work_item',
+        entityId: 'wi-timeout-2',
+        previousState: 'running',
+        newState: 'failed',
+        reason: 'WorkItem (type=delegate) exceeded timeout of 14400000ms',
+        evidence: 'running for 5h (limit 4h)',
+        correctedAt: new Date().toISOString(),
+      });
+
+      expect(mockEscalationRouter.escalateFailedWorkItem).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'wi-timeout-2' }),
+        expect.stringContaining('exceeded timeout'),
+      );
+    });
+
     it('does not escalate when work_item transitions to a non-failed state', async () => {
       // blocked / cancelled / queued corrections must NOT trip escalation;
       // they're not terminal failures and have their own surfacing paths.

--- a/backend/src/services/reconciler/reconciler-data-provider.ts
+++ b/backend/src/services/reconciler/reconciler-data-provider.ts
@@ -484,13 +484,37 @@ export class LiveReconcilerDataProvider implements ReconcilerDataProvider {
         // reconciler-cancelled "agent inactive" WI silently flips to
         // failed and the user is never told. Escalate directly here so
         // the failure surfaces through the same EscalationRouter path
-        // an agent-reported terminal failure would take. By definition
-        // these are terminal (the reconciler only fails a WI after its
-        // retry/grace policies have run out), so we skip retry logic.
+        // an agent-reported terminal failure would take.
+        //
+        // The retry budget MUST be re-checked here. This code previously
+        // skipped that on the stated grounds that "the reconciler only
+        // fails a WI after its retry/grace policies have run out" — an
+        // invariant its own rules do not honour. `detectStuckWorkItems`
+        // has two branches: the agent-dead branch respects the budget
+        // (`retryCount < maxRetries ? 'blocked' : 'failed'`), but the
+        // TIMEOUT branch sets `failed` unconditionally. So a first-attempt
+        // timeout arrived here with retryCount=0 and escalated to the
+        // owner claiming its retries were spent, while
+        // `detectRetryableFailedWorkItems` re-queued the very same item as
+        // "attempt 1/3" on the next sweep. The owner was asked to decide
+        // about work that was already quietly retrying.
+        //
+        // Gating on the budget here rather than in the timeout branch is
+        // deliberate: `failed` + `detectRetryableFailedWorkItems` already
+        // produces the correct retry, whereas routing timeouts to
+        // `blocked` would recover them through the agent-back-online rule
+        // and report "Agent is back online" for an agent that never left.
         if (correction.newState === 'failed') {
           try {
             const failed = await pool.findWorkItem(correction.entityId);
-            if (failed) {
+            if (failed && failed.retryCount < failed.maxRetries) {
+              this.logger.info('Skipping escalation — retry budget remains', {
+                workItemId: correction.entityId,
+                retryCount: failed.retryCount,
+                maxRetries: failed.maxRetries,
+                reason: correction.reason,
+              });
+            } else if (failed) {
               const { EscalationRouterService } = await import('../v3/escalation-router.service.js');
               await EscalationRouterService.getInstance().escalateFailedWorkItem(
                 failed,

--- a/backend/src/services/v3/escalation-router.service.test.ts
+++ b/backend/src/services/v3/escalation-router.service.test.ts
@@ -240,6 +240,25 @@ describe('EscalationRouterService', () => {
       expect(written.summary).toContain('3 retries');
     });
 
+    // WI ece797e7 — the headline previously read `failed after
+    // ${wi.maxRetries} retries` regardless of how many attempts actually
+    // happened, while the DM body printed the truthful `Attempts: 0 / 3`
+    // two lines below. One escalation contradicted itself.
+    it('reports the ACTUAL attempt count, not maxRetries', async () => {
+      const fileIo = jest.requireMock('../../utils/file-io.utils.js') as {
+        atomicWriteJson: jest.Mock;
+      };
+      const service = EscalationRouterService.getInstance('/tmp/test');
+      await service.escalateFailedWorkItem(
+        makeFailedWI({ retryCount: 1, maxRetries: 3 }) as Parameters<typeof service.escalateFailedWorkItem>[0],
+        'timed out',
+      );
+
+      const [, written] = fileIo.atomicWriteJson.mock.calls[0];
+      expect(written.summary).toContain('1 of 3 retries');
+      expect(written.summary).not.toContain('after 3 retries');
+    });
+
     it('enqueues a structured message to ORC via MessageQueue', async () => {
       const service = EscalationRouterService.getInstance('/tmp/test');
       await service.escalateFailedWorkItem(makeFailedWI(), 'agent crashed');

--- a/backend/src/services/v3/escalation-router.service.ts
+++ b/backend/src/services/v3/escalation-router.service.ts
@@ -323,7 +323,7 @@ export class EscalationRouterService {
       status: 'pending',
       source: 'workitem_failed',
       target: 'orchestrator',
-      summary: `WorkItem "${wi.title}" failed after ${wi.maxRetries} retries`,
+      summary: `WorkItem "${wi.title}" failed after ${wi.retryCount} of ${wi.maxRetries} retries`,
       details: {
         workItemId: wi.id,
         title: wi.title,
@@ -380,7 +380,7 @@ export class EscalationRouterService {
     const safeError = sanitize(wi.error ?? reason, 2_000);
 
     const lines = [
-      `[ESCALATION] WorkItem failed after ${wi.maxRetries} retries — your decision needed.`,
+      `[ESCALATION] WorkItem failed after ${wi.retryCount} of ${wi.maxRetries} retries — your decision needed.`,
       '',
       `WorkItem: ${wi.id} "${safeTitle}"`,
       `Type:     ${wi.type}`,


### PR DESCRIPTION
WI ece797e7. **Base SHA: `6f2dd964`.** Re-measured before touching anything, as instructed.

## Verdict: it STILL REPRODUCES

#739 did not fix it and was never implicated. #739 stopped churn from **inflating** `retryCount`; this bug is the mirror image — `retryCount` is 0 and the code never looks at it.

Measured by executing the real rule functions against a first-attempt timeout (`retryCount=0`, `maxRetries=3`, agent **alive**):

```
detectStuckWorkItems        -> [{"newState":"failed","reason":"exceeded timeout of 14400000ms"}]
detectRetryableFailedWorkItems -> [{"failed -> queued","reason":"Auto-retry ... (attempt 1/3)"}]
same WI, agent DEAD instead -> ["blocked"]     <- the sibling branch DOES respect the budget
```

So the owner is told **"failed after 3 retries — your decision needed"** about a WorkItem that the very next sweep re-queues as **attempt 1 of 3**. The DM contradicts its own headline: it prints `Attempts: 0 / 3` three lines below.

*(Measurement note: my first attempt showed nothing, because `delegate` carries a 4-hour per-type timeout that overrode the 60s default I passed. The fixture simply wasn't old enough. Worth stating — a naive repro here produces a false "does not reproduce".)*

## Three defects, adjudicated separately

**1 — Wrong decision (fixed).** `applyCorrection` escalated on *any* `failed` correction, justified by a comment: *"the reconciler only fails a WI after its retry/grace policies have run out."* Its own rules don't honour that. `detectStuckWorkItems` has two branches — agent-dead respects the budget (`retryCount < maxRetries ? 'blocked' : 'failed'`), the timeout branch sets `failed` unconditionally. The budget is now re-checked before escalating, so the code satisfies the invariant it was already asserting.

**2 — Misleading message (fixed, separately).** The summary and DM headline interpolated `wi.maxRetries` unconditionally, so they misreported the count *even on a legitimate escalation*. Both now report `${wi.retryCount} of ${wi.maxRetries}`. This is a genuinely different defect from (1): one is a wrong decision, the other a wrong number — and (2) was wrong even when (1) was right.

**3 — "Escalate/auto-retry race" — real, but not a race.** It's a two-sweep **sequence**: pass N escalates, pass N+1 re-queues. Nothing concurrent, so there is no interleaving to guard. Fixing (1) eliminates it, because escalation no longer fires while a retry is still owed. Pinned by a test rather than assumed.

## What I deliberately did NOT change

The timeout branch still targets `failed` rather than mirroring its agent-dead sibling's `blocked`.

I checked what `blocked` would actually do: `detectRecoverableWorkItems` re-queues a blocked item when its agent is **active** — which, for a timeout, it always is. So the item would recover, but via a rule whose correction reads *"Agent X is back online, retry 1/3"* for an agent that never went offline. `failed` + `detectRetryableFailedWorkItems` already produces the correct retry with an honest reason. Fixing the escalation gate rather than the target state is the smaller, truer change.

This also means the fix does **not** alter retry behaviour at all — timed-out items retried before and retry now, identically. Only the false alarm goes away.

## Mutation-tested

| mutation | result |
|---|---|
| remove the retry-budget gate (reintroduce the false escalation) | **1 failed** — `does NOT escalate ... while retry budget remains` |
| gate too hard, never escalate | **2 failed** — including the pre-existing `escalates reconciler-driven work_item failures` |
| revert the text to `maxRetries` | **1 failed** — `reports the ACTUAL attempt count` |

Mutant B matters as much as A: it proves the gate cannot silently degrade into "never escalate", which would trade a false alarm for a **silent failure** — strictly worse.

## Results

`reconciler-data-provider` 87/87, `reconcile-rules` 142/142, `escalation-router` 20/20. Wider sweep across reconciler + v3 + task-pool: **1134/1135**.

Everything not green is pre-existing and **proven** so, not asserted: the 4 non-running suites are vitest-syntax files under jest plus the `TS2554` in `escalation.service.test.ts`, and the single failing test (`RequestNotificationService › should send interactive buttons`) **fails identically with all five of my files reverted to `origin/main`** — I ran it that way to check. It has no dependency on anything I touched.

Typecheck 25 errors, identical to baseline, none in my files. Lint: 6 errors across the touched files, **identical count on the pristine `origin/main` versions** — all pre-existing unused-import/var warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)