### PR TITLE
feat(build): stamp the commit into the build and refuse to serve a stale one

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -106,6 +106,7 @@ import { RuntimeExitMonitorService } from './services/agent/runtime-exit-monitor
 import { ContextWindowMonitorService } from './services/agent/context-window-monitor.service.js';
 import { OAuthReloginMonitorService } from './services/agent/oauth-relogin-monitor.service.js';
 import { findPackageRoot } from './utils/package-root.js';
+import { assertBuildProvenance } from './utils/build-provenance.js';
 import { isNativeBindingFatalError } from './utils/native-binding.utils.js';
 import { VersionCheckService } from './services/system/version-check.service.js';
 import { LogRotationService } from './services/session/log-rotation.service.js';
@@ -3673,6 +3674,26 @@ const isMainModule = process.argv[1] && (
 if (isMainModule) {
 	const server = new CrewlyServer();
 	const logger = LoggerService.getInstance().createComponentLogger('CrewlyServer');
+
+	// Build provenance (WI 763c8e30). On 2026-08-21 this process was found
+	// serving a `dist/` built months earlier: five merged fixes were not
+	// executing and nothing said so, so every conclusion drawn from live
+	// behaviour that day was produced by stale code. Verify BEFORE any
+	// service starts, so a stale build is refused rather than half-run.
+	//
+	// A stale build throws here and stops startup — that is the point. Every
+	// other outcome (unstamped build, no repository, skip flag set) only
+	// warns, so this can never block a legitimate container deploy.
+	try {
+		assertBuildProvenance({
+			log: (message) => logger.info(message),
+			warn: (message) => logger.warn(message),
+		});
+	} catch (error) {
+		logger.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+
 	server.start().catch((error) => {
 		logger.error('Failed to start Crewly server', { error: error instanceof Error ? error.message : String(error) });
 		process.exit(1);

--- a/backend/src/scripts/stamp-build.test.ts
+++ b/backend/src/scripts/stamp-build.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { readBuildInfo, BUILD_INFO_FILENAME } from '../utils/build-provenance.js';
+import { stampBuild } from './stamp-build.js';
+
+/**
+ * Tests for the build-time stamper.
+ *
+ * The stamper must never break a build: an unstamped build degrades to a
+ * startup warning, whereas a stamper that throws would stop people building
+ * at all.
+ */
+
+let dir: string;
+const logs: string[] = [];
+const warns: string[] = [];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'crewly-stamp-'));
+  logs.length = 0;
+  warns.length = 0;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('stampBuild', () => {
+  it('skips without throwing when HEAD cannot be resolved', () => {
+    // A temp dir is not a repository. A build outside git must still succeed.
+    const out = join(dir, 'out');
+    let result!: boolean;
+    expect(() => {
+      result = stampBuild(out, dir, (m) => logs.push(m), (m) => warns.push(m));
+    }).not.toThrow();
+    expect(result).toBe(false);
+    expect(existsSync(join(out, BUILD_INFO_FILENAME))).toBe(false);
+    expect(warns.join()).toContain('unstamped');
+  });
+
+  it('writes a readable stamp when HEAD resolves, creating the output dir', () => {
+    // Stamp against this repository, whose HEAD is resolvable.
+    const out = join(dir, 'nested', 'out');
+    const ok = stampBuild(out, process.cwd(), (m) => logs.push(m), (m) => warns.push(m));
+
+    expect(ok).toBe(true);
+    const info = readBuildInfo(out);
+    expect(info?.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(() => new Date(info!.builtAt).toISOString()).not.toThrow();
+    expect(logs.join()).toContain('stamp-build:');
+  });
+});

--- a/backend/src/scripts/stamp-build.ts
+++ b/backend/src/scripts/stamp-build.ts
@@ -1,0 +1,58 @@
+/**
+ * Build-time stamper: records which commit produced the compiled output.
+ *
+ * Run as the last step of `npm run build:backend`. Writes
+ * `build-info.json` into the backend build directory, which
+ * {@link assertBuildProvenance} reads at startup to detect a `dist/` that no
+ * longer matches the checked-out source.
+ *
+ * Failure here is non-fatal by design: a build must not break because the
+ * stamp could not be written. An unstamped build degrades to a startup
+ * warning, never a startup failure.
+ *
+ * @module backend/scripts/stamp-build
+ */
+
+import { existsSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
+
+import { readGitHead, writeBuildInfo } from '../utils/build-provenance.js';
+
+/**
+ * Stamps the build output with the current HEAD commit.
+ *
+ * @param outDir - Build output directory to stamp
+ * @param repoRoot - Repository root used to resolve HEAD
+ * @param log - Sink for the confirmation line
+ * @param warn - Sink for non-fatal problems
+ * @returns true when a stamp was written, false when skipped
+ */
+export function stampBuild(
+  outDir: string,
+  repoRoot: string,
+  log: (message: string) => void = (m) => console.log(m),
+  warn: (message: string) => void = (m) => console.warn(m),
+): boolean {
+  const head = readGitHead(repoRoot);
+  if (!head) {
+    warn('stamp-build: HEAD unavailable (no .git or no git binary) — build left unstamped.');
+    return false;
+  }
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true });
+  }
+  const builtAt = new Date().toISOString();
+  const written = writeBuildInfo(outDir, head, builtAt);
+  log(`stamp-build: ${written} → commit ${head.slice(0, 8)} (built ${builtAt})`);
+  return true;
+}
+
+/* c8 ignore start — CLI entry, exercised by the build not by unit tests */
+const invokedDirectly =
+  process.argv[1] !== undefined && process.argv[1].endsWith('stamp-build.js');
+
+if (invokedDirectly) {
+  const repoRoot = process.cwd();
+  stampBuild(resolve(repoRoot, 'dist', 'backend'), repoRoot);
+}
+/* c8 ignore stop */

--- a/backend/src/utils/build-provenance.test.ts
+++ b/backend/src/utils/build-provenance.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  BUILD_INFO_FILENAME,
+  SKIP_BUILD_CHECK_ENV,
+  assertBuildProvenance,
+  evaluateBuildProvenance,
+  formatVerdict,
+  readBuildInfo,
+  readGitHead,
+  writeBuildInfo,
+} from './build-provenance.js';
+
+/**
+ * Tests for the stale-build guard.
+ *
+ * The guard exists because five merged fixes were found not to be executing
+ * on 2026-08-21 — the backend served a `dist/` built months earlier and
+ * nothing said so. Its two obligations are: fail loudly when the compiled
+ * output is from a different commit than HEAD, and never fire spuriously in
+ * a deploy that legitimately has no repository.
+ */
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'crewly-provenance-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('evaluateBuildProvenance', () => {
+  const builtAt = '2026-08-21T00:00:00.000Z';
+
+  it('reports ok when the build commit matches HEAD', () => {
+    const v = evaluateBuildProvenance({ commit: 'a'.repeat(40), builtAt }, 'a'.repeat(40));
+    expect(v.state).toBe('ok');
+  });
+
+  it('reports stale when the build is from a different commit', () => {
+    const v = evaluateBuildProvenance({ commit: 'a'.repeat(40), builtAt }, 'b'.repeat(40));
+    expect(v.state).toBe('stale');
+    expect(v).toMatchObject({ builtCommit: 'a'.repeat(40), headCommit: 'b'.repeat(40) });
+  });
+
+  it('reports unstamped when there is no build info', () => {
+    expect(evaluateBuildProvenance(null, 'a'.repeat(40)).state).toBe('unstamped');
+  });
+
+  it('reports unknown — never stale — when HEAD cannot be read', () => {
+    // A container or tarball deploy has no .git. The guard must not fire
+    // there: a false alarm gets the check disabled, which would leave us
+    // with neither the check nor the attention.
+    expect(evaluateBuildProvenance({ commit: 'a'.repeat(40), builtAt }, null).state).toBe('unknown');
+  });
+
+  it('prefers unstamped over unknown when both are missing', () => {
+    expect(evaluateBuildProvenance(null, null).state).toBe('unstamped');
+  });
+
+  it('does not depend on timestamps at all', () => {
+    // Commit identity, not mtimes: `git checkout` does not preserve mtimes,
+    // so a time-based check would cry wolf after a branch switch.
+    const older = { commit: 'a'.repeat(40), builtAt: '2020-01-01T00:00:00.000Z' };
+    expect(evaluateBuildProvenance(older, 'a'.repeat(40)).state).toBe('ok');
+  });
+});
+
+describe('formatVerdict', () => {
+  it('names the running commit on the happy path', () => {
+    const msg = formatVerdict({ state: 'ok', commit: 'abcdef1234', builtAt: 'T' });
+    expect(msg).toContain('abcdef12');
+  });
+
+  it('names both commits and the remedy when stale', () => {
+    const msg = formatVerdict({
+      state: 'stale',
+      builtCommit: 'a'.repeat(40),
+      headCommit: 'b'.repeat(40),
+      builtAt: 'T',
+    });
+    expect(msg).toContain('STALE BUILD');
+    expect(msg).toContain('aaaaaaaa');
+    expect(msg).toContain('bbbbbbbb');
+    expect(msg).toContain('npm run build');
+    expect(msg).toContain(SKIP_BUILD_CHECK_ENV);
+  });
+});
+
+describe('readBuildInfo / writeBuildInfo', () => {
+  it('round-trips a stamp', () => {
+    writeBuildInfo(dir, 'c'.repeat(40), '2026-08-21T00:00:00.000Z');
+    expect(readBuildInfo(dir)).toEqual({
+      commit: 'c'.repeat(40),
+      builtAt: '2026-08-21T00:00:00.000Z',
+    });
+  });
+
+  it('finds a stamp in an ancestor directory', () => {
+    // The compiled module sits several levels below the build root, so the
+    // lookup walks up rather than hardcoding a fragile relative path.
+    writeBuildInfo(dir, 'd'.repeat(40), 'T');
+    const nested = join(dir, 'backend', 'src', 'utils');
+    mkdirSync(nested, { recursive: true });
+    expect(readBuildInfo(nested)?.commit).toBe('d'.repeat(40));
+  });
+
+  it('returns null rather than throwing on malformed json', () => {
+    writeFileSync(join(dir, BUILD_INFO_FILENAME), '{ not json', 'utf8');
+    expect(readBuildInfo(dir)).toBeNull();
+  });
+
+  it('returns null when the stamp is missing required fields', () => {
+    writeFileSync(join(dir, BUILD_INFO_FILENAME), JSON.stringify({ commit: 'x' }), 'utf8');
+    expect(readBuildInfo(dir)).toBeNull();
+  });
+
+  it('returns null when no stamp exists anywhere above', () => {
+    expect(readBuildInfo(dir)).toBeNull();
+  });
+});
+
+describe('readGitHead', () => {
+  it('returns null outside a repository instead of throwing', () => {
+    expect(readGitHead(dir)).toBeNull();
+  });
+});
+
+describe('assertBuildProvenance', () => {
+  const logs: string[] = [];
+  const warns: string[] = [];
+  const sinks = {
+    log: (m: string) => logs.push(m),
+    warn: (m: string) => warns.push(m),
+  };
+
+  beforeEach(() => {
+    logs.length = 0;
+    warns.length = 0;
+  });
+
+  it('THROWS on a stale build — the failure mode this guard exists for', () => {
+    writeBuildInfo(dir, 'a'.repeat(40), 'T');
+    expect(() =>
+      assertBuildProvenance({
+        moduleDir: dir,
+        repoRoot: dir,
+        headCommit: 'b'.repeat(40),
+        env: {},
+        ...sinks,
+      }),
+    ).toThrow(/STALE BUILD/);
+  });
+
+  it('downgrades a stale build to a warning when the skip flag is set', () => {
+    writeBuildInfo(dir, 'a'.repeat(40), 'T');
+    const v = assertBuildProvenance({
+      moduleDir: dir,
+      repoRoot: dir,
+      headCommit: 'b'.repeat(40),
+      env: { [SKIP_BUILD_CHECK_ENV]: '1' },
+      ...sinks,
+    });
+    expect(v.state).toBe('stale');
+    expect(warns.join()).toContain('STALE BUILD');
+  });
+
+  it('warns without throwing when the build is unstamped', () => {
+    const v = assertBuildProvenance({ moduleDir: dir, repoRoot: dir, env: {}, ...sinks });
+    expect(v.state).toBe('unstamped');
+    expect(warns).toHaveLength(1);
+  });
+
+  it('never throws when there is no repository to compare against', () => {
+    // The container / tarball case: a stamped build with no .git must report
+    // `unknown` and carry on. If this ever throws, the guard would break
+    // every deploy that does not ship a repository.
+    writeBuildInfo(dir, 'a'.repeat(40), 'T');
+    let v!: ReturnType<typeof assertBuildProvenance>;
+    expect(() => {
+      v = assertBuildProvenance({
+        moduleDir: dir,
+        repoRoot: dir,
+        headCommit: null,
+        env: {},
+        ...sinks,
+      });
+    }).not.toThrow();
+    expect(v.state).toBe('unknown');
+    expect(warns).toHaveLength(1);
+  });
+
+  it('reports the running commit on the happy path', () => {
+    writeBuildInfo(dir, 'e'.repeat(40), 'T');
+    const v = assertBuildProvenance({
+      moduleDir: dir,
+      repoRoot: dir,
+      headCommit: 'e'.repeat(40),
+      env: {},
+      ...sinks,
+    });
+    expect(v.state).toBe('ok');
+    expect(logs.join()).toContain('eeeeeeee');
+    expect(warns).toHaveLength(0);
+  });
+});

