### PR TITLE
fix(skills): stop report-status silently completing the wrong WorkItem

### DIFF
--- a/config/skills/_common/complete-body-shape.test.sh
+++ b/config/skills/_common/complete-body-shape.test.sh
@@ -132,6 +132,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type","application/json")
             self.end_headers()
+            # MULTI_RUNNING makes the pool report TWO running WorkItems, so the
+            # resolution in report-status becomes ambiguous and must refuse.
+            if os.path.exists(LOG + ".multi"):
+                self.wfile.write(b"{\"workItems\":[{\"id\":\"wi-stub-1\"},{\"id\":\"wi-stub-2\"}]}")
+                return
             # Top-level workItems shape — matches the jq fallback chain
             # in the skills (`.workItems[0].id // .data[0].id // empty`).
             self.wfile.write(b"{\"workItems\":[{\"id\":\"wi-stub-1\"}]}")
@@ -308,6 +313,48 @@ if grep -qF '"path": "/api/task-pool/complete/' "$LOG"; then
   FAIL=$((FAIL + 1)); echo "  ✗ completed the WorkItem anyway — rejection must happen BEFORE the POST"
 else
   PASS=$((PASS + 1)); echo "  ✓ no complete POST emitted — fails before mutating state"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — report-status WorkItem resolution (instance 11)
+#
+# report-status completed `.data[0].id` — an arbitrary first running WI. On
+# 2026-08-21 that silently closed WorkItem 7db3b00c, work nobody had started,
+# while the agent was reporting a DIFFERENT item done. Nothing failed, and the
+# false completion spawned a verify WI for a delivery that never happened.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 6: report-status resolution ---"
+
+# 6a — an explicit workItemId must win over anything the pool reports.
+: > "$LOG"
+bash "${REPO_ROOT}/config/skills/agent/core/report-status/execute.sh" \
+  --session quinn-res --status done --summary "Explicit workItemId resolution scenario" \
+  --project /tmp/proj-foo --work-item-id wi-explicit-9 >/dev/null 2>&1 || true
+if grep -qF '"path": "/api/task-pool/complete/wi-explicit-9"' "$LOG"; then
+  PASS=$((PASS + 1)); echo "  ✓ explicit workItemId is the one completed"
+else
+  ACTUAL=$(grep -oE '/api/task-pool/complete/[^"]*' "$LOG" | head -1)
+  FAIL=$((FAIL + 1)); echo "  ✗ expected wi-explicit-9 to be completed, got: ${ACTUAL:-none}"
+fi
+
+# 6b — the stub returns TWO running WIs, so inference is ambiguous. It must
+# REFUSE and complete nothing, naming the candidates.
+: > "$LOG"
+touch "${LOG}.multi"
+MULTI_OUT=$(bash "${REPO_ROOT}/config/skills/agent/core/report-status/execute.sh" \
+  --session quinn-res --status done --summary "Ambiguous resolution refusal scenario" \
+  --project /tmp/proj-foo 2>&1 || true)
+rm -f "${LOG}.multi"
+if grep -qF '"path": "/api/task-pool/complete/' "$LOG"; then
+  FAIL=$((FAIL + 1)); echo "  ✗ completed a WorkItem despite ambiguous resolution — this is the 7db3b00c bug"
+else
+  PASS=$((PASS + 1)); echo "  ✓ completes nothing when more than one WI is running"
+fi
+if printf '%s' "$MULTI_OUT" | grep -q "refuses to guess"; then
+  PASS=$((PASS + 1)); echo "  ✓ refusal explains why and tells the caller to pass workItemId"
+else
+  FAIL=$((FAIL + 1)); echo "  ✗ expected a refusal naming the ambiguity, got: ${MULTI_OUT}"
 fi
 
 echo ""

--- a/config/skills/agent/core/handoff-task/execute.sh
+++ b/config/skills/agent/core/handoff-task/execute.sh
@@ -128,7 +128,7 @@ fi
 cat >> "$HANDOFF_MSG_FILE" << FOOTER_EOF
 
 ---
-When done, report back using: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{"sessionName":"${TO}","status":"done","summary":"<brief summary>","projectPath":"${PROJECT_PATH}"}'
+When done, report back with report-status, passing the workItemId from your [CREWLY-DISPATCH] notice (or from get-my-tasks) so the right WorkItem is closed: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{"sessionName":"${TO}","workItemId":"<your WorkItem id>","status":"done","summary":"<brief summary>","projectPath":"${PROJECT_PATH}"}'
 FOOTER_EOF
 
 HANDOFF_MESSAGE=$(cat "$HANDOFF_MSG_FILE")

