### PR TITLE
fix(skills): replace the dangling delegate-task symlink with a signpost, and guard the class

### DIFF
--- a/config/skills/_common/no-dangling-symlinks.test.sh
+++ b/config/skills/_common/no-dangling-symlinks.test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# =============================================================================
+# Class guard: no dangling symlinks anywhere under config/skills/
+#
+# A dangling symlink is worse than a missing file. `ls` shows the entry, the
+# path matches the naming pattern of its neighbours, and nothing fails until
+# someone runs it — at which point the error ("No such file or directory")
+# points at the LINK TARGET, not at the fact that the link itself is wrong.
+#
+# The instance that motivated this: config/skills/agent/core/delegate-task/
+# execute.sh was a symlink to ../../../../team-leader/delegate-task/execute.sh
+# — one `../` too many. Four levels up from that directory is `config/`, not
+# `config/skills/`, so it targeted config/team-leader/... which does not exist.
+# It sat broken long enough to produce a recorded onboarding gotcha (a TL agent
+# taking that path and self-correcting) and, later, a wrong conclusion in a PR
+# review (that fixing the team-leader file fixed both call paths — it did not,
+# because this path was broken outright).
+#
+# It surfaced only because an unrelated scanner CRASHED on it while walking the
+# tree. Nothing was watching for it. This test watches for it.
+#
+# Test runner:
+#   bash config/skills/_common/no-dangling-symlinks.test.sh
+#   echo $?    # 0 on pass, 1 on fail
+# =============================================================================
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SKILLS_DIR="${REPO_ROOT}/config/skills"
+
+echo "=== no dangling symlinks under config/skills/ ==="
+
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "  ✗ skills directory not found: ${SKILLS_DIR}"
+  exit 1
+fi
+
+# `-type l` finds symlinks; `! -exec test -e {} \;` keeps only those whose
+# target does not resolve. Both BSD (macOS) and GNU find support this form.
+DANGLING=$(find "$SKILLS_DIR" -type l ! -exec test -e {} \; -print 2>/dev/null || true)
+
+if [ -n "$DANGLING" ]; then
+  COUNT=$(printf '%s\n' "$DANGLING" | grep -c . || true)
+  echo "  ✗ ${COUNT} dangling symlink(s) found:"
+  while IFS= read -r link; do
+    [ -z "$link" ] && continue
+    REL="${link#${REPO_ROOT}/}"
+    echo "      ${REL}"
+    echo "        -> $(readlink "$link") (does not resolve)"
+  done <<< "$DANGLING"
+  echo ""
+  echo "    A dangling symlink LOOKS like a real path and fails only on use."
+  echo "    Either point it at a file that exists, or remove it so the path"
+  echo "    fails honestly. Do not leave it in the middle state."
+  exit 1
+fi
+
+TOTAL_LINKS=$(find "$SKILLS_DIR" -type l 2>/dev/null | grep -c . || true)
+echo "  ✓ no dangling symlinks (${TOTAL_LINKS} symlink(s) checked)"
+echo ""
+echo "=== Results: 1 passed, 0 failed ==="
+exit 0