--- a/backend/src/utils/build-provenance.ts
+++ b/backend/src/utils/build-provenance.ts
@@ -1,0 +1,258 @@
+/**
+ * Build provenance: answer "which commit is this process actually running?"
+ * and fail loudly when the compiled output is older than the checked-out
+ * source it claims to serve.
+ *
+ * WHY THIS EXISTS (2026-08-21): five merged fixes were found not to be
+ * executing. The backend was serving `dist/` built on May 5 from a process
+ * started two weeks earlier, so every conclusion drawn from live behaviour
+ * that day was produced by stale code. Nothing in the system said so. The
+ * discipline of "always rebuild" had already been written down and it still
+ * did not hold, which is the argument for a mechanical check rather than
+ * another reminder.
+ *
+ * WHY COMMIT IDENTITY AND NOT MTIMES: `git checkout` does not preserve
+ * modification times, so a fresh clone or a branch switch can make source
+ * look newer than a perfectly current build. An mtime check would cry wolf,
+ * get switched off, and leave us with neither the check nor the attention.
+ * Comparing the stamped HEAD SHA to the current HEAD is exact, has no clock
+ * or filesystem dependence, and answers the question a debugger actually
+ * has.
+ *
+ * KNOWN LIMIT, deliberately accepted: this compares COMMITS, so uncommitted
+ * edits to tracked files are invisible to it. That is the right trade —
+ * flagging every dirty working tree would reintroduce exactly the false-alarm
+ * problem this design avoids. It catches the case that actually bit us: HEAD
+ * moved and nobody rebuilt.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+/** Filename written into the build output directory at build time. */
+export const BUILD_INFO_FILENAME = 'build-info.json';
+
+/** Env var that downgrades a stale-build failure to a warning. */
+export const SKIP_BUILD_CHECK_ENV = 'CREWLY_SKIP_BUILD_CHECK';
+
+/** How many directories to walk up when locating the build stamp. */
+const MAX_UPWARD_LOOKUP = 6;
+
+/**
+ * Provenance stamp written beside the compiled output.
+ */
+export interface BuildInfo {
+  /** Full 40-char SHA of HEAD at build time. */
+  commit: string;
+  /** ISO8601 timestamp of the build, for humans reading the log line. */
+  builtAt: string;
+}
+
+/**
+ * Result of comparing the build stamp against the current checkout.
+ *
+ * - `ok` — the build matches HEAD.
+ * - `stale` — the build is from a different commit than HEAD. This is the
+ *   condition worth failing on.
+ * - `unstamped` — no build stamp found (a build predating this guard).
+ * - `unknown` — HEAD could not be determined (no `.git`, no `git` binary —
+ *   i.e. a container or a tarball deploy). Never an error.
+ */
+export type ProvenanceVerdict =
+  | { state: 'ok'; commit: string; builtAt: string }
+  | { state: 'stale'; builtCommit: string; headCommit: string; builtAt: string }
+  | { state: 'unstamped'; reason: string }
+  | { state: 'unknown'; reason: string };
+
+/**
+ * Compares a build stamp against the current HEAD.
+ *
+ * Pure: all filesystem and git access happens in the callers, so the
+ * decision logic is testable without a repository.
+ *
+ * @param build - Stamp read from the build output, or null if absent
+ * @param headCommit - Current HEAD SHA, or null if it could not be read
+ * @returns The verdict describing how build and checkout relate
+ *
+ * @example
+ * ```typescript
+ * evaluateBuildProvenance({ commit: 'abc', builtAt: t }, 'def');
+ * // → { state: 'stale', builtCommit: 'abc', headCommit: 'def', builtAt: t }
+ * ```
+ */
+export function evaluateBuildProvenance(
+  build: BuildInfo | null,
+  headCommit: string | null,
+): ProvenanceVerdict {
+  if (!build || !build.commit) {
+    return {
+      state: 'unstamped',
+      reason: `no ${BUILD_INFO_FILENAME} beside the compiled output — rebuild to stamp it`,
+    };
+  }
+  if (!headCommit) {
+    return {
+      state: 'unknown',
+      reason: 'current HEAD could not be determined (no .git or no git binary)',
+    };
+  }
+  if (build.commit === headCommit) {
+    return { state: 'ok', commit: build.commit, builtAt: build.builtAt };
+  }
+  return {
+    state: 'stale',
+    builtCommit: build.commit,
+    headCommit,
+    builtAt: build.builtAt,
+  };
+}
+
+/**
+ * Renders a verdict as a single operator-readable line.
+ *
+ * @param verdict - Verdict from {@link evaluateBuildProvenance}
+ * @returns A message naming the running commit, or what is wrong
+ */
+export function formatVerdict(verdict: ProvenanceVerdict): string {
+  switch (verdict.state) {
+    case 'ok':
+      return `Running commit ${verdict.commit.slice(0, 8)} (built ${verdict.builtAt}).`;
+    case 'stale':
+      return (
+        `STALE BUILD: serving compiled output from commit ${verdict.builtCommit.slice(0, 8)} ` +
+        `(built ${verdict.builtAt}) while HEAD is ${verdict.headCommit.slice(0, 8)}. ` +
+        `The code running is NOT the code checked out. Run \`npm run build\` and restart. ` +
+        `Set ${SKIP_BUILD_CHECK_ENV}=1 to downgrade this to a warning.`
+      );
+    case 'unstamped':
+      return `Build provenance unknown: ${verdict.reason}.`;
+    case 'unknown':
+      return `Build provenance not checked: ${verdict.reason}.`;
+  }
+}
+
+/**
+ * Reads the current HEAD commit via the `git` binary.
+ *
+ * @param repoRoot - Directory to run `git` in
+ * @returns The 40-char SHA, or null when git is unavailable or this is not a
+ *   repository (a container or tarball deploy, where the check must not fire)
+ */
+export function readGitHead(repoRoot: string): string | null {
+  try {
+    const out = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const sha = out.trim();
+    return sha.length > 0 ? sha : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locates and reads the build stamp by walking up from a starting directory.
+ *
+ * Walking up (rather than hardcoding a path) keeps the guard working if the
+ * compiled layout shifts; a miss degrades to `unstamped`, which warns rather
+ * than failing.
+ *
+ * @param startDir - Directory to begin the upward search from
+ * @returns The parsed stamp, or null when absent or unparseable
+ */
+export function readBuildInfo(startDir: string): BuildInfo | null {
+  let dir = startDir;
+  for (let i = 0; i < MAX_UPWARD_LOOKUP; i += 1) {
+    const candidate = join(dir, BUILD_INFO_FILENAME);
+    if (existsSync(candidate)) {
+      try {
+        const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as Partial<BuildInfo>;
+        if (typeof parsed.commit === 'string' && typeof parsed.builtAt === 'string') {
+          return { commit: parsed.commit, builtAt: parsed.builtAt };
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Writes the build stamp. Called once at the end of the backend build.
+ *
+ * @param outDir - Directory to write {@link BUILD_INFO_FILENAME} into
+ * @param commit - HEAD SHA at build time
+ * @param builtAt - ISO8601 build timestamp
+ * @returns Absolute path of the file written
+ */
+export function writeBuildInfo(outDir: string, commit: string, builtAt: string): string {
+  const target = join(outDir, BUILD_INFO_FILENAME);
+  const payload: BuildInfo = { commit, builtAt };
+  writeFileSync(target, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return target;
+}
+
+/**
+ * Checks build provenance at startup and reports it.
+ *
+ * A stale build throws, because a silent stale build is the exact failure
+ * this guard exists to end. Every other outcome — unstamped, no git, the
+ * skip flag set — only reports, so the check can never block a legitimate
+ * container deploy.
+ *
+ * @param options - Injection points, all defaulted for production use
+ * @param options.moduleDir - Directory to search upward from for the stamp.
+ *   Defaults to the backend build directory. Deliberately a parameter rather
+ *   than an `import.meta.url` lookup: this module is compiled as ESM for
+ *   production but as CommonJS by ts-jest, and `import.meta` is illegal in
+ *   the latter — so depending on it would make the guard untestable.
+ * @param options.repoRoot - Directory to resolve HEAD in
+ * @param options.headCommit - Overrides HEAD resolution. Present so the
+ *   stale path is testable without constructing a git repository
+ * @param options.env - Environment to read the skip flag from
+ * @param options.log - Sink for the informational line
+ * @param options.warn - Sink for non-fatal problems
+ * @returns The verdict, for callers that want to surface it elsewhere
+ * @throws Error when the build is stale and the skip flag is not set
+ */
+export function assertBuildProvenance(options: {
+  moduleDir?: string;
+  repoRoot?: string;
+  headCommit?: string | null;
+  env?: NodeJS.ProcessEnv;
+  log?: (message: string) => void;
+  warn?: (message: string) => void;
+} = {}): ProvenanceVerdict {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const moduleDir = options.moduleDir ?? join(repoRoot, 'dist', 'backend');
+  const env = options.env ?? process.env;
+  const log = options.log ?? ((m: string) => console.log(m));
+  const warn = options.warn ?? ((m: string) => console.warn(m));
+
+  const head =
+    options.headCommit !== undefined ? options.headCommit : readGitHead(repoRoot);
+  const verdict = evaluateBuildProvenance(readBuildInfo(moduleDir), head);
+  const message = formatVerdict(verdict);
+
+  if (verdict.state === 'ok') {
+    log(message);
+    return verdict;
+  }
+  if (verdict.state !== 'stale') {
+    warn(message);
+    return verdict;
+  }
+  if (env[SKIP_BUILD_CHECK_ENV]) {
+    warn(message);
+    return verdict;
+  }
+  throw new Error(message);
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "npm run build:backend && npm run build:frontend && npm run build:cli",
     "build:server": "npm run build:backend && npm run build:cli",
-    "build:backend": "tsc -p backend/tsconfig.json",
+    "build:backend": "tsc -p backend/tsconfig.json && node dist/backend/backend/src/scripts/stamp-build.js",
     "build:frontend": "cd frontend && npm run build",
     "build:cli": "tsc -p cli/tsconfig.json",
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",


### PR DESCRIPTION
WI 763c8e30. **Base SHA: `87017697`.**

**Deployment class: BACKEND TypeScript — merged ≠ live.** It takes effect after a build and a restart. Stating it up front, since this PR exists because that distinction was invisible.

## Why a mechanical check

Five merged fixes were found not to be executing: the backend served a `dist/` built May 5 from a process started two weeks earlier. Nothing said so. "Always rebuild" was already written down and still didn't hold — which is the case for a guard rather than another reminder.

## Commit identity, not mtimes

Per your steer, and it's the right call: `git checkout` doesn't preserve mtimes, so a fresh clone or branch switch makes source look newer than a perfectly current build. A false alarm gets the check disabled, leaving neither the check nor the attention — the same argument that stopped Quinn's fuzzy scanner shipping as a gate.

SHA comparison is exact, has no clock or filesystem dependence, and answers what a debugger actually asks: *which commit is running?*

## Behaviour

| verdict | action |
|---|---|
| `stale` — build ≠ HEAD | **throws, startup refused** (override `CREWLY_SKIP_BUILD_CHECK=1`) |
| `unstamped` — no stamp | warn (builds predating this guard) |
| `unknown` — no `.git`/git binary | warn — container and tarball deploys must never be blocked |
| `ok` | info line naming the running commit |

The check runs **before any service starts**, so a stale build is refused rather than half-run.

## Verified end-to-end against real compiled output

Not unit tests — the actual `npm run build:backend`, then the compiled guard:

```
1. build + stamp            → LOG: Running commit 87017697 (built …). verdict: ok
2. move HEAD, no rebuild    → THREW: STALE BUILD: serving compiled output from
                              commit 87017697 while HEAD is 66320a55 …
3. CREWLY_SKIP_BUILD_CHECK=1 → WARN: (same message). verdict: stale
4. re-stamp (as a rebuild)  → LOG: Running commit 66320a55. verdict: ok
```

## Two limits, stated rather than papered over

1. **It compares commits, so uncommitted edits are invisible.** Deliberate: flagging every dirty working tree reintroduces exactly the false-alarm problem this design avoids. It catches the case that actually bit us — HEAD moved, nobody rebuilt.
2. **It only becomes protective after the first stamped build.** I checked what today's incident would produce: `unstamped → warn`, not a failure. It cannot retroactively know an unstamped `dist` is stale. Failing on unstamped would break every existing deployment until rebuilt, so warning is the correct degradation — but it does mean the guard's value starts one build from now, not immediately.

## Scope

Dev tooling only, per ORC's framing. Nothing here justifies or performs a restart; the rebuild/restart decision stays separate and still pending.

## Tests

21 tests across two co-located files. The decision logic (`evaluateBuildProvenance`) is pure — all filesystem and git access sits in thin wrappers — so every verdict is testable without constructing a repository. Notable cases: `unknown` is asserted to **never** be `stale` (the container case, where a false positive would be worst), and one test pins that verdict does not depend on timestamps at all, so nobody can quietly reintroduce mtime logic.

`import.meta` is deliberately absent from the module: production compiles it as ESM but ts-jest compiles it as CommonJS, where `import.meta` is illegal — depending on it would have made the guard untestable. The lookup directory is a parameter instead.

Typecheck 25 errors, identical to baseline, none in the added files. Lint: 0 errors in the new files; `index.ts` reports 9, **identical count on the pristine `origin/main` version** — all pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)