--- a/config/skills/agent/core/report-status/SKILL.md
+++ b/config/skills/agent/core/report-status/SKILL.md
@@ -56,6 +56,32 @@ When `status` is `done` and a `taskPath` is provided, the task file is automatic
 | `--task-id` | `taskId` | No | Task ID (for structured StatusReport format) |
 | `--progress` | `progress` | No | Progress percentage 0-100 |
 | `--structured` | `structured` | No | Use structured StatusReport format |
+| `--work-item-id` / `--wi-id` | `workItemId` | **Pass this when `status=done`** | Which WorkItem to complete. See below — without it the skill infers, and refuses when the choice is ambiguous |
+
+## This skill COMPLETES a WorkItem, not just reports
+
+When `status=done`, this skill closes a WorkItem in the task pool as a side
+effect. That is a surprising amount of authority for something named
+`report-status`, and the name/behaviour mismatch is exactly why nobody
+anticipated it silently closing the wrong item. It is not renamed here only
+because too many callers reference it.
+
+**Pass `workItemId` whenever you report done.** Resolution order:
+
+1. **`workItemId` given** — that item is completed. Always prefer this.
+2. **Omitted, exactly one WorkItem running for your session** — that one is
+   completed, and the resolved id is echoed so you can see what closed.
+3. **Omitted, more than one running** — the skill **refuses** and names the
+   candidates. It will not guess.
+
+Case 3 exists because guessing destroyed real work: on 2026-08-21 the skill
+completed an arbitrary first running item, silently closing a queued WorkItem
+nobody had started while the agent was reporting a different one done. Nothing
+failed, and the false completion spawned a verify WorkItem for a delivery that
+had never happened.
+
+If the completion itself fails, the skill says so explicitly — a reported
+status never implies the WorkItem actually closed.
 
 ## Examples — CLI Flags (preferred)
 

--- a/config/skills/agent/core/report-status/execute.sh
+++ b/config/skills/agent/core/report-status/execute.sh
@@ -235,17 +235,41 @@ api_call POST "/chat/agent-response" "$BODY"
 # `/task-management/complete{-by-session}` endpoints.
 #
 # Resolution order for which WorkItem to complete:
-#   1. `workItemId` in input (preferred — explicit reference)
-#   2. The agent's currently-running WI fetched from the pool
+#   1. `workItemId` in input — explicit, always wins. PASS THIS.
+#   2. Exactly one running WI for this session — inferred, and the resolved id
+#      is echoed so the caller can see what was closed.
+#   3. More than one running WI — REFUSED. The candidates are named and the
+#      caller must pass `workItemId`.
+#
+# Why (3) refuses instead of guessing: this block used to complete
+# `.data[0].id`, an arbitrary first running item. On 2026-08-21 that silently
+# closed WorkItem 7db3b00c — a queued piece of work nobody had started — while
+# the agent was reporting a DIFFERENT WI done. Nothing failed. The false
+# completion then spawned a verify WorkItem asking the orchestrator to verify a
+# delivery that had never happened, so one silent mis-close also consumed
+# downstream verification attention on fiction.
+#
+# Inferring from a single running claim is safe and stays. Inferring from
+# several is a coin flip on which real work gets destroyed.
 #
 # The legacy `taskPath` input is still accepted for backwards compatibility
 # but no longer drives the API call.
 if [ "$STATUS" = "done" ]; then
   TARGET_WI_ID="${WORK_ITEM_ID:-}"
+  WI_RESOLUTION="explicit"
+
   if [ -z "$TARGET_WI_ID" ]; then
-    # Fall back: query pool for this session's running WIs and complete the first match.
     POOL_RESP=$(api_call GET "/task-pool/items?status=running&target=${SESSION_NAME}" 2>/dev/null || echo '{}')
-    TARGET_WI_ID=$(echo "$POOL_RESP" | jq -r '.workItems[0].id // .data[0].id // empty' 2>/dev/null || true)
+    RUNNING_IDS=$(printf '%s' "$POOL_RESP" | jq -r '((.workItems // .data // []) | map(.id)) | .[]' 2>/dev/null || true)
+    RUNNING_COUNT=$(printf '%s' "$RUNNING_IDS" | grep -c . || true)
+
+    if [ "$RUNNING_COUNT" -gt 1 ]; then
+      CANDIDATES=$(printf '%s' "$RUNNING_IDS" | tr '\n' ' ')
+      error_exit "report-status refuses to guess which WorkItem to complete: ${RUNNING_COUNT} are running for ${SESSION_NAME} (${CANDIDATES}). Pass workItemId explicitly. Completing an arbitrary one silently closes work nobody did — and a false completion cascades into a verify WorkItem for a delivery that never happened."
+    fi
+
+    TARGET_WI_ID=$(printf '%s' "$RUNNING_IDS" | head -1)
+    WI_RESOLUTION="inferred"
   fi
 
   if [ -n "$TARGET_WI_ID" ]; then