--- a/config/skills/agent/core/delegate-task/execute.sh
+++ b/config/skills/agent/core/delegate-task/execute.sh
@@ -1,1 +1,46 @@
-../../../../team-leader/delegate-task/execute.sh
+#!/bin/bash
+# =============================================================================
+# NOT A SKILL — a signpost.
+#
+# `delegate-task` does not live here. It is a TEAM LEADER skill:
+#
+#     config/skills/team-leader/delegate-task/execute.sh
+#
+# This path exists because agents reach for it. Every other core skill lives at
+# config/skills/agent/core/<name>/execute.sh, so the pattern predicts a
+# delegate-task here, and project memory records at least one TL agent taking
+# that path and having to self-correct.
+#
+# It used to be a symlink — and a BROKEN one: it pointed at
+# ../../../../team-leader/delegate-task/execute.sh, which is one `../` too many
+# (four levels up from here is `config/`, not `config/skills/`). So it resolved
+# to config/team-leader/delegate-task/execute.sh, which does not exist.
+# `test -e` failed and running it printed "No such file or directory".
+#
+# That is the worst of the three states: `ls` showed a delegate-task directory
+# containing an execute.sh, so the path LOOKED real to anyone browsing, and
+# failed only on use.
+#
+# WHY A SIGNPOST RATHER THAN A REPAIRED SYMLINK
+#
+# Repairing the link would work, but it would create a SECOND working entry
+# point to one skill. Two paths to one implementation is the drift shape this
+# codebase keeps paying for — the hand-copied mock in the TL delegate-task
+# test, the template copies of norms. Anyone editing or testing delegate-task
+# would have to remember both. There are zero callers of this path, so there is
+# nothing to preserve by making it work.
+#
+# So: one canonical implementation, and a path that fails loudly and tells you
+# where to go. Same disposition as the `skipGates` rejection (#742) and the
+# `block-task` status pre-check (#747): reject, and name the remedy.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_SKILL="$(cd "${SCRIPT_DIR}/../../.." && pwd)/team-leader/delegate-task/execute.sh"
+
+cat >&2 <<EOF_MSG
+{"error":"delegate-task is a TEAM LEADER skill and does not live under agent/core. Use: ${REAL_SKILL}","correctPath":"config/skills/team-leader/delegate-task/execute.sh","calledPath":"config/skills/agent/core/delegate-task/execute.sh"}
+EOF_MSG
+
+exit 1


### PR DESCRIPTION
Closes WI `4052aa2c`. Base `78f2d938`.

## The bug

`config/skills/agent/core/delegate-task/execute.sh` was a symlink to `../../../../team-leader/delegate-task/execute.sh` — **one `../` too many**. Four levels up from that directory is `config/`, not `config/skills/`, so it targeted `config/team-leader/delegate-task/execute.sh`, which doesn't exist.

**This is the worst of the three possible states.** `ls` showed a `delegate-task` directory containing an `execute.sh`; the path matched the naming pattern every other core skill follows; and it failed only on use.

It has already cost twice:
- Project memory records a TL agent taking this path and self-correcting — **the onboarding gotcha exists because of this link**.
- It later produced a wrong conclusion in review: that fixing the team-leader file fixed both call paths. It didn't — this path was broken outright, so it was neither fixed nor working.

## Disposition: signpost, not a repaired link

Repairing would work, but it would create a **second working entry point to one skill**. Two paths to one implementation is the drift shape this codebase keeps paying for — the hand-copied mock inside the TL delegate-task test, the template copies of norms — and anyone editing or testing `delegate-task` would have to remember both.

**Zero callers reference this path** (verified by grep across the repo), so nothing is preserved by making it work.

The path now exists and fails loudly:

```
{"error":"delegate-task is a TEAM LEADER skill and does not live under agent/core.
Use: /…/config/skills/team-leader/delegate-task/execute.sh",
 "correctPath":"config/skills/team-leader/delegate-task/execute.sh", …}
```

`test -e` passes; the script exits 1. Same disposition as the `skipGates` rejection (#742) and the `block-task` pre-check (#747): reject, and name the remedy. The shim resolves the real path at runtime rather than hardcoding it, so the message is correct from a worktree as well as the main checkout.

## The part that closes the class

`config/skills/_common/no-dangling-symlinks.test.sh` asserts no dangling symlink exists anywhere under `config/skills/`, **and reports how many symlinks it checked** — so a pass over an empty set reads as exactly that, rather than as health.

**Mutation-verified in both directions:**

| Condition | Result |
|---|---|
| Planted dangling link | **fails**, naming the link and its unresolvable target |
| Genuinely healthy link | **passes** (`1 symlink(s) checked`) |

> Worth recording: my first "healthy" probe was *itself* dangling — I wrote `../../../` from `agent/core/` where `../../` is correct. That's the same off-by-one that produced the original bug, made while writing the test for it. The correct depth depends on how deep the link sits, which is precisely why this needs a test rather than care.

This surfaced only because an unrelated scanner **crashed** while walking the tree. Nothing was watching for it; now something is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)