### PR TITLE
fix(skills): create the delegate-task WorkItem before delivery, not after

### DIFF
--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -166,6 +166,63 @@ fi
 TASK_MESSAGE="New task from Team Leader (priority: ${PRIORITY}):\n\n**[REQUIRED] When done, you MUST:** (1) Output a text summary of your work, findings, and any issues. (2) Call report-status, passing the workItemId from your [CREWLY-DISPATCH] notice (or from get-my-tasks) so the right WorkItem is closed:\nbash ${CREWLY_ROOT}/config/skills/agent/core/report-status/execute.sh '{\"sessionName\":\"${TO}\",\"workItemId\":\"<your WorkItem id>\",\"status\":\"done\",\"summary\":\"<brief summary>\",\"projectPath\":\"${PROJECT_PATH}\"}'\n\n---\n\n${TASK}"
 [ -n "$CONTEXT" ] && TASK_MESSAGE="${TASK_MESSAGE}\n\nContext: ${CONTEXT}"
 
+# V3-only producer (spec 2026-05-06-task-management-v1-deprecation.md):
+# We no longer write a `.crewly/tasks/delegated/*.md` file via the legacy
+# `/task-management/create` endpoint. Instead the long-form brief travels
+# on the WorkItem itself (`briefMarkdown` field) and the WI is the sole
+# durable record of this delegation.
+#
+# ORDERING (WI 65578471): the WorkItem is created BEFORE delivery is
+# attempted, and that order is load-bearing. Previously the pool-add ran
+# only after delivery succeeded, so a delivery failure exited the script
+# with NO RECORD ANYWHERE — not in the pool, not targeted, nothing for a
+# reconciler or a human to find. Every other orphan class in this system
+# at least left a WorkItem behind; this one left the intent with no system
+# of record at all.
+#
+# On a delivery failure the WI is deliberately left `queued` with its
+# `target` set, plus an explicit `[UNDELIVERED]` note (see below). That
+# state is chosen, not incidental:
+#   - `queued` + `target` is recoverable — the wake gate admits a worker
+#     for a queued WI targeting them, so the task can still be delivered.
+#   - `queued` is NOT `running`, so it never masquerades as in-flight work.
+#   - the note makes an undelivered item distinguishable from a normally
+#     queued one, so a silent nothing is not traded for a silent something.
+TASK_ID=""
+
+case "$PRIORITY" in
+  critical|urgent) WI_PRIORITY="critical" ;;
+  high)            WI_PRIORITY="high" ;;
+  low)             WI_PRIORITY="low" ;;
+  *)               WI_PRIORITY="medium" ;;
+esac
+
+WI_TITLE="$(echo "$TASK" | head -c 200)"
+
+POOL_BODY=$(jq -n \
+  --arg type "delegate" \
+  --arg owner "team_lead" \
+  --arg target "$TO" \
+  --arg title "$WI_TITLE" \
+  --arg description "$TASK_MESSAGE" \
+  --arg briefMarkdown "$TASK" \
+  --arg priority "$WI_PRIORITY" \
+  --arg projectPath "${PROJECT_PATH:-}" \
+  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, metadata: ({priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end))}')
+
+POOL_RESULT=$(api_call POST "/task-pool/add" "$POOL_BODY" 2>/dev/null || echo '{"success":false}')
+POOL_OK=$(echo "$POOL_RESULT" | jq -r '.success // "false"' 2>/dev/null)
+TASK_ID=$(echo "$POOL_RESULT" | jq -r '.data.id // .workItemId // empty' 2>/dev/null || true)
+
+if [ "$POOL_OK" != "true" ]; then
+  # Unchanged from before the reorder: warn and still attempt delivery.
+  # Aborting here instead would be a behavioural change beyond this WI's
+  # scope, so it is deliberately NOT made. The residual gap (record
+  # creation fails, task delivered anyway) is reported, not silently
+  # fixed — it is the mirror of the bug fixed here and wants its own call.
+  echo "{\"warning\":\"Failed to create WorkItem in TaskPool — delivering anyway, so this task will have no durable record\",\"details\":$(echo "$POOL_RESULT" | jq -c . 2>/dev/null || echo '{}')}" >&2
+fi
+
 # Deliver the task message with fallback strategy:
 # 1. Try normal delivery (waitForReady)
 # 2. If fails, try force delivery