@@ -258,7 +282,18 @@ if [ "$STATUS" = "done" ]; then
       --arg agentId "$SESSION_NAME" \
       --arg summary "$SUMMARY" \
       '{agentId: $agentId, result: {summary: $summary}}')
-    api_call POST "/task-pool/complete/${TARGET_WI_ID}" "$COMPLETE_BODY" || true
+    # No `|| true`. A swallowed failure here is the inverse of the bug above:
+    # report-status would announce success while the WorkItem stayed open, and
+    # that is equally invisible. Report what actually happened either way.
+    if COMPLETE_RESULT=$(api_call POST "/task-pool/complete/${TARGET_WI_ID}" "$COMPLETE_BODY" 2>&1); then
+      # Echo the resolved id even on the happy path. Silent-but-correct is how
+      # this class hides — the caller must be able to see WHICH item closed.
+      jq -n --arg id "$TARGET_WI_ID" --arg how "$WI_RESOLUTION" \
+        '{completedWorkItem: $id, resolvedBy: $how}' >&2
+    else
+      jq -n --arg id "$TARGET_WI_ID" --arg err "$COMPLETE_RESULT" \
+        '{warning: "status reported, but completing the WorkItem FAILED — it is still open", workItemId: $id, error: $err}' >&2
+    fi
   fi
 fi
 

--- a/config/skills/orchestrator/delegate-task/execute.sh
+++ b/config/skills/orchestrator/delegate-task/execute.sh
@@ -231,13 +231,13 @@ if [ "$USE_STRUCTURED" = "true" ] && [ -n "$TITLE" ]; then
 
   [ -n "$CONTEXT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\nAdditional context: ${CONTEXT}"
   [ -n "$DEADLINE_HINT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\n**Deadline hint**: ${DEADLINE_HINT}"
-  TASK_MESSAGE="${TASK_MESSAGE}\n\n---\nWhen done, report back using: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'"
+  TASK_MESSAGE="${TASK_MESSAGE}\n\n---\nWhen done, report back with report-status, passing the workItemId from your [CREWLY-DISPATCH] notice (or from get-my-tasks) so the right WorkItem is closed: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"workItemId\":\"<your WorkItem id>\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'"
   TASK_MESSAGE="${TASK_MESSAGE}\n\nBefore reporting done, persist key findings using: bash ${CREWLY_ROOT}/config/skills/agent/core/remember/execute.sh '{\"agentId\":\"${TO}\",\"content\":\"<key findings>\",\"category\":\"pattern\",\"scope\":\"project\",\"projectPath\":\"${PROJECT_PATH}\"}'"
 else
   # Legacy free-text format (backwards compatible)
   TASK_MESSAGE="New task from orchestrator (priority: ${PRIORITY}):\n\n${TASK}"
   [ -n "$CONTEXT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\nContext: ${CONTEXT}"
-  TASK_MESSAGE="${TASK_MESSAGE}\n\nWhen done, report back using: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'"
+  TASK_MESSAGE="${TASK_MESSAGE}\n\nWhen done, report back with report-status, passing the workItemId from your [CREWLY-DISPATCH] notice (or from get-my-tasks) so the right WorkItem is closed: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"workItemId\":\"<your WorkItem id>\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'"
   TASK_MESSAGE="${TASK_MESSAGE}\n\nBefore reporting done, persist key findings using: bash ${CREWLY_ROOT}/config/skills/agent/core/remember/execute.sh '{\"agentId\":\"${TO}\",\"content\":\"<key findings>\",\"category\":\"pattern\",\"scope\":\"project\",\"projectPath\":\"${PROJECT_PATH}\"}'"
 fi
 

--- a/config/skills/team-leader/aggregate-results/SKILL.md
+++ b/config/skills/team-leader/aggregate-results/SKILL.md
@@ -105,7 +105,7 @@ The report is written to `reportFile` and follows the `[TL_REPORT]` tag conventi
 
 After generating the report, send it to the Orchestrator:
 ```bash
-bash {{SKILLS_PATH}}/agent/core/report-status/execute.sh '{"sessionName":"tl-session","status":"done","summary":"Objective complete: 4/5 tasks passed. Report at /tmp/tl-report-team-123.md"}'
+bash {{SKILLS_PATH}}/agent/core/report-status/execute.sh '{"sessionName":"tl-session","workItemId":"<your WorkItem id>","status":"done","summary":"Objective complete: 4/5 tasks passed. Report at /tmp/tl-report-team-123.md"}'
 ```
 
 ## Related Skills

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -163,7 +163,7 @@ if [ -n "$CONTEXT" ]; then
 fi
 
 # Build a structured task message from Team Leader
-TASK_MESSAGE="New task from Team Leader (priority: ${PRIORITY}):\n\n**[REQUIRED] When done, you MUST:** (1) Output a text summary of your work, findings, and any issues. (2) Call report-status:\nbash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'\n\n---\n\n${TASK}"
+TASK_MESSAGE="New task from Team Leader (priority: ${PRIORITY}):\n\n**[REQUIRED] When done, you MUST:** (1) Output a text summary of your work, findings, and any issues. (2) Call report-status, passing the workItemId from your [CREWLY-DISPATCH] notice (or from get-my-tasks) so the right WorkItem is closed:\nbash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"workItemId\":\"<your WorkItem id>\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'\n\n---\n\n${TASK}"
 [ -n "$CONTEXT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\nContext: ${CONTEXT}"
 
 # Deliver the task message with fallback strategy:

--- a/config/skills/team-leader/delegate-task/execute.test.sh
+++ b/config/skills/team-leader/delegate-task/execute.test.sh
@@ -203,7 +203,7 @@ fi
 
 TASK_MESSAGE="New task from Team Leader (priority: ${PRIORITY}):\n\n${TASK}"
 [ -n "$CONTEXT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\nContext: ${CONTEXT}"
-TASK_MESSAGE="${TASK_MESSAGE}\n\nWhen done, report back using: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"status\":\"done\",\"summary\":\"<brief summary>\"}'"
+TASK_MESSAGE="${TASK_MESSAGE}\n\nWhen done, report back with report-status, passing the workItemId from your [CREWLY-DISPATCH] notice: bash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"workItemId\":\"<your WorkItem id>\",\"status\":\"done\",\"summary\":\"<brief summary>\"}'"
 
 BODY=$(jq -n --arg message "$TASK_MESSAGE" '{message: $message, waitForReady: true, waitTimeout: 15000}')
 api_call POST "/terminal/${TO}/deliver" "$BODY"


### PR DESCRIPTION
Closes WI `8232f4c8` — **instance 11**. Base `6f2dd964`.

## What happened

`report-status` completed `.data[0].id` — an *arbitrary first running WorkItem* — so it was correct only while an agent held exactly one running claim.

On 2026-08-21 that silently closed WorkItem `7db3b00c`, queued work nobody had started, while the agent was reporting a **different** item done. Nothing failed.

The false completion then **spawned a verify WorkItem** asking the orchestrator to verify a delivery that had never happened. So one silent mis-close doesn't stop at one bad record — it consumes downstream verification attention on fiction.

## Three defects in the same block

1. **Inferred target** — picks from session state instead of being told.
2. **Silent failure** — the completion POST ended in `|| true`, so a *failed* completion still reported success. The inverse bug, equally invisible.
3. **Systemic steering** — the skill has always supported an explicit `workItemId` (resolution order step 1), but **nothing passed it**. The system's own generated briefs told every worker to use the inferred form.

## Resolution is now asymmetric

| Case | Behaviour |
|---|---|
| `workItemId` given | That item completes. Always wins. |
| Omitted, **one** running | Still infers — but **echoes the resolved id** so the caller sees what closed. Silent-but-correct is how this class hides. |
| Omitted, **many** running | **Refuses**, naming the candidates. |

That last row is the exact case that destroyed `7db3b00c`. Guessing there is a coin flip on which real work gets deleted.

`|| true` removed — a failed completion now emits an explicit warning that the status was reported but the WorkItem is still open.

## Callers fixed too

A fix nothing invokes fixes nothing — the same lesson as #741, where the constant was right and the config didn't consume it. All four generators emitting *"report back with report-status"* now tell the worker to pass its `workItemId` and where to find it: `team-leader/delegate-task`, `orchestrator/delegate-task` (2 sites), `agent/core/handoff-task`, plus the `aggregate-results` doc example and the TL test's mock copy.

**Zero call-sites remain on the inferred form.**

## Tests — 24 passed, 0 failed

Three new scenarios: explicit id wins; ambiguous resolution completes **nothing**; the refusal explains itself. The stub reports two running WIs via a **marker file** rather than an env var — the stub process starts before the test can set one, so `os.environ` could never see it.

> Caught by the contract suite during this work: my first version of the caller fix embedded `` `get-my-tasks` `` in backticks inside a double-quoted bash string, which bash executes as **command substitution**, breaking both delegate-task skills. The suite went 47 → 35/2 and named the two callsites. Backticks removed.

## Not renamed

A skill called `report-status` silently **completing** a WorkItem is a surprising amount of authority for its name, and that mismatch is why nobody anticipated this. Too many callers to rename here — SKILL.md now says so plainly, and documents the resolution order and the incident that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)