### PR TITLE
fix(delivery): replace the inlined waitTimeout default, document the rest

### DIFF
--- a/backend/src/controllers/monitoring/terminal.controller.test.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { EVENT_DELIVERY_CONSTANTS } from '../../constants.js';
 import { Request, Response } from 'express';
 import * as terminalController from './terminal.controller.js';
 
@@ -46,6 +47,14 @@ const mockLoggerError = (globalThis as any).__terminalControllerMockLogger?.erro
 
 // Mock the constants
 jest.mock('../../constants.js', () => ({
+	// WI dae79289: the controller reads TOTAL_DELIVERY_TIMEOUT as the
+	// waitForReady fallback, so the mock must carry it. Without this the
+	// constant is `undefined` here and the fallback path throws in tests
+	// while working fine in production — the worst kind of gap.
+	EVENT_DELIVERY_CONSTANTS: {
+		TOTAL_DELIVERY_TIMEOUT: 30000,
+		AGENT_READY_TIMEOUT: 120000,
+	},
 	TERMINAL_CONTROLLER_CONSTANTS: {
 		DEFAULT_CAPTURE_LINES: 50,
 		MAX_CAPTURE_LINES: 500,
@@ -1108,6 +1117,26 @@ describe('TerminalController', () => {
 				success: true,
 				verified: true,
 			});
+		});
+
+		it('falls back to TOTAL_DELIVERY_TIMEOUT when no waitTimeout is supplied', async () => {
+			// WI dae79289: this fallback used to be an inlined 30000 while an
+			// identically-valued EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT
+			// sat unused. Asserting against the CONSTANT (not the number) is
+			// the point — if someone retunes the constant, this test moves with
+			// it instead of pinning a stale literal.
+			mockReq = {
+				params: { sessionName: 'test-session' } as any,
+				body: { message: 'Hello', waitForReady: true },
+			};
+
+			await terminalController.deliverMessage.call(mockApiContext, mockReq as Request, mockRes as Response);
+
+			expect(mockApiContext.agentRegistrationService.waitForAgentReady).toHaveBeenCalledWith(
+				'test-session',
+				EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT,
+				undefined
+			);
 		});
 
 		it('should return 408 when agent not ready within timeout', async () => {

--- a/backend/src/controllers/monitoring/terminal.controller.ts
+++ b/backend/src/controllers/monitoring/terminal.controller.ts
@@ -11,7 +11,7 @@ import { Request, Response } from 'express';
 import { ApiResponse } from '../../types/index.js';
 import { getSessionBackendSync, getSessionBackend } from '../../services/session/index.js';
 import { LoggerService, ComponentLogger } from '../../services/core/logger.service.js';
-import { TERMINAL_CONTROLLER_CONSTANTS, ORCHESTRATOR_SESSION_NAME, CREWLY_CONSTANTS, RuntimeType, RUNTIME_TYPES } from '../../constants.js';
+import { TERMINAL_CONTROLLER_CONSTANTS, ORCHESTRATOR_SESSION_NAME, CREWLY_CONSTANTS, EVENT_DELIVERY_CONSTANTS, RuntimeType, RUNTIME_TYPES } from '../../constants.js';
 import {
 	validateTerminalInput,
 	sanitizeTerminalInput,
@@ -988,9 +988,25 @@ export async function deliverMessage(this: ApiContext, req: Request, res: Respon
 			return;
 		}
 
-		// Optionally wait for agent to be at prompt before delivering
+		// Optionally wait for agent to be at prompt before delivering.
+		//
+		// WI dae79289: this fallback was an inlined 30000 while an
+		// identically-valued EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT
+		// sat unused in constants.ts. Substituting it is behaviour-identical.
+		//
+		// Recorded because it is NOT obvious and nobody should have to
+		// re-derive it: this value is passed as the agent-READY timeout, and
+		// `waitForAgentReady` has its own dedicated default for that —
+		// EVENT_DELIVERY_CONSTANTS.AGENT_READY_TIMEOUT, which is 120000, not
+		// 30000. So this endpoint deliberately waits a quarter as long as the
+		// service would on its own. Whether that divergence is intentional
+		// fail-fast or accumulated drift is NOT established, so the value is
+		// left exactly as it was; only the magic number is removed.
 		if (waitForReady) {
-			const timeout = typeof waitTimeout === 'number' ? waitTimeout : 30000;
+			const timeout =
+				typeof waitTimeout === 'number'
+					? waitTimeout
+					: EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT;
 			const ready = await this.agentRegistrationService.waitForAgentReady(
 				sessionName,
 				timeout,

--- a/config/skills/_conventions/mirror-comment.test.ts
+++ b/config/skills/_conventions/mirror-comment.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Enforces the mirror-comment convention across skill shell scripts.
+ *
+ * Shell skills cannot import TypeScript constants, so a literal on the wire
+ * is unavoidable. The convention makes that literal auditable instead of
+ * mysterious: write the literal, and name the constant it mirrors in a
+ * comment directly above it.
+ *
+ *     # waitTimeout matches EVENT_DELIVERY_CONSTANTS.AGENT_READY_TIMEOUT (120000ms)
+ *     ... waitTimeout: 120000 ...
+ *
+ * The value of the convention is entirely in being CHECKABLE. A mirror
+ * comment nobody verifies is worse than no comment, because it asserts a
+ * relationship a reader will trust — and if the constant later moves, the
+ * comment becomes a confident lie. This test is what makes the claim
+ * mechanical: every mirror comment must name a constant that exists and
+ * whose value is exactly the number the comment states.
+ *
+ * Scope note (WI dae79289): this checks mirror comments that EXIST. It
+ * deliberately does not demand one at every literal — several delivery
+ * literals have no constant they can honestly be said to mirror, and
+ * inventing one by value-matching would manufacture exactly the false
+ * relationship this test exists to prevent.
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const SKILLS_DIR = join(REPO_ROOT, 'config', 'skills');
+const CONSTANTS_FILE = join(REPO_ROOT, 'backend', 'src', 'constants.ts');
+
+/**
+ * A mirror comment found in a shell script.
+ */
+interface MirrorClaim {
+  file: string;
+  line: number;
+  /** Dotted constant path, e.g. `EVENT_DELIVERY_CONSTANTS.AGENT_READY_TIMEOUT`. */
+  constantPath: string;
+  /** Numeric value the comment claims the constant holds. */
+  claimedValue: number;
+}
+
+/**
+ * Recursively lists shell scripts under a directory.
+ *
+ * @param dir - Directory to walk
+ * @returns Absolute paths of every `.sh` file found
+ */
+function listShellScripts(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let stats;
+    try {
+      stats = statSync(full);
+    } catch {
+      continue; // dangling symlink — covered by its own guard, not this one
+    }
+    if (stats.isDirectory()) out.push(...listShellScripts(full));
+    else if (entry.endsWith('.sh')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Extracts mirror-comment claims from a script.
+ *
+ * Matches comments of the shape `... matches SOME_CONST.PATH (12345ms)`.
+ *
+ * @param file - Absolute path of the script
+ * @returns Every claim the file makes
+ */
+function extractClaims(file: string): MirrorClaim[] {
+  const claims: MirrorClaim[] = [];
+  const lines = readFileSync(file, 'utf8').split('\n');
+  const pattern = /#.*\bmatches\s+([A-Z][A-Z0-9_]*(?:\.[A-Z][A-Z0-9_]*)+)\s*\((\d[\d_]*)\s*ms\)/;
+  lines.forEach((line, i) => {
+    const m = pattern.exec(line);
+    if (m && m[1] && m[2]) {
+      claims.push({
+        file,
+        line: i + 1,
+        constantPath: m[1],
+        claimedValue: Number(m[2].replace(/_/g, '')),
+      });
+    }
+  });
+  return claims;
+}
+
+/**
+ * Reads a constant's numeric value out of `constants.ts` by its dotted path.
+ *
+ * Deliberately textual: importing the module would drag the backend's
+ * dependency graph into a config-level test.
+ *
+ * @param source - Full text of constants.ts
+ * @param path - Dotted path such as `GROUP.MEMBER`
+ * @returns The numeric value, or null when the constant is absent
+ */
+function lookupConstant(source: string, path: string): number | null {
+  const [group, member] = path.split('.');
+  if (!group || !member) return null;
+  const groupMatch = new RegExp(
+    `export const ${group}\\s*=\\s*\\{([\\s\\S]*?)\\n\\}\\s*as const;`,
+  ).exec(source);
+  if (!groupMatch || !groupMatch[1]) return null;
+  const memberMatch = new RegExp(`\\b${member}\\s*:\\s*(\\d[\\d_]*)`).exec(groupMatch[1]);
+  if (!memberMatch || !memberMatch[1]) return null;
+  return Number(memberMatch[1].replace(/_/g, ''));
+}
+
+describe('mirror-comment convention', () => {
+  const constantsSource = readFileSync(CONSTANTS_FILE, 'utf8');
+  const claims = listShellScripts(SKILLS_DIR).flatMap(extractClaims);
+
+  it('finds the mirror comments that exist in the skill corpus', () => {
+    // A guard that silently matches nothing would pass forever while
+    // enforcing nothing, so pin that the scanner actually sees the corpus.
+    expect(claims.length).toBeGreaterThan(0);
+  });
+
+  it.each(claims.length ? claims : [])(
+    'names a real constant with the stated value: $constantPath',
+    ({ file, line, constantPath, claimedValue }: MirrorClaim) => {
+      const actual = lookupConstant(constantsSource, constantPath);
+      const where = `${relative(REPO_ROOT, file)}:${line}`;
+      expect(actual === null ? `MISSING CONSTANT (${where})` : actual).toBe(claimedValue);
+    },
+  );
+
+  it('resolves a known-good constant, proving the lookup is not vacuously passing', () => {
+    // If lookupConstant silently returned null for everything, every claim
+    // above would fail loudly rather than pass — but pin the positive case
+    // too, so a lookup that broke toward `undefined` could not hide.
+    expect(lookupConstant(constantsSource, 'EVENT_DELIVERY_CONSTANTS.AGENT_READY_TIMEOUT')).toBe(120000);
+    expect(lookupConstant(constantsSource, 'EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT')).toBe(30000);
+  });
+
+  it('returns null for a constant that does not exist', () => {
+    expect(lookupConstant(constantsSource, 'EVENT_DELIVERY_CONSTANTS.NOT_A_REAL_CONSTANT')).toBeNull();
+  });
+});

--- a/config/skills/agent/core/handoff-task/execute.sh
+++ b/config/skills/agent/core/handoff-task/execute.sh
@@ -141,6 +141,13 @@ echo "Delivering handoff context to ${TO}..." >&2
 deliver_result=$(api_call POST "/terminal/${TO}/write" "$DELIVER_BODY" 2>/dev/null) || {
   # Retry with deliver endpoint (agent may need wake-up)
   DELIVER_BODY_V2=$(jq -n --arg message "$HANDOFF_MESSAGE" \
+    # waitTimeout 15000, matching delegate-task's initial attempt. Handoff
+    # targets a worker expected to be already running, so the same fail-fast
+    # budget applies.
+    #
+    # ORIGIN NOT ESTABLISHED (WI dae79289): no delivery constant carries this
+    # value, so there is nothing to mirror. Documented, deliberately not
+    # changed.
     '{message: $message, waitForReady: true, waitTimeout: 15000}')
   deliver_result=$(api_call POST "/terminal/${TO}/deliver" "$DELIVER_BODY_V2" 2>/dev/null) || {
     deliver_result='{"error":"delivery failed — target agent may be offline"}'

--- a/config/skills/team-leader/delegate-task/execute.sh
+++ b/config/skills/team-leader/delegate-task/execute.sh
@@ -227,6 +227,16 @@ fi
 # 1. Try normal delivery (waitForReady)
 # 2. If fails, try force delivery
 # 3. If still fails, auto-start the worker then retry
+# waitTimeout 15000: the INITIAL attempt against a worker expected to be
+# already running, so it fails fast and lets the fallback ladder below take
+# over. The retry after auto-start uses 30000 — see the note there; the two
+# values differ deliberately and must not be normalised to one number.
+#
+# ORIGIN NOT ESTABLISHED (WI dae79289): 15000 matches no delivery-related
+# constant. Seven constants share the value, none of them about terminal
+# delivery, so there is nothing here that this literal can honestly be said
+# to mirror. Left exactly as-is rather than attached to a plausible-looking
+# constant that does not actually govern it.
 BODY=$(jq -n --arg message "$TASK_MESSAGE" '{message: $message, waitForReady: true, waitTimeout: 15000}')
 
 DELIVER_OK=true
@@ -259,6 +269,16 @@ if [ "$DELIVER_OK" = "false" ]; then
           echo '{"info":"Worker '"$TO"' start triggered — retrying delivery in 10s..."}' >&2
           sleep 10
           # Retry delivery after agent boots
+          # waitTimeout 30000, double the initial 15000 above. This retry
+          # follows an auto-start, so the worker is booting from cold and
+          # legitimately needs longer to reach a prompt than one that was
+          # expected to be up already. The asymmetry is the point: it is not
+          # drift between two copies of the same call.
+          #
+          # ORIGIN NOT ESTABLISHED (WI dae79289): the value coincides with
+          # EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT, but coincidence
+          # of value is not evidence of relationship — eleven constants share
+          # 30000. Not claimed as a mirror.
           RETRY_BODY=$(jq -n --arg message "$TASK_MESSAGE" '{message: $message, waitForReady: true, waitTimeout: 30000}')
           api_call POST "/terminal/${TO}/deliver" "$RETRY_BODY" && STARTED=true || {
             # Final fallback: force deliver


### PR DESCRIPTION
WI dae79289. **Base SHA: `1c352524`.** **No delivery value changes.**

## Deployment class — this PR straddles both, deliberately called out

| change | class | when it takes effect |
|---|---|---|
| Tier 1 endpoint constant (`terminal.controller.ts`) | backend TS | **pending the deploy still awaiting Steve** |
| Tier 2/3 comments in `delegate-task` / `handoff-task` | bash skills | **live on merge** |
| `mirror-comment.test.ts` | test | CI/local only |

So merging this produces a **partial activation**: the documentation lands immediately, the constant substitution does not. Since the substitution is behaviour-identical that's harmless — but it is exactly the confusion we've been fighting, so it should be stated rather than discovered.

## Tier 1 — fixed, and one thing you should rule on

The endpoint inlined `30000` while an identically-valued `TOTAL_DELIVERY_TIMEOUT` sat unused. Now uses the constant. Behaviour-identical.

**But Tier 1 was less unambiguous than it looked.** That value is passed as the agent-**ready** timeout, and `waitForAgentReady` has its own dedicated default for exactly that:

```
waitForAgentReady(sessionName, timeoutMs = EVENT_DELIVERY_CONSTANTS.AGENT_READY_TIMEOUT)   // 120000
deliverMessage fallback                     = EVENT_DELIVERY_CONSTANTS.TOTAL_DELIVERY_TIMEOUT  // 30000
```

So the semantically-apt constant is `AGENT_READY_TIMEOUT` — with a **different value**. Using it would quadruple the endpoint's wait. I took the behaviour-preserving option you ruled for and recorded the divergence at the call site rather than resolving it silently.

The residual risk is worth naming: `TOTAL_DELIVERY_TIMEOUT` is documented as *"total timeout for message delivery with retries"*, so if someone later retunes it for retry budgeting they will also, invisibly, change how long this endpoint waits for a prompt. If you'd prefer a dedicated constant for the endpoint's ready-wait, that's a one-line follow-up — your call, not mine to make unilaterally.

## Tiers 2 and 3 — documented, values untouched

`delegate-task`'s initial 15000 vs retry 30000 is explained: the retry follows an auto-start, so the worker is booting cold and legitimately needs longer. The asymmetry is the point. 15000 is left exactly as found in both skills, origin recorded as unestablished.

## The convention corpus — and it does NOT scale by inspection

Applied as a **test**, not as more comments: `mirror-comment.test.ts` asserts every mirror comment in the skill tree names a constant that exists and holds the value claimed. Mutation-tested both drift modes — a stale value fails; a renamed-away constant fails and names `file:line`.

**The finding you asked for, and it's a real limit.** The convention needs a *known referent*, and at four sites two already lack one:

| site | value | mirrorable? |
|---|---|---|
| `send-message` | 120000 | **yes** — `AGENT_READY_TIMEOUT`, verified true |
| endpoint | 30000 | now uses the constant directly, no comment needed |
| `delegate-task` initial / `handoff-task` | 15000 | **no** — 7 constants share the value, none delivery-related |
| `delegate-task` retry | 30000 | **no** — 11 constants share it; coincidence of value is not evidence |

Value equality is not a semantic relationship. Attaching those literals to a plausible-looking constant would manufacture exactly the false claim the test exists to catch — and a false mirror is worse than none, because a reader trusts it and a later edit propagates through it.

**So the honest answer at n=4: the convention works where provenance is known and cannot be applied where it isn't.** Half this corpus isn't mirrorable, and the missing ingredient is the call-site tracing we deferred — not comment discipline. Learning that at four sites was cheap; the test is what makes it enforceable at forty.

## Tests

72 pass across the three affected suites. Typecheck 25 errors, identical to baseline, none mine. Lint 0 in the new file; the two touched files report 8, **identical count on pristine `origin/main`**.

One incidental find: the `terminal.controller` test mock **omitted `EVENT_DELIVERY_CONSTANTS`**, so the fallback path read `undefined` in tests while working in production. It only surfaced because the new test is the first to exercise the no-`waitTimeout` branch. Mock extended.

Did not touch `reconciler-data-provider.test.ts` — Leo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)