@@ -212,46 +269,27 @@ if [ "$DELIVER_OK" = "false" ]; then
     fi
 
     if [ "$STARTED" = "false" ]; then
-      echo '{"error":"Failed to deliver task to '"$TO"'. Worker is offline and could not be auto-started. Ensure the worker is a team member with a valid session.","to":"'"$TO"'","teamId":"'"$TEAM_ID"'"}'
+      # WI 65578471 — delivery failed, but the WorkItem already exists
+      # (created above, deliberately, before delivery was attempted). Mark
+      # it explicitly so an undelivered item is never mistaken for a
+      # normally queued one, then fail loudly. The WI stays `queued` with
+      # its `target`, which is the recoverable state: the worker can still
+      # be woken for it and re-delivery can be retried.
+      #
+      # Best-effort: a failure to annotate must not swallow the delivery
+      # error, which is the more important signal.
+      if [ -n "$TASK_ID" ]; then
+        NOTE_AUTHOR="${CREWLY_SESSION_NAME:-${FROM_SESSION:-team-leader}}"
+        NOTE_BODY=$(jq -n --arg author "$NOTE_AUTHOR" --arg note "[UNDELIVERED] Delivery to ${TO} failed — worker offline and could not be auto-started. WorkItem left queued and targeted for re-delivery." \
+          '{author: $author, note: $note}')
+        api_call POST "/task-pool/items/${TASK_ID}/notes" "$NOTE_BODY" >/dev/null 2>&1 || true
+      fi
+      echo '{"error":"Failed to deliver task to '"$TO"'. Worker is offline and could not be auto-started. Ensure the worker is a team member with a valid session.","to":"'"$TO"'","teamId":"'"$TEAM_ID"'","workItemId":"'"$TASK_ID"'","workItemState":"queued+targeted, marked [UNDELIVERED] — re-delivery can be retried"}'
       exit 1
     fi
   }
 fi
 
-# V3-only producer (spec 2026-05-06-task-management-v1-deprecation.md):
-# We no longer write a `.crewly/tasks/delegated/*.md` file via the legacy
-# `/task-management/create` endpoint. Instead the long-form brief travels
-# on the WorkItem itself (`briefMarkdown` field) and the WI is the sole
-# durable record of this delegation.
-TASK_ID=""
-
-case "$PRIORITY" in
-  critical|urgent) WI_PRIORITY="critical" ;;
-  high)            WI_PRIORITY="high" ;;
-  low)             WI_PRIORITY="low" ;;
-  *)               WI_PRIORITY="medium" ;;
-esac
-
-WI_TITLE="$(echo "$TASK" | head -c 200)"
-
-POOL_BODY=$(jq -n \
-  --arg type "delegate" \
-  --arg owner "team_lead" \
-  --arg target "$TO" \
-  --arg title "$WI_TITLE" \
-  --arg description "$TASK_MESSAGE" \
-  --arg briefMarkdown "$TASK" \
-  --arg priority "$WI_PRIORITY" \
-  --arg projectPath "${PROJECT_PATH:-}" \
-  '{type: $type, owner: $owner, target: $target, title: $title, description: $description, briefMarkdown: $briefMarkdown, metadata: ({priority: $priority} + (if $projectPath != "" then {projectPath: $projectPath} else {} end))}')
-
-POOL_RESULT=$(api_call POST "/task-pool/add" "$POOL_BODY" 2>/dev/null || echo '{"success":false}')
-POOL_OK=$(echo "$POOL_RESULT" | jq -r '.success // "false"' 2>/dev/null)
-TASK_ID=$(echo "$POOL_RESULT" | jq -r '.data.id // .workItemId // empty' 2>/dev/null || true)
-
-if [ "$POOL_OK" != "true" ]; then
-  echo "{\"warning\":\"Failed to create WorkItem in TaskPool — task delivered to terminal but no durable record\",\"details\":$(echo "$POOL_RESULT" | jq -c . 2>/dev/null || echo '{}')}" >&2
-fi
 
 # Set up idle event subscription for TL monitoring
 MONITOR_IDLE=$(printf '%s' "$INPUT" | jq -r 'if .monitor.idleEvent == null then true else .monitor.idleEvent end')

--- a/config/skills/team-leader/delegate-task/tests/delegate-task.test.ts
+++ b/config/skills/team-leader/delegate-task/tests/delegate-task.test.ts
@@ -1,0 +1,152 @@
+import { execFile } from 'child_process';
+import { createServer, Server, IncomingMessage, ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+import { join } from 'path';
+
+/**
+ * Behavioural tests for the team-leader `delegate-task` skill's
+ * record-before-delivery ordering (WI 65578471).
+ *
+ * The skill previously created its WorkItem only AFTER delivery succeeded,
+ * so a delivery failure exited with no record anywhere — not in the pool,
+ * not targeted, nothing for a reconciler or a human to find. Every other
+ * orphan class in this system left a WorkItem behind; this one left the
+ * intent with no system of record at all.
+ *
+ * These run the real `execute.sh` against a stub API captured on a random
+ * port (the skill honours `CREWLY_API_URL`), so they assert observable call
+ * ordering rather than mirroring the implementation.
+ */
+
+const SKILL = join(__dirname, '..', 'execute.sh');
+
+interface Captured {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+let server: Server;
+let baseUrl: string;
+let captured: Captured[];
+/** When true the stub fails every delivery attempt. */
+let failDelivery = false;
+
+/**
+ * Runs the skill with the stub API wired in.
+ *
+ * @param args - CLI arguments for execute.sh
+ * @returns exit code and stdout/stderr
+ */
+function runSkill(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      'bash',
+      [SKILL, ...args],
+      { env: { ...process.env, CREWLY_API_URL: baseUrl }, timeout: 60_000 },
+      (err, stdout, stderr) => {
+        const code = err && typeof (err as { code?: number }).code === 'number' ? (err as { code: number }).code : 0;
+        resolve({ code, stdout, stderr });
+      },
+    );
+  });
+}
+
+beforeAll((done) => {
+  server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(c as Buffer));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      let body: unknown = raw;
+      try { body = raw ? JSON.parse(raw) : {}; } catch { /* keep raw */ }
+      const path = req.url ?? '';
+      captured.push({ method: req.method ?? '', path, body });
+
+      if (path.includes('/terminal/') && path.includes('/deliver')) {
+        if (failDelivery) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, error: 'worker offline' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+        return;
+      }
+      if (path.includes('/task-pool/add')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true, data: { id: 'wi-created-1' } }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, data: {} }));
+    });
+  });
+  server.listen(0, '127.0.0.1', () => {
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}/api`;
+    done();
+  });
+});
+
+afterAll((done) => { server.close(() => done()); });
+
+beforeEach(() => { captured = []; failDelivery = false; });
+
+/** Index of the first captured call whose path matches, or -1. */
+const indexOf = (needle: string): number =>
+  captured.findIndex((c) => c.path.includes(needle));
+
+describe('delegate-task record-before-delivery (WI 65578471)', () => {
+  const args = ['--to', 'worker-1', '--task', 'do the thing', '--project', '/tmp/proj'];
+
+  it('creates the WorkItem BEFORE attempting delivery', async () => {
+    await runSkill(args);
+
+    const add = indexOf('/task-pool/add');
+    const deliver = indexOf('/deliver');
+    expect(add).toBeGreaterThanOrEqual(0);
+    expect(deliver).toBeGreaterThanOrEqual(0);
+    expect(add).toBeLessThan(deliver);
+  });
+
+  it('still creates the WorkItem when delivery fails', async () => {
+    failDelivery = true;
+    await runSkill(args);
+
+    // The regression: previously the pool-add never ran on this path, so
+    // the intended work had no record anywhere.
+    expect(indexOf('/task-pool/add')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('marks the undelivered WorkItem explicitly rather than leaving it to look normal', async () => {
+    failDelivery = true;
+    await runSkill(args);
+
+    const note = captured.find((c) => c.path.includes('/notes'));
+    expect(note).toBeDefined();
+    expect(JSON.stringify(note?.body)).toContain('[UNDELIVERED]');
+  });
+
+  it('still fails loudly on a delivery failure, and names the WorkItem it left behind', async () => {
+    failDelivery = true;
+    const { code, stdout } = await runSkill(args);
+
+    // Creating the record must not soften the failure into a success.
+    expect(code).not.toBe(0);
+    expect(stdout).toContain('Failed to deliver');
+    expect(stdout).toContain('wi-created-1');
+  });
+
+  it('targets the WorkItem at the intended worker so it stays recoverable', async () => {
+    failDelivery = true;
+    await runSkill(args);
+
+    const add = captured.find((c) => c.path.includes('/task-pool/add'));
+    expect((add?.body as { target?: string })?.target).toBe('worker-1');
+  });
+
+  it('does not annotate anything on the happy path', async () => {
+    await runSkill(args);
+    expect(captured.find((c) => c.path.includes('/notes'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
WI 65578471. **Base SHA: `aa146a40`.**

**Deployment class: BASH SKILL — live on merge, no build or restart required.** (Flagging explicitly because the day's other fixes are backend TypeScript sitting behind a stale `dist`; this one is not. See the note at the bottom.)

## The defect

`delegate-task` created its WorkItem *after* delivery succeeded, and the delivery-failure branch `exit 1`s above that point:

```
line 226  deliver → force-deliver → auto-start → retry
line 273  exit 1        ← failure leaves here
line 213  pool-add      ← (was at 248, after delivery)
```

So a failed delivery left **no record anywhere**: nothing in the pool, no target, nothing for a reconciler or a human to find. Every other orphan class fixed today left a WorkItem behind — `releaseBack` cleared the target but the item survived, the SLA path leaked a claim but the item survived. Here the intent simply evaporated.

## Criterion 3 — the state I chose, and why

On a delivery failure the WorkItem is now left as:

> **`queued` + `target` + an explicit `[UNDELIVERED]` note**

- **`queued` + `target` is recoverable.** The wake gate admits a worker when a queued WI targets them, so the worker can still be woken and re-delivery retried. This isn't a parking state; it's the state the task would have been in anyway.
- **`queued` is not `running`.** It can never masquerade as in-flight work — which was the failure mode you named.
- **The note makes it distinguishable.** Without it, an undelivered item is byte-identical to a normally queued one, and I'd have traded a silent nothing for a silent something. The marker uses the existing `POST /items/:id/notes` audit endpoint rather than inventing a metadata field.

The script still exits non-zero and still prints the delivery error — creating the record must not soften a real failure into a success — and the error payload now names the `workItemId` it left behind, so an operator can find it without grepping the pool.

## The behavioural change I did NOT make, per your instruction

Reordering forces a decision about the *other* failure: what if the pool-add itself fails?

I left it **exactly as before** — warn, and deliver anyway. Aborting instead would be a behavioural change beyond criterion 3, and you asked me to stop rather than smuggle one in. The residual gap (record creation fails, task delivered anyway) is the mirror image of the bug fixed here, and it's reported rather than silently closed. It wants its own call, because "refuse to delegate when the pool is unavailable" is a policy question, not a bug fix.

## Tests

6 behavioural tests running the **real** `execute.sh` against a stub API on a random port (the skill honours `CREWLY_API_URL`), asserting observed call ordering rather than mirroring the implementation:

- pool-add happens **before** delivery
- the WorkItem is still created **when delivery fails** ← the regression
- the undelivered item is **explicitly marked**
- delivery failure still **exits non-zero** and names the WorkItem
- the WorkItem is **targeted** at the intended worker, so it stays recoverable
- the happy path annotates **nothing**

`config/` jest root: 8 suites pass including the new one; the only failure is the known pre-existing `computer-use` 35. Typecheck 25 errors, identical to baseline, none in the added file. Lint clean.

## Two scope findings

1. **`config/skills/agent/core/delegate-task/execute.sh` is a symlink to this file**, so both call paths are fixed by the one change. Worth knowing before anyone "fixes the other one".
2. **The orchestrator's `delegate-task` is a separate implementation and does not have this defect** — it performs no direct PTY delivery (auto-claim delivers) and its pool-add is unconditional. Checked rather than assumed.

**Not addressed, deliberately:** the `<your WorkItem id>` placeholder in the task message. You ruled it cosmetic, and the reorder now makes the real id available before the message is built — so the improvement is free if wanted, but it changes delivered message content and belongs to a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)