### PR TITLE
fix(task-pool): return 409 for an invalid block transition, and pre-check status in block-task

### DIFF
--- a/backend/src/controllers/task-pool/task-pool.controller.test.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.test.ts
@@ -18,6 +18,7 @@ import {
   addItem,
   cancelQueuedItem,
   listAllItems,
+  blockItem,
 } from './task-pool.controller.js';
 import { TaskPoolService, WorkItemClaimedError } from '../../services/task-pool/task-pool.service.js';
 import { StorageService } from '../../services/core/storage.service.js';
@@ -62,6 +63,7 @@ const mockService = {
   addToPool: jest.fn(),
   getAllItems: jest.fn().mockResolvedValue([]),
   cancelQueued: jest.fn(),
+  updateItemStatus: jest.fn(),
 };
 
 (TaskPoolService.getInstance as any) = jest.fn().mockReturnValue(mockService);
@@ -1180,6 +1182,74 @@ describe('TaskPoolController', () => {
   // -------------------------------------------------------------------------
   // GET /api/task-pool/items — listAllItems (status/target filters, #679)
   // -------------------------------------------------------------------------
+
+  describe('blockItem status-code mapping', () => {
+    it('maps an invalid status transition to 409, not 500', async () => {
+      // WORK_ITEM_TRANSITIONS allows `blocked` only from `running`, so
+      // blocking a queued item throws. That is a CLIENT error — the caller
+      // asked for something the state machine forbids. Reporting it as a 500
+      // makes retry logic treat a PERMANENT failure as transient and hammer
+      // the endpoint.
+      mockService.updateItemStatus.mockRejectedValue(
+        new Error('Invalid status transition for WorkItem wi-1: queued → blocked'),
+      );
+
+      const req = mockReq({
+        params: { workItemId: 'wi-1' } as Record<string, string>,
+        body: { agentId: 'dev-1', reason: 'missing creds' },
+      });
+      const res = mockRes();
+      await blockItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.status).not.toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.stringContaining('queued → blocked'),
+        }),
+      );
+    });
+
+    it('still maps a missing WorkItem to 404', async () => {
+      mockService.updateItemStatus.mockRejectedValue(new Error('WorkItem wi-nope not found'));
+
+      const req = mockReq({
+        params: { workItemId: 'wi-nope' } as Record<string, string>,
+        body: { agentId: 'dev-1', reason: 'r' },
+      });
+      const res = mockRes();
+      await blockItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('still maps a genuine server fault to 500', async () => {
+      // The 409 mapping must not swallow real failures.
+      mockService.updateItemStatus.mockRejectedValue(new Error('ENOSPC: disk full'));
+
+      const req = mockReq({
+        params: { workItemId: 'wi-1' } as Record<string, string>,
+        body: { agentId: 'dev-1', reason: 'r' },
+      });
+      const res = mockRes();
+      await blockItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+
+    it('still rejects a missing agentId with 400', async () => {
+      const req = mockReq({
+        params: { workItemId: 'wi-1' } as Record<string, string>,
+        body: { reason: 'r' },
+      });
+      const res = mockRes();
+      await blockItem(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockService.updateItemStatus).not.toHaveBeenCalled();
+    });
+  });
 
   describe('listAllItems (#679 status/target filters)', () => {
     const items = [

--- a/backend/src/controllers/task-pool/task-pool.controller.ts
+++ b/backend/src/controllers/task-pool/task-pool.controller.ts
@@ -681,12 +681,15 @@ export async function blockItem(req: Request, res: Response): Promise<void> {
 
     res.json({ success: true, message: `WorkItem ${workItemId} blocked` });
   } catch (error) {
-    const message = (error as Error).message;
-    if (message.includes('not found')) {
-      res.status(404).json({ success: false, error: message });
-    } else {
-      res.status(500).json({ success: false, error: message });
-    }
+    // Use the shared mapper rather than an inline not-found/500 split.
+    // `updateItemStatus` throws "Invalid status transition ..." when the item
+    // is not `running` (WORK_ITEM_TRANSITIONS allows `blocked` only from
+    // `running`). That is a CLIENT error — the caller asked for something the
+    // state machine forbids — and the inline catch reported it as a 500, so
+    // retry logic treated a permanent failure as transient and hammered it.
+    // handleServiceError maps `Invalid` to 409 Conflict, which is what a
+    // state-machine conflict is.
+    handleServiceError(res, error);
   }
 }
 

--- a/config/skills/_common/task-pool-body-shape.test.sh
+++ b/config/skills/_common/task-pool-body-shape.test.sh
@@ -176,6 +176,20 @@ class Handler(http.server.BaseHTTPRequestHandler):
         self._json(b"{\"success\":true}")
     def do_GET(self):
         self._record(b"")
+        # block-task pre-checks item status before calling /block.
+        # NOTE: this block lives inside a bash single-quoted python3 -c
+        # argument, so it must contain NO apostrophe characters at all —
+        # a stray one silently terminates the bash string and the file
+        # then fails to parse many lines later.
+        # A marker file lets a scenario choose what status is reported; with
+        # no marker the status is absent and the pre-check is skipped, which
+        # keeps every pre-existing scenario behaving as before.
+        marker = LOG + ".status"
+        if self.path.startswith("/api/task-pool/items/") and os.path.exists(marker):
+            with open(marker) as f:
+                st = f.read().strip()
+            self._json(json.dumps({"success": True, "data": {"id": "wi-stub-1", "status": st}}).encode())
+            return
         self._json(b"{\"success\":true,\"data\":[],\"workItems\":[]}")
 
 httpd = http.server.HTTPServer(("127.0.0.1", PORT), Handler)
@@ -360,6 +374,41 @@ else
   assert_block_contract "block-task" "$BODY"
   assert_jq "block-task: urgency folded into reason, not dropped" '.reason | test("urgency")' "$BODY"
   assert_jq "block-task: questions folded into reason, not dropped" '.reason | test("who owns X")' "$BODY"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 11 — block-task pre-checks status instead of letting the state
+# machine answer with a bare conflict.
+#
+# WORK_ITEM_TRANSITIONS allows `blocked` only from `running`. Blocking a queued
+# item previously surfaced as a raw HTTP 500 carrying a state-machine string —
+# a CLIENT error dressed as a server fault, which makes retry logic treat a
+# PERMANENT failure as transient.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Scenario 11: block-task status pre-check ---"
+: > "$LOG"
+echo "queued" > "${LOG}.status"
+PRECHECK_OUT=$(bash "${REPO_ROOT}/config/skills/agent/core/block-task/execute.sh" \
+  '{"workItemId":"wi-stub-1","sessionName":"quinn-blocker","reason":"missing creds"}' 2>&1 || true)
+rm -f "${LOG}.status"
+
+if printf '%s' "$PRECHECK_OUT" | grep -q "not 'running'"; then
+  PASS=$((PASS + 1)); echo "  ✓ refuses a queued item, naming its actual status"
+else
+  FAIL=$((FAIL + 1)); echo "  ✗ expected a status refusal, got: ${PRECHECK_OUT}"
+fi
+
+if printf '%s' "$PRECHECK_OUT" | grep -q "accept-task"; then
+  PASS=$((PASS + 1)); echo "  ✓ names the remedy skill rather than the state machine"
+else
+  FAIL=$((FAIL + 1)); echo "  ✗ refusal does not tell the caller how to proceed"
+fi
+
+if grep -qF '"path": "/api/task-pool/block/' "$LOG"; then
+  FAIL=$((FAIL + 1)); echo "  ✗ called /block anyway — the pre-check must short-circuit"
+else
+  PASS=$((PASS + 1)); echo "  ✓ no /block POST emitted"
 fi
 
 echo ""

--- a/config/skills/agent/core/block-task/execute.sh
+++ b/config/skills/agent/core/block-task/execute.sh
@@ -63,6 +63,34 @@ if [ -n "$QUESTIONS" ]; then
 Open questions: ${QUESTIONS}"
 fi
 
+# Pre-check the status and explain, rather than letting the state machine
+# answer with a bare conflict.
+#
+# WORK_ITEM_TRANSITIONS (backend/src/types/v2/work-item.types.ts) allows
+# `blocked` ONLY from `running` — you can block work you have claimed, not work
+# you have merely been dispatched. That rule is deliberate and stays: `blocked`
+# has a single outbound edge (-> queued), so every consumer treats it as a
+# near-terminal parking state while the state machine does not. Widening the
+# ways IN would widen the surface for stranding.
+#
+# So the fix is the message, not the rule: name the current status and the
+# remedy skill, the same disposition as the skipGates rejection.
+CURRENT_STATUS=$(api_call GET "/task-pool/items/${WORK_ITEM_ID}" 2>/dev/null \
+  | jq -r '(.data // .) | .status // empty' 2>/dev/null || true)
+
+if [ -n "$CURRENT_STATUS" ] && [ "$CURRENT_STATUS" != "running" ]; then
+  case "$CURRENT_STATUS" in
+    queued|scheduled)
+      error_exit "WorkItem ${WORK_ITEM_ID} is '${CURRENT_STATUS}', not 'running' — only a claimed WorkItem can be blocked. Claim it first with the accept-task skill, then block it. If you cannot start it at all, cancel it instead (POST /task-pool/items/${WORK_ITEM_ID}/cancel)." ;;
+    blocked)
+      error_exit "WorkItem ${WORK_ITEM_ID} is already blocked. To add detail, append a note with the report-progress skill rather than blocking again." ;;
+    done|done_by_worker|verified|cancelled|failed|rejected)
+      error_exit "WorkItem ${WORK_ITEM_ID} is '${CURRENT_STATUS}' and cannot be blocked — it has already left the running state. If this is wrong, raise it with your team lead rather than forcing a transition." ;;
+    *)
+      error_exit "WorkItem ${WORK_ITEM_ID} is '${CURRENT_STATUS}', not 'running' — only a claimed (running) WorkItem can be blocked." ;;
+  esac
+fi
+
 BODY=$(jq -n \
   --arg agentId "$SESSION_NAME" \
   --arg reason "$REASON" \


### PR DESCRIPTION
Closes WI `ccb8706e`. Base `aa146a40`.

Two defects behind one symptom: blocking an unclaimed WorkItem returned a raw **HTTP 500** carrying a state-machine string.

## 1. A client error dressed as a server error

`WORK_ITEM_TRANSITIONS` allows `blocked` only from `running`, so blocking a queued item throws. `blockItem` caught that with its **own inline handler**, mapping only `'not found'` → 404 and everything else → 500. A caller can't distinguish *"I asked for something illegal"* from *"the server broke"* — so retry logic treats a **permanent** failure as transient and hammers the endpoint.

The fix turned out not to be new mapping logic. The shared `handleServiceError` **in the same file already maps `Invalid` → 409**; `blockItem` simply bypassed it.

> Audited the rest while there: **14 of 19 handlers bypass the shared mapper**, but only `blockItem` calls a state-changing service method that can throw a transition error. So only `blockItem` changes here — converting the other 13 is a separate refactor with no defect behind it.

## 2. The skill gave the agent nothing to act on

`block-task` neither documented nor checked the `running` precondition. It now reads the status first and fails with the actual status **and the remedy**:

```
WorkItem 6102c10b… is 'queued', not 'running' — only a claimed WorkItem can be
blocked. Claim it first with the accept-task skill, then block it. If you cannot
start it at all, cancel it instead (POST /task-pool/items/6102c10b…/cancel).
```

**The state machine is not widened** — `queued → blocked` stays illegal. `blocked` has a single outbound edge (`→ queued`), so every consumer treats it as a near-terminal parking state while the state machine does not; widening the ways *in* would widen the surface for stranding. Same disposition as the `skipGates` rejection in #742: reject loudly, name the remedy.

## Tests

**4 controller cases** — and three of them guard the fix rather than demonstrate it:

| Case | Expect |
|---|---|
| Invalid transition | **409**, and explicitly *not* 500 |
| Not found | still 404 |
| Genuine fault (`ENOSPC`) | still **500** — the 409 mapping must not swallow real failures |
| Missing `agentId` | still 400, before any service call |

**3 contract-suite cases** — the pre-check refuses a queued item naming its status, names the remedy skill, and emits **no `/block` POST at all**. Suite: 50 passed.

Verified live against the running backend — the raw 500 is replaced by the message above.

## A note for future editors of the contract stub

The Python block lives inside a bash single-quoted `python3 -c` argument, so it must contain **no apostrophes** — a stray one terminates the bash string and the file then fails to parse many lines later. It cost me two debugging rounds, including one where the comment I wrote *warning about apostrophes* contained apostrophes. There's now a comment saying so.

That's the third bash-quoting-inside-generated-strings bug today after `${INPUT:-{}}` (#742) and the backticks (#746) — all three invisible to review, all three caught by executing